### PR TITLE
feat: Implement  health-check command (closes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ list, so there is no drift.
 
 ```bash
 research --help
+research --version          # print package version
+research doctor             # environment readiness checks (Rich table)
+research doctor --json      # same report as machine-readable JSON
 ```
 
-Subcommands land here as later issues introduce them.
+`research doctor` exits non-zero if any required check fails — safe to wire
+into CI as a pre-flight gate. Optional checks (LM Studio reachability, optional
+env keys) never affect the exit code.
+
+More subcommands land here as later issues introduce them.

--- a/src/research_agent/__init__.py
+++ b/src/research_agent/__init__.py
@@ -1,1 +1,3 @@
 """Research agent package — autonomous CLI research tool (see implementation guide §4)."""
+
+__version__ = "0.1.0"

--- a/src/research_agent/cli.py
+++ b/src/research_agent/cli.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import typer
 
-from research_agent import config
+from research_agent import __version__, config, doctor
 
-config.load_env()
+_LOADED_ENV_FILES = config.load_env()
 
 app = typer.Typer(
     name="research",
@@ -15,9 +15,42 @@ app = typer.Typer(
 )
 
 
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(__version__)
+        raise typer.Exit()
+
+
 @app.callback()
-def _main() -> None:
+def _main(
+    version: bool = typer.Option(  # noqa: ARG001 — eager callback handles exit
+        False,
+        "--version",
+        "-V",
+        callback=_version_callback,
+        is_eager=True,
+        help="Print version and exit.",
+    ),
+) -> None:
     """Top-level callback — subcommands land here once registered."""
+
+
+@app.command(name="doctor")
+def doctor_command(
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of the Rich table.",
+    ),
+) -> None:
+    """Report environment readiness for the research agent."""
+    results = doctor.run_all_checks(_LOADED_ENV_FILES)
+    if json_output:
+        typer.echo(doctor.emit_json(results, _LOADED_ENV_FILES))
+    else:
+        doctor.render_table(results)
+    if doctor.has_required_failure(results):
+        raise typer.Exit(code=1)
 
 
 if __name__ == "__main__":

--- a/src/research_agent/doctor.py
+++ b/src/research_agent/doctor.py
@@ -1,0 +1,267 @@
+"""Environment readiness checks for `research doctor`.
+
+Each check returns a :class:`CheckResult` with a status of ``ok``, ``fail``, or
+``skip``. Required checks failing cause `research doctor` to exit non-zero;
+optional check absences (`skip`) never affect the exit code. Secrets are
+masked everywhere — only the last four characters of any value ever appear in
+output.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+import yaml  # type: ignore[import-untyped]
+
+from research_agent import config
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    status: str  # "ok" | "fail" | "skip"
+    required: bool
+    detail: str
+
+
+def mask_secret(value: str) -> str:
+    """Return a masked form of ``value`` safe for logs.
+
+    Long values render as ``...XXXX`` (last four characters); shorter values
+    collapse to ``***`` so we never leak more than half a key.
+    """
+    if not value:
+        return "***"
+    if len(value) <= 8:
+        return "***"
+    return f"...{value[-4:]}"
+
+
+def check_python() -> CheckResult:
+    major, minor = sys.version_info[:2]
+    detail = f"{major}.{minor}.{sys.version_info.micro}"
+    if (major, minor) >= (3, 12):
+        return CheckResult("python", "ok", required=True, detail=detail)
+    return CheckResult(
+        "python",
+        "fail",
+        required=True,
+        detail=f"{detail} (need >= 3.12)",
+    )
+
+
+def check_env_files(loaded: list[Path]) -> CheckResult:
+    """Report which `.env*` files were loaded. Never required (defaults exist)."""
+    if not loaded:
+        return CheckResult("env_files", "skip", required=False, detail="not found")
+    cwd = Path.cwd()
+    rendered: list[str] = []
+    for path in loaded:
+        try:
+            rendered.append(str(path.relative_to(cwd)))
+        except ValueError:
+            rendered.append(str(path))
+    return CheckResult("env_files", "ok", required=False, detail=", ".join(rendered))
+
+
+def check_env_keys() -> list[CheckResult]:
+    """Per-key presence + masked detail for everything in EXPECTED_ENV_KEYS."""
+    results: list[CheckResult] = []
+    for key in config.EXPECTED_ENV_KEYS:
+        # Read the raw process value (not the declared default) — defaults are
+        # for runtime fallback, not for "is this configured" reporting.
+        raw = os.environ.get(key.name)
+        name = f"env:{key.name}"
+        if raw:
+            results.append(
+                CheckResult(
+                    name,
+                    "ok",
+                    required=key.required,
+                    detail=f"present ({mask_secret(raw)})",
+                )
+            )
+        elif key.required:
+            results.append(CheckResult(name, "fail", required=True, detail="missing (required)"))
+        else:
+            results.append(CheckResult(name, "skip", required=False, detail="missing (optional)"))
+    return results
+
+
+def check_openrouter_key_shape() -> CheckResult:
+    """Verify the OpenRouter key starts with ``sk-or-`` (no network call)."""
+    raw = os.environ.get("OPENROUTER_API_KEY")
+    name = "openrouter_key_shape"
+    if not raw:
+        return CheckResult(name, "skip", required=False, detail="key not set")
+    if raw.startswith("sk-or-"):
+        return CheckResult(name, "ok", required=True, detail=f"prefix ok ({mask_secret(raw)})")
+    return CheckResult(
+        name,
+        "fail",
+        required=True,
+        detail="OPENROUTER_API_KEY does not start with 'sk-or-'",
+    )
+
+
+def check_lm_studio(base_url: str | None) -> CheckResult:
+    """GET ``{base_url}/models`` with a short timeout. Never required."""
+    name = "lm_studio"
+    if not base_url:
+        return CheckResult(name, "skip", required=False, detail="LMSTUDIO_BASE_URL unset")
+    url = base_url.rstrip("/") + "/models"
+    try:
+        response = httpx.get(url, timeout=2.0)
+    except httpx.HTTPError as exc:
+        return CheckResult(
+            name,
+            "skip",
+            required=False,
+            detail=f"not reachable at {url} ({type(exc).__name__})",
+        )
+    if response.status_code >= 400:
+        return CheckResult(
+            name,
+            "skip",
+            required=False,
+            detail=f"{url} returned HTTP {response.status_code}",
+        )
+    return CheckResult(name, "ok", required=False, detail=f"reachable at {url}")
+
+
+def check_writable_dirs(repo_root: Path) -> CheckResult:
+    """Ensure ``data/`` and ``jobs/`` exist under repo_root and are writable."""
+    name = "writable_dirs"
+    failures: list[str] = []
+    for sub in ("data", "jobs"):
+        target = repo_root / sub
+        try:
+            target.mkdir(parents=True, exist_ok=True)
+            probe = target / ".doctor-probe"
+            probe.write_text("ok", encoding="utf-8")
+            probe.unlink()
+        except OSError as exc:
+            failures.append(f"{sub}/: {exc}")
+    if failures:
+        return CheckResult(name, "fail", required=True, detail="; ".join(failures))
+    return CheckResult(
+        name,
+        "ok",
+        required=True,
+        detail=f"data/ and jobs/ writable under {repo_root}",
+    )
+
+
+def check_sqlite_wal() -> CheckResult:
+    """Open a tempdir SQLite DB and verify WAL mode is selectable."""
+    name = "sqlite_wal"
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "probe.sqlite"
+        try:
+            conn = sqlite3.connect(db_path)
+            try:
+                cursor = conn.execute("PRAGMA journal_mode=WAL")
+                mode = cursor.fetchone()[0]
+            finally:
+                conn.close()
+        except sqlite3.Error as exc:
+            return CheckResult(name, "fail", required=True, detail=str(exc))
+    if str(mode).lower() == "wal":
+        return CheckResult(name, "ok", required=True, detail="journal_mode=wal")
+    return CheckResult(
+        name,
+        "fail",
+        required=True,
+        detail=f"PRAGMA journal_mode returned {mode!r}",
+    )
+
+
+def check_models_yaml(path: Path) -> CheckResult:
+    """Parse ``config/models.yaml`` — fail if missing or invalid YAML."""
+    name = "models_yaml"
+    if not path.is_file():
+        return CheckResult(name, "fail", required=True, detail=f"not found: {path}")
+    try:
+        text = path.read_text(encoding="utf-8")
+        yaml.safe_load(text)
+    except (OSError, yaml.YAMLError) as exc:
+        return CheckResult(name, "fail", required=True, detail=f"{path}: {exc}")
+    return CheckResult(name, "ok", required=True, detail=f"parses ({path})")
+
+
+def run_all_checks(
+    loaded_env_files: list[Path],
+    *,
+    repo_root: Path | None = None,
+) -> list[CheckResult]:
+    root = repo_root or Path.cwd()
+    results: list[CheckResult] = [
+        check_python(),
+        check_env_files(loaded_env_files),
+    ]
+    results.extend(check_env_keys())
+    results.append(check_openrouter_key_shape())
+    results.append(check_lm_studio(config.get("LMSTUDIO_BASE_URL")))
+    results.append(check_writable_dirs(root))
+    results.append(check_sqlite_wal())
+    results.append(check_models_yaml(root / "config" / "models.yaml"))
+    return results
+
+
+_GLYPHS = {
+    "ok": ("[green]✓[/green]", "green"),
+    "fail": ("[red]✗[/red]", "red"),
+    "skip": ("[yellow]–[/yellow]", "yellow"),
+}
+
+
+def render_table(results: list[CheckResult]) -> None:
+    """Print a Rich table summarising every check."""
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+    table = Table(title="research doctor", show_lines=False)
+    table.add_column("", width=2)
+    table.add_column("Check")
+    table.add_column("Required")
+    table.add_column("Detail")
+
+    for result in results:
+        glyph, _ = _GLYPHS.get(result.status, ("?", "white"))
+        table.add_row(
+            glyph,
+            result.name,
+            "yes" if result.required else "no",
+            result.detail,
+        )
+    console.print(table)
+
+
+def to_json(results: list[CheckResult], loaded_env_files: list[Path]) -> dict[str, Any]:
+    """Return a JSON-serialisable summary. Never includes raw secret values."""
+    return {
+        "loaded_env_files": [str(p) for p in loaded_env_files],
+        "checks": [asdict(r) for r in results],
+        "ok": all(r.status != "fail" for r in results if r.required),
+    }
+
+
+def has_required_failure(results: list[CheckResult]) -> bool:
+    return any(r.status == "fail" and r.required for r in results)
+
+
+def emit_json(
+    results: list[CheckResult],
+    loaded_env_files: list[Path],
+) -> str:
+    """Serialise the report exactly the way the CLI prints it."""
+    return json.dumps(to_json(results, loaded_env_files), indent=2, sort_keys=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,119 @@
+"""End-to-end tests for the `research` CLI surface."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from research_agent import __version__, cli, config
+
+
+@pytest.fixture(autouse=True)
+def _reset_env_loader(monkeypatch):
+    """Force env discovery to start clean for each invocation."""
+    for key in (
+        "OPENROUTER_API_KEY",
+        "RESEARCH_USER_AGENT",
+        "RESEARCH_HEADFUL",
+        "LMSTUDIO_BASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    config.reset_for_tests()
+    yield
+    config.reset_for_tests()
+
+
+@pytest.fixture
+def isolated_repo(tmp_path, monkeypatch):
+    """Run the CLI from a tmp dir that contains a minimal valid layout."""
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "models.yaml").write_text("tiers: {}\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    # Ensure run_all_checks treats this tmp dir as the repo root.
+    monkeypatch.setattr(cli, "_LOADED_ENV_FILES", [])
+    return tmp_path
+
+
+def test_version_flag_prints_version_and_exits_zero():
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["--version"])
+    assert result.exit_code == 0
+    assert __version__ in result.stdout
+
+
+def test_version_short_flag_works():
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["-V"])
+    assert result.exit_code == 0
+    assert __version__ in result.stdout
+
+
+def test_no_args_shows_help():
+    runner = CliRunner()
+    result = runner.invoke(cli.app, [])
+    # Typer's no_args_is_help convention exits 2 with help on stderr/stdout.
+    assert "Usage" in result.stdout or "Usage" in (result.stderr or "")
+
+
+def test_doctor_json_returns_valid_json_with_required_keys(isolated_repo, monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-abcdef0123456789")
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["doctor", "--json"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert {"checks", "loaded_env_files", "ok"} <= payload.keys()
+    assert payload["ok"] is True
+
+
+def test_doctor_json_exit_one_on_required_failure(isolated_repo):
+    # No OPENROUTER_API_KEY in env → required env-key check fails.
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["doctor", "--json"])
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    by_name = {c["name"]: c for c in payload["checks"]}
+    assert by_name["env:OPENROUTER_API_KEY"]["status"] == "fail"
+
+
+def test_doctor_table_does_not_leak_secret(isolated_repo, monkeypatch):
+    secret = "sk-or-abcdef0123456789"
+    monkeypatch.setenv("OPENROUTER_API_KEY", secret)
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["doctor"])
+    assert result.exit_code == 0, result.stdout
+    assert secret not in result.stdout
+    assert "abcdef" not in result.stdout
+    # Masked suffix should appear.
+    assert "...6789" in result.stdout
+
+
+def test_doctor_json_does_not_leak_secret(isolated_repo, monkeypatch):
+    secret = "sk-or-abcdef0123456789"
+    monkeypatch.setenv("OPENROUTER_API_KEY", secret)
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["doctor", "--json"])
+    assert result.exit_code == 0, result.stdout
+    assert secret not in result.stdout
+    assert "abcdef" not in result.stdout
+
+
+def test_doctor_optional_missing_does_not_fail(isolated_repo, monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-abcdef0123456789")
+    # All optional keys remain unset (per autouse fixture).
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["doctor", "--json"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    by_name = {c["name"]: c for c in payload["checks"]}
+    assert by_name["env:RESEARCH_HEADFUL"]["status"] == "skip"
+    assert by_name["env:RESEARCH_HEADFUL"]["required"] is False
+
+
+def test_doctor_help_lists_command():
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["doctor", "--help"])
+    assert result.exit_code == 0
+    assert "--json" in result.stdout

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,223 @@
+"""Tests for `research_agent.doctor` checks and rendering."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from research_agent import config, doctor
+
+
+@pytest.fixture(autouse=True)
+def _scrub_env(monkeypatch):
+    """Each test starts with a clean slate for keys we toggle."""
+    for key in (
+        "OPENROUTER_API_KEY",
+        "RESEARCH_USER_AGENT",
+        "RESEARCH_HEADFUL",
+        "LMSTUDIO_BASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    config.reset_for_tests()
+    yield
+    config.reset_for_tests()
+
+
+def test_mask_secret_long_value():
+    assert doctor.mask_secret("sk-or-abcdef0123456789") == "...6789"
+
+
+def test_mask_secret_short_value():
+    assert doctor.mask_secret("short") == "***"
+    assert doctor.mask_secret("12345678") == "***"
+    assert doctor.mask_secret("") == "***"
+
+
+def test_check_env_keys_marks_required_missing_as_fail():
+    results = doctor.check_env_keys()
+    by_name = {r.name: r for r in results}
+    required = by_name["env:OPENROUTER_API_KEY"]
+    assert required.status == "fail"
+    assert required.required is True
+    assert "missing (required)" in required.detail
+
+
+def test_check_env_keys_marks_optional_missing_as_skip():
+    results = doctor.check_env_keys()
+    by_name = {r.name: r for r in results}
+    optional = by_name["env:RESEARCH_HEADFUL"]
+    assert optional.status == "skip"
+    assert optional.required is False
+    assert "missing (optional)" in optional.detail
+
+
+def test_check_env_keys_masks_present_value(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-abcdef0123456789")
+    results = doctor.check_env_keys()
+    by_name = {r.name: r for r in results}
+    present = by_name["env:OPENROUTER_API_KEY"]
+    assert present.status == "ok"
+    assert "...6789" in present.detail
+    assert "abcdef" not in present.detail
+
+
+def test_check_openrouter_key_shape_pass(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-abcdef0123456789")
+    result = doctor.check_openrouter_key_shape()
+    assert result.status == "ok"
+    assert "abcdef" not in result.detail
+
+
+def test_check_openrouter_key_shape_fail_on_bad_prefix(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "totally-wrong-prefix-12345")
+    result = doctor.check_openrouter_key_shape()
+    assert result.status == "fail"
+    assert result.required is True
+
+
+def test_check_openrouter_key_shape_skip_when_missing():
+    result = doctor.check_openrouter_key_shape()
+    assert result.status == "skip"
+    assert result.required is False
+
+
+def test_check_writable_dirs_creates_and_cleans(tmp_path):
+    result = doctor.check_writable_dirs(tmp_path)
+    assert result.status == "ok"
+    assert (tmp_path / "data").is_dir()
+    assert (tmp_path / "jobs").is_dir()
+    # The probe file must be cleaned up.
+    assert not (tmp_path / "data" / ".doctor-probe").exists()
+    assert not (tmp_path / "jobs" / ".doctor-probe").exists()
+
+
+def test_check_sqlite_wal_passes_in_tempdir():
+    result = doctor.check_sqlite_wal()
+    assert result.status == "ok"
+    assert "wal" in result.detail.lower()
+
+
+def test_check_models_yaml_passes_for_valid_yaml(tmp_path):
+    path = tmp_path / "models.yaml"
+    path.write_text("tiers:\n  cloud:\n    provider: openrouter\n", encoding="utf-8")
+    result = doctor.check_models_yaml(path)
+    assert result.status == "ok"
+
+
+def test_check_models_yaml_fails_for_invalid_yaml(tmp_path):
+    path = tmp_path / "models.yaml"
+    path.write_text("tiers: [unterminated\n", encoding="utf-8")
+    result = doctor.check_models_yaml(path)
+    assert result.status == "fail"
+    assert result.required is True
+
+
+def test_check_models_yaml_fails_when_missing(tmp_path):
+    result = doctor.check_models_yaml(tmp_path / "absent.yaml")
+    assert result.status == "fail"
+
+
+def test_check_lm_studio_skip_when_unreachable(monkeypatch):
+    # Point at a port that should refuse the connection.
+    result = doctor.check_lm_studio("http://127.0.0.1:1/v1")
+    assert result.status == "skip"
+    assert result.required is False
+
+
+def test_check_lm_studio_skip_when_unset():
+    result = doctor.check_lm_studio(None)
+    assert result.status == "skip"
+
+
+def test_check_python_reports_current_runtime():
+    result = doctor.check_python()
+    # We're running on >= 3.12 in CI per pyproject; sanity check the shape.
+    assert result.status == "ok"
+    assert result.required is True
+
+
+def test_check_env_files_with_loaded_paths(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    env_file = tmp_path / ".env"
+    env_file.write_text("X=1\n", encoding="utf-8")
+    result = doctor.check_env_files([env_file])
+    assert result.status == "ok"
+    assert ".env" in result.detail
+
+
+def test_check_env_files_reports_not_found():
+    result = doctor.check_env_files([])
+    assert result.status == "skip"
+    assert "not found" in result.detail
+
+
+def test_to_json_contains_no_raw_secret_value(monkeypatch, tmp_path):
+    secret = "sk-or-abcdef0123456789"
+    monkeypatch.setenv("OPENROUTER_API_KEY", secret)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "models.yaml").write_text("tiers: {}\n", encoding="utf-8")
+
+    results = doctor.run_all_checks([], repo_root=tmp_path)
+    payload = doctor.to_json(results, [])
+    serialised = json.dumps(payload)
+    assert secret not in serialised
+    assert "abcdef" not in serialised
+    # Last four chars are allowed (masked form).
+    assert "6789" in serialised
+
+
+def test_run_all_checks_returns_required_failure_when_keys_missing(tmp_path):
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "models.yaml").write_text("tiers: {}\n", encoding="utf-8")
+    results = doctor.run_all_checks([], repo_root=tmp_path)
+    assert doctor.has_required_failure(results)
+
+
+def test_run_all_checks_passes_when_required_satisfied(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-abcdef0123456789")
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "models.yaml").write_text("tiers: {}\n", encoding="utf-8")
+    results = doctor.run_all_checks([], repo_root=tmp_path)
+    assert not doctor.has_required_failure(results)
+
+
+def test_emit_json_returns_valid_json(tmp_path):
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "models.yaml").write_text("tiers: {}\n", encoding="utf-8")
+    results = doctor.run_all_checks([], repo_root=tmp_path)
+    payload = json.loads(doctor.emit_json(results, []))
+    assert "checks" in payload
+    assert "loaded_env_files" in payload
+    assert "ok" in payload
+
+
+def test_render_table_runs_without_error(capsys, tmp_path):
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "models.yaml").write_text("tiers: {}\n", encoding="utf-8")
+    results = doctor.run_all_checks([], repo_root=tmp_path)
+    doctor.render_table(results)
+    captured = capsys.readouterr()
+    assert "research doctor" in captured.out
+
+
+def test_render_table_does_not_print_raw_secret(capsys, monkeypatch, tmp_path):
+    secret = "sk-or-abcdef0123456789"
+    monkeypatch.setenv("OPENROUTER_API_KEY", secret)
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "models.yaml").write_text("tiers: {}\n", encoding="utf-8")
+    results = doctor.run_all_checks([], repo_root=tmp_path)
+    doctor.render_table(results)
+    captured = capsys.readouterr()
+    assert secret not in captured.out
+    assert "abcdef" not in captured.out
+
+
+def test_check_result_dataclass_shape():
+    from dataclasses import FrozenInstanceError
+
+    result = doctor.CheckResult(name="x", status="ok", required=True, detail="d")
+    # Frozen dataclass — must reject mutation.
+    with pytest.raises(FrozenInstanceError):
+        result.status = "fail"  # type: ignore[misc]


### PR DESCRIPTION
Closes #3

## Summary

Automated implementation of **Implement `research doctor` health-check command**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

All acceptance criteria met; tests, ruff, and mypy all pass. README docs-sync gap fixed (now documents `research doctor` and `--version`).

- **WARNING** [FIXED] `README.md`: README said 'Subcommands land here as later issues introduce them' but the `doctor` subcommand is now shipped. Updated the CLI section to document `research --version`, `research doctor`, and `research doctor --json`, plus exit-code semantics.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*