### PR TITLE
feat: LLM response cache (llm/cache.py) backed by SQLite (closes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ research logs <job-id> -f          # follow appended events
 research logs <job-id> --level ERROR
 ```
 
+### Config verbs
+
+```bash
+research config cache-clear        # wipe data/llm_cache.sqlite (LLM response cache)
+```
+
+The LLM response cache lives in its own SQLite file (`data/llm_cache.sqlite`),
+keyed on `(provider, model, prompt, sampling-params, tool-defs)` with a 30-day
+default TTL. The router opts in per call (`cache=True`) — deterministic
+extractions opt in, exploratory synthesis opts out. `cache-clear` removes the
+file (and its `-wal`/`-shm` sidecars) without touching the main index DB.
+
 The interactive intake (`research start` without `--skip-intake`) lands in a
 later issue; until then `--skip-intake --goal "..."` is the supported entry
 point and the testing back door used throughout phases 1–4.

--- a/src/research_agent/cli.py
+++ b/src/research_agent/cli.py
@@ -25,6 +25,22 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
+config_app = typer.Typer(
+    name="config",
+    help="Configuration / state management commands.",
+    no_args_is_help=True,
+)
+app.add_typer(config_app)
+
+
+@config_app.command(name="cache-clear")
+def cache_clear_command() -> None:
+    """Wipe the LLM response cache file."""
+    from research_agent.llm.cache import DEFAULT_CACHE_PATH, LLMCache
+
+    LLMCache.wipe_file(DEFAULT_CACHE_PATH)
+    typer.echo(f"cleared {DEFAULT_CACHE_PATH}")
+
 
 def _version_callback(value: bool) -> None:
     if value:

--- a/src/research_agent/llm/__init__.py
+++ b/src/research_agent/llm/__init__.py
@@ -1,6 +1,7 @@
 """LLM clients, routing, budget enforcement, and response cache (implementation guide §4)."""
 
 from .budgets import BudgetExceeded, BudgetTracker, TokenUsage
+from .cache import DEFAULT_CACHE_PATH, DEFAULT_TTL_SECONDS, LLMCache, make_key
 from .router import (
     EXPECTED_TIERS,
     LMSTUDIO_DEFAULT_BASE_URL,
@@ -11,8 +12,11 @@ from .router import (
 )
 
 __all__ = [
+    "DEFAULT_CACHE_PATH",
+    "DEFAULT_TTL_SECONDS",
     "EXPECTED_TIERS",
     "LMSTUDIO_DEFAULT_BASE_URL",
+    "LLMCache",
     "OPENROUTER_BASE_URL",
     "BudgetExceeded",
     "BudgetTracker",
@@ -20,4 +24,5 @@ __all__ = [
     "Tier",
     "TokenUsage",
     "load_models_config",
+    "make_key",
 ]

--- a/src/research_agent/llm/cache.py
+++ b/src/research_agent/llm/cache.py
@@ -1,0 +1,172 @@
+"""LLM response cache (implementation guide §11).
+
+Backed by a *separate* SQLite file at ``data/llm_cache.sqlite`` so wiping the
+cache cannot accidentally clobber the cross-job index (``data/index.sqlite``).
+The router opts in per call (``cache=True``) — synthesis passes that should
+explore opt out, deterministic extractions opt in. Default TTL is 30 days.
+
+Cache key is a sha256 of a canonical JSON dict over ``(provider, model,
+prompt, params, tool_defs)`` so the same logical call hits regardless of
+dict ordering. Sampling params we hash today: ``temperature``, ``top_p``,
+``top_k`` — anything outside that subset is intentionally ignored.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+DEFAULT_CACHE_PATH = Path("data/llm_cache.sqlite")
+DEFAULT_TTL_SECONDS = 30 * 24 * 3600
+
+# Sampling params we hash into the cache key. Anything not in this allow-list
+# is *not* part of the key — keep it stable; expanding it invalidates entries.
+_PARAM_KEYS: tuple[str, ...] = ("temperature", "top_p", "top_k")
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS llm_cache (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    model_meta TEXT,
+    created_at INTEGER NOT NULL,
+    ttl_seconds INTEGER NOT NULL
+);
+"""
+
+
+def _canonical_json(obj: Any) -> str:
+    """JSON dump with sorted keys + tight separators — stable across runs."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _normalize_params(params: dict[str, Any] | None) -> dict[str, Any]:
+    """Project ``params`` onto the hashed sampling subset."""
+    if not params:
+        return {}
+    return {k: params[k] for k in _PARAM_KEYS if k in params and params[k] is not None}
+
+
+def _hash_tool_defs(tool_defs: Any) -> str | None:
+    """Return a sha256 hex of the canonical-JSON tool defs, or ``None``."""
+    if tool_defs is None:
+        return None
+    if isinstance(tool_defs, (list, tuple)) and not tool_defs:
+        return None
+    blob = _canonical_json(tool_defs).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def make_key(
+    provider: str,
+    model: str,
+    prompt: str,
+    params: dict[str, Any] | None = None,
+    tool_defs: Any = None,
+) -> str:
+    """Build the canonical sha256 key for a cache lookup."""
+    canonical = {
+        "provider": provider,
+        "model": model,
+        "prompt": prompt,
+        "params": _normalize_params(params),
+        "tools_hash": _hash_tool_defs(tool_defs),
+    }
+    blob = _canonical_json(canonical).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+class LLMCache:
+    """SQLite-backed response cache, independent of the main index DB."""
+
+    def __init__(
+        self,
+        path: Path | str = DEFAULT_CACHE_PATH,
+        *,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+        now: Callable[[], float] = time.time,
+    ) -> None:
+        self.path = Path(path)
+        self.ttl_seconds = int(ttl_seconds)
+        self._now = now
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(self.path)
+        self._conn.row_factory = sqlite3.Row
+        # WAL + foreign_keys=OFF: this DB is wipeable on its own and never
+        # references rows in the main index, so we don't need FK enforcement.
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA foreign_keys=OFF")
+        with self._conn:
+            self._conn.executescript(SCHEMA_SQL)
+
+    def get(self, key: str) -> str | None:
+        """Return the cached value for ``key`` or ``None`` if missing/expired.
+
+        Expired rows are deleted inline so the table doesn't accumulate
+        tombstones over time.
+        """
+        row = self._conn.execute(
+            "SELECT value, created_at, ttl_seconds FROM llm_cache WHERE key = ?",
+            (key,),
+        ).fetchone()
+        if row is None:
+            return None
+        if int(self._now()) - int(row["created_at"]) > int(row["ttl_seconds"]):
+            with self._conn:
+                self._conn.execute("DELETE FROM llm_cache WHERE key = ?", (key,))
+            return None
+        return str(row["value"])
+
+    def put(
+        self,
+        key: str,
+        value: str,
+        model_meta: dict[str, Any] | str | None = None,
+        *,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        """Insert (or replace) a cache entry."""
+        if isinstance(model_meta, dict):
+            meta_blob: str | None = _canonical_json(model_meta)
+        else:
+            meta_blob = model_meta
+        effective_ttl = int(ttl_seconds) if ttl_seconds is not None else self.ttl_seconds
+        ts = int(self._now())
+        with self._conn:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO llm_cache"
+                " (key, value, model_meta, created_at, ttl_seconds)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (key, value, meta_blob, ts, effective_ttl),
+            )
+
+    def clear(self) -> None:
+        """Delete every row in the cache. File stays in place."""
+        with self._conn:
+            self._conn.execute("DELETE FROM llm_cache")
+
+    def close(self) -> None:
+        self._conn.close()
+
+    @staticmethod
+    def wipe_file(path: Path | str = DEFAULT_CACHE_PATH) -> None:
+        """Delete the cache sqlite file plus any -wal/-shm sidecars."""
+        p = Path(path)
+        for suffix in ("", "-wal", "-shm"):
+            target = p.with_name(p.name + suffix) if suffix else p
+            try:
+                target.unlink()
+            except FileNotFoundError:
+                continue
+
+
+__all__ = [
+    "DEFAULT_CACHE_PATH",
+    "DEFAULT_TTL_SECONDS",
+    "LLMCache",
+    "make_key",
+]

--- a/src/research_agent/llm/router.py
+++ b/src/research_agent/llm/router.py
@@ -32,6 +32,7 @@ from research_agent.storage import db
 from research_agent.storage.jobs import Job
 
 from .budgets import BudgetTracker, TokenUsage
+from .cache import LLMCache, make_key
 
 Tier = Literal[
     "fast",
@@ -73,6 +74,85 @@ def load_models_config(path: Path | str = "config/models.yaml") -> dict[str, Any
     if not isinstance(data["tiers"], dict):
         raise ValueError(f"'tiers' in {p} must be a mapping; got {type(data['tiers']).__name__}")
     return data
+
+
+_PARAM_KEYS: tuple[str, ...] = ("temperature", "top_p", "top_k")
+
+
+class _CachedResult:
+    """Lightweight stand-in for a Pydantic AI ``AgentRunResult`` on cache hits.
+
+    Exposes the same surface the rest of the router/orchestrator expects:
+    ``.output`` (the cached string) and a ``usage()`` callable returning a
+    zero-token :class:`TokenUsage`. No tokens were spent, so cost is $0.
+    """
+
+    __slots__ = ("output", "_usage", "finish_reason")
+
+    def __init__(self, output: str) -> None:
+        self.output = output
+        self._usage = TokenUsage()
+        self.finish_reason = "cache"
+
+    def usage(self) -> TokenUsage:
+        return self._usage
+
+
+def _extract_prompt(args: tuple[Any, ...]) -> str:
+    """Pull the prompt string out of ``agent.run`` positional args.
+
+    Pydantic AI's ``Agent.run`` takes the prompt as the first positional arg
+    when it's a plain string; for richer inputs we fall back to ``repr`` so
+    the cache key still varies with the input shape.
+    """
+    if not args:
+        return ""
+    head = args[0]
+    if isinstance(head, str):
+        return head
+    return repr(args)
+
+
+def _extract_params(kwargs: dict[str, Any]) -> dict[str, Any] | None:
+    """Pull the cache-relevant sampling params out of ``agent.run`` kwargs."""
+    settings = kwargs.get("model_settings")
+    if settings is None:
+        return None
+    if isinstance(settings, dict):
+        source: dict[str, Any] = settings
+    else:
+        source = {k: getattr(settings, k, None) for k in _PARAM_KEYS}
+    out = {k: source[k] for k in _PARAM_KEYS if source.get(k) is not None}
+    return out or None
+
+
+def _extract_tool_defs(agent: Any) -> Any:
+    """Probe a Pydantic AI ``Agent`` for its tool definitions, if any.
+
+    The exact attribute name has shifted across pydantic-ai releases. We
+    probe a small allow-list and return a lightweight ``[{name, schema}]``
+    list — enough to make the cache key sensitive to tool changes without
+    coupling to a specific internal type.
+    """
+    for attr in ("_function_tools", "tools", "_tools"):
+        defs = getattr(agent, attr, None)
+        if defs:
+            return _serialize_tool_defs(defs)
+    return None
+
+
+def _serialize_tool_defs(defs: Any) -> list[dict[str, Any]]:
+    items = list(defs.values()) if isinstance(defs, dict) else list(defs)
+    out: list[dict[str, Any]] = []
+    for t in items:
+        name = getattr(t, "name", None) or getattr(t, "__name__", None) or t.__class__.__name__
+        schema = (
+            getattr(t, "parameters_json_schema", None)
+            or getattr(t, "json_schema", None)
+            or getattr(t, "schema", None)
+        )
+        out.append({"name": str(name), "schema": schema})
+    return out
 
 
 def _extract_usage(result: Any, latency_ms: int) -> TokenUsage:
@@ -128,6 +208,7 @@ class Router:
         *,
         job: Job | None = None,
         db_path: Path | str | None = None,
+        cache: LLMCache | None = None,
     ) -> None:
         if "tiers" not in config:
             raise ValueError("router config missing 'tiers' key")
@@ -142,6 +223,7 @@ class Router:
         self.budget = budget
         self.job = job
         self.db_path = Path(db_path) if db_path is not None else None
+        self.cache = cache
         self._model_cache: dict[str, OpenAIModel] = {}
 
     # ---- Provider wiring ---------------------------------------------------
@@ -223,6 +305,7 @@ class Router:
         Local-tier failures are *not* silently rerouted to cloud (per §16);
         the original exception propagates to the caller.
         """
+        cache_enabled = bool(kwargs.pop("cache", False))
         if tier not in self.tiers:
             raise KeyError(f"unknown tier: {tier!r}")
         spec = self.tiers[tier]
@@ -231,6 +314,28 @@ class Router:
         timeout_s = spec.get("timeout_s")
         is_cloud = provider == "openrouter"
         fallback_used = False
+
+        cache_key: str | None = None
+        if cache_enabled and self.cache is not None:
+            cache_key = make_key(
+                provider,
+                model_name,
+                _extract_prompt(args),
+                _extract_params(kwargs),
+                _extract_tool_defs(agent),
+            )
+            hit = self.cache.get(cache_key)
+            if hit is not None:
+                self._emit_llm_call_event(
+                    tier=tier,
+                    provider=provider,
+                    model=model_name,
+                    usage=TokenUsage(),
+                    cost_usd=0.0,
+                    fallback_used=False,
+                    cached=True,
+                )
+                return _CachedResult(hit)
 
         if is_cloud:
             self.budget.precheck(tier)
@@ -261,6 +366,15 @@ class Router:
                 usage=usage,
             )
 
+        if cache_enabled and self.cache is not None and cache_key is not None:
+            output = getattr(result, "output", None)
+            if isinstance(output, str):
+                self.cache.put(
+                    cache_key,
+                    output,
+                    model_meta={"tier": tier, "provider": provider, "model": model_name},
+                )
+
         self._emit_llm_call_event(
             tier=tier,
             provider=provider,
@@ -268,6 +382,7 @@ class Router:
             usage=usage,
             cost_usd=cost_usd,
             fallback_used=fallback_used,
+            cached=False,
         )
 
         return result
@@ -340,6 +455,7 @@ class Router:
         usage: TokenUsage,
         cost_usd: float,
         fallback_used: bool,
+        cached: bool = False,
     ) -> None:
         if self.job is None:
             return
@@ -353,6 +469,7 @@ class Router:
             "cost_usd": cost_usd,
             "finish_reason": usage.finish_reason,
             "fallback_used": fallback_used,
+            "cached": cached,
         }
         # Round-trip through json so the payload always contains JSON-safe
         # primitives — `emit` re-serializes in the SQL mirror.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -391,9 +391,7 @@ def test_logs_unknown_job_errors(isolated_jobs_repo: Path):
 
 def test_view_unknown_job_errors(isolated_jobs_repo: Path):
     runner = CliRunner()
-    result = runner.invoke(
-        cli.app, ["view", "2026-05-02-does-not-exist"], env={"EDITOR": ""}
-    )
+    result = runner.invoke(cli.app, ["view", "2026-05-02-does-not-exist"], env={"EDITOR": ""})
     assert result.exit_code == 1
     combined = result.stdout + (result.stderr or "")
     assert "job not found" in combined
@@ -419,3 +417,32 @@ def test_format_event_line_includes_ts_level_kind():
     assert "INFO" in line
     assert "job_started" in line
     assert "daemon" in line
+
+
+# ---------------------------------------------------------------------------
+# config cache-clear
+# ---------------------------------------------------------------------------
+
+
+def test_config_cache_clear_removes_cache_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from research_agent.llm.cache import DEFAULT_CACHE_PATH, LLMCache, make_key
+
+    cache_path = tmp_path / DEFAULT_CACHE_PATH
+    cache = LLMCache(cache_path)
+    cache.put(make_key("p", "m", "x"), "v")
+    cache.close()
+    assert cache_path.exists()
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["config", "cache-clear"])
+    assert result.exit_code == 0, result.stdout
+    assert "cleared" in result.stdout
+    assert not cache_path.exists()
+
+
+def test_config_cache_clear_is_idempotent_when_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["config", "cache-clear"])
+    assert result.exit_code == 0, result.stdout

--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -1,0 +1,225 @@
+"""Tests for ``research_agent.llm.cache``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from research_agent.llm.cache import (
+    DEFAULT_TTL_SECONDS,
+    LLMCache,
+    make_key,
+)
+
+# ---------------------------------------------------------------------------
+# make_key
+# ---------------------------------------------------------------------------
+
+
+def test_make_key_stable_across_dict_ordering() -> None:
+    a = make_key(
+        "openrouter",
+        "anthropic/claude-opus-4-7",
+        "summarize this",
+        params={"top_p": 0.9, "temperature": 0.2},
+        tool_defs=[{"name": "search", "schema": {"type": "object"}}],
+    )
+    b = make_key(
+        "openrouter",
+        "anthropic/claude-opus-4-7",
+        "summarize this",
+        params={"temperature": 0.2, "top_p": 0.9},
+        tool_defs=[{"name": "search", "schema": {"type": "object"}}],
+    )
+    assert a == b
+
+
+def test_make_key_distinct_when_any_axis_differs() -> None:
+    base = make_key("openrouter", "claude-opus", "extract", params={"temperature": 0.0})
+    # Provider
+    assert base != make_key("lmstudio", "claude-opus", "extract", params={"temperature": 0.0})
+    # Model
+    assert base != make_key("openrouter", "claude-haiku", "extract", params={"temperature": 0.0})
+    # Prompt
+    assert base != make_key("openrouter", "claude-opus", "extract!", params={"temperature": 0.0})
+    # Temperature
+    assert base != make_key("openrouter", "claude-opus", "extract", params={"temperature": 0.7})
+    # Tool defs
+    assert base != make_key(
+        "openrouter",
+        "claude-opus",
+        "extract",
+        params={"temperature": 0.0},
+        tool_defs=[{"name": "fetch", "schema": {}}],
+    )
+
+
+def test_make_key_ignores_unknown_params() -> None:
+    """Only temperature/top_p/top_k participate in the key."""
+    a = make_key("p", "m", "x")
+    b = make_key("p", "m", "x", params={"max_tokens": 100, "seed": 42})
+    assert a == b
+
+
+# ---------------------------------------------------------------------------
+# LLMCache: round trip + collision behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_returns_same_value(tmp_path: Path) -> None:
+    cache = LLMCache(tmp_path / "c.sqlite")
+    key = make_key("openrouter", "x", "hello world")
+    cache.put(key, "<<the answer>>", model_meta={"tier": "frontier"})
+    assert cache.get(key) == "<<the answer>>"
+    cache.close()
+
+
+def test_distinct_keys_do_not_collide(tmp_path: Path) -> None:
+    cache = LLMCache(tmp_path / "c.sqlite")
+    k1 = make_key("p", "m", "prompt-1")
+    k2 = make_key("p", "m", "prompt-2")
+    cache.put(k1, "first")
+    cache.put(k2, "second")
+    assert cache.get(k1) == "first"
+    assert cache.get(k2) == "second"
+    cache.close()
+
+
+def test_get_missing_key_returns_none(tmp_path: Path) -> None:
+    cache = LLMCache(tmp_path / "c.sqlite")
+    assert cache.get("not-there") is None
+    cache.close()
+
+
+def test_put_replaces_existing_entry(tmp_path: Path) -> None:
+    cache = LLMCache(tmp_path / "c.sqlite")
+    key = make_key("p", "m", "prompt")
+    cache.put(key, "v1")
+    cache.put(key, "v2")
+    assert cache.get(key) == "v2"
+    cache.close()
+
+
+# ---------------------------------------------------------------------------
+# TTL
+# ---------------------------------------------------------------------------
+
+
+def test_expired_entry_returns_none_and_is_removed(tmp_path: Path) -> None:
+    clock = {"t": 1_000_000.0}
+    cache = LLMCache(tmp_path / "c.sqlite", ttl_seconds=10, now=lambda: clock["t"])
+    key = make_key("p", "m", "old prompt")
+    cache.put(key, "expiring soon")
+    # Within TTL → still present.
+    clock["t"] += 5
+    assert cache.get(key) == "expiring soon"
+    # Past TTL → gone.
+    clock["t"] += 100
+    assert cache.get(key) is None
+    # Inline delete: row should not be in the table any more.
+    rows = cache._conn.execute(  # noqa: SLF001 — direct read for assertion
+        "SELECT COUNT(*) FROM llm_cache WHERE key = ?", (key,)
+    ).fetchone()
+    assert rows[0] == 0
+    cache.close()
+
+
+def test_per_call_ttl_override_takes_precedence(tmp_path: Path) -> None:
+    clock = {"t": 0.0}
+    cache = LLMCache(tmp_path / "c.sqlite", ttl_seconds=1000, now=lambda: clock["t"])
+    short_key = make_key("p", "m", "short")
+    long_key = make_key("p", "m", "long")
+    cache.put(short_key, "v", ttl_seconds=5)
+    cache.put(long_key, "v")
+    clock["t"] = 50
+    assert cache.get(short_key) is None  # overridden TTL elapsed
+    assert cache.get(long_key) == "v"  # default TTL still alive
+    cache.close()
+
+
+def test_default_ttl_is_30_days() -> None:
+    assert DEFAULT_TTL_SECONDS == 30 * 24 * 3600
+
+
+# ---------------------------------------------------------------------------
+# clear / wipe_file
+# ---------------------------------------------------------------------------
+
+
+def test_clear_removes_all_rows(tmp_path: Path) -> None:
+    cache = LLMCache(tmp_path / "c.sqlite")
+    cache.put(make_key("p", "m", "a"), "1")
+    cache.put(make_key("p", "m", "b"), "2")
+    cache.clear()
+    assert cache.get(make_key("p", "m", "a")) is None
+    assert cache.get(make_key("p", "m", "b")) is None
+    cache.close()
+
+
+def test_wipe_file_removes_db_and_sidecars(tmp_path: Path) -> None:
+    path = tmp_path / "c.sqlite"
+    cache = LLMCache(path)
+    cache.put(make_key("p", "m", "x"), "v")
+    cache.close()
+
+    assert path.exists()
+    LLMCache.wipe_file(path)
+    assert not path.exists()
+    assert not path.with_name(path.name + "-wal").exists()
+    assert not path.with_name(path.name + "-shm").exists()
+
+
+def test_wipe_file_is_safe_when_file_missing(tmp_path: Path) -> None:
+    LLMCache.wipe_file(tmp_path / "no-such.sqlite")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Independence from the main index
+# ---------------------------------------------------------------------------
+
+
+def test_cache_lives_in_its_own_sqlite_file(tmp_path: Path) -> None:
+    """The cache must NOT touch the main index DB path."""
+    main_db = tmp_path / "data" / "index.sqlite"
+    cache_db = tmp_path / "data" / "llm_cache.sqlite"
+    cache = LLMCache(cache_db)
+    cache.put(make_key("p", "m", "x"), "v")
+    cache.close()
+    assert cache_db.exists()
+    assert not main_db.exists()
+
+
+def test_model_meta_dict_is_serialized(tmp_path: Path) -> None:
+    cache = LLMCache(tmp_path / "c.sqlite")
+    key = make_key("p", "m", "x")
+    cache.put(key, "v", model_meta={"tier": "frontier", "provider": "openrouter"})
+    row = cache._conn.execute(  # noqa: SLF001
+        "SELECT model_meta FROM llm_cache WHERE key = ?", (key,)
+    ).fetchone()
+    assert row is not None
+    # Stored as compact canonical JSON.
+    assert "tier" in row[0]
+    assert "frontier" in row[0]
+    cache.close()
+
+
+@pytest.fixture
+def cache_factory(tmp_path: Path):
+    caches: list[LLMCache] = []
+
+    def _make(**kwargs):
+        c = LLMCache(tmp_path / f"c{len(caches)}.sqlite", **kwargs)
+        caches.append(c)
+        return c
+
+    yield _make
+    for c in caches:
+        c.close()
+
+
+def test_factory_smoke(cache_factory) -> None:
+    """Sanity check: the test fixture itself works."""
+    cache = cache_factory()
+    cache.put("k", "v")
+    assert cache.get("k") == "v"

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -102,9 +102,15 @@ class _FakeUsage:
 
 
 class _FakeResult:
-    def __init__(self, usage: _FakeUsage | None = None) -> None:
+    def __init__(
+        self,
+        usage: _FakeUsage | None = None,
+        *,
+        output: str | None = None,
+    ) -> None:
         self._usage = usage or _FakeUsage()
         self.finish_reason = "stop"
+        self.output = output if output is not None else "fake-output"
 
     def usage(self) -> _FakeUsage:
         return self._usage
@@ -638,3 +644,194 @@ def test_budget_charge_persists_to_ledger_and_jobs_total(job: Job, db_path: Path
     assert len(rows) == 1
     assert rows[0]["cost_usd"] == pytest.approx(expected)
     assert cost_so_far == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# Router ↔ LLMCache integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_skips_agent_run_and_budget_charge(
+    monkeypatch: pytest.MonkeyPatch,
+    models_config: dict[str, Any],
+    db_path: Path,
+    tmp_path: Path,
+    job: Job,
+) -> None:
+    """Same prompt+params twice → second call serves from cache."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    from research_agent.llm.cache import LLMCache
+
+    cache = LLMCache(tmp_path / "llm_cache.sqlite")
+    budget = _RecordingBudget()
+    router = Router(
+        models_config,
+        budget,  # type: ignore[arg-type]
+        job=job,
+        db_path=db_path,
+        cache=cache,
+    )
+
+    agent = _FakeAgent(result=_FakeResult(output="cached body"))
+
+    # Miss → real call, cache write.
+    out1 = await router.call("frontier_speed", agent, "summarize this", cache=True)
+    assert out1.output == "cached body"
+    assert len(agent.calls) == 1
+    assert len(budget.precheck_calls) == 1
+    assert len(budget.charge_calls) == 1
+
+    # Hit → no agent.run, no precheck, no charge.
+    out2 = await router.call("frontier_speed", agent, "summarize this", cache=True)
+    assert out2.output == "cached body"
+    assert len(agent.calls) == 1, "cache hit must not invoke agent.run again"
+    assert len(budget.precheck_calls) == 1, "cache hit must skip budget precheck"
+    assert len(budget.charge_calls) == 1, "cache hit must skip budget charge"
+
+    # Event payload distinguishes hits via cached=True.
+    events_path = job.root / "events.jsonl"
+    import json as _json
+
+    payloads = []
+    for line in events_path.read_text().splitlines():
+        if not line.strip():
+            continue
+        ev = _json.loads(line)
+        if ev.get("kind") == "llm_call":
+            payloads.append(ev["payload"])
+    cached_flags = [p.get("cached") for p in payloads]
+    assert cached_flags.count(True) == 1
+    assert cached_flags.count(False) == 1
+    cache.close()
+
+
+@pytest.mark.asyncio
+async def test_cache_default_off_does_not_consult_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    models_config: dict[str, Any],
+    db_path: Path,
+    tmp_path: Path,
+    job: Job,
+) -> None:
+    """Without ``cache=True`` the router never reads or writes the cache."""
+    monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
+    from research_agent.llm.cache import LLMCache, make_key
+
+    cache = LLMCache(tmp_path / "llm_cache.sqlite")
+    budget = _RecordingBudget()
+    router = Router(
+        models_config,
+        budget,  # type: ignore[arg-type]
+        job=job,
+        db_path=db_path,
+        cache=cache,
+    )
+    agent = _FakeAgent(result=_FakeResult(output="hello"))
+    await router.call("general", agent, "x")
+    # No write
+    spec = models_config["tiers"]["general"]
+    key = make_key(spec["provider"], spec["model"], "x", None, None)
+    assert cache.get(key) is None
+    cache.close()
+
+
+@pytest.mark.asyncio
+async def test_cache_keys_split_on_prompt_and_params(
+    monkeypatch: pytest.MonkeyPatch,
+    models_config: dict[str, Any],
+    db_path: Path,
+    tmp_path: Path,
+    job: Job,
+) -> None:
+    """Different prompt or sampling params → independent cache entries."""
+    monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
+    from research_agent.llm.cache import LLMCache
+
+    cache = LLMCache(tmp_path / "llm_cache.sqlite")
+    budget = _RecordingBudget()
+    router = Router(
+        models_config,
+        budget,  # type: ignore[arg-type]
+        job=job,
+        db_path=db_path,
+        cache=cache,
+    )
+
+    a = _FakeAgent(result=_FakeResult(output="A"))
+    b = _FakeAgent(result=_FakeResult(output="B"))
+    c = _FakeAgent(result=_FakeResult(output="C"))
+
+    await router.call("general", a, "prompt-1", cache=True)
+    await router.call("general", b, "prompt-2", cache=True)
+    await router.call("general", c, "prompt-1", cache=True, model_settings={"temperature": 0.7})
+
+    # All three must have actually run — different cache keys.
+    assert len(a.calls) == 1
+    assert len(b.calls) == 1
+    assert len(c.calls) == 1
+
+    # Re-run prompt-1 with no params → hits the first entry.
+    again = _FakeAgent(result=_FakeResult(output="should-not-be-used"))
+    out = await router.call("general", again, "prompt-1", cache=True)
+    assert out.output == "A"
+    assert len(again.calls) == 0
+    cache.close()
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_emits_zero_cost_event(
+    monkeypatch: pytest.MonkeyPatch,
+    models_config: dict[str, Any],
+    db_path: Path,
+    tmp_path: Path,
+    job: Job,
+) -> None:
+    """The llm_call event for a hit shows zero tokens/cost."""
+    monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
+    from research_agent.llm.cache import LLMCache, make_key
+
+    cache = LLMCache(tmp_path / "llm_cache.sqlite")
+    spec = models_config["tiers"]["general"]
+    cache.put(
+        make_key(spec["provider"], spec["model"], "preloaded prompt", None, None),
+        "preloaded answer",
+    )
+
+    budget = _RecordingBudget()
+    router = Router(
+        models_config,
+        budget,  # type: ignore[arg-type]
+        job=job,
+        db_path=db_path,
+        cache=cache,
+    )
+
+    agent = _FakeAgent(result=_FakeResult(output="should-not-run"))
+    out = await router.call("general", agent, "preloaded prompt", cache=True)
+    assert out.output == "preloaded answer"
+    assert len(agent.calls) == 0
+
+    # No llm_calls ledger row written for a pure cache hit.
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute("SELECT COUNT(*) FROM llm_calls WHERE job_id = ?", (job.id,)).fetchone()
+    finally:
+        conn.close()
+    assert rows[0] == 0
+
+    import json as _json
+
+    events_path = job.root / "events.jsonl"
+    payloads = [
+        _json.loads(line)["payload"]
+        for line in events_path.read_text().splitlines()
+        if line.strip() and _json.loads(line).get("kind") == "llm_call"
+    ]
+    assert len(payloads) == 1
+    p = payloads[0]
+    assert p["cached"] is True
+    assert p["input_tokens"] == 0
+    assert p["output_tokens"] == 0
+    assert p["cost_usd"] == 0.0
+    cache.close()


### PR DESCRIPTION
Closes #11

## Summary

Automated implementation of **LLM response cache (llm/cache.py) backed by SQLite**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

All acceptance criteria for the LLM response cache are implemented and tested; only finding was a docs-sync gap, fixed in this review.

- **WARNING** [FIXED] `README.md`: README's CLI section did not document the new `research config cache-clear` command or the cache's design (separate sqlite file, 30-day TTL, opt-in via cache=True). Added a `Config verbs` block + a paragraph explaining the cache.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*