### PR TITLE
feat: CLI verbs: start --skip-intake, list, status, view (closes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,30 @@ research doctor --json      # same report as machine-readable JSON
 into CI as a pre-flight gate. Optional checks (LM Studio reachability, optional
 env keys) never affect the exit code.
 
-More subcommands land here as later issues introduce them.
+### Job verbs
+
+```bash
+# Register a new job (testing back door — the daemon is not yet wired up).
+research start --skip-intake --goal "Investigate Widget Co" \
+    [--budget-usd 5.0] [--time-cap 24] [--corpus path/to/notes]
+
+research list                      # newest first; Rich table on a TTY, JSON otherwise
+research list --json               # force JSON output
+research list --status running     # filter by job status
+
+research status <job-id>           # detailed Rich panel
+research status <job-id> --watch   # refresh every 2 seconds
+
+research view <job-id>             # open report.md in $EDITOR (or print on non-TTY)
+research view <job-id> --report    # same as default
+research view <job-id> --findings  # latest findings/NNNNNN.md
+research view <job-id> --sources   # generated list of recorded sources
+
+research logs <job-id>             # print existing events.jsonl entries
+research logs <job-id> -f          # follow appended events
+research logs <job-id> --level ERROR
+```
+
+The interactive intake (`research start` without `--skip-intake`) lands in a
+later issue; until then `--skip-intake --goal "..."` is the supported entry
+point and the testing back door used throughout phases 1–4.

--- a/src/research_agent/cli.py
+++ b/src/research_agent/cli.py
@@ -127,13 +127,22 @@ def list_command(
     Console().print(render.render_jobs_table(jobs))
 
 
+def _load_job_or_exit(job_id: str) -> Job:
+    """Load a job or emit a clean ``not found`` error and exit(1)."""
+    try:
+        return Job.load(job_id)
+    except (FileNotFoundError, KeyError, ValueError) as e:
+        typer.echo(f"job not found: {job_id} ({e})", err=True)
+        raise typer.Exit(code=1) from e
+
+
 @app.command(name="status")
 def status_command(
     job_id: str = typer.Argument(..., help="Job id (e.g. 2026-05-02-some-slug)."),
     watch: bool = typer.Option(False, "--watch", help="Refresh every 2 seconds."),
 ) -> None:
     """Show a detailed Rich panel for a single job."""
-    job = Job.load(job_id)
+    job = _load_job_or_exit(job_id)
     console = Console()
 
     def _panel():
@@ -197,7 +206,7 @@ def view_command(
     sources: bool = typer.Option(False, "--sources", help="View a list of job sources."),
 ) -> None:
     """View a research artifact (report, finding, or sources list)."""
-    job = Job.load(job_id)
+    job = _load_job_or_exit(job_id)
 
     if findings:
         path = _latest_finding_path(job.root)
@@ -230,7 +239,7 @@ def logs_command(
     level: str = typer.Option(None, "--level", help="Filter by event level (e.g. INFO, ERROR)."),
 ) -> None:
     """Tail a job's events.jsonl. With ``-f`` follows appended events."""
-    job = Job.load(job_id)
+    job = _load_job_or_exit(job_id)
     events_path = job.root / "events.jsonl"
     try:
         for event in render.tail_events_jsonl(events_path, follow=follow, level=level):

--- a/src/research_agent/cli.py
+++ b/src/research_agent/cli.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
 import typer
+from rich.console import Console
+from rich.live import Live
 
 from research_agent import __version__, config, doctor
+from research_agent.storage import db
+from research_agent.storage.jobs import Job, list_jobs
+from research_agent.ui import render
 
 _LOADED_ENV_FILES = config.load_env()
 
@@ -51,6 +62,181 @@ def doctor_command(
         doctor.render_table(results)
     if doctor.has_required_failure(results):
         raise typer.Exit(code=1)
+
+
+@app.command(name="start")
+def start_command(
+    goal: str = typer.Option(None, "--goal", help="Research goal (required with --skip-intake)."),
+    skip_intake: bool = typer.Option(
+        False,
+        "--skip-intake",
+        help="Skip the interactive intake (testing back door for phases 1–4).",
+    ),
+    budget_usd: float = typer.Option(None, "--budget-usd", help="USD cost cap for the job."),
+    time_cap: int = typer.Option(None, "--time-cap", help="Wall-clock cap, in hours."),
+    corpus: str = typer.Option(
+        None,
+        "--corpus",
+        help="Path to a local corpus directory to scope the research.",
+    ),
+) -> None:
+    """Register a new research job (does NOT spawn the daemon — that's phase 5)."""
+    if not skip_intake:
+        typer.echo(
+            "interactive intake not yet implemented (phase 5) — use --skip-intake",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    if not goal or not goal.strip():
+        typer.echo("--goal is required when --skip-intake is set", err=True)
+        raise typer.Exit(code=2)
+
+    intake: dict[str, object] = {
+        "goal": goal.strip(),
+        "domain": "general",
+        "time_cap_hours": time_cap,
+        "budget_cap_usd": budget_usd,
+    }
+    if corpus:
+        intake["corpus"] = corpus
+
+    # Make sure the schema exists so the testing back door is self-bootstrapping.
+    db.migrate().close()
+
+    job = Job.create(intake)
+    typer.echo(f"Started job {job.id} (status: {job.status})")
+    typer.echo("note: the daemon is not yet wired up — register-only for now (phase 5)")
+
+
+@app.command(name="list")
+def list_command(
+    status: str = typer.Option(None, "--status", help="Filter by job status."),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON. Implied when stdout is not a TTY.",
+    ),
+) -> None:
+    """List research jobs (newest first)."""
+    jobs = list_jobs(status=status)
+    use_json = json_output or not sys.stdout.isatty()
+    if use_json:
+        typer.echo(render.jobs_to_json(jobs))
+        return
+    Console().print(render.render_jobs_table(jobs))
+
+
+@app.command(name="status")
+def status_command(
+    job_id: str = typer.Argument(..., help="Job id (e.g. 2026-05-02-some-slug)."),
+    watch: bool = typer.Option(False, "--watch", help="Refresh every 2 seconds."),
+) -> None:
+    """Show a detailed Rich panel for a single job."""
+    job = Job.load(job_id)
+    console = Console()
+
+    def _panel():
+        data = render.load_status_data(job)
+        return render.render_status_panel(
+            job,
+            plan_version=data["plan_version"],
+            task_counts=data["task_counts"],
+            cost=data["cost"],
+            recent_events=data["recent_events"],
+        )
+
+    if not watch:
+        console.print(_panel())
+        return
+
+    try:
+        with Live(_panel(), console=console, refresh_per_second=4) as live:
+            while True:
+                time.sleep(2.0)
+                live.update(_panel())
+    except KeyboardInterrupt:
+        return
+
+
+def _latest_finding_path(root: Path) -> Path | None:
+    findings_dir = root / "findings"
+    if not findings_dir.is_dir():
+        return None
+    candidates = sorted(findings_dir.glob("*.md"))
+    return candidates[-1] if candidates else None
+
+
+def _render_sources_block(job: Job) -> str:
+    conn = db.connect(job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT s.id, s.url, s.title, s.fetched_at, s.md_path"
+            " FROM job_sources js JOIN sources s ON js.source_id = s.id"
+            " WHERE js.job_id = ?"
+            " ORDER BY s.fetched_at DESC",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    if not rows:
+        return f"# Sources for {job.id}\n\n(no sources recorded)\n"
+    lines = [f"# Sources for {job.id}", ""]
+    for r in rows:
+        title = r["title"] or "(untitled)"
+        url = r["url"] or "(no url)"
+        lines.append(f"- [{r['id']}] {title} — {url} (fetched {r['fetched_at']}, {r['md_path']})")
+    return "\n".join(lines) + "\n"
+
+
+@app.command(name="view")
+def view_command(
+    job_id: str = typer.Argument(..., help="Job id (e.g. 2026-05-02-some-slug)."),
+    report: bool = typer.Option(False, "--report", help="View report.md (default)."),
+    findings: bool = typer.Option(False, "--findings", help="View the latest finding."),
+    sources: bool = typer.Option(False, "--sources", help="View a list of job sources."),
+) -> None:
+    """View a research artifact (report, finding, or sources list)."""
+    job = Job.load(job_id)
+
+    if findings:
+        path = _latest_finding_path(job.root)
+        if path is None:
+            typer.echo(f"no findings present for job {job_id}", err=True)
+            raise typer.Exit(code=1)
+        body = path.read_text(encoding="utf-8")
+    elif sources:
+        body = _render_sources_block(job)
+        path = None
+    else:  # report (default; --report is treated as the same path)
+        _ = report  # accepted explicitly even though it's the default
+        path = job.root / "report.md"
+        if not path.exists():
+            typer.echo(f"report.md not present for job {job_id}", err=True)
+            raise typer.Exit(code=1)
+        body = path.read_text(encoding="utf-8")
+
+    editor = os.environ.get("EDITOR")
+    if path is not None and editor and sys.stdout.isatty():
+        subprocess.run([editor, str(path)], check=False)
+        return
+    typer.echo(body)
+
+
+@app.command(name="logs")
+def logs_command(
+    job_id: str = typer.Argument(..., help="Job id (e.g. 2026-05-02-some-slug)."),
+    follow: bool = typer.Option(False, "-f", "--follow", help="Tail and follow new events."),
+    level: str = typer.Option(None, "--level", help="Filter by event level (e.g. INFO, ERROR)."),
+) -> None:
+    """Tail a job's events.jsonl. With ``-f`` follows appended events."""
+    job = Job.load(job_id)
+    events_path = job.root / "events.jsonl"
+    try:
+        for event in render.tail_events_jsonl(events_path, follow=follow, level=level):
+            typer.echo(render.format_event_line(event))
+    except KeyboardInterrupt:
+        return
 
 
 if __name__ == "__main__":

--- a/src/research_agent/ui/__init__.py
+++ b/src/research_agent/ui/__init__.py
@@ -1,1 +1,24 @@
-"""UI placeholder — see implementation guide §11. No UI in v1."""
+"""UI helpers — see implementation guide §11.
+
+In v1 this is a thin pure-Python rendering layer used by the CLI verbs
+(`research list/status/logs`). A future TUI or web UI can sit alongside
+these helpers without refactoring the core.
+"""
+
+from research_agent.ui.render import (
+    format_event_line,
+    jobs_to_json,
+    load_status_data,
+    render_jobs_table,
+    render_status_panel,
+    tail_events_jsonl,
+)
+
+__all__ = [
+    "format_event_line",
+    "jobs_to_json",
+    "load_status_data",
+    "render_jobs_table",
+    "render_status_panel",
+    "tail_events_jsonl",
+]

--- a/src/research_agent/ui/render.py
+++ b/src/research_agent/ui/render.py
@@ -1,0 +1,265 @@
+"""Rendering helpers for the `research list/status/logs` CLI verbs.
+
+Pure helpers, no Typer dependency, so CLI handlers stay thin and tests can
+exercise the table/panel/JSON shapes directly.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from rich.console import Group
+from rich.panel import Panel
+from rich.table import Table
+
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+
+_STATUS_STYLE = {
+    "running": "green",
+    "stopping": "yellow",
+    "failed": "red",
+}
+
+_GOAL_TRUNCATE = 60
+
+
+def _humanize_age(now_epoch: int, then_epoch: int | None) -> str:
+    if then_epoch is None:
+        return "—"
+    delta = max(0, int(now_epoch) - int(then_epoch))
+    if delta < 60:
+        return f"{delta}s"
+    if delta < 3600:
+        return f"{delta // 60}m"
+    if delta < 86400:
+        return f"{delta // 3600}h"
+    return f"{delta // 86400}d"
+
+
+def _truncate(text: str, limit: int = _GOAL_TRUNCATE) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+def _format_cost(value: Any) -> str:
+    if value is None:
+        return "$0.00"
+    try:
+        return f"${float(value):.2f}"
+    except (TypeError, ValueError):
+        return "$0.00"
+
+
+def _status_cell(status: str) -> str:
+    style = _STATUS_STYLE.get(status)
+    if style is None:
+        return status
+    return f"[{style}]{status}[/{style}]"
+
+
+def render_jobs_table(jobs: list[dict[str, Any]], *, now: int | None = None) -> Table:
+    """Render a Rich table for `research list`."""
+    now_epoch = int(now) if now is not None else int(time.time())
+    table = Table(title="research jobs", show_lines=False)
+    table.add_column("id", overflow="fold")
+    table.add_column("status")
+    table.add_column("goal")
+    table.add_column("age")
+    table.add_column("cost")
+    table.add_column("last activity")
+
+    for row in jobs:
+        table.add_row(
+            str(row.get("id", "")),
+            _status_cell(str(row.get("status", ""))),
+            _truncate(str(row.get("goal", ""))),
+            _humanize_age(now_epoch, row.get("created_at")),
+            _format_cost(row.get("cost_so_far_usd")),
+            _humanize_age(now_epoch, row.get("last_activity_at")),
+        )
+    return table
+
+
+def jobs_to_json(jobs: list[dict[str, Any]]) -> str:
+    """Serialize the list returned by ``list_jobs`` for non-TTY callers."""
+    return json.dumps(jobs, indent=2, sort_keys=True, default=str)
+
+
+def load_status_data(job: Job, *, db_path: Path | None = None) -> dict[str, Any]:
+    """Pull plan version, task counts, cost, and last 10 events for a job."""
+    path = db_path if db_path is not None else job.db_path
+    conn = db.connect(path)
+    try:
+        plan_row = conn.execute(
+            "SELECT COALESCE(MAX(version), 0) AS v FROM plans WHERE job_id = ?",
+            (job.id,),
+        ).fetchone()
+        plan_version = int(plan_row["v"]) if plan_row is not None else 0
+
+        task_rows = conn.execute(
+            "SELECT status, COUNT(*) AS n FROM tasks WHERE job_id = ? GROUP BY status",
+            (job.id,),
+        ).fetchall()
+        task_counts: dict[str, int] = {str(r["status"]): int(r["n"]) for r in task_rows}
+
+        cost_row = conn.execute(
+            "SELECT cost_so_far_usd FROM jobs WHERE id = ?",
+            (job.id,),
+        ).fetchone()
+        cost_val = cost_row["cost_so_far_usd"] if cost_row else None
+        cost = float(cost_val) if cost_val else 0.0
+
+        event_rows = conn.execute(
+            "SELECT ts, level, actor, kind, payload_json FROM events"
+            " WHERE job_id = ? ORDER BY ts DESC LIMIT 10",
+            (job.id,),
+        ).fetchall()
+        recent_events: list[dict[str, Any]] = [
+            {
+                "ts": int(r["ts"]),
+                "level": r["level"],
+                "actor": r["actor"],
+                "kind": r["kind"],
+                "payload_json": r["payload_json"],
+            }
+            for r in event_rows
+        ]
+    finally:
+        conn.close()
+
+    return {
+        "plan_version": plan_version,
+        "task_counts": task_counts,
+        "cost": cost,
+        "recent_events": recent_events,
+    }
+
+
+def render_status_panel(
+    job: Job,
+    plan_version: int,
+    task_counts: dict[str, int],
+    cost: float,
+    recent_events: list[dict[str, Any]],
+) -> Panel:
+    """Render the detail panel for `research status <job-id>`."""
+    intake = job.intake or {}
+    summary_lines = [
+        f"[bold]Status:[/bold] {_status_cell(job.status)}",
+        f"[bold]Goal:[/bold] {job.goal}",
+        f"[bold]Domain:[/bold] {job.domain or '—'}",
+        f"[bold]Plan version:[/bold] {plan_version}",
+        f"[bold]Cost so far:[/bold] {_format_cost(cost)}",
+        (
+            f"[bold]Budget cap:[/bold] {_format_cost(intake.get('budget_cap_usd'))} | "
+            f"[bold]Time cap (h):[/bold] {intake.get('time_cap_hours') or '—'}"
+        ),
+    ]
+
+    if task_counts:
+        counts_str = ", ".join(f"{k}={v}" for k, v in sorted(task_counts.items()))
+    else:
+        counts_str = "(none)"
+    summary_lines.append(f"[bold]Task counts:[/bold] {counts_str}")
+
+    summary = "\n".join(summary_lines)
+
+    events_table = Table(title="Recent events", show_header=True, expand=False)
+    events_table.add_column("ts")
+    events_table.add_column("level")
+    events_table.add_column("actor")
+    events_table.add_column("kind")
+    if recent_events:
+        for ev in recent_events:
+            events_table.add_row(
+                str(ev.get("ts", "")),
+                str(ev.get("level", "")),
+                str(ev.get("actor") or "—"),
+                str(ev.get("kind", "")),
+            )
+    else:
+        events_table.add_row("—", "—", "—", "(no events yet)")
+
+    body = Group(summary, events_table)
+    return Panel(body, title=f"job {job.id}", border_style="cyan")
+
+
+def tail_events_jsonl(
+    path: Path,
+    *,
+    follow: bool = False,
+    level: str | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Yield parsed events from ``events.jsonl``.
+
+    When ``follow`` is True, blocks waiting for appended lines using
+    :mod:`watchfiles`. Otherwise reads the existing file once and returns.
+    """
+    level_norm = level.upper() if level else None
+
+    def _emit_from(pos: int) -> tuple[list[dict[str, Any]], int]:
+        if not path.exists():
+            return [], pos
+        with path.open("rb") as f:
+            f.seek(pos)
+            data = f.read()
+            new_pos = f.tell()
+        out: list[dict[str, Any]] = []
+        text = data.decode("utf-8", errors="replace")
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                obj = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(obj, dict):
+                continue
+            if level_norm and str(obj.get("level", "")).upper() != level_norm:
+                continue
+            out.append(obj)
+        return out, new_pos
+
+    events, offset = _emit_from(0)
+    for ev in events:
+        yield ev
+
+    if not follow:
+        return
+
+    from watchfiles import watch  # local import — only paid when --follow used
+
+    for _changes in watch(path):
+        events, offset = _emit_from(offset)
+        for ev in events:
+            yield ev
+
+
+def format_event_line(event: dict[str, Any]) -> str:
+    """One-line printable form of an event for `research logs`."""
+    ts = event.get("ts", "?")
+    level = str(event.get("level", "?"))
+    kind = event.get("kind", "?")
+    payload = {k: v for k, v in event.items() if k not in ("ts", "level", "kind")}
+    if payload:
+        payload_str = json.dumps(payload, sort_keys=True, default=str)
+    else:
+        payload_str = ""
+    return f"{ts} {level:<5} {kind} {payload_str}".rstrip()
+
+
+__all__ = [
+    "format_event_line",
+    "jobs_to_json",
+    "load_status_data",
+    "render_jobs_table",
+    "render_status_panel",
+    "tail_events_jsonl",
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -298,7 +298,11 @@ def test_status_renders_panel_for_pending_job(isolated_jobs_repo: Path):
 def test_status_unknown_job_errors(isolated_jobs_repo: Path):
     runner = CliRunner()
     result = runner.invoke(cli.app, ["status", "2026-05-02-does-not-exist"])
-    assert result.exit_code != 0
+    assert result.exit_code == 1
+    combined = result.stdout + (result.stderr or "")
+    assert "job not found" in combined
+    # No Python traceback should leak to the user.
+    assert "Traceback" not in combined
 
 
 def test_view_report_prints_content(isolated_jobs_repo: Path):
@@ -379,7 +383,21 @@ def test_logs_level_filter(isolated_jobs_repo: Path):
 def test_logs_unknown_job_errors(isolated_jobs_repo: Path):
     runner = CliRunner()
     result = runner.invoke(cli.app, ["logs", "2026-05-02-does-not-exist"])
-    assert result.exit_code != 0
+    assert result.exit_code == 1
+    combined = result.stdout + (result.stderr or "")
+    assert "job not found" in combined
+    assert "Traceback" not in combined
+
+
+def test_view_unknown_job_errors(isolated_jobs_repo: Path):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app, ["view", "2026-05-02-does-not-exist"], env={"EDITOR": ""}
+    )
+    assert result.exit_code == 1
+    combined = result.stdout + (result.stderr or "")
+    assert "job not found" in combined
+    assert "Traceback" not in combined
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 import json
+import time
+from datetime import date
+from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
 
 from research_agent import __version__, cli, config
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+from research_agent.ui import render
 
 
 @pytest.fixture(autouse=True)
@@ -117,3 +123,281 @@ def test_doctor_help_lists_command():
     result = runner.invoke(cli.app, ["doctor", "--help"])
     assert result.exit_code == 0
     assert "--json" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 verbs: start / list / status / view / logs
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_jobs_repo(tmp_path, monkeypatch):
+    """Tmp cwd with a migrated DB so jobs can be created via the default paths."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "_LOADED_ENV_FILES", [])
+    db_path = tmp_path / "data" / "index.sqlite"
+    db.migrate(path=db_path).close()
+    (tmp_path / "jobs").mkdir(exist_ok=True)
+    return tmp_path
+
+
+def _make_synthetic_job(
+    repo: Path,
+    *,
+    goal: str = "Synthetic test goal",
+    today: date = date(2026, 5, 2),
+    status: str = "pending",
+    cost: float = 1.23,
+    plan_version: int | None = None,
+    finding_text: str | None = None,
+    event_lines: list[dict] | None = None,
+) -> Job:
+    """Hand-create a job, optionally seed plan/finding/events for richer tests."""
+    job = Job.create(
+        {"goal": goal, "domain": "general"},
+        jobs_root=repo / "jobs",
+        db_path=repo / "data" / "index.sqlite",
+        today=today,
+    )
+    if status != "pending":
+        job.set_status(status)
+
+    conn = db.connect(repo / "data" / "index.sqlite")
+    try:
+        with conn:
+            if cost is not None:
+                conn.execute("UPDATE jobs SET cost_so_far_usd = ? WHERE id = ?", (cost, job.id))
+            if plan_version is not None:
+                conn.execute(
+                    "INSERT INTO plans (job_id, version, payload_json, created_at)"
+                    " VALUES (?, ?, ?, ?)",
+                    (job.id, plan_version, "{}", int(time.time())),
+                )
+    finally:
+        conn.close()
+
+    if finding_text is not None:
+        finding_path = job.root / "findings" / "000001.md"
+        finding_path.write_text(finding_text, encoding="utf-8")
+
+    if event_lines is not None:
+        path = job.root / "events.jsonl"
+        with path.open("a", encoding="utf-8") as f:
+            for ev in event_lines:
+                f.write(json.dumps(ev) + "\n")
+
+    return job
+
+
+def test_start_skip_intake_creates_job(isolated_jobs_repo: Path):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        ["start", "--skip-intake", "--goal", "Investigate widgets", "--budget-usd", "5.0"],
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "Started job" in result.stdout
+    assert "pending" in result.stdout
+
+    # Folder + sidecars exist.
+    today = time.strftime("%Y-%m-%d")
+    job_id = f"{today}-investigate-widgets"
+    job_root = isolated_jobs_repo / "jobs" / job_id
+    assert (job_root / "job.json").exists()
+    assert (job_root / "events.jsonl").exists()
+
+    # DB row exists with status=pending.
+    conn = db.connect(isolated_jobs_repo / "data" / "index.sqlite")
+    try:
+        row = conn.execute(
+            "SELECT status, budget_cap_usd FROM jobs WHERE id = ?", (job_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    assert row["status"] == "pending"
+    assert row["budget_cap_usd"] == 5.0
+
+
+def test_start_without_skip_intake_exits_nonzero(isolated_jobs_repo: Path):
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["start", "--goal", "x"])
+    assert result.exit_code != 0
+    # Combined output should mention the missing flag.
+    assert "skip-intake" in (result.stdout + (result.stderr or ""))
+
+
+def test_start_skip_intake_requires_goal(isolated_jobs_repo: Path):
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["start", "--skip-intake"])
+    assert result.exit_code != 0
+
+
+def test_list_emits_json_when_not_a_tty(isolated_jobs_repo: Path):
+    _make_synthetic_job(isolated_jobs_repo, goal="alpha", today=date(2026, 5, 1))
+    _make_synthetic_job(isolated_jobs_repo, goal="beta", today=date(2026, 5, 2))
+
+    runner = CliRunner()
+    # CliRunner stdin/stdout are not TTYs → list should emit JSON implicitly.
+    result = runner.invoke(cli.app, ["list"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, list)
+    ids = {r["id"] for r in payload}
+    assert ids == {"2026-05-02-beta", "2026-05-01-alpha"}
+
+
+def test_list_explicit_json_flag(isolated_jobs_repo: Path):
+    _make_synthetic_job(isolated_jobs_repo)
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["list", "--json"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, list)
+    assert payload[0]["status"] == "pending"
+
+
+def test_list_status_filter(isolated_jobs_repo: Path):
+    j1 = _make_synthetic_job(isolated_jobs_repo, goal="alpha", today=date(2026, 5, 1))
+    j2 = _make_synthetic_job(isolated_jobs_repo, goal="beta", today=date(2026, 5, 2))
+    j2.set_status("running")
+
+    runner = CliRunner()
+    pending = json.loads(runner.invoke(cli.app, ["list", "--status", "pending", "--json"]).stdout)
+    running = json.loads(runner.invoke(cli.app, ["list", "--status", "running", "--json"]).stdout)
+    assert [r["id"] for r in pending] == [j1.id]
+    assert [r["id"] for r in running] == [j2.id]
+
+
+def test_list_table_renders_for_tty(isolated_jobs_repo: Path):
+    """Direct check on the table renderer (TTY branch is hard to simulate)."""
+    _make_synthetic_job(isolated_jobs_repo, goal="alpha", today=date(2026, 5, 1))
+    from research_agent.storage.jobs import list_jobs
+
+    table = render.render_jobs_table(list_jobs())
+    # Rich Table has a row for every job.
+    assert table.row_count == 1
+
+
+def test_status_renders_panel_for_pending_job(isolated_jobs_repo: Path):
+    job = _make_synthetic_job(isolated_jobs_repo, goal="Investigate Y", cost=2.5)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["status", job.id])
+    assert result.exit_code == 0, result.stdout
+    out = result.stdout
+    assert job.id in out
+    assert "Investigate Y" in out
+    assert "pending" in out
+    # Plan version 0, no tasks.
+    assert "Plan version" in out
+    assert "0" in out
+    assert "$2.50" in out
+
+
+def test_status_unknown_job_errors(isolated_jobs_repo: Path):
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["status", "2026-05-02-does-not-exist"])
+    assert result.exit_code != 0
+
+
+def test_view_report_prints_content(isolated_jobs_repo: Path):
+    job = _make_synthetic_job(isolated_jobs_repo)
+    (job.root / "report.md").write_text("# Final Report\n\nfinding A\n", encoding="utf-8")
+
+    runner = CliRunner()
+    # Don't let a real $EDITOR path leak in.
+    result = runner.invoke(cli.app, ["view", job.id, "--report"], env={"EDITOR": ""})
+    assert result.exit_code == 0, result.stdout
+    assert "Final Report" in result.stdout
+
+
+def test_view_report_default_when_no_flag(isolated_jobs_repo: Path):
+    job = _make_synthetic_job(isolated_jobs_repo)
+    (job.root / "report.md").write_text("default-report-body", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["view", job.id], env={"EDITOR": ""})
+    assert result.exit_code == 0, result.stdout
+    assert "default-report-body" in result.stdout
+
+
+def test_view_report_missing_fails_clearly(isolated_jobs_repo: Path):
+    job = _make_synthetic_job(isolated_jobs_repo)
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["view", job.id, "--report"], env={"EDITOR": ""})
+    assert result.exit_code != 0
+    assert "report.md" in (result.stdout + (result.stderr or ""))
+
+
+def test_view_findings_prints_latest(isolated_jobs_repo: Path):
+    job = _make_synthetic_job(
+        isolated_jobs_repo,
+        finding_text="# Finding 1\n\nclaim about widgets\n",
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["view", job.id, "--findings"], env={"EDITOR": ""})
+    assert result.exit_code == 0, result.stdout
+    assert "claim about widgets" in result.stdout
+
+
+def test_view_findings_when_none_fails(isolated_jobs_repo: Path):
+    job = _make_synthetic_job(isolated_jobs_repo)
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["view", job.id, "--findings"], env={"EDITOR": ""})
+    assert result.exit_code != 0
+
+
+def test_logs_prints_existing_events(isolated_jobs_repo: Path):
+    events = [
+        {"ts": 1700000000, "level": "INFO", "kind": "job_started", "actor": "daemon"},
+        {"ts": 1700000010, "level": "ERROR", "kind": "fetch_failed", "url": "http://x"},
+    ]
+    job = _make_synthetic_job(isolated_jobs_repo, event_lines=events)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["logs", job.id])
+    assert result.exit_code == 0, result.stdout
+    assert "job_started" in result.stdout
+    assert "fetch_failed" in result.stdout
+
+
+def test_logs_level_filter(isolated_jobs_repo: Path):
+    events = [
+        {"ts": 1700000000, "level": "INFO", "kind": "job_started"},
+        {"ts": 1700000010, "level": "ERROR", "kind": "fetch_failed"},
+    ]
+    job = _make_synthetic_job(isolated_jobs_repo, event_lines=events)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["logs", job.id, "--level", "error"])
+    assert result.exit_code == 0, result.stdout
+    assert "fetch_failed" in result.stdout
+    assert "job_started" not in result.stdout
+
+
+def test_logs_unknown_job_errors(isolated_jobs_repo: Path):
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["logs", "2026-05-02-does-not-exist"])
+    assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Pure render helpers
+# ---------------------------------------------------------------------------
+
+
+def test_jobs_to_json_round_trips():
+    rows = [{"id": "a", "status": "pending", "goal": "g", "created_at": 1, "cost_so_far_usd": 0.0}]
+    payload = json.loads(render.jobs_to_json(rows))
+    assert payload == rows
+
+
+def test_format_event_line_includes_ts_level_kind():
+    line = render.format_event_line(
+        {"ts": 1700000000, "level": "INFO", "kind": "job_started", "actor": "daemon"}
+    )
+    assert "1700000000" in line
+    assert "INFO" in line
+    assert "job_started" in line
+    assert "daemon" in line


### PR DESCRIPTION
Closes #7

## Summary

Automated implementation of **CLI verbs: start --skip-intake, list, status, view**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

All acceptance criteria met. Fixed one warning: status/view/logs leaked Python tracebacks for unknown job ids; now emit a clean 'job not found' message with exit 1.

- **WARNING** [FIXED] `src/research_agent/cli.py`: status/view/logs commands leaked full Python tracebacks when given an unknown job id, instead of a clean error message. Wrapped Job.load() in _load_job_or_exit() helper that catches FileNotFoundError/KeyError/ValueError and emits 'job not found: <id> (<reason>)' to stderr with exit code 1. Added regression tests for all three commands asserting no 'Traceback' leaks.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*