### PR TITLE
feat: Markdown writers + source dedup in storage/markdown.py and storage/sources.py (closes #6)

### DIFF
--- a/src/research_agent/storage/__init__.py
+++ b/src/research_agent/storage/__init__.py
@@ -12,14 +12,32 @@ from research_agent.storage.jobs import (
     Job,
     list_jobs,
 )
+from research_agent.storage.markdown import (
+    write_finding,
+    write_plan,
+    write_report,
+    write_synthesis,
+)
+from research_agent.storage.sources import (
+    clean_content,
+    content_sha256,
+    write_source,
+)
 
 __all__ = [
     "DEFAULT_DB_PATH",
     "DEFAULT_JOBS_ROOT",
     "Job",
     "SCHEMA_SQL",
+    "clean_content",
     "connect",
     "connect_for_checkpoints",
+    "content_sha256",
     "list_jobs",
     "migrate",
+    "write_finding",
+    "write_plan",
+    "write_report",
+    "write_source",
+    "write_synthesis",
 ]

--- a/src/research_agent/storage/markdown.py
+++ b/src/research_agent/storage/markdown.py
@@ -1,0 +1,293 @@
+"""Markdown writers for findings, plans, syntheses, and reports.
+
+Implements the per-job content layout from §4 of the implementation guide:
+findings get monotonic six-digit ids (``findings/000001.md`` + sidecar JSON);
+plans and syntheses are versioned four-digit (``plan/0001.md``,
+``synthesis/0001.md``); ``report.md`` rotates prior copies into
+``report.history/<UTC ISO timestamp>.md`` before each new write.
+
+Every write produces both a markdown file (the human-readable content)
+and a JSON sidecar (structured metadata mirrored into SQLite). All file
+writes go through the atomic ``*.tmp`` + :func:`os.replace` pattern from
+§16 to keep tail-watching readers from observing half-written content.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from research_agent.storage import db
+from research_agent.storage.jobs import Job, _atomic_write_json, _atomic_write_text
+
+
+def _now_epoch() -> int:
+    return int(time.time())
+
+
+def _validate_confidence(value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"confidence must be a number in [0, 1]; got {value!r}")
+    conf = float(value)
+    if conf < 0.0 or conf > 1.0:
+        raise ValueError(f"confidence must be in [0, 1]; got {conf}")
+    return conf
+
+
+def _validate_source_ids(value: Any) -> list[int]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"source_ids must be a non-empty list of ints; got {value!r}")
+    out: list[int] = []
+    for item in value:
+        if isinstance(item, bool) or not isinstance(item, int):
+            raise ValueError(f"source_ids must contain ints; got {item!r}")
+        out.append(item)
+    return out
+
+
+def _render_finding_md(
+    *,
+    finding_id: int,
+    claim: str,
+    confidence: float,
+    source_ids: list[int],
+    contradicts: list[int] | None,
+    tags: list[str] | None,
+) -> str:
+    contradicts_str = ", ".join(str(i) for i in contradicts) if contradicts else "—"
+    tags_str = ", ".join(tags) if tags else "—"
+    sources_str = ", ".join(str(i) for i in source_ids)
+    return (
+        f"# Finding {finding_id:06d}\n"
+        f"\n"
+        f"**Confidence:** {confidence}\n"
+        f"**Sources:** {sources_str}\n"
+        f"**Contradicts:** {contradicts_str}\n"
+        f"**Tags:** {tags_str}\n"
+        f"\n"
+        f"---\n"
+        f"\n"
+        f"{claim.strip()}\n"
+    )
+
+
+def write_finding(
+    job: Job,
+    claim: str,
+    confidence: float,
+    source_ids: list[int],
+    contradicts: list[int] | None = None,
+    tags: list[str] | None = None,
+) -> int:
+    """Write a finding's md + json sidecar and insert the ``findings`` row.
+
+    The autoincrement id from the DB drives the zero-padded filename
+    (``findings/{id:06d}.md``) so a future UI can deep-link.
+    """
+    if not isinstance(claim, str) or not claim.strip():
+        raise ValueError("claim must be a non-empty string")
+    conf = _validate_confidence(confidence)
+    sids = _validate_source_ids(source_ids)
+    contradicts_list = list(contradicts) if contradicts else None
+    tags_list = list(tags) if tags else None
+
+    now = _now_epoch()
+    source_ids_json = json.dumps(sids)
+    contradicts_json = json.dumps(contradicts_list) if contradicts_list is not None else None
+    tags_json = json.dumps(tags_list) if tags_list is not None else None
+
+    conn = db.connect(job.db_path)
+    try:
+        with conn:
+            cur = conn.execute(
+                """
+                INSERT INTO findings (
+                    job_id, md_path, claim, confidence,
+                    source_ids, contradicts, tags, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    job.id,
+                    "",
+                    claim,
+                    conf,
+                    source_ids_json,
+                    contradicts_json,
+                    tags_json,
+                    now,
+                ),
+            )
+            assert cur.lastrowid is not None
+            finding_id = int(cur.lastrowid)
+            md_rel = f"findings/{finding_id:06d}.md"
+            json_rel = f"findings/{finding_id:06d}.json"
+
+            md_body = _render_finding_md(
+                finding_id=finding_id,
+                claim=claim,
+                confidence=conf,
+                source_ids=sids,
+                contradicts=contradicts_list,
+                tags=tags_list,
+            )
+            sidecar = {
+                "id": finding_id,
+                "claim": claim,
+                "confidence": conf,
+                "source_ids": sids,
+                "contradicts": contradicts_list,
+                "tags": tags_list,
+                "md_path": md_rel,
+                "created_at": now,
+            }
+            _atomic_write_text(job.root / md_rel, md_body)
+            _atomic_write_json(job.root / json_rel, sidecar)
+
+            conn.execute(
+                "UPDATE findings SET md_path = ? WHERE id = ?",
+                (md_rel, finding_id),
+            )
+    finally:
+        conn.close()
+
+    return finding_id
+
+
+def _next_version(conn: Any, table: str, job_id: str) -> int:
+    row = conn.execute(
+        f"SELECT COALESCE(MAX(version), 0) + 1 AS next FROM {table} WHERE job_id = ?",
+        (job_id,),
+    ).fetchone()
+    return int(row["next"])
+
+
+def _render_plan_md(version: int, payload: dict[str, Any], created_at: int) -> str:
+    pretty = json.dumps(payload, indent=2, sort_keys=True)
+    return (
+        f"# Plan v{version:04d}\n"
+        f"\n"
+        f"Created: {datetime.fromtimestamp(created_at, UTC).isoformat()}\n"
+        f"\n"
+        f"```json\n"
+        f"{pretty}\n"
+        f"```\n"
+    )
+
+
+def write_plan(job: Job, payload: dict[str, Any]) -> int:
+    """Write the next plan version (md + json) and insert into ``plans``."""
+    if not isinstance(payload, dict):
+        raise ValueError(f"payload must be a dict; got {type(payload).__name__}")
+
+    now = _now_epoch()
+    payload_json = json.dumps(payload, sort_keys=True)
+
+    conn = db.connect(job.db_path)
+    try:
+        with conn:
+            version = _next_version(conn, "plans", job.id)
+            md_rel = f"plan/{version:04d}.md"
+            json_rel = f"plan/{version:04d}.json"
+
+            _atomic_write_text(job.root / md_rel, _render_plan_md(version, payload, now))
+            _atomic_write_json(job.root / json_rel, payload)
+
+            conn.execute(
+                """
+                INSERT INTO plans (job_id, version, payload_json, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (job.id, version, payload_json, now),
+            )
+    finally:
+        conn.close()
+
+    return version
+
+
+def write_synthesis(
+    job: Job,
+    content: str,
+    model: str,
+    cost_usd: float | None = None,
+) -> int:
+    """Write the next synthesis version (md + json) and insert into ``syntheses``."""
+    if not isinstance(content, str) or not content.strip():
+        raise ValueError("content must be a non-empty string")
+    if not isinstance(model, str) or not model:
+        raise ValueError("model must be a non-empty string")
+    if cost_usd is not None and (
+        isinstance(cost_usd, bool) or not isinstance(cost_usd, (int, float))
+    ):
+        raise ValueError(f"cost_usd must be a number or None; got {cost_usd!r}")
+
+    now = _now_epoch()
+    cost = float(cost_usd) if cost_usd is not None else None
+
+    conn = db.connect(job.db_path)
+    try:
+        with conn:
+            version = _next_version(conn, "syntheses", job.id)
+            md_rel = f"synthesis/{version:04d}.md"
+            json_rel = f"synthesis/{version:04d}.json"
+
+            md_body = content if content.endswith("\n") else content + "\n"
+            _atomic_write_text(job.root / md_rel, md_body)
+            _atomic_write_json(
+                job.root / json_rel,
+                {
+                    "version": version,
+                    "model": model,
+                    "cost_usd": cost,
+                    "created_at": now,
+                },
+            )
+
+            conn.execute(
+                """
+                INSERT INTO syntheses (job_id, version, md_path, model, cost_usd, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (job.id, version, md_rel, model, cost, now),
+            )
+    finally:
+        conn.close()
+
+    return version
+
+
+def write_report(job: Job, content: str) -> Path:
+    """Rotate any prior ``report.md`` into ``report.history/`` then write fresh content."""
+    if not isinstance(content, str):
+        raise ValueError(f"content must be a string; got {type(content).__name__}")
+
+    report = job.root / "report.md"
+    history_dir = job.root / "report.history"
+    history_dir.mkdir(parents=True, exist_ok=True)
+
+    if report.exists():
+        stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        archived = history_dir / f"{stamp}.md"
+        # If two rotations land in the same second, append a suffix rather
+        # than clobbering. Atomic via os.replace inside _atomic rename below
+        # is unnecessary — the source already exists fully written.
+        suffix = 1
+        while archived.exists():
+            archived = history_dir / f"{stamp}-{suffix}.md"
+            suffix += 1
+        os.replace(report, archived)
+
+    _atomic_write_text(report, content if content.endswith("\n") else content + "\n")
+    return report
+
+
+__all__ = [
+    "write_finding",
+    "write_plan",
+    "write_report",
+    "write_synthesis",
+]

--- a/src/research_agent/storage/sources.py
+++ b/src/research_agent/storage/sources.py
@@ -1,0 +1,136 @@
+"""Source ingestion with content-hash dedup across jobs.
+
+Implements the §4 layout: per-job ``sources/<sha256>.md`` (cleaned content)
+plus ``<sha256>.json`` sidecar (url, fetched_at, archive_url, kind), and the
+§10 schema's ``sources`` + ``job_sources`` tables. The same content fetched
+by two different jobs collapses to a single ``sources`` row with two
+``job_sources`` links — the canonical markdown lives under the first job
+that wrote it.
+
+Cleaning is intentionally minimal in v1 (line-ending normalization,
+horizontal whitespace collapse, strip). Richer extraction — readability,
+boilerplate stripping — belongs in the fetch tool layer (``tools/web_fetch``)
+upstream of this module.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import time
+from typing import Any
+
+from research_agent.storage import db
+from research_agent.storage.jobs import Job, _atomic_write_json, _atomic_write_text
+
+_HORIZONTAL_WS = re.compile(r"[ \t]+")
+_BLANK_LINE_RUN = re.compile(r"\n{3,}")
+
+
+def clean_content(raw: str) -> str:
+    """Normalize ``raw`` for deterministic hashing.
+
+    Strips, normalizes line endings to ``\\n``, collapses runs of horizontal
+    whitespace into a single space, and collapses runs of three+ newlines
+    into a paragraph break. Richer cleanup belongs upstream in the fetch layer.
+    """
+    if not isinstance(raw, str):
+        raise ValueError(f"raw must be a string; got {type(raw).__name__}")
+    text = raw.replace("\r\n", "\n").replace("\r", "\n")
+    text = _HORIZONTAL_WS.sub(" ", text)
+    text = _BLANK_LINE_RUN.sub("\n\n", text)
+    return text.strip()
+
+
+def content_sha256(cleaned: str) -> str:
+    """Return the lowercase hex sha256 of the cleaned content."""
+    if not isinstance(cleaned, str):
+        raise ValueError(f"cleaned must be a string; got {type(cleaned).__name__}")
+    return hashlib.sha256(cleaned.encode("utf-8")).hexdigest()
+
+
+def write_source(
+    job: Job,
+    *,
+    url: str | None,
+    title: str | None,
+    raw_content: str,
+    kind: str | None,
+    archive_url: str | None = None,
+    fetched_at: int | None = None,
+) -> int:
+    """Write a source under ``job`` with cross-job dedup by sha256.
+
+    First writer for a given hash creates the canonical ``sources/<sha>.md``
+    + sidecar under that job and inserts a ``sources`` row. Subsequent
+    writers (any job) only insert a ``job_sources`` link — no duplicate
+    file is written. Returns the source id (new or existing).
+    """
+    if not isinstance(raw_content, str) or not raw_content:
+        raise ValueError("raw_content must be a non-empty string")
+    if url is not None and not isinstance(url, str):
+        raise ValueError(f"url must be a string or None; got {type(url).__name__}")
+    if title is not None and not isinstance(title, str):
+        raise ValueError(f"title must be a string or None; got {type(title).__name__}")
+    if kind is not None and not isinstance(kind, str):
+        raise ValueError(f"kind must be a string or None; got {type(kind).__name__}")
+    if archive_url is not None and not isinstance(archive_url, str):
+        raise ValueError(f"archive_url must be a string or None; got {type(archive_url).__name__}")
+
+    cleaned = clean_content(raw_content)
+    if not cleaned:
+        raise ValueError("raw_content cleans to an empty string")
+    sha = content_sha256(cleaned)
+    fetched = int(fetched_at) if fetched_at is not None else int(time.time())
+    md_rel = f"sources/{sha}.md"
+    json_rel = f"sources/{sha}.json"
+
+    conn = db.connect(job.db_path)
+    try:
+        with conn:
+            existing = conn.execute(
+                "SELECT id FROM sources WHERE sha256 = ?",
+                (sha,),
+            ).fetchone()
+
+            if existing is None:
+                _atomic_write_text(job.root / md_rel, cleaned + "\n")
+                sidecar: dict[str, Any] = {
+                    "sha256": sha,
+                    "url": url,
+                    "title": title,
+                    "fetched_at": fetched,
+                    "archive_url": archive_url or "",
+                    "kind": kind,
+                    "md_path": md_rel,
+                }
+                _atomic_write_json(job.root / json_rel, sidecar)
+
+                cur = conn.execute(
+                    """
+                    INSERT INTO sources (
+                        sha256, url, title, fetched_at, archive_url, md_path, kind
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (sha, url, title, fetched, archive_url, md_rel, kind),
+                )
+                assert cur.lastrowid is not None
+                source_id = int(cur.lastrowid)
+            else:
+                source_id = int(existing["id"])
+
+            conn.execute(
+                "INSERT OR IGNORE INTO job_sources (job_id, source_id) VALUES (?, ?)",
+                (job.id, source_id),
+            )
+    finally:
+        conn.close()
+
+    return source_id
+
+
+__all__ = [
+    "clean_content",
+    "content_sha256",
+    "write_source",
+]

--- a/tests/test_storage_markdown.py
+++ b/tests/test_storage_markdown.py
@@ -1,0 +1,321 @@
+"""Tests for `research_agent.storage.markdown`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+from research_agent.storage.markdown import (
+    write_finding,
+    write_plan,
+    write_report,
+    write_synthesis,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def jobs_root(tmp_path: Path) -> Path:
+    return tmp_path / "jobs"
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "index.sqlite"
+    db.migrate(path=path).close()
+    return path
+
+
+@pytest.fixture
+def job(jobs_root: Path, db_path: Path) -> Job:
+    return Job.create(
+        {"goal": "Test markdown writers"},
+        jobs_root=jobs_root,
+        db_path=db_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# write_finding
+# ---------------------------------------------------------------------------
+
+
+def test_write_finding_writes_md_json_and_db_row(job: Job) -> None:
+    fid = write_finding(
+        job,
+        claim="Widget Co revenue grew 12% YoY in Q4 2025.",
+        confidence=0.85,
+        source_ids=[1, 2],
+        tags=["finance", "q4"],
+    )
+    assert fid == 1
+
+    md_path = job.root / "findings" / "000001.md"
+    json_path = job.root / "findings" / "000001.json"
+    assert md_path.exists()
+    assert json_path.exists()
+
+    md_text = md_path.read_text()
+    assert "Finding 000001" in md_text
+    assert "Widget Co revenue grew 12% YoY" in md_text
+    assert "0.85" in md_text
+
+    sidecar = json.loads(json_path.read_text())
+    assert sidecar["id"] == 1
+    assert sidecar["claim"] == "Widget Co revenue grew 12% YoY in Q4 2025."
+    assert sidecar["confidence"] == 0.85
+    assert sidecar["source_ids"] == [1, 2]
+    assert sidecar["tags"] == ["finance", "q4"]
+    assert sidecar["contradicts"] is None
+    assert sidecar["md_path"] == "findings/000001.md"
+
+    conn = db.connect(job.db_path)
+    try:
+        row = conn.execute(
+            "SELECT id, job_id, md_path, claim, confidence, source_ids,"
+            " contradicts, tags FROM findings WHERE id = ?",
+            (fid,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row["id"] == 1
+    assert row["job_id"] == job.id
+    assert row["md_path"] == "findings/000001.md"
+    assert row["claim"] == "Widget Co revenue grew 12% YoY in Q4 2025."
+    assert row["confidence"] == 0.85
+    assert json.loads(row["source_ids"]) == [1, 2]
+    assert row["contradicts"] is None
+    assert json.loads(row["tags"]) == ["finance", "q4"]
+
+
+def test_write_finding_zero_pads_to_six_digits(job: Job) -> None:
+    fid = write_finding(job, claim="x", confidence=0.5, source_ids=[1])
+    assert (job.root / "findings" / "000001.md").exists()
+    assert (job.root / "findings" / "000001.json").exists()
+    assert fid == 1
+
+
+def test_write_finding_monotonic_ids(job: Job) -> None:
+    a = write_finding(job, claim="claim a", confidence=0.5, source_ids=[1])
+    b = write_finding(job, claim="claim b", confidence=0.5, source_ids=[1])
+    assert a == 1
+    assert b == 2
+    assert (job.root / "findings" / "000002.md").exists()
+
+
+def test_write_finding_with_contradicts(job: Job) -> None:
+    first = write_finding(job, claim="claim a", confidence=0.6, source_ids=[1])
+    second = write_finding(
+        job,
+        claim="claim b",
+        confidence=0.7,
+        source_ids=[2],
+        contradicts=[first],
+    )
+    sidecar = json.loads((job.root / "findings" / f"{second:06d}.json").read_text())
+    assert sidecar["contradicts"] == [first]
+
+
+@pytest.mark.parametrize("bad_conf", [-0.1, 1.5, 2.0, -1.0])
+def test_write_finding_rejects_out_of_range_confidence(job: Job, bad_conf: float) -> None:
+    with pytest.raises(ValueError):
+        write_finding(job, claim="x", confidence=bad_conf, source_ids=[1])
+
+
+def test_write_finding_rejects_non_numeric_confidence(job: Job) -> None:
+    with pytest.raises(ValueError):
+        write_finding(job, claim="x", confidence="0.5", source_ids=[1])  # type: ignore[arg-type]
+
+
+def test_write_finding_rejects_empty_source_ids(job: Job) -> None:
+    with pytest.raises(ValueError):
+        write_finding(job, claim="x", confidence=0.5, source_ids=[])
+
+
+def test_write_finding_rejects_non_int_source_ids(job: Job) -> None:
+    with pytest.raises(ValueError):
+        write_finding(job, claim="x", confidence=0.5, source_ids=["1"])  # type: ignore[list-item]
+
+
+def test_write_finding_rejects_empty_claim(job: Job) -> None:
+    with pytest.raises(ValueError):
+        write_finding(job, claim="   ", confidence=0.5, source_ids=[1])
+
+
+def test_write_finding_leaves_no_tmp_files(job: Job) -> None:
+    write_finding(job, claim="x", confidence=0.5, source_ids=[1])
+    leftover = list((job.root / "findings").glob("*.tmp"))
+    assert leftover == []
+
+
+# ---------------------------------------------------------------------------
+# write_plan
+# ---------------------------------------------------------------------------
+
+
+def test_write_plan_versions_monotonically(job: Job) -> None:
+    v1 = write_plan(job, {"steps": ["s1", "s2"]})
+    v2 = write_plan(job, {"steps": ["s1", "s2", "s3"]})
+    assert v1 == 1
+    assert v2 == 2
+    assert (job.root / "plan" / "0001.md").exists()
+    assert (job.root / "plan" / "0001.json").exists()
+    assert (job.root / "plan" / "0002.md").exists()
+    assert (job.root / "plan" / "0002.json").exists()
+
+
+def test_write_plan_json_sidecar_is_raw_payload(job: Job) -> None:
+    payload = {"steps": ["alpha", "beta"], "budget": 5.0}
+    write_plan(job, payload)
+    on_disk = json.loads((job.root / "plan" / "0001.json").read_text())
+    assert on_disk == payload
+
+
+def test_write_plan_md_contains_pretty_payload(job: Job) -> None:
+    payload = {"steps": ["alpha"], "budget": 5.0}
+    write_plan(job, payload)
+    md = (job.root / "plan" / "0001.md").read_text()
+    assert "Plan v0001" in md
+    assert '"alpha"' in md
+    assert '"budget"' in md
+
+
+def test_write_plan_inserts_db_row(job: Job) -> None:
+    payload = {"steps": ["s1"]}
+    version = write_plan(job, payload)
+
+    conn = db.connect(job.db_path)
+    try:
+        row = conn.execute(
+            "SELECT job_id, version, payload_json FROM plans WHERE job_id = ? AND version = ?",
+            (job.id, version),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row["job_id"] == job.id
+    assert row["version"] == 1
+    assert json.loads(row["payload_json"]) == payload
+
+
+def test_write_plan_rejects_non_dict(job: Job) -> None:
+    with pytest.raises(ValueError):
+        write_plan(job, ["not", "a", "dict"])  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# write_synthesis
+# ---------------------------------------------------------------------------
+
+
+def test_write_synthesis_versions_monotonically(job: Job) -> None:
+    v1 = write_synthesis(job, content="first pass", model="opus-4")
+    v2 = write_synthesis(job, content="second pass", model="opus-4", cost_usd=0.42)
+    assert v1 == 1
+    assert v2 == 2
+    assert (job.root / "synthesis" / "0001.md").exists()
+    assert (job.root / "synthesis" / "0002.md").exists()
+
+
+def test_write_synthesis_sidecar_records_metadata(job: Job) -> None:
+    write_synthesis(job, content="report body", model="opus-4", cost_usd=0.5)
+    sidecar = json.loads((job.root / "synthesis" / "0001.json").read_text())
+    assert sidecar["version"] == 1
+    assert sidecar["model"] == "opus-4"
+    assert sidecar["cost_usd"] == 0.5
+    assert "created_at" in sidecar
+
+
+def test_write_synthesis_cost_optional(job: Job) -> None:
+    write_synthesis(job, content="x", model="opus-4")
+    sidecar = json.loads((job.root / "synthesis" / "0001.json").read_text())
+    assert sidecar["cost_usd"] is None
+
+
+def test_write_synthesis_inserts_db_row(job: Job) -> None:
+    write_synthesis(job, content="report body", model="opus-4", cost_usd=0.5)
+    conn = db.connect(job.db_path)
+    try:
+        row = conn.execute(
+            "SELECT version, md_path, model, cost_usd FROM syntheses WHERE job_id = ?",
+            (job.id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row["version"] == 1
+    assert row["md_path"] == "synthesis/0001.md"
+    assert row["model"] == "opus-4"
+    assert row["cost_usd"] == 0.5
+
+
+def test_write_synthesis_rejects_empty(job: Job) -> None:
+    with pytest.raises(ValueError):
+        write_synthesis(job, content="", model="opus-4")
+    with pytest.raises(ValueError):
+        write_synthesis(job, content="content", model="")
+
+
+# ---------------------------------------------------------------------------
+# write_report
+# ---------------------------------------------------------------------------
+
+
+def test_write_report_writes_to_report_md(job: Job) -> None:
+    path = write_report(job, "first report\n")
+    assert path == job.root / "report.md"
+    assert path.read_text() == "first report\n"
+
+
+def test_write_report_appends_trailing_newline(job: Job) -> None:
+    write_report(job, "no newline")
+    assert (job.root / "report.md").read_text() == "no newline\n"
+
+
+def test_write_report_rotates_prior_to_history(job: Job) -> None:
+    write_report(job, "first")
+    write_report(job, "second")
+
+    assert (job.root / "report.md").read_text() == "second\n"
+
+    history_files = sorted((job.root / "report.history").glob("*.md"))
+    assert len(history_files) == 1
+    assert history_files[0].read_text() == "first\n"
+    assert history_files[0].name.endswith(".md")
+    # Filename like 20260502T123456Z.md or 20260502T123456Z-1.md
+    assert "T" in history_files[0].stem
+    assert history_files[0].stem.split("-")[0].endswith("Z")
+
+
+def test_write_report_rotation_handles_same_second(job: Job) -> None:
+    write_report(job, "a")
+    write_report(job, "b")
+    write_report(job, "c")
+    history_files = list((job.root / "report.history").glob("*.md"))
+    assert len(history_files) == 2
+
+
+def test_write_report_no_rotation_when_no_prior(job: Job) -> None:
+    write_report(job, "only one")
+    history_files = list((job.root / "report.history").glob("*.md"))
+    assert history_files == []
+
+
+def test_write_report_leaves_no_tmp_files(job: Job) -> None:
+    write_report(job, "x")
+    write_report(job, "y")
+    leftover = list(job.root.rglob("*.tmp"))
+    assert leftover == []
+
+
+def test_write_report_rejects_non_string(job: Job) -> None:
+    with pytest.raises(ValueError):
+        write_report(job, 123)  # type: ignore[arg-type]

--- a/tests/test_storage_sources.py
+++ b/tests/test_storage_sources.py
@@ -1,0 +1,267 @@
+"""Tests for `research_agent.storage.sources`."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+from research_agent.storage.sources import clean_content, content_sha256, write_source
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def jobs_root(tmp_path: Path) -> Path:
+    return tmp_path / "jobs"
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "index.sqlite"
+    db.migrate(path=path).close()
+    return path
+
+
+@pytest.fixture
+def job1(jobs_root: Path, db_path: Path) -> Job:
+    return Job.create(
+        {"goal": "first investigation"},
+        jobs_root=jobs_root,
+        db_path=db_path,
+        today=date(2026, 5, 1),
+    )
+
+
+@pytest.fixture
+def job2(jobs_root: Path, db_path: Path) -> Job:
+    return Job.create(
+        {"goal": "second investigation"},
+        jobs_root=jobs_root,
+        db_path=db_path,
+        today=date(2026, 5, 2),
+    )
+
+
+# ---------------------------------------------------------------------------
+# clean_content
+# ---------------------------------------------------------------------------
+
+
+def test_clean_content_strips_and_normalizes_endings() -> None:
+    out = clean_content("\r\n  hello world  \r\n")
+    assert out == "hello world"
+
+
+def test_clean_content_collapses_horizontal_whitespace() -> None:
+    assert clean_content("foo    \t   bar") == "foo bar"
+
+
+def test_clean_content_collapses_blank_line_runs() -> None:
+    assert clean_content("a\n\n\n\nb") == "a\n\nb"
+
+
+def test_clean_content_idempotent() -> None:
+    once = clean_content("  hello\n\n\nworld  ")
+    twice = clean_content(once)
+    assert once == twice
+
+
+def test_clean_content_rejects_non_string() -> None:
+    with pytest.raises(ValueError):
+        clean_content(123)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# content_sha256
+# ---------------------------------------------------------------------------
+
+
+def test_content_sha256_matches_hashlib() -> None:
+    text = "hello"
+    assert content_sha256(text) == hashlib.sha256(b"hello").hexdigest()
+
+
+def test_content_sha256_is_lowercase_hex() -> None:
+    digest = content_sha256("anything")
+    assert len(digest) == 64
+    assert digest == digest.lower()
+    assert all(c in "0123456789abcdef" for c in digest)
+
+
+# ---------------------------------------------------------------------------
+# write_source
+# ---------------------------------------------------------------------------
+
+
+def test_write_source_creates_md_json_and_db_row(job1: Job) -> None:
+    sid = write_source(
+        job1,
+        url="https://example.com/page",
+        title="Example",
+        raw_content="Hello world.\n",
+        kind="html",
+        archive_url="https://web.archive.org/example",
+        fetched_at=1700000000,
+    )
+    assert sid >= 1
+
+    cleaned = clean_content("Hello world.\n")
+    sha = content_sha256(cleaned)
+
+    md_path = job1.root / "sources" / f"{sha}.md"
+    json_path = job1.root / "sources" / f"{sha}.json"
+    assert md_path.exists()
+    assert json_path.exists()
+    assert md_path.read_text().rstrip("\n") == cleaned
+
+    sidecar = json.loads(json_path.read_text())
+    assert sidecar["sha256"] == sha
+    assert sidecar["url"] == "https://example.com/page"
+    assert sidecar["title"] == "Example"
+    assert sidecar["fetched_at"] == 1700000000
+    assert sidecar["archive_url"] == "https://web.archive.org/example"
+    assert sidecar["kind"] == "html"
+    assert sidecar["md_path"] == f"sources/{sha}.md"
+
+    conn = db.connect(job1.db_path)
+    try:
+        srow = conn.execute(
+            "SELECT id, sha256, url, title, fetched_at, archive_url, md_path, kind"
+            " FROM sources WHERE id = ?",
+            (sid,),
+        ).fetchone()
+        jrow = conn.execute(
+            "SELECT job_id, source_id FROM job_sources WHERE source_id = ?", (sid,)
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert srow["sha256"] == sha
+    assert srow["md_path"] == f"sources/{sha}.md"
+    assert len(jrow) == 1
+    assert jrow[0]["job_id"] == job1.id
+
+
+def test_write_source_archive_url_defaults_to_empty_string(job1: Job) -> None:
+    sid = write_source(
+        job1,
+        url="https://example.com",
+        title="t",
+        raw_content="content",
+        kind="html",
+    )
+    sha = content_sha256(clean_content("content"))
+    sidecar = json.loads((job1.root / "sources" / f"{sha}.json").read_text())
+    assert sidecar["archive_url"] == ""
+
+    conn = db.connect(job1.db_path)
+    try:
+        row = conn.execute("SELECT archive_url FROM sources WHERE id = ?", (sid,)).fetchone()
+    finally:
+        conn.close()
+    # DB column allows NULL when not provided.
+    assert row["archive_url"] is None
+
+
+def test_write_source_dedups_across_jobs(job1: Job, job2: Job) -> None:
+    raw = "shared content for two jobs"
+    sid1 = write_source(
+        job1,
+        url="https://a.example.com",
+        title="A",
+        raw_content=raw,
+        kind="html",
+    )
+    sid2 = write_source(
+        job2,
+        url="https://b.example.com",
+        title="B",
+        raw_content=raw,
+        kind="html",
+    )
+    assert sid1 == sid2
+
+    sha = content_sha256(clean_content(raw))
+
+    # Canonical file lives under the first writer's job folder only.
+    assert (job1.root / "sources" / f"{sha}.md").exists()
+    assert not (job2.root / "sources" / f"{sha}.md").exists()
+    assert not (job2.root / "sources" / f"{sha}.json").exists()
+
+    conn = db.connect(job1.db_path)
+    try:
+        sources_count = conn.execute(
+            "SELECT COUNT(*) AS n FROM sources WHERE sha256 = ?", (sha,)
+        ).fetchone()["n"]
+        link_rows = conn.execute(
+            "SELECT job_id FROM job_sources WHERE source_id = ? ORDER BY job_id", (sid1,)
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert sources_count == 1
+    assert sorted(r["job_id"] for r in link_rows) == sorted([job1.id, job2.id])
+
+
+def test_write_source_dedups_on_whitespace_variation(job1: Job, job2: Job) -> None:
+    sid1 = write_source(job1, url=None, title=None, raw_content="payload", kind=None)
+    sid2 = write_source(
+        job2,
+        url=None,
+        title=None,
+        raw_content="  payload\n\n",
+        kind=None,
+    )
+    assert sid1 == sid2
+
+
+def test_write_source_same_job_link_idempotent(job1: Job) -> None:
+    sid_a = write_source(job1, url=None, title=None, raw_content="dup", kind=None)
+    sid_b = write_source(job1, url=None, title=None, raw_content="dup", kind=None)
+    assert sid_a == sid_b
+
+    conn = db.connect(job1.db_path)
+    try:
+        n = conn.execute(
+            "SELECT COUNT(*) AS n FROM job_sources WHERE source_id = ?", (sid_a,)
+        ).fetchone()["n"]
+    finally:
+        conn.close()
+    assert n == 1
+
+
+def test_write_source_rejects_empty_content(job1: Job) -> None:
+    with pytest.raises(ValueError):
+        write_source(job1, url=None, title=None, raw_content="", kind=None)
+    with pytest.raises(ValueError):
+        write_source(job1, url=None, title=None, raw_content="   \n  ", kind=None)
+
+
+def test_write_source_leaves_no_tmp_files(job1: Job) -> None:
+    write_source(job1, url=None, title=None, raw_content="some content", kind=None)
+    leftover = list((job1.root / "sources").glob("*.tmp"))
+    assert leftover == []
+
+
+def test_write_source_fetched_at_defaults_to_now(job1: Job) -> None:
+    import time
+
+    before = int(time.time())
+    sid = write_source(job1, url=None, title=None, raw_content="content", kind=None)
+    after = int(time.time())
+
+    conn = db.connect(job1.db_path)
+    try:
+        row = conn.execute("SELECT fetched_at FROM sources WHERE id = ?", (sid,)).fetchone()
+    finally:
+        conn.close()
+
+    assert before <= row["fetched_at"] <= after


### PR DESCRIPTION
Closes #6

## Summary

Automated implementation of **Markdown writers + source dedup in storage/markdown.py and storage/sources.py**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

All 8 acceptance criteria met; 45 new tests pass (127 total); ruff and mypy clean; cross-job source dedup, atomic writes, and monotonic IDs all verified.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*