### PR TITLE
feat: BudgetTracker with hard cap enforcement (llm/budgets.py) (closes #10)

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -66,3 +66,18 @@ tiers:
     purpose: |
       Fast cloud calls when a local model isn't enough but Opus is
       overkill. Adaptive intake follow-ups, micro-summaries.
+
+# Per-cloud-tier list prices (USD per 1M tokens). Manually maintained — the
+# OpenRouter pricing API is a future-deps item. Update whenever the upstream
+# provider changes a list price; `BudgetTracker.charge` reads this block to
+# compute cost from token counts. Local tiers omit pricing (cost is $0).
+pricing:
+  frontier:
+    input_usd_per_mtok: 15.00
+    output_usd_per_mtok: 75.00
+  frontier_alt:
+    input_usd_per_mtok: 0.60
+    output_usd_per_mtok: 2.50
+  frontier_speed:
+    input_usd_per_mtok: 1.00
+    output_usd_per_mtok: 5.00

--- a/src/research_agent/llm/budgets.py
+++ b/src/research_agent/llm/budgets.py
@@ -1,27 +1,31 @@
 """Per-job cost cap enforcement (implementation guide §9).
 
-This module exposes the minimal contract the LLM router depends on:
+This module is the single point of truth for cloud LLM spend on a job:
 
 - :class:`TokenUsage` — provider-agnostic shape for the numbers we ledger.
 - :class:`BudgetExceeded` — raised by ``precheck()`` once the cap is hit.
 - :class:`BudgetTracker` — ``precheck()`` before cloud calls, ``charge()`` after.
 
-The full per-model cost table lives in ``config/models.yaml`` and will be
-consumed by a richer pricing implementation in a later issue. For now
-``charge()`` accepts an explicit ``cost_usd`` from the caller and bumps the
-in-memory running total. The :mod:`router` is the single writer of the
-``llm_calls`` ledger row, so a cloud call produces exactly one row no matter
-which path it took. ``BudgetTracker`` re-hydrates its running total from that
-ledger at construction so a daemon that restarts mid-run picks up where it
-left off.
+The pricing block lives in ``config/models.yaml`` (manually maintained — the
+OpenRouter pricing API is a future-deps item). ``charge()`` reads it to
+compute cost from ``usage`` and is the single writer of the cloud
+``llm_calls`` row plus the ``jobs.cost_so_far_usd`` running total. The
+:mod:`router` no longer writes the ledger for cloud tiers; that lives here
+so the cap stays consistent across crashes and restarts. ``BudgetTracker``
+re-hydrates ``spent`` from ``jobs.cost_so_far_usd`` at construction.
 """
 
 from __future__ import annotations
 
+import logging
+import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from research_agent.storage import db
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -49,8 +53,8 @@ class BudgetTracker:
     """Track per-job cloud spend and enforce a USD cap.
 
     ``cap_usd`` of ``None`` disables enforcement (precheck always passes).
-    State is loaded from the ``llm_calls`` ledger at construction so a daemon
-    that restarts mid-run picks up the same running total.
+    State is loaded from ``jobs.cost_so_far_usd`` at construction so a
+    daemon that restarts mid-run picks up the same running total.
     """
 
     def __init__(
@@ -58,49 +62,116 @@ class BudgetTracker:
         job_id: str,
         cap_usd: float | None,
         *,
+        pricing: dict[str, dict[str, Any]] | None = None,
         db_path: Path | str | None = None,
     ) -> None:
         self.job_id = job_id
         self.cap = cap_usd
+        self.pricing: dict[str, dict[str, Any]] = pricing or {}
         self.db_path = Path(db_path) if db_path is not None else db.DEFAULT_DB_PATH
         self.spent = self._load_from_db()
+        self.last_cost: float = 0.0
+        self._warned_90pct = False
 
     def _load_from_db(self) -> float:
         conn = db.connect(self.db_path)
         try:
             row = conn.execute(
-                "SELECT COALESCE(SUM(cost_usd), 0) FROM llm_calls WHERE job_id = ?",
+                "SELECT cost_so_far_usd FROM jobs WHERE id = ?",
                 (self.job_id,),
             ).fetchone()
         finally:
             conn.close()
-        if row is None:
+        if row is None or row[0] is None:
             return 0.0
-        return float(row[0] or 0.0)
+        return float(row[0])
 
     def precheck(self, tier: str) -> None:  # noqa: ARG002 — tier reserved for future per-tier caps
-        """Raise :class:`BudgetExceeded` if the running total has reached the cap."""
+        """Raise :class:`BudgetExceeded` if the running total has reached the cap.
+
+        Logs a single ``WARNING`` once spend crosses 90% of the cap so an
+        operator tailing logs gets a heads-up before enforcement bites.
+        """
         if self.cap is None:
             return
         if self.spent >= self.cap:
             raise BudgetExceeded(self.job_id, self.spent, self.cap)
+        if not self._warned_90pct and self.spent >= 0.9 * self.cap:
+            logger.warning(
+                "budget at 90%% for job %r: $%.4f / $%.4f",
+                self.job_id,
+                self.spent,
+                self.cap,
+            )
+            self._warned_90pct = True
 
     def charge(
         self,
-        tier: str,  # noqa: ARG002 — tier reserved for future per-tier accounting
-        provider: str,  # noqa: ARG002 — same
-        model: str,  # noqa: ARG002 — same
-        usage: TokenUsage,  # noqa: ARG002 — same
-        cost_usd: float,
-    ) -> None:
-        """Bump the in-memory running total by ``cost_usd``.
+        tier: str,
+        provider: str,
+        model: str,
+        usage: TokenUsage,
+    ) -> float:
+        """Compute cost from ``pricing`` block, ledger one row, bump running total.
 
-        The :mod:`router` writes the actual ``llm_calls`` ledger row so the
-        ledger has exactly one row per call. Keeping this in-memory makes
-        ``precheck`` cheap and lets the cap survive a daemon restart by
-        reloading from the ledger in :meth:`__init__`.
+        Inserts one row into ``llm_calls`` and updates ``jobs.cost_so_far_usd``
+        in a single transaction so the rehydratable total never drifts from
+        the per-call ledger. Returns the priced cost for the caller to embed
+        in observability events.
         """
-        self.spent += cost_usd
+        cost = self._compute_cost(tier, usage)
+        new_total = self.spent + cost
+        ts = int(time.time())
+
+        conn = db.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    "INSERT INTO llm_calls ("
+                    " job_id, ts, tier, provider, model,"
+                    " input_tokens, output_tokens, cached_tokens,"
+                    " latency_ms, cost_usd, finish_reason"
+                    ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        self.job_id,
+                        ts,
+                        tier,
+                        provider,
+                        model,
+                        usage.input_tokens,
+                        usage.output_tokens,
+                        usage.cached_tokens,
+                        usage.latency_ms,
+                        cost,
+                        usage.finish_reason,
+                    ),
+                )
+                conn.execute(
+                    "UPDATE jobs SET cost_so_far_usd = ? WHERE id = ?",
+                    (new_total, self.job_id),
+                )
+        finally:
+            conn.close()
+
+        self.spent = new_total
+        self.last_cost = cost
+        return cost
+
+    def _compute_cost(self, tier: str, usage: TokenUsage) -> float:
+        block = self.pricing.get(tier)
+        if not block:
+            logger.warning("no pricing for tier %r; charging $0.00 for this call", tier)
+            return 0.0
+        try:
+            input_rate = float(block.get("input_usd_per_mtok") or 0.0)
+            output_rate = float(block.get("output_usd_per_mtok") or 0.0)
+        except (TypeError, ValueError):
+            logger.warning("unparseable pricing for tier %r: %r; charging $0.00", tier, block)
+            return 0.0
+        if input_rate <= 0.0 and output_rate <= 0.0:
+            logger.warning("zero pricing for tier %r; charging $0.00 for this call", tier)
+            return 0.0
+        return (usage.input_tokens * input_rate + usage.output_tokens * output_rate) / 1_000_000
 
 
 __all__ = ["BudgetExceeded", "BudgetTracker", "TokenUsage"]

--- a/src/research_agent/llm/router.py
+++ b/src/research_agent/llm/router.py
@@ -211,12 +211,14 @@ class Router:
     ) -> Any:
         """Run ``agent.run(*args, **kwargs)`` for ``tier`` with full bookkeeping.
 
-        - precheck/charge the budget for cloud tiers
+        - precheck the budget for cloud tiers; ``charge`` is the single
+          writer of the cloud ``llm_calls`` row + ``jobs.cost_so_far_usd``
+        - for local tiers the router writes the ledger row directly with
+          cost ``0.0`` (no budget enforcement)
         - enforce the per-tier ``timeout_s`` via :func:`asyncio.wait_for`
         - on :class:`openai.RateLimitError` for a cloud tier with a configured
           ``fallback_model``, retry once on the fallback model
-        - write one row to ``llm_calls`` and emit one ``llm_call`` event
-          regardless of provider (so the ledger covers local calls too)
+        - emit exactly one ``llm_call`` event regardless of provider
 
         Local-tier failures are *not* silently rerouted to cloud (per §16);
         the original exception propagates to the caller.
@@ -247,15 +249,19 @@ class Router:
 
         latency_ms = int((time.perf_counter() - t0) * 1000)
         usage = _extract_usage(result, latency_ms)
-        # Cost computation lives in a later issue; the ledger schema already
-        # has the column, so we record 0.0 for now and let `BudgetTracker`
-        # handle the running total once pricing lands.
-        cost_usd = 0.0
 
         if is_cloud:
-            self.budget.charge(tier, provider, model_name, usage, cost_usd)
+            cost_usd = self.budget.charge(tier, provider, model_name, usage)
+        else:
+            cost_usd = 0.0
+            self._record_local_call(
+                tier=tier,
+                provider=provider,
+                model=model_name,
+                usage=usage,
+            )
 
-        self._record_call(
+        self._emit_llm_call_event(
             tier=tier,
             provider=provider,
             model=model_name,
@@ -286,16 +292,15 @@ class Router:
             return self.job.db_path
         return db.DEFAULT_DB_PATH
 
-    def _record_call(
+    def _record_local_call(
         self,
         *,
         tier: str,
         provider: str,
         model: str,
         usage: TokenUsage,
-        cost_usd: float,
-        fallback_used: bool,
     ) -> None:
+        """Write the ``llm_calls`` row for a local-tier call (cost = 0)."""
         ts = int(time.time())
         job_id = self.job.id if self.job is not None else None
         db_path = self._resolve_db_path()
@@ -319,36 +324,47 @@ class Router:
                         usage.output_tokens,
                         usage.cached_tokens,
                         usage.latency_ms,
-                        cost_usd,
+                        0.0,
                         usage.finish_reason,
                     ),
                 )
         finally:
             conn.close()
 
-        if self.job is not None:
-            payload = {
-                "tier": tier,
-                "provider": provider,
-                "model": model,
-                "latency_ms": usage.latency_ms,
-                "input_tokens": usage.input_tokens,
-                "output_tokens": usage.output_tokens,
-                "cost_usd": cost_usd,
-                "finish_reason": usage.finish_reason,
-                "fallback_used": fallback_used,
-            }
-            # Round-trip through json so the payload always contains JSON-safe
-            # primitives — `emit` re-serializes in the SQL mirror.
-            payload = json.loads(json.dumps(payload, default=str))
-            emit(
-                self.job,
-                "INFO",
-                "router",
-                "llm_call",
-                payload,
-                db_path=db_path,
-            )
+    def _emit_llm_call_event(
+        self,
+        *,
+        tier: str,
+        provider: str,
+        model: str,
+        usage: TokenUsage,
+        cost_usd: float,
+        fallback_used: bool,
+    ) -> None:
+        if self.job is None:
+            return
+        payload = {
+            "tier": tier,
+            "provider": provider,
+            "model": model,
+            "latency_ms": usage.latency_ms,
+            "input_tokens": usage.input_tokens,
+            "output_tokens": usage.output_tokens,
+            "cost_usd": cost_usd,
+            "finish_reason": usage.finish_reason,
+            "fallback_used": fallback_used,
+        }
+        # Round-trip through json so the payload always contains JSON-safe
+        # primitives — `emit` re-serializes in the SQL mirror.
+        payload = json.loads(json.dumps(payload, default=str))
+        emit(
+            self.job,
+            "INFO",
+            "router",
+            "llm_call",
+            payload,
+            db_path=self._resolve_db_path(),
+        )
 
 
 __all__ = [

--- a/tests/test_llm_budgets.py
+++ b/tests/test_llm_budgets.py
@@ -1,0 +1,255 @@
+"""Focused tests for ``research_agent.llm.budgets``.
+
+The router has its own integration tests in ``test_llm_router.py``; this
+file pins the BudgetTracker contract directly: precheck/charge math,
+ledger + ``jobs.cost_so_far_usd`` dual write, the 90% warning threshold,
+graceful degradation when pricing is missing, and the boundary behavior
+the daemon depends on (a charge that lands exactly on the cap must trip
+the *next* precheck, not the current call).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from research_agent.llm.budgets import (
+    BudgetExceeded,
+    BudgetTracker,
+    TokenUsage,
+)
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+
+PRICING = {
+    "frontier": {"input_usd_per_mtok": 10.0, "output_usd_per_mtok": 30.0},
+    "frontier_speed": {"input_usd_per_mtok": 1.0, "output_usd_per_mtok": 5.0},
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "index.sqlite"
+    db.migrate(path=path).close()
+    return path
+
+
+@pytest.fixture
+def jobs_root(tmp_path: Path) -> Path:
+    return tmp_path / "jobs"
+
+
+@pytest.fixture
+def job(jobs_root: Path, db_path: Path) -> Job:
+    return Job.create(
+        {"goal": "Investigate budget tracker"},
+        jobs_root=jobs_root,
+        db_path=db_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# precheck — no cap, pre-cap, boundary, post-cap
+# ---------------------------------------------------------------------------
+
+
+def test_precheck_no_cap_disables_enforcement(job: Job, db_path: Path) -> None:
+    bt = BudgetTracker(job.id, cap_usd=None, pricing=PRICING, db_path=db_path)
+    bt.spent = 999_999.99
+    bt.precheck("frontier")  # must not raise
+
+
+def test_precheck_passes_below_cap(job: Job, db_path: Path) -> None:
+    bt = BudgetTracker(job.id, cap_usd=1.00, pricing=PRICING, db_path=db_path)
+    bt.spent = 0.50
+    bt.precheck("frontier")
+
+
+def test_charge_landing_exactly_on_cap_trips_next_precheck(job: Job, db_path: Path) -> None:
+    """A charge that hits the cap exactly is allowed; the *next* precheck blocks."""
+    cap = 0.30  # = 10*10/1e6 + 30000*30/1e6 below — tuned by usage.
+    bt = BudgetTracker(job.id, cap_usd=cap, pricing=PRICING, db_path=db_path)
+
+    # Spend exactly $0.30 in one call: 30,000 input @ $10/Mtok ($0.30 input only).
+    usage = TokenUsage(input_tokens=30_000, output_tokens=0)
+    cost = bt.charge("frontier", "openrouter", "model-a", usage)
+    assert cost == pytest.approx(0.30)
+    assert bt.spent == pytest.approx(cap)
+
+    with pytest.raises(BudgetExceeded) as ei:
+        bt.precheck("frontier")
+    assert ei.value.spent == pytest.approx(cap)
+    assert ei.value.cap == pytest.approx(cap)
+
+
+def test_precheck_post_cap_continues_to_raise(job: Job, db_path: Path) -> None:
+    bt = BudgetTracker(job.id, cap_usd=1.0, pricing=PRICING, db_path=db_path)
+    bt.spent = 5.0
+    with pytest.raises(BudgetExceeded):
+        bt.precheck("frontier")
+    # Re-checking does not magically reset.
+    with pytest.raises(BudgetExceeded):
+        bt.precheck("frontier_speed")
+
+
+# ---------------------------------------------------------------------------
+# 90% warning
+# ---------------------------------------------------------------------------
+
+
+def test_precheck_emits_single_90pct_warning(
+    job: Job, db_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    bt = BudgetTracker(job.id, cap_usd=1.0, pricing=PRICING, db_path=db_path)
+    bt.spent = 0.95  # >= 90% but below cap
+
+    caplog.set_level(logging.WARNING, logger="research_agent.llm.budgets")
+    bt.precheck("frontier")  # must not raise
+    bt.precheck("frontier")  # second call must not re-emit
+    bt.precheck("frontier")
+
+    warnings = [r for r in caplog.records if "90%%" in r.msg or "90%" in r.msg]
+    assert len(warnings) == 1
+    assert bt._warned_90pct is True
+
+
+def test_precheck_does_not_warn_below_90pct(
+    job: Job, db_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    bt = BudgetTracker(job.id, cap_usd=1.0, pricing=PRICING, db_path=db_path)
+    bt.spent = 0.5
+    caplog.set_level(logging.WARNING, logger="research_agent.llm.budgets")
+    bt.precheck("frontier")
+    assert not [r for r in caplog.records if "90%%" in r.msg or "90%" in r.msg]
+    assert bt._warned_90pct is False
+
+
+# ---------------------------------------------------------------------------
+# charge — math, dual write, missing pricing
+# ---------------------------------------------------------------------------
+
+
+def test_charge_cost_math_matches_formula(job: Job, db_path: Path) -> None:
+    bt = BudgetTracker(job.id, cap_usd=10.0, pricing=PRICING, db_path=db_path)
+    usage = TokenUsage(input_tokens=1234, output_tokens=5678)
+    cost = bt.charge("frontier_speed", "openrouter", "haiku", usage)
+    expected = (1234 * 1.0 + 5678 * 5.0) / 1_000_000
+    assert cost == pytest.approx(expected, abs=1e-9)
+    assert round(cost, 6) == round(expected, 6)
+
+
+def test_charge_persists_ledger_row_and_jobs_total_in_one_transaction(
+    job: Job, db_path: Path
+) -> None:
+    bt = BudgetTracker(job.id, cap_usd=10.0, pricing=PRICING, db_path=db_path)
+    usage = TokenUsage(input_tokens=100_000, output_tokens=50_000, latency_ms=42)
+    cost = bt.charge("frontier", "openrouter", "claude-opus", usage)
+
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT tier, provider, model, input_tokens, output_tokens,"
+            " latency_ms, cost_usd FROM llm_calls WHERE job_id = ?",
+            (job.id,),
+        ).fetchall()
+        cost_so_far = conn.execute(
+            "SELECT cost_so_far_usd FROM jobs WHERE id = ?", (job.id,)
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["tier"] == "frontier"
+    assert row["provider"] == "openrouter"
+    assert row["model"] == "claude-opus"
+    assert row["input_tokens"] == 100_000
+    assert row["output_tokens"] == 50_000
+    assert row["latency_ms"] == 42
+    assert row["cost_usd"] == pytest.approx(cost)
+    assert cost_so_far == pytest.approx(cost)
+
+
+def test_charge_unknown_tier_logs_warning_and_records_zero_cost(
+    job: Job, db_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    bt = BudgetTracker(job.id, cap_usd=10.0, pricing=PRICING, db_path=db_path)
+    usage = TokenUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+
+    caplog.set_level(logging.WARNING, logger="research_agent.llm.budgets")
+    cost = bt.charge("mystery_tier", "openrouter", "unknown-model", usage)
+
+    assert cost == 0.0
+    assert bt.spent == 0.0
+    assert any(
+        "no pricing for tier" in (r.getMessage() if hasattr(r, "getMessage") else r.msg)
+        for r in caplog.records
+    )
+
+    # Row still landed; the run kept going.
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute("SELECT cost_usd FROM llm_calls WHERE job_id = ?", (job.id,)).fetchall()
+        cost_so_far = conn.execute(
+            "SELECT cost_so_far_usd FROM jobs WHERE id = ?", (job.id,)
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    assert rows[0]["cost_usd"] == 0.0
+    assert cost_so_far == 0.0
+
+
+def test_charge_zero_pricing_logs_warning_and_records_zero_cost(
+    job: Job, db_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    pricing = {"frontier": {"input_usd_per_mtok": 0.0, "output_usd_per_mtok": 0.0}}
+    bt = BudgetTracker(job.id, cap_usd=1.0, pricing=pricing, db_path=db_path)
+    usage = TokenUsage(input_tokens=10_000_000, output_tokens=10_000_000)
+
+    caplog.set_level(logging.WARNING, logger="research_agent.llm.budgets")
+    cost = bt.charge("frontier", "openrouter", "claude-opus", usage)
+    assert cost == 0.0
+    assert any("zero pricing" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# rehydration
+# ---------------------------------------------------------------------------
+
+
+def test_rehydrate_picks_up_jobs_cost_so_far_usd(job: Job, db_path: Path) -> None:
+    conn = db.connect(db_path)
+    try:
+        with conn:
+            conn.execute(
+                "UPDATE jobs SET cost_so_far_usd = ? WHERE id = ?",
+                (3.14, job.id),
+            )
+    finally:
+        conn.close()
+
+    bt = BudgetTracker(job.id, cap_usd=10.0, pricing=PRICING, db_path=db_path)
+    assert bt.spent == pytest.approx(3.14)
+
+
+def test_rehydrate_with_missing_job_row_starts_at_zero(db_path: Path) -> None:
+    bt = BudgetTracker("nonexistent-job", cap_usd=10.0, pricing=PRICING, db_path=db_path)
+    assert bt.spent == 0.0
+
+
+def test_charge_then_rehydrate_preserves_total(job: Job, db_path: Path) -> None:
+    """A daemon that crashes after charge() must see the same running total on restart."""
+    bt = BudgetTracker(job.id, cap_usd=10.0, pricing=PRICING, db_path=db_path)
+    usage = TokenUsage(input_tokens=500_000, output_tokens=200_000)
+    cost = bt.charge("frontier", "openrouter", "claude-opus", usage)
+
+    bt2 = BudgetTracker(job.id, cap_usd=10.0, pricing=PRICING, db_path=db_path)
+    assert bt2.spent == pytest.approx(cost)

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from pathlib import Path
 from typing import Any
 
@@ -263,9 +264,26 @@ def test_router_construction_validates_required_tiers(
 
 
 class _RecordingBudget:
-    def __init__(self) -> None:
+    """Test double for :class:`BudgetTracker`.
+
+    Mirrors the production contract: ``charge`` returns the priced cost and
+    is the single writer of the cloud ``llm_calls`` row, so cloud-tier tests
+    that assert ledger state see exactly what production would emit.
+    """
+
+    def __init__(
+        self,
+        *,
+        cost_per_call: float = 0.0,
+        db_path: Path | None = None,
+        job_id: str | None = None,
+    ) -> None:
         self.precheck_calls: list[str] = []
-        self.charge_calls: list[tuple[str, str, str, TokenUsage, float]] = []
+        self.charge_calls: list[tuple[str, str, str, TokenUsage]] = []
+        self._cost = cost_per_call
+        self._db_path = db_path
+        self._job_id = job_id
+        self.last_cost: float = 0.0
 
     def precheck(self, tier: str) -> None:
         self.precheck_calls.append(tier)
@@ -276,9 +294,38 @@ class _RecordingBudget:
         provider: str,
         model: str,
         usage: TokenUsage,
-        cost_usd: float,
-    ) -> None:
-        self.charge_calls.append((tier, provider, model, usage, cost_usd))
+    ) -> float:
+        self.charge_calls.append((tier, provider, model, usage))
+        cost = self._cost
+        if self._db_path is not None and self._job_id is not None:
+            ts = int(time.time())
+            conn = db.connect(self._db_path)
+            try:
+                with conn:
+                    conn.execute(
+                        "INSERT INTO llm_calls ("
+                        " job_id, ts, tier, provider, model,"
+                        " input_tokens, output_tokens, cached_tokens,"
+                        " latency_ms, cost_usd, finish_reason"
+                        ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        (
+                            self._job_id,
+                            ts,
+                            tier,
+                            provider,
+                            model,
+                            usage.input_tokens,
+                            usage.output_tokens,
+                            usage.cached_tokens,
+                            usage.latency_ms,
+                            cost,
+                            usage.finish_reason,
+                        ),
+                    )
+            finally:
+                conn.close()
+        self.last_cost = cost
+        return cost
 
 
 @pytest.mark.asyncio
@@ -298,7 +345,7 @@ async def test_call_runs_precheck_and_charge_for_cloud(
     assert result is agent.result
     assert budget.precheck_calls == ["frontier_speed"]
     assert len(budget.charge_calls) == 1
-    tier, provider, model, usage, _cost = budget.charge_calls[0]
+    tier, provider, model, usage = budget.charge_calls[0]
     assert tier == "frontier_speed"
     assert provider == "openrouter"
     assert model == "anthropic/claude-haiku-4-5"
@@ -338,8 +385,13 @@ async def test_ratelimit_falls_back_to_fallback_model_for_cloud(
     job: Job,
 ) -> None:
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
-    budget = _RecordingBudget()
-    router = Router(models_config, budget, job=job, db_path=db_path)  # type: ignore[arg-type]
+    budget = BudgetTracker(
+        job.id,
+        cap_usd=None,
+        pricing=models_config.get("pricing"),
+        db_path=db_path,
+    )
+    router = Router(models_config, budget, job=job, db_path=db_path)
 
     fallback_agent = _FakeAgent(result=_FakeResult())
     monkeypatch.setattr(
@@ -355,11 +407,12 @@ async def test_ratelimit_falls_back_to_fallback_model_for_cloud(
     assert len(primary_agent.calls) == 1
     assert len(fallback_agent.calls) == 1
 
-    # llm_calls row should be tagged with the fallback model.
+    # llm_calls row should be tagged with the fallback model and carry the
+    # priced cost computed from frontier-tier rates.
     conn = db.connect(db_path)
     try:
         row = conn.execute(
-            "SELECT model, tier, provider FROM llm_calls WHERE job_id = ?",
+            "SELECT model, tier, provider, cost_usd FROM llm_calls WHERE job_id = ?",
             (job.id,),
         ).fetchone()
     finally:
@@ -368,6 +421,11 @@ async def test_ratelimit_falls_back_to_fallback_model_for_cloud(
     assert row["model"] == "openai/gpt-5"
     assert row["tier"] == "frontier"
     assert row["provider"] == "openrouter"
+    pricing = models_config["pricing"]["frontier"]
+    expected_cost = (
+        12 * float(pricing["input_usd_per_mtok"]) + 34 * float(pricing["output_usd_per_mtok"])
+    ) / 1_000_000
+    assert row["cost_usd"] == pytest.approx(expected_cost)
 
     # Event payload should mark fallback_used=True.
     events_path = job.root / "events.jsonl"
@@ -541,21 +599,13 @@ def test_budget_precheck_no_cap_is_noop(db_path: Path) -> None:
     bt.precheck("frontier")  # must not raise
 
 
-def test_budget_rehydrates_running_total_from_ledger(job: Job, db_path: Path) -> None:
+def test_budget_rehydrates_running_total_from_jobs_row(job: Job, db_path: Path) -> None:
     conn = db.connect(db_path)
     try:
         with conn:
             conn.execute(
-                "INSERT INTO llm_calls ("
-                " job_id, ts, tier, provider, model, cost_usd"
-                ") VALUES (?, ?, ?, ?, ?, ?)",
-                (job.id, 1, "frontier", "openrouter", "anthropic/claude-opus-4-7", 1.5),
-            )
-            conn.execute(
-                "INSERT INTO llm_calls ("
-                " job_id, ts, tier, provider, model, cost_usd"
-                ") VALUES (?, ?, ?, ?, ?, ?)",
-                (job.id, 2, "frontier", "openrouter", "anthropic/claude-opus-4-7", 0.75),
+                "UPDATE jobs SET cost_so_far_usd = ? WHERE id = ?",
+                (2.25, job.id),
             )
     finally:
         conn.close()
@@ -564,18 +614,27 @@ def test_budget_rehydrates_running_total_from_ledger(job: Job, db_path: Path) ->
     assert bt.spent == pytest.approx(2.25)
 
 
-def test_budget_charge_only_bumps_in_memory(db_path: Path) -> None:
-    bt = BudgetTracker("ledger-1", cap_usd=10.0, db_path=db_path)
-    usage = TokenUsage(input_tokens=10, output_tokens=20)
-    bt.charge("frontier", "openrouter", "anthropic/claude-opus-4-7", usage, 0.5)
-    assert bt.spent == pytest.approx(0.5)
+def test_budget_charge_persists_to_ledger_and_jobs_total(job: Job, db_path: Path) -> None:
+    pricing = {
+        "frontier": {"input_usd_per_mtok": 10.0, "output_usd_per_mtok": 30.0},
+    }
+    bt = BudgetTracker(job.id, cap_usd=10.0, pricing=pricing, db_path=db_path)
+    usage = TokenUsage(input_tokens=1_000_000, output_tokens=500_000)
+    cost = bt.charge("frontier", "openrouter", "anthropic/claude-opus-4-7", usage)
+
+    expected = 1_000_000 * 10.0 / 1_000_000 + 500_000 * 30.0 / 1_000_000
+    assert cost == pytest.approx(expected)
+    assert bt.spent == pytest.approx(expected)
 
     conn = db.connect(db_path)
     try:
-        rows = conn.execute(
-            "SELECT COUNT(*) FROM llm_calls WHERE job_id = ?", ("ledger-1",)
-        ).fetchone()
+        rows = conn.execute("SELECT cost_usd FROM llm_calls WHERE job_id = ?", (job.id,)).fetchall()
+        cost_so_far = conn.execute(
+            "SELECT cost_so_far_usd FROM jobs WHERE id = ?", (job.id,)
+        ).fetchone()[0]
     finally:
         conn.close()
-    # Router is the single writer of the ledger; charge() must not.
-    assert rows[0] == 0
+    # charge() is the single writer of the cloud ledger row.
+    assert len(rows) == 1
+    assert rows[0]["cost_usd"] == pytest.approx(expected)
+    assert cost_so_far == pytest.approx(expected)


### PR DESCRIPTION
Closes #10

## Summary

Automated implementation of **BudgetTracker with hard cap enforcement (llm/budgets.py)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

BudgetTracker meets all acceptance criteria — pricing-driven charge() with atomic ledger+jobs.cost_so_far_usd write, precheck with 90% one-shot warning, graceful $0 fallback for missing/zero/unparseable pricing, rehydration on restart, and 13 focused tests covering boundary/pre-cap/post-cap. Full suite (193 tests) passes.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*