### PR TITLE
feat: LLM router with tier→provider mapping (llm/router.py) (closes #9)

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -1,1 +1,68 @@
-# Model tier → provider routing — populated in later issues.
+# Model tier → provider routing (research-agent-implementation-guide.md §8.1).
+#
+# The router reads this at startup and maps logical tiers to (provider, model)
+# pairs. Edit freely; never hardcode a model name in business logic — pick a
+# tier. Local tiers go through LM Studio at http://localhost:1234/v1; cloud
+# tiers go through OpenRouter at https://openrouter.ai/api/v1.
+
+tiers:
+  fast:
+    provider: lmstudio
+    model: qwen3-4b-instruct-q4_k_m
+    timeout_s: 30
+    purpose: |
+      Classification, deduplication, language detection, simple
+      relevance scoring. ~100 tok/s on M-series.
+
+  general:
+    provider: lmstudio
+    model: qwen3-32b-instruct-q6_k
+    timeout_s: 90
+    purpose: |
+      Research worker default. Query rewriting, source extraction,
+      per-source summarization, finding generation.
+
+  reasoner:
+    provider: lmstudio
+    model: deepseek-r1-distill-32b-q6_k
+    timeout_s: 300
+    purpose: |
+      Complex extraction, hypothesis ranking, contradiction detection.
+      Use sparingly.
+
+  vision:
+    provider: lmstudio
+    model: qwen3-vl-8b-instruct
+    timeout_s: 60
+    purpose: PDF page screenshots, chart reading.
+
+  embeddings:
+    provider: lmstudio
+    model: qwen3-embedding-4b
+    timeout_s: 60
+    purpose: Semantic search across findings and sources.
+
+  frontier:
+    provider: openrouter
+    model: anthropic/claude-opus-4-7
+    fallback_model: openai/gpt-5
+    timeout_s: 600
+    purpose: |
+      Major synthesis, critique, final report, planner rewrites.
+      Cost-tracked.
+
+  frontier_alt:
+    provider: openrouter
+    model: moonshotai/kimi-k2-1t
+    timeout_s: 600
+    purpose: |
+      Diverse second opinion. Use for the critique pass so the
+      synthesizer and critic disagree productively.
+
+  frontier_speed:
+    provider: openrouter
+    model: anthropic/claude-haiku-4-5
+    timeout_s: 60
+    purpose: |
+      Fast cloud calls when a local model isn't enough but Opus is
+      overkill. Adaptive intake follow-ups, micro-summaries.

--- a/src/research_agent/llm/__init__.py
+++ b/src/research_agent/llm/__init__.py
@@ -1,1 +1,23 @@
 """LLM clients, routing, budget enforcement, and response cache (implementation guide §4)."""
+
+from .budgets import BudgetExceeded, BudgetTracker, TokenUsage
+from .router import (
+    EXPECTED_TIERS,
+    LMSTUDIO_DEFAULT_BASE_URL,
+    OPENROUTER_BASE_URL,
+    Router,
+    Tier,
+    load_models_config,
+)
+
+__all__ = [
+    "EXPECTED_TIERS",
+    "LMSTUDIO_DEFAULT_BASE_URL",
+    "OPENROUTER_BASE_URL",
+    "BudgetExceeded",
+    "BudgetTracker",
+    "Router",
+    "Tier",
+    "TokenUsage",
+    "load_models_config",
+]

--- a/src/research_agent/llm/budgets.py
+++ b/src/research_agent/llm/budgets.py
@@ -1,0 +1,106 @@
+"""Per-job cost cap enforcement (implementation guide §9).
+
+This module exposes the minimal contract the LLM router depends on:
+
+- :class:`TokenUsage` — provider-agnostic shape for the numbers we ledger.
+- :class:`BudgetExceeded` — raised by ``precheck()`` once the cap is hit.
+- :class:`BudgetTracker` — ``precheck()`` before cloud calls, ``charge()`` after.
+
+The full per-model cost table lives in ``config/models.yaml`` and will be
+consumed by a richer pricing implementation in a later issue. For now
+``charge()`` accepts an explicit ``cost_usd`` from the caller and bumps the
+in-memory running total. The :mod:`router` is the single writer of the
+``llm_calls`` ledger row, so a cloud call produces exactly one row no matter
+which path it took. ``BudgetTracker`` re-hydrates its running total from that
+ledger at construction so a daemon that restarts mid-run picks up where it
+left off.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from research_agent.storage import db
+
+
+@dataclass(slots=True)
+class TokenUsage:
+    """Provider-agnostic usage shape mirrored to the ``llm_calls`` table."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_tokens: int = 0
+    latency_ms: int = 0
+    finish_reason: str | None = None
+
+
+class BudgetExceeded(Exception):
+    """Raised by :meth:`BudgetTracker.precheck` when the per-job cap is hit."""
+
+    def __init__(self, job_id: str, spent: float, cap: float) -> None:
+        self.job_id = job_id
+        self.spent = spent
+        self.cap = cap
+        super().__init__(f"budget cap exceeded for job {job_id!r}: ${spent:.4f} >= ${cap:.4f}")
+
+
+class BudgetTracker:
+    """Track per-job cloud spend and enforce a USD cap.
+
+    ``cap_usd`` of ``None`` disables enforcement (precheck always passes).
+    State is loaded from the ``llm_calls`` ledger at construction so a daemon
+    that restarts mid-run picks up the same running total.
+    """
+
+    def __init__(
+        self,
+        job_id: str,
+        cap_usd: float | None,
+        *,
+        db_path: Path | str | None = None,
+    ) -> None:
+        self.job_id = job_id
+        self.cap = cap_usd
+        self.db_path = Path(db_path) if db_path is not None else db.DEFAULT_DB_PATH
+        self.spent = self._load_from_db()
+
+    def _load_from_db(self) -> float:
+        conn = db.connect(self.db_path)
+        try:
+            row = conn.execute(
+                "SELECT COALESCE(SUM(cost_usd), 0) FROM llm_calls WHERE job_id = ?",
+                (self.job_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        if row is None:
+            return 0.0
+        return float(row[0] or 0.0)
+
+    def precheck(self, tier: str) -> None:  # noqa: ARG002 — tier reserved for future per-tier caps
+        """Raise :class:`BudgetExceeded` if the running total has reached the cap."""
+        if self.cap is None:
+            return
+        if self.spent >= self.cap:
+            raise BudgetExceeded(self.job_id, self.spent, self.cap)
+
+    def charge(
+        self,
+        tier: str,  # noqa: ARG002 — tier reserved for future per-tier accounting
+        provider: str,  # noqa: ARG002 — same
+        model: str,  # noqa: ARG002 — same
+        usage: TokenUsage,  # noqa: ARG002 — same
+        cost_usd: float,
+    ) -> None:
+        """Bump the in-memory running total by ``cost_usd``.
+
+        The :mod:`router` writes the actual ``llm_calls`` ledger row so the
+        ledger has exactly one row per call. Keeping this in-memory makes
+        ``precheck`` cheap and lets the cap survive a daemon restart by
+        reloading from the ledger in :meth:`__init__`.
+        """
+        self.spent += cost_usd
+
+
+__all__ = ["BudgetExceeded", "BudgetTracker", "TokenUsage"]

--- a/src/research_agent/llm/router.py
+++ b/src/research_agent/llm/router.py
@@ -1,0 +1,361 @@
+"""Tier → provider routing for every LLM call (implementation guide §8).
+
+The router is the single chokepoint between the orchestrator and any model.
+Business logic picks a logical *tier* (``fast``, ``general``, ``frontier``…)
+and the router maps it to a Pydantic AI :class:`OpenAIModel` bound to either
+LM Studio (local, no cost) or OpenRouter (cloud, cost-tracked).
+
+Per §16 the router never silently falls back from a local tier to a cloud
+tier — that would let a paid call slip in disguised as a free one. Cloud
+tiers can fall back to a configured ``fallback_model`` (still cloud) on
+:class:`openai.RateLimitError`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml  # type: ignore[import-untyped]
+from openai import RateLimitError
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+from research_agent.config import get as cfg_get
+from research_agent.observability.events import emit
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+
+from .budgets import BudgetTracker, TokenUsage
+
+Tier = Literal[
+    "fast",
+    "general",
+    "reasoner",
+    "vision",
+    "embeddings",
+    "frontier",
+    "frontier_alt",
+    "frontier_speed",
+]
+
+EXPECTED_TIERS: tuple[str, ...] = (
+    "fast",
+    "general",
+    "reasoner",
+    "vision",
+    "embeddings",
+    "frontier",
+    "frontier_alt",
+    "frontier_speed",
+)
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+LMSTUDIO_DEFAULT_BASE_URL = "http://localhost:1234/v1"
+
+
+def load_models_config(path: Path | str = "config/models.yaml") -> dict[str, Any]:
+    """Parse ``config/models.yaml`` and return the raw dict.
+
+    Raises :class:`ValueError` if the top-level ``tiers`` key is missing —
+    every other layer of the system assumes it exists.
+    """
+    p = Path(path)
+    with p.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict) or "tiers" not in data:
+        raise ValueError(f"models config at {p} missing required top-level 'tiers' key")
+    if not isinstance(data["tiers"], dict):
+        raise ValueError(f"'tiers' in {p} must be a mapping; got {type(data['tiers']).__name__}")
+    return data
+
+
+def _extract_usage(result: Any, latency_ms: int) -> TokenUsage:
+    """Map a Pydantic AI ``AgentRunResult.usage()`` into our :class:`TokenUsage`."""
+    input_tokens = 0
+    output_tokens = 0
+    cached_tokens = 0
+    finish_reason: str | None = None
+
+    usage_obj: Any = None
+    raw = getattr(result, "usage", None)
+    if callable(raw):
+        try:
+            usage_obj = raw()
+        except Exception:
+            usage_obj = None
+    elif raw is not None:
+        usage_obj = raw
+
+    if usage_obj is not None:
+        input_tokens = int(getattr(usage_obj, "input_tokens", 0) or 0)
+        output_tokens = int(getattr(usage_obj, "output_tokens", 0) or 0)
+        cached_tokens = int(getattr(usage_obj, "cache_read_tokens", 0) or 0)
+
+    fr = getattr(result, "finish_reason", None)
+    if isinstance(fr, str):
+        finish_reason = fr
+
+    return TokenUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cached_tokens=cached_tokens,
+        latency_ms=latency_ms,
+        finish_reason=finish_reason,
+    )
+
+
+class Router:
+    """Map a logical tier to a configured :class:`OpenAIModel` and run calls.
+
+    Construct once per daemon. ``model_for(tier)`` returns the cached model
+    object (so repeated calls reuse the same provider client). ``call(...)``
+    is the wrapper to use whenever orchestrator code wants to run an agent —
+    it precharges/charges the budget for cloud tiers, enforces the per-tier
+    timeout, falls back on rate limits, and writes the ``llm_calls`` ledger
+    + emits an ``llm_call`` observability event.
+    """
+
+    def __init__(
+        self,
+        config: dict[str, Any],
+        budget: BudgetTracker,
+        *,
+        job: Job | None = None,
+        db_path: Path | str | None = None,
+    ) -> None:
+        if "tiers" not in config:
+            raise ValueError("router config missing 'tiers' key")
+        tiers = config["tiers"]
+        if not isinstance(tiers, dict):
+            raise ValueError("router config 'tiers' must be a mapping")
+        missing = [t for t in EXPECTED_TIERS if t not in tiers]
+        if missing:
+            raise ValueError(f"router config missing required tiers: {missing}")
+
+        self.tiers: dict[str, dict[str, Any]] = tiers
+        self.budget = budget
+        self.job = job
+        self.db_path = Path(db_path) if db_path is not None else None
+        self._model_cache: dict[str, OpenAIModel] = {}
+
+    # ---- Provider wiring ---------------------------------------------------
+
+    def _build_model(self, tier: str, model_name: str) -> OpenAIModel:
+        spec = self.tiers[tier]
+        provider = spec["provider"]
+        if provider == "lmstudio":
+            base_url = cfg_get("LMSTUDIO_BASE_URL") or LMSTUDIO_DEFAULT_BASE_URL
+            api_key = "lm-studio"
+        elif provider == "openrouter":
+            api_key_env = os.environ.get("OPENROUTER_API_KEY")
+            if not api_key_env:
+                raise RuntimeError(
+                    f"OPENROUTER_API_KEY environment variable is required for "
+                    f"cloud tier {tier!r} (provider=openrouter)"
+                )
+            base_url = OPENROUTER_BASE_URL
+            api_key = api_key_env
+        else:
+            raise ValueError(
+                f"unknown provider for tier {tier!r}: {provider!r} "
+                "(expected 'lmstudio' or 'openrouter')"
+            )
+        return OpenAIModel(
+            model_name,
+            provider=OpenAIProvider(base_url=base_url, api_key=api_key),
+        )
+
+    def model_for(self, tier: Tier | str) -> OpenAIModel:
+        """Return the cached :class:`OpenAIModel` for ``tier``.
+
+        Builds it on first access, then memoizes per Router instance so
+        callers can call this on every dispatch without re-creating the
+        underlying ``AsyncOpenAI`` client.
+        """
+        if tier not in self.tiers:
+            raise KeyError(f"unknown tier: {tier!r}")
+        cached = self._model_cache.get(tier)
+        if cached is not None:
+            return cached
+        model = self._build_model(tier, self.tiers[tier]["model"])
+        self._model_cache[tier] = model
+        return model
+
+    def _make_fallback_agent(self, tier: str, fallback_model_name: str) -> Agent:
+        """Construct a one-shot Agent bound to the cloud fallback model."""
+        api_key = os.environ.get("OPENROUTER_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                f"OPENROUTER_API_KEY environment variable is required for fallback on tier {tier!r}"
+            )
+        model = OpenAIModel(
+            fallback_model_name,
+            provider=OpenAIProvider(base_url=OPENROUTER_BASE_URL, api_key=api_key),
+        )
+        return Agent(model)
+
+    # ---- Call wrapper ------------------------------------------------------
+
+    async def call(
+        self,
+        tier: Tier | str,
+        agent: Any,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Run ``agent.run(*args, **kwargs)`` for ``tier`` with full bookkeeping.
+
+        - precheck/charge the budget for cloud tiers
+        - enforce the per-tier ``timeout_s`` via :func:`asyncio.wait_for`
+        - on :class:`openai.RateLimitError` for a cloud tier with a configured
+          ``fallback_model``, retry once on the fallback model
+        - write one row to ``llm_calls`` and emit one ``llm_call`` event
+          regardless of provider (so the ledger covers local calls too)
+
+        Local-tier failures are *not* silently rerouted to cloud (per §16);
+        the original exception propagates to the caller.
+        """
+        if tier not in self.tiers:
+            raise KeyError(f"unknown tier: {tier!r}")
+        spec = self.tiers[tier]
+        provider = spec["provider"]
+        model_name = spec["model"]
+        timeout_s = spec.get("timeout_s")
+        is_cloud = provider == "openrouter"
+        fallback_used = False
+
+        if is_cloud:
+            self.budget.precheck(tier)
+
+        t0 = time.perf_counter()
+        try:
+            result = await self._run_with_timeout(agent, timeout_s, args, kwargs)
+        except RateLimitError:
+            fallback_model = spec.get("fallback_model")
+            if not (is_cloud and fallback_model):
+                raise
+            fallback_agent = self._make_fallback_agent(tier, fallback_model)
+            result = await self._run_with_timeout(fallback_agent, timeout_s, args, kwargs)
+            fallback_used = True
+            model_name = fallback_model
+
+        latency_ms = int((time.perf_counter() - t0) * 1000)
+        usage = _extract_usage(result, latency_ms)
+        # Cost computation lives in a later issue; the ledger schema already
+        # has the column, so we record 0.0 for now and let `BudgetTracker`
+        # handle the running total once pricing lands.
+        cost_usd = 0.0
+
+        if is_cloud:
+            self.budget.charge(tier, provider, model_name, usage, cost_usd)
+
+        self._record_call(
+            tier=tier,
+            provider=provider,
+            model=model_name,
+            usage=usage,
+            cost_usd=cost_usd,
+            fallback_used=fallback_used,
+        )
+
+        return result
+
+    @staticmethod
+    async def _run_with_timeout(
+        agent: Any,
+        timeout_s: float | None,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        if timeout_s is None:
+            return await agent.run(*args, **kwargs)
+        return await asyncio.wait_for(agent.run(*args, **kwargs), timeout=timeout_s)
+
+    # ---- Ledger + event ----------------------------------------------------
+
+    def _resolve_db_path(self) -> Path:
+        if self.db_path is not None:
+            return self.db_path
+        if self.job is not None:
+            return self.job.db_path
+        return db.DEFAULT_DB_PATH
+
+    def _record_call(
+        self,
+        *,
+        tier: str,
+        provider: str,
+        model: str,
+        usage: TokenUsage,
+        cost_usd: float,
+        fallback_used: bool,
+    ) -> None:
+        ts = int(time.time())
+        job_id = self.job.id if self.job is not None else None
+        db_path = self._resolve_db_path()
+
+        conn = db.connect(db_path)
+        try:
+            with conn:
+                conn.execute(
+                    "INSERT INTO llm_calls ("
+                    " job_id, ts, tier, provider, model,"
+                    " input_tokens, output_tokens, cached_tokens,"
+                    " latency_ms, cost_usd, finish_reason"
+                    ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        job_id,
+                        ts,
+                        tier,
+                        provider,
+                        model,
+                        usage.input_tokens,
+                        usage.output_tokens,
+                        usage.cached_tokens,
+                        usage.latency_ms,
+                        cost_usd,
+                        usage.finish_reason,
+                    ),
+                )
+        finally:
+            conn.close()
+
+        if self.job is not None:
+            payload = {
+                "tier": tier,
+                "provider": provider,
+                "model": model,
+                "latency_ms": usage.latency_ms,
+                "input_tokens": usage.input_tokens,
+                "output_tokens": usage.output_tokens,
+                "cost_usd": cost_usd,
+                "finish_reason": usage.finish_reason,
+                "fallback_used": fallback_used,
+            }
+            # Round-trip through json so the payload always contains JSON-safe
+            # primitives — `emit` re-serializes in the SQL mirror.
+            payload = json.loads(json.dumps(payload, default=str))
+            emit(
+                self.job,
+                "INFO",
+                "router",
+                "llm_call",
+                payload,
+                db_path=db_path,
+            )
+
+
+__all__ = [
+    "EXPECTED_TIERS",
+    "LMSTUDIO_DEFAULT_BASE_URL",
+    "OPENROUTER_BASE_URL",
+    "Router",
+    "Tier",
+    "load_models_config",
+]

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -1,0 +1,581 @@
+"""Tests for ``research_agent.llm.router`` and the supporting BudgetTracker."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import yaml
+from openai import RateLimitError
+
+from research_agent.llm.budgets import BudgetTracker, TokenUsage
+from research_agent.llm.router import (
+    EXPECTED_TIERS,
+    LMSTUDIO_DEFAULT_BASE_URL,
+    OPENROUTER_BASE_URL,
+    Router,
+    load_models_config,
+)
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SHIPPED_MODELS_YAML = REPO_ROOT / "config" / "models.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "index.sqlite"
+    db.migrate(path=path).close()
+    return path
+
+
+@pytest.fixture
+def jobs_root(tmp_path: Path) -> Path:
+    return tmp_path / "jobs"
+
+
+@pytest.fixture
+def job(jobs_root: Path, db_path: Path) -> Job:
+    return Job.create(
+        {"goal": "Investigate router"},
+        jobs_root=jobs_root,
+        db_path=db_path,
+    )
+
+
+@pytest.fixture
+def models_config() -> dict[str, Any]:
+    return load_models_config(SHIPPED_MODELS_YAML)
+
+
+@pytest.fixture
+def budget(db_path: Path) -> BudgetTracker:
+    return BudgetTracker("budget-test", cap_usd=None, db_path=db_path)
+
+
+@pytest.fixture
+def make_router(models_config: dict[str, Any], db_path: Path):
+    def _factory(
+        *,
+        budget: BudgetTracker | None = None,
+        job: Job | None = None,
+    ) -> Router:
+        b = (
+            budget
+            if budget is not None
+            else BudgetTracker(
+                job.id if job is not None else "router-test",
+                cap_usd=None,
+                db_path=db_path,
+            )
+        )
+        return Router(models_config, b, job=job, db_path=db_path)
+
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeUsage:
+    def __init__(
+        self,
+        input_tokens: int = 12,
+        output_tokens: int = 34,
+        cache_read_tokens: int = 5,
+    ) -> None:
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.cache_read_tokens = cache_read_tokens
+
+
+class _FakeResult:
+    def __init__(self, usage: _FakeUsage | None = None) -> None:
+        self._usage = usage or _FakeUsage()
+        self.finish_reason = "stop"
+
+    def usage(self) -> _FakeUsage:
+        return self._usage
+
+
+class _FakeAgent:
+    """Minimal stand-in for `pydantic_ai.Agent` — exposes async ``run``."""
+
+    def __init__(
+        self,
+        *,
+        result: Any = None,
+        raises: list[BaseException] | None = None,
+        sleep_s: float = 0.0,
+    ) -> None:
+        self.result = result if result is not None else _FakeResult()
+        self.raises = list(raises or [])
+        self.sleep_s = sleep_s
+        self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    async def run(self, *args: Any, **kwargs: Any) -> Any:
+        self.calls.append((args, kwargs))
+        if self.sleep_s:
+            await asyncio.sleep(self.sleep_s)
+        if self.raises:
+            raise self.raises.pop(0)
+        return self.result
+
+
+def _rate_limit_error() -> RateLimitError:
+    request = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+    response = httpx.Response(429, request=request)
+    return RateLimitError("rate limited", response=response, body=None)
+
+
+# ---------------------------------------------------------------------------
+# load_models_config + shipped tier table
+# ---------------------------------------------------------------------------
+
+
+def test_load_models_config_ships_with_tier_table() -> None:
+    cfg = load_models_config(SHIPPED_MODELS_YAML)
+    tiers = cfg["tiers"]
+
+    for t in EXPECTED_TIERS:
+        assert t in tiers, f"missing tier: {t}"
+
+    expected_provider = {
+        "fast": "lmstudio",
+        "general": "lmstudio",
+        "reasoner": "lmstudio",
+        "vision": "lmstudio",
+        "embeddings": "lmstudio",
+        "frontier": "openrouter",
+        "frontier_alt": "openrouter",
+        "frontier_speed": "openrouter",
+    }
+    expected_model = {
+        "fast": "qwen3-4b-instruct-q4_k_m",
+        "general": "qwen3-32b-instruct-q6_k",
+        "reasoner": "deepseek-r1-distill-32b-q6_k",
+        "vision": "qwen3-vl-8b-instruct",
+        "embeddings": "qwen3-embedding-4b",
+        "frontier": "anthropic/claude-opus-4-7",
+        "frontier_alt": "moonshotai/kimi-k2-1t",
+        "frontier_speed": "anthropic/claude-haiku-4-5",
+    }
+    for tier, provider in expected_provider.items():
+        assert tiers[tier]["provider"] == provider
+        assert tiers[tier]["model"] == expected_model[tier]
+    assert tiers["frontier"]["fallback_model"] == "openai/gpt-5"
+
+
+def test_load_models_config_raises_when_tiers_missing(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(yaml.safe_dump({"something_else": {}}), encoding="utf-8")
+    with pytest.raises(ValueError, match="tiers"):
+        load_models_config(bad)
+
+
+# ---------------------------------------------------------------------------
+# model_for(tier)
+# ---------------------------------------------------------------------------
+
+
+def test_model_for_lmstudio_tier_uses_local_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+    make_router,
+) -> None:
+    monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
+    router = make_router()
+    model = router.model_for("fast")
+
+    base_url = str(model.provider.base_url).rstrip("/")
+    assert base_url == LMSTUDIO_DEFAULT_BASE_URL.rstrip("/")
+    # api_key is not strictly required for LM Studio but the provider stores it.
+    assert model.provider.client.api_key == "lm-studio"
+
+
+def test_model_for_lmstudio_respects_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+    make_router,
+) -> None:
+    monkeypatch.setenv("LMSTUDIO_BASE_URL", "http://lmstudio.local:9999/v1")
+    router = make_router()
+    model = router.model_for("general")
+    base_url = str(model.provider.base_url).rstrip("/")
+    assert base_url == "http://lmstudio.local:9999/v1"
+
+
+def test_model_for_openrouter_tier_uses_cloud_base_url_and_env_key(
+    monkeypatch: pytest.MonkeyPatch,
+    make_router,
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test-12345")
+    router = make_router()
+    model = router.model_for("frontier")
+
+    base_url = str(model.provider.base_url).rstrip("/")
+    assert base_url == OPENROUTER_BASE_URL.rstrip("/")
+    assert model.provider.client.api_key == "sk-or-test-12345"
+
+
+def test_missing_openrouter_key_raises_clearly(
+    monkeypatch: pytest.MonkeyPatch,
+    make_router,
+) -> None:
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    router = make_router()
+    with pytest.raises(RuntimeError, match="OPENROUTER_API_KEY"):
+        router.model_for("frontier")
+
+
+def test_model_for_caches_per_tier(
+    monkeypatch: pytest.MonkeyPatch,
+    make_router,
+) -> None:
+    monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
+    router = make_router()
+    a = router.model_for("fast")
+    b = router.model_for("fast")
+    assert a is b
+
+
+def test_router_construction_validates_required_tiers(
+    db_path: Path,
+) -> None:
+    bad_cfg = {"tiers": {"fast": {"provider": "lmstudio", "model": "x", "timeout_s": 1}}}
+    budget = BudgetTracker("x", cap_usd=None, db_path=db_path)
+    with pytest.raises(ValueError, match="missing required tiers"):
+        Router(bad_cfg, budget, db_path=db_path)
+
+
+# ---------------------------------------------------------------------------
+# call(...) — budget interaction
+# ---------------------------------------------------------------------------
+
+
+class _RecordingBudget:
+    def __init__(self) -> None:
+        self.precheck_calls: list[str] = []
+        self.charge_calls: list[tuple[str, str, str, TokenUsage, float]] = []
+
+    def precheck(self, tier: str) -> None:
+        self.precheck_calls.append(tier)
+
+    def charge(
+        self,
+        tier: str,
+        provider: str,
+        model: str,
+        usage: TokenUsage,
+        cost_usd: float,
+    ) -> None:
+        self.charge_calls.append((tier, provider, model, usage, cost_usd))
+
+
+@pytest.mark.asyncio
+async def test_call_runs_precheck_and_charge_for_cloud(
+    monkeypatch: pytest.MonkeyPatch,
+    models_config: dict[str, Any],
+    db_path: Path,
+    job: Job,
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    budget = _RecordingBudget()
+    router = Router(models_config, budget, job=job, db_path=db_path)  # type: ignore[arg-type]
+
+    agent = _FakeAgent()
+    result = await router.call("frontier_speed", agent, "hello")
+
+    assert result is agent.result
+    assert budget.precheck_calls == ["frontier_speed"]
+    assert len(budget.charge_calls) == 1
+    tier, provider, model, usage, _cost = budget.charge_calls[0]
+    assert tier == "frontier_speed"
+    assert provider == "openrouter"
+    assert model == "anthropic/claude-haiku-4-5"
+    assert usage.input_tokens == 12
+    assert usage.output_tokens == 34
+    assert usage.cached_tokens == 5
+
+
+@pytest.mark.asyncio
+async def test_call_skips_budget_for_local(
+    monkeypatch: pytest.MonkeyPatch,
+    models_config: dict[str, Any],
+    db_path: Path,
+    job: Job,
+) -> None:
+    monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
+    budget = _RecordingBudget()
+    router = Router(models_config, budget, job=job, db_path=db_path)  # type: ignore[arg-type]
+
+    agent = _FakeAgent()
+    await router.call("fast", agent, "hello")
+
+    assert budget.precheck_calls == []
+    assert budget.charge_calls == []
+
+
+# ---------------------------------------------------------------------------
+# call(...) — fallback semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ratelimit_falls_back_to_fallback_model_for_cloud(
+    monkeypatch: pytest.MonkeyPatch,
+    models_config: dict[str, Any],
+    db_path: Path,
+    job: Job,
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    budget = _RecordingBudget()
+    router = Router(models_config, budget, job=job, db_path=db_path)  # type: ignore[arg-type]
+
+    fallback_agent = _FakeAgent(result=_FakeResult())
+    monkeypatch.setattr(
+        router,
+        "_make_fallback_agent",
+        lambda tier, fm: fallback_agent,
+    )
+
+    primary_agent = _FakeAgent(raises=[_rate_limit_error()])
+    result = await router.call("frontier", primary_agent, "synthesize this")
+
+    assert result is fallback_agent.result
+    assert len(primary_agent.calls) == 1
+    assert len(fallback_agent.calls) == 1
+
+    # llm_calls row should be tagged with the fallback model.
+    conn = db.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT model, tier, provider FROM llm_calls WHERE job_id = ?",
+            (job.id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    assert row["model"] == "openai/gpt-5"
+    assert row["tier"] == "frontier"
+    assert row["provider"] == "openrouter"
+
+    # Event payload should mark fallback_used=True.
+    events_path = job.root / "events.jsonl"
+    lines = [line for line in events_path.read_text().splitlines() if line]
+    payloads = [_json_payload(line) for line in lines if '"llm_call"' in line]
+    llm_call_payloads = [p for p in payloads if p is not None]
+    assert any(p.get("fallback_used") is True for p in llm_call_payloads)
+    assert any(p.get("model") == "openai/gpt-5" for p in llm_call_payloads)
+
+
+def _json_payload(line: str) -> dict[str, Any] | None:
+    import json as _json
+
+    try:
+        ev = _json.loads(line)
+    except _json.JSONDecodeError:
+        return None
+    if ev.get("kind") != "llm_call":
+        return None
+    payload = ev.get("payload")
+    return payload if isinstance(payload, dict) else None
+
+
+@pytest.mark.asyncio
+async def test_local_failure_does_not_silently_reroute_to_cloud(
+    monkeypatch: pytest.MonkeyPatch,
+    models_config: dict[str, Any],
+    db_path: Path,
+    job: Job,
+) -> None:
+    monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
+    budget = _RecordingBudget()
+    router = Router(models_config, budget, job=job, db_path=db_path)  # type: ignore[arg-type]
+
+    def _fail_if_called(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("fallback path must not run for lmstudio failures")
+
+    monkeypatch.setattr(router, "_make_fallback_agent", _fail_if_called)
+
+    boom = RuntimeError("LM Studio process crashed")
+    agent = _FakeAgent(raises=[boom])
+
+    with pytest.raises(RuntimeError, match="LM Studio process crashed"):
+        await router.call("general", agent, "extract")
+
+    # Nothing should have been charged or logged.
+    assert budget.charge_calls == []
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute("SELECT COUNT(*) FROM llm_calls WHERE job_id = ?", (job.id,)).fetchone()
+    finally:
+        conn.close()
+    assert rows[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_ratelimit_on_local_tier_reraises(
+    monkeypatch: pytest.MonkeyPatch,
+    models_config: dict[str, Any],
+    db_path: Path,
+    job: Job,
+) -> None:
+    monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
+    budget = _RecordingBudget()
+    router = Router(models_config, budget, job=job, db_path=db_path)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        router,
+        "_make_fallback_agent",
+        lambda *a, **k: pytest.fail("local tier must not invoke openrouter fallback"),
+    )
+
+    agent = _FakeAgent(raises=[_rate_limit_error()])
+    with pytest.raises(RateLimitError):
+        await router.call("fast", agent, "x")
+
+
+# ---------------------------------------------------------------------------
+# Timeouts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_tier_timeout_is_enforced(
+    monkeypatch: pytest.MonkeyPatch,
+    db_path: Path,
+    job: Job,
+) -> None:
+    monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
+    cfg = {
+        "tiers": {
+            t: {"provider": "lmstudio", "model": "stub", "timeout_s": 60} for t in EXPECTED_TIERS
+        }
+    }
+    # Clamp the tier we'll exercise to a tiny timeout.
+    cfg["tiers"]["fast"]["timeout_s"] = 0.05  # type: ignore[index]
+    budget = _RecordingBudget()
+    router = Router(cfg, budget, job=job, db_path=db_path)  # type: ignore[arg-type]
+
+    agent = _FakeAgent(sleep_s=1.0)
+    with pytest.raises(asyncio.TimeoutError):
+        await router.call("fast", agent, "slow")
+
+
+# ---------------------------------------------------------------------------
+# Ledger + event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_emits_llm_call_event_and_inserts_llm_calls_row(
+    monkeypatch: pytest.MonkeyPatch,
+    models_config: dict[str, Any],
+    db_path: Path,
+    job: Job,
+) -> None:
+    monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
+    budget = _RecordingBudget()
+    router = Router(models_config, budget, job=job, db_path=db_path)  # type: ignore[arg-type]
+
+    agent = _FakeAgent()
+    await router.call("general", agent, "summarize")
+
+    conn = db.connect(db_path)
+    try:
+        llm_rows = conn.execute(
+            "SELECT tier, provider, model, input_tokens, output_tokens, cached_tokens,"
+            " latency_ms, finish_reason FROM llm_calls WHERE job_id = ?",
+            (job.id,),
+        ).fetchall()
+        event_rows = conn.execute(
+            "SELECT kind, actor FROM events WHERE job_id = ? AND kind = 'llm_call'",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert len(llm_rows) == 1
+    row = llm_rows[0]
+    assert row["tier"] == "general"
+    assert row["provider"] == "lmstudio"
+    assert row["model"] == "qwen3-32b-instruct-q6_k"
+    assert row["input_tokens"] == 12
+    assert row["output_tokens"] == 34
+    assert row["cached_tokens"] == 5
+    assert row["latency_ms"] >= 0
+    assert row["finish_reason"] == "stop"
+
+    assert len(event_rows) == 1
+    assert event_rows[0]["kind"] == "llm_call"
+    assert event_rows[0]["actor"] == "router"
+
+
+# ---------------------------------------------------------------------------
+# BudgetTracker
+# ---------------------------------------------------------------------------
+
+
+def test_budget_precheck_raises_when_cap_reached(db_path: Path) -> None:
+    from research_agent.llm.budgets import BudgetExceeded
+
+    bt = BudgetTracker("budget-1", cap_usd=1.0, db_path=db_path)
+    bt.spent = 1.0
+    with pytest.raises(BudgetExceeded):
+        bt.precheck("frontier")
+
+
+def test_budget_precheck_no_cap_is_noop(db_path: Path) -> None:
+    bt = BudgetTracker("budget-2", cap_usd=None, db_path=db_path)
+    bt.spent = 999.0
+    bt.precheck("frontier")  # must not raise
+
+
+def test_budget_rehydrates_running_total_from_ledger(job: Job, db_path: Path) -> None:
+    conn = db.connect(db_path)
+    try:
+        with conn:
+            conn.execute(
+                "INSERT INTO llm_calls ("
+                " job_id, ts, tier, provider, model, cost_usd"
+                ") VALUES (?, ?, ?, ?, ?, ?)",
+                (job.id, 1, "frontier", "openrouter", "anthropic/claude-opus-4-7", 1.5),
+            )
+            conn.execute(
+                "INSERT INTO llm_calls ("
+                " job_id, ts, tier, provider, model, cost_usd"
+                ") VALUES (?, ?, ?, ?, ?, ?)",
+                (job.id, 2, "frontier", "openrouter", "anthropic/claude-opus-4-7", 0.75),
+            )
+    finally:
+        conn.close()
+
+    bt = BudgetTracker(job.id, cap_usd=10.0, db_path=db_path)
+    assert bt.spent == pytest.approx(2.25)
+
+
+def test_budget_charge_only_bumps_in_memory(db_path: Path) -> None:
+    bt = BudgetTracker("ledger-1", cap_usd=10.0, db_path=db_path)
+    usage = TokenUsage(input_tokens=10, output_tokens=20)
+    bt.charge("frontier", "openrouter", "anthropic/claude-opus-4-7", usage, 0.5)
+    assert bt.spent == pytest.approx(0.5)
+
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM llm_calls WHERE job_id = ?", ("ledger-1",)
+        ).fetchone()
+    finally:
+        conn.close()
+    # Router is the single writer of the ledger; charge() must not.
+    assert rows[0] == 0


### PR DESCRIPTION
Closes #9

## Summary

Automated implementation of **LLM router with tier→provider mapping (llm/router.py)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Router meets all acceptance criteria: tier→provider mapping, base_url/api_key wiring, missing-key error, budget precheck/charge for cloud only, RateLimitError fallback (cloud-only), per-tier asyncio.wait_for timeout, llm_calls ledger row + llm_call event, all 8 §8.1 tiers shipped. 19 router tests + 180 total tests pass.

- **INFO** [OPEN] `src/research_agent/llm/router.py`: Pydantic AI emits a DeprecationWarning: OpenAIModel was renamed to OpenAIChatModel. Issue spec uses 'OpenAIModel' literally and the alias still works, so this is not blocking — flag for a future minor cleanup when other call sites migrate.
- **INFO** [OPEN] `src/research_agent/llm/router.py`: router.call() emits the llm_call event only when self.job is not None; the SQL ledger row is always written. Production paths will always pass a job (Router is constructed per-job), so this matches the acceptance criterion in practice. Worth a follow-up if a job-less call site appears.
- **INFO** [OPEN] `src/research_agent/llm/router.py`: cost_usd is hardcoded to 0.0 in router._record_call with an explicit comment that pricing computation lands in a later issue. BudgetTracker.charge takes cost_usd from the caller, so the contract is in place — only the price book is missing. Intentional scope deferral, consistent with project conventions.
- **INFO** [OPEN] `src/research_agent/orchestrator/__init__.py`: Router is not yet imported by any non-test module (orchestrator/__init__.py is empty). Expected for issue #9 scope — orchestrator wiring belongs to a later issue.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*