### PR TITLE
feat: SQLite schema + migrate() in storage/db.py (closes #4)

### DIFF
--- a/src/research_agent/storage/__init__.py
+++ b/src/research_agent/storage/__init__.py
@@ -1,1 +1,17 @@
 """Storage layer — job folders, SQLite index, markdown/JSON sidecars, source dedup."""
+
+from research_agent.storage.db import (
+    DEFAULT_DB_PATH,
+    SCHEMA_SQL,
+    connect,
+    connect_for_checkpoints,
+    migrate,
+)
+
+__all__ = [
+    "DEFAULT_DB_PATH",
+    "SCHEMA_SQL",
+    "connect",
+    "connect_for_checkpoints",
+    "migrate",
+]

--- a/src/research_agent/storage/db.py
+++ b/src/research_agent/storage/db.py
@@ -1,0 +1,213 @@
+"""SQLite cross-job index.
+
+Implements the schema locked in by §10 of ``research-agent-implementation-guide.md``:
+the 10 content tables (``jobs``, ``plans``, ``tasks``, ``findings``, ``sources``,
+``job_sources``, ``syntheses``, ``checkpoints``, ``events``, ``llm_calls``) plus
+two FTS5 virtual tables (``findings_fts``, ``sources_fts``) wired to their content
+tables via ``content=``/``content_rowid=``.
+
+The DB lives at ``data/index.sqlite`` and is opened in WAL mode with foreign-key
+enforcement. ``synchronous`` defaults to ``NORMAL``; checkpoint writers may opt
+into ``FULL`` via :func:`connect_for_checkpoints`.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+DEFAULT_DB_PATH = Path("data/index.sqlite")
+
+SCHEMA_SQL = """
+-- Jobs
+CREATE TABLE IF NOT EXISTS jobs (
+    id TEXT PRIMARY KEY,
+    goal TEXT NOT NULL,
+    domain TEXT,
+    status TEXT NOT NULL,
+    intake_json TEXT NOT NULL,
+    time_cap_hours INTEGER,
+    budget_cap_usd REAL,
+    aggressiveness TEXT,
+    created_at INTEGER NOT NULL,
+    started_at INTEGER,
+    finished_at INTEGER,
+    last_activity_at INTEGER,
+    pid INTEGER,
+    cost_so_far_usd REAL DEFAULT 0
+);
+
+-- Plan versions
+CREATE TABLE IF NOT EXISTS plans (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL REFERENCES jobs(id),
+    version INTEGER NOT NULL,
+    payload_json TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    UNIQUE(job_id, version)
+);
+
+-- Tasks (the queue)
+CREATE TABLE IF NOT EXISTS tasks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL REFERENCES jobs(id),
+    plan_version INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    status TEXT NOT NULL,
+    parent_task_id INTEGER REFERENCES tasks(id),
+    depth INTEGER DEFAULT 0,
+    started_at INTEGER,
+    finished_at INTEGER,
+    result_json TEXT,
+    error TEXT,
+    retry_count INTEGER DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_tasks_status_job ON tasks(job_id, status);
+
+-- Findings
+CREATE TABLE IF NOT EXISTS findings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL REFERENCES jobs(id),
+    md_path TEXT NOT NULL,
+    claim TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    source_ids TEXT NOT NULL,
+    contradicts TEXT,
+    embedding BLOB,
+    tags TEXT,
+    created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_findings_job ON findings(job_id);
+
+-- Sources (deduplicated across jobs)
+CREATE TABLE IF NOT EXISTS sources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sha256 TEXT NOT NULL UNIQUE,
+    url TEXT,
+    title TEXT,
+    fetched_at INTEGER NOT NULL,
+    archive_url TEXT,
+    md_path TEXT NOT NULL,
+    kind TEXT,
+    embedding BLOB
+);
+
+-- Job ↔ source many-to-many
+CREATE TABLE IF NOT EXISTS job_sources (
+    job_id TEXT NOT NULL REFERENCES jobs(id),
+    source_id INTEGER NOT NULL REFERENCES sources(id),
+    PRIMARY KEY (job_id, source_id)
+);
+
+-- Synthesis passes
+CREATE TABLE IF NOT EXISTS syntheses (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL REFERENCES jobs(id),
+    version INTEGER NOT NULL,
+    md_path TEXT NOT NULL,
+    model TEXT NOT NULL,
+    cost_usd REAL,
+    created_at INTEGER NOT NULL,
+    UNIQUE(job_id, version)
+);
+
+-- Checkpoints (one per state transition)
+CREATE TABLE IF NOT EXISTS checkpoints (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL REFERENCES jobs(id),
+    kind TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    ts INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_checkpoints_job_ts ON checkpoints(job_id, ts);
+
+-- Events (mirror of events.jsonl, for SQL queries from the future UI)
+CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT,
+    ts INTEGER NOT NULL,
+    level TEXT NOT NULL,
+    actor TEXT,
+    kind TEXT NOT NULL,
+    payload_json TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_events_job_ts ON events(job_id, ts);
+
+-- LLM call ledger (cost tracking)
+CREATE TABLE IF NOT EXISTS llm_calls (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT REFERENCES jobs(id),
+    ts INTEGER NOT NULL,
+    tier TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    input_tokens INTEGER,
+    output_tokens INTEGER,
+    cached_tokens INTEGER,
+    latency_ms INTEGER,
+    cost_usd REAL,
+    finish_reason TEXT
+);
+
+-- FTS5 over findings.claim and sources.title
+CREATE VIRTUAL TABLE IF NOT EXISTS findings_fts USING fts5(
+    claim, content=findings, content_rowid=id
+);
+CREATE VIRTUAL TABLE IF NOT EXISTS sources_fts USING fts5(
+    title, content=sources, content_rowid=id
+);
+"""
+
+_ALLOWED_SYNCHRONOUS = {"OFF", "NORMAL", "FULL", "EXTRA"}
+
+
+def connect(
+    path: Path | str = DEFAULT_DB_PATH,
+    *,
+    synchronous: str = "NORMAL",
+) -> sqlite3.Connection:
+    """Open a SQLite connection with the project's standard pragmas.
+
+    - WAL journal mode (concurrent readers + single writer)
+    - Foreign keys enforced
+    - ``synchronous`` defaults to ``NORMAL``; pass ``'FULL'`` for checkpoint writers
+    - ``row_factory`` set to :class:`sqlite3.Row`
+    """
+    sync = synchronous.upper()
+    if sync not in _ALLOWED_SYNCHRONOUS:
+        raise ValueError(
+            f"synchronous must be one of {sorted(_ALLOWED_SYNCHRONOUS)}; got {synchronous!r}"
+        )
+
+    db_path = Path(path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(db_path, detect_types=sqlite3.PARSE_DECLTYPES)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.execute(f"PRAGMA synchronous={sync}")
+    return conn
+
+
+def connect_for_checkpoints(path: Path | str = DEFAULT_DB_PATH) -> sqlite3.Connection:
+    """Open a connection with ``synchronous=FULL`` for durable checkpoint writes."""
+    return connect(path, synchronous="FULL")
+
+
+def migrate(
+    conn: sqlite3.Connection | None = None,
+    *,
+    path: Path | str = DEFAULT_DB_PATH,
+) -> sqlite3.Connection:
+    """Apply :data:`SCHEMA_SQL` to ``conn`` (or a new connection at ``path``).
+
+    Idempotent: every DDL statement uses ``IF NOT EXISTS`` so repeated calls are safe.
+    Returns the connection so callers can reuse it.
+    """
+    if conn is None:
+        conn = connect(path)
+    with conn:
+        conn.executescript(SCHEMA_SQL)
+    return conn

--- a/tests/test_storage_db.py
+++ b/tests/test_storage_db.py
@@ -1,0 +1,319 @@
+"""Tests for `research_agent.storage.db` schema and connection helpers."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from research_agent.storage import db
+
+EXPECTED_TABLES = {
+    "jobs",
+    "plans",
+    "tasks",
+    "findings",
+    "sources",
+    "job_sources",
+    "syntheses",
+    "checkpoints",
+    "events",
+    "llm_calls",
+    "findings_fts",
+    "sources_fts",
+}
+
+EXPECTED_INDEXES = {
+    "idx_tasks_status_job",
+    "idx_findings_job",
+    "idx_checkpoints_job_ts",
+    "idx_events_job_ts",
+}
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "index.sqlite"
+
+
+def _scalar(conn: sqlite3.Connection, sql: str) -> object:
+    cur = conn.execute(sql)
+    row = cur.fetchone()
+    assert row is not None, f"expected a row from: {sql}"
+    return row[0]
+
+
+def test_migrate_creates_wal_db(db_path: Path) -> None:
+    conn = db.migrate(path=db_path)
+    try:
+        assert db_path.exists()
+        assert _scalar(conn, "PRAGMA journal_mode") == "wal"
+        assert _scalar(conn, "PRAGMA foreign_keys") == 1
+        # synchronous=NORMAL maps to integer 1
+        assert _scalar(conn, "PRAGMA synchronous") == 1
+    finally:
+        conn.close()
+
+
+def test_migrate_idempotent(db_path: Path) -> None:
+    conn = db.migrate(path=db_path)
+    try:
+        before = _scalar(
+            conn,
+            "SELECT count(*) FROM sqlite_master WHERE type IN ('table','index')",
+        )
+    finally:
+        conn.close()
+
+    conn2 = db.migrate(path=db_path)
+    try:
+        after = _scalar(
+            conn2,
+            "SELECT count(*) FROM sqlite_master WHERE type IN ('table','index')",
+        )
+    finally:
+        conn2.close()
+
+    assert before == after
+
+
+def test_all_tables_present(db_path: Path) -> None:
+    conn = db.migrate(path=db_path)
+    try:
+        table_names = {
+            row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        index_names = {
+            row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='index'")
+        }
+    finally:
+        conn.close()
+
+    missing_tables = EXPECTED_TABLES - table_names
+    assert not missing_tables, f"missing tables: {missing_tables}"
+
+    missing_indexes = EXPECTED_INDEXES - index_names
+    assert not missing_indexes, f"missing indexes: {missing_indexes}"
+
+
+def test_insert_and_query_each_table(db_path: Path) -> None:
+    conn = db.migrate(path=db_path)
+    try:
+        now = int(time.time())
+        job_id = "2026-05-02-test-job"
+
+        # jobs (parent of nearly everything)
+        conn.execute(
+            """
+            INSERT INTO jobs (id, goal, status, intake_json, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (job_id, "investigate widget co", "pending", "{}", now),
+        )
+
+        # plans
+        conn.execute(
+            """
+            INSERT INTO plans (job_id, version, payload_json, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (job_id, 1, "{}", now),
+        )
+
+        # tasks
+        conn.execute(
+            """
+            INSERT INTO tasks (job_id, plan_version, kind, payload_json, status)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (job_id, 1, "web_search", "{}", "pending"),
+        )
+
+        # findings
+        conn.execute(
+            """
+            INSERT INTO findings
+                (job_id, md_path, claim, confidence, source_ids, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (job_id, "findings/0001.md", "the sky is blue", 0.9, "[]", now),
+        )
+
+        # sources (must precede job_sources)
+        cur = conn.execute(
+            """
+            INSERT INTO sources (sha256, url, title, fetched_at, md_path, kind)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("a" * 64, "https://example.com", "Example", now, "sources/0001.md", "web"),
+        )
+        source_id = cur.lastrowid
+
+        # job_sources
+        conn.execute(
+            "INSERT INTO job_sources (job_id, source_id) VALUES (?, ?)",
+            (job_id, source_id),
+        )
+
+        # syntheses
+        conn.execute(
+            """
+            INSERT INTO syntheses (job_id, version, md_path, model, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (job_id, 1, "synthesis-v1.md", "gpt-test", now),
+        )
+
+        # checkpoints
+        conn.execute(
+            """
+            INSERT INTO checkpoints (job_id, kind, payload_json, ts)
+            VALUES (?, ?, ?, ?)
+            """,
+            (job_id, "job_started", "{}", now),
+        )
+
+        # events
+        conn.execute(
+            """
+            INSERT INTO events (job_id, ts, level, kind)
+            VALUES (?, ?, ?, ?)
+            """,
+            (job_id, now, "INFO", "test"),
+        )
+
+        # llm_calls
+        conn.execute(
+            """
+            INSERT INTO llm_calls (job_id, ts, tier, provider, model)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (job_id, now, "cloud", "openrouter", "anthropic/claude-test"),
+        )
+
+        conn.commit()
+
+        # Round-trip every table.
+        assert _scalar(conn, "SELECT count(*) FROM jobs") == 1
+        assert _scalar(conn, "SELECT count(*) FROM plans") == 1
+        assert _scalar(conn, "SELECT count(*) FROM tasks") == 1
+        assert _scalar(conn, "SELECT count(*) FROM findings") == 1
+        assert _scalar(conn, "SELECT count(*) FROM sources") == 1
+        assert _scalar(conn, "SELECT count(*) FROM job_sources") == 1
+        assert _scalar(conn, "SELECT count(*) FROM syntheses") == 1
+        assert _scalar(conn, "SELECT count(*) FROM checkpoints") == 1
+        assert _scalar(conn, "SELECT count(*) FROM events") == 1
+        assert _scalar(conn, "SELECT count(*) FROM llm_calls") == 1
+
+        row = conn.execute("SELECT goal, status FROM jobs WHERE id = ?", (job_id,)).fetchone()
+        assert row["goal"] == "investigate widget co"
+        assert row["status"] == "pending"
+    finally:
+        conn.close()
+
+
+def test_foreign_keys_enforced(db_path: Path) -> None:
+    conn = db.migrate(path=db_path)
+    try:
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                INSERT INTO plans (job_id, version, payload_json, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                ("does-not-exist", 1, "{}", 0),
+            )
+    finally:
+        conn.close()
+
+
+def test_findings_fts_roundtrip(db_path: Path) -> None:
+    conn = db.migrate(path=db_path)
+    try:
+        now = int(time.time())
+        job_id = "fts-job"
+        conn.execute(
+            "INSERT INTO jobs (id, goal, status, intake_json, created_at) VALUES (?, ?, ?, ?, ?)",
+            (job_id, "g", "pending", "{}", now),
+        )
+        cur = conn.execute(
+            """
+            INSERT INTO findings
+                (job_id, md_path, claim, confidence, source_ids, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                job_id,
+                "findings/q.md",
+                "quantum supremacy benchmark",
+                0.5,
+                "[]",
+                now,
+            ),
+        )
+        finding_id = cur.lastrowid
+
+        # External-content FTS5: rebuild syncs the index from the content table.
+        conn.execute("INSERT INTO findings_fts(findings_fts) VALUES('rebuild')")
+        conn.commit()
+
+        rows = conn.execute(
+            "SELECT rowid FROM findings_fts WHERE findings_fts MATCH 'quantum'"
+        ).fetchall()
+        assert [r[0] for r in rows] == [finding_id]
+    finally:
+        conn.close()
+
+
+def test_sources_fts_roundtrip(db_path: Path) -> None:
+    conn = db.migrate(path=db_path)
+    try:
+        now = int(time.time())
+        cur = conn.execute(
+            """
+            INSERT INTO sources (sha256, url, title, fetched_at, md_path, kind)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("b" * 64, "https://ex.com", "Annual Report 2025", now, "s.md", "pdf"),
+        )
+        source_id = cur.lastrowid
+
+        conn.execute("INSERT INTO sources_fts(sources_fts) VALUES('rebuild')")
+        conn.commit()
+
+        rows = conn.execute(
+            "SELECT rowid FROM sources_fts WHERE sources_fts MATCH 'annual'"
+        ).fetchall()
+        assert [r[0] for r in rows] == [source_id]
+    finally:
+        conn.close()
+
+
+def test_checkpoint_helper_uses_synchronous_full(db_path: Path) -> None:
+    db.migrate(path=db_path).close()
+    conn = db.connect_for_checkpoints(path=db_path)
+    try:
+        # synchronous=FULL maps to integer 2
+        assert _scalar(conn, "PRAGMA synchronous") == 2
+        # WAL + foreign_keys must still hold for this connection.
+        assert _scalar(conn, "PRAGMA journal_mode") == "wal"
+        assert _scalar(conn, "PRAGMA foreign_keys") == 1
+    finally:
+        conn.close()
+
+
+def test_connect_creates_parent_dir(tmp_path: Path) -> None:
+    nested = tmp_path / "nested" / "dir" / "index.sqlite"
+    conn = db.connect(path=nested)
+    try:
+        assert nested.parent.is_dir()
+        assert nested.exists()
+    finally:
+        conn.close()
+
+
+def test_connect_rejects_invalid_synchronous(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        db.connect(path=tmp_path / "x.sqlite", synchronous="LOOSE")


### PR DESCRIPTION
Closes #4

## Summary

Automated implementation of **SQLite schema + migrate() in storage/db.py**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Schema matches §10 exactly; WAL/FK/synchronous pragmas correct; FTS5 wired via content=/content_rowid=; migrate() idempotent; 10 tests cover all ACs and pass.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*