### PR TITLE
feat: Uniform SearchResult / Source Pydantic models for connectors (closes #13)

### DIFF
--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from research_agent.tools.models import SearchResult, Source, SourceKind
+
 # Registered tool callables, keyed by the name `research _smoke-tool` and the
 # orchestrator dispatch by. Empty until Phase 3 lands the actual connectors;
 # the smoke verb checks against this dict so the dispatch surface is in place
 # from day one.
 TOOL_REGISTRY: dict[str, Callable[[str], object]] = {}
 
-__all__ = ["TOOL_REGISTRY"]
+__all__ = ["TOOL_REGISTRY", "SearchResult", "Source", "SourceKind"]

--- a/src/research_agent/tools/models.py
+++ b/src/research_agent/tools/models.py
@@ -1,0 +1,73 @@
+"""Uniform Pydantic shapes every connector returns.
+
+Locks in the `SearchResult` / `Source` contract from §7 of the implementation
+guide. Connectors live in sibling modules (`web.py`, `github.py`, …) and each
+expose ``async def search(query, **kwargs) -> list[SearchResult]`` and, where
+applicable, ``async def fetch(url, **kwargs) -> Source | None``. The planner
+and orchestrator only ever see these two shapes — connector implementations
+are interchangeable.
+
+The ``source_kind`` literal is the closed set the planner branches on; adding
+a new vertical requires extending it here so type-checkers flag callers that
+forgot to update.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+SourceKind = Literal[
+    "web",
+    "pdf",
+    "github",
+    "arxiv",
+    "news",
+    "reddit",
+    "hn",
+    "local",
+    "gdelt",
+    "sec",
+    "fec",
+    "courtlistener",
+]
+
+
+class SearchResult(BaseModel):
+    """One hit from a connector's ``search()`` method.
+
+    Lightweight by design — full content lives in :class:`Source` after a
+    follow-up ``fetch()``. ``extras`` is an escape hatch for connector-specific
+    metadata (e.g. arXiv ids, GitHub stars) that downstream re-rankers can
+    optionally consume.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    url: str
+    title: str
+    snippet: str
+    published_at: datetime | None = None
+    source_kind: SourceKind
+    score: float | None = None
+    extras: dict[str, Any] = Field(default_factory=dict)
+
+
+class Source(BaseModel):
+    """A fetched, cleaned document — the unit of citation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    url: str
+    title: str
+    cleaned_text: str
+    raw_html: str | None = None
+    fetched_at: datetime
+    source_kind: SourceKind
+    archive_url: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+__all__ = ["SearchResult", "Source", "SourceKind"]

--- a/tests/test_tools_models.py
+++ b/tests/test_tools_models.py
@@ -1,0 +1,268 @@
+"""Tests for `research_agent.tools.models`.
+
+Locks the connector return-shape contract from §7 of the implementation guide.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import get_args
+
+import pytest
+from pydantic import ValidationError
+
+from research_agent.tools.models import SearchResult, Source, SourceKind
+
+EXPECTED_SOURCE_KINDS = (
+    "web",
+    "pdf",
+    "github",
+    "arxiv",
+    "news",
+    "reddit",
+    "hn",
+    "local",
+    "gdelt",
+    "sec",
+    "fec",
+    "courtlistener",
+)
+
+
+# ---------------------------------------------------------------------------
+# SourceKind enum coverage
+# ---------------------------------------------------------------------------
+
+
+def test_source_kind_covers_all_12_verticals() -> None:
+    assert set(get_args(SourceKind)) == set(EXPECTED_SOURCE_KINDS)
+    assert len(get_args(SourceKind)) == 12
+
+
+@pytest.mark.parametrize("kind", EXPECTED_SOURCE_KINDS)
+def test_search_result_accepts_each_source_kind(kind: str) -> None:
+    sr = SearchResult(url="https://e.com", title="t", snippet="s", source_kind=kind)  # type: ignore[arg-type]
+    assert sr.source_kind == kind
+
+
+@pytest.mark.parametrize("kind", EXPECTED_SOURCE_KINDS)
+def test_source_accepts_each_source_kind(kind: str) -> None:
+    src = Source(
+        url="https://e.com",
+        title="t",
+        cleaned_text="body",
+        fetched_at=datetime.now(UTC),
+        source_kind=kind,  # type: ignore[arg-type]
+    )
+    assert src.source_kind == kind
+
+
+# ---------------------------------------------------------------------------
+# SearchResult
+# ---------------------------------------------------------------------------
+
+
+def test_search_result_minimal_construction() -> None:
+    sr = SearchResult(
+        url="https://example.com/a",
+        title="Example A",
+        snippet="An example snippet.",
+        source_kind="web",
+    )
+    assert sr.url == "https://example.com/a"
+    assert sr.title == "Example A"
+    assert sr.snippet == "An example snippet."
+    assert sr.source_kind == "web"
+    assert sr.published_at is None
+    assert sr.score is None
+    assert sr.extras == {}
+
+
+def test_search_result_full_construction() -> None:
+    pub = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+    sr = SearchResult(
+        url="https://example.com/b",
+        title="Example B",
+        snippet="Snippet",
+        published_at=pub,
+        source_kind="news",
+        score=0.87,
+        extras={"author": "j.doe", "tags": ["politics"]},
+    )
+    assert sr.published_at == pub
+    assert sr.score == 0.87
+    assert sr.extras == {"author": "j.doe", "tags": ["politics"]}
+
+
+def test_search_result_published_at_accepts_iso_string() -> None:
+    sr = SearchResult(
+        url="https://e.com",
+        title="t",
+        snippet="s",
+        published_at="2025-06-01T12:00:00+00:00",  # type: ignore[arg-type]
+        source_kind="web",
+    )
+    assert sr.published_at == datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+
+
+def test_search_result_invalid_source_kind_raises() -> None:
+    with pytest.raises(ValidationError):
+        SearchResult(
+            url="https://e.com",
+            title="t",
+            snippet="s",
+            source_kind="twitter",  # type: ignore[arg-type]
+        )
+
+
+def test_search_result_extras_default_is_independent_dict() -> None:
+    a = SearchResult(url="https://a", title="a", snippet="a", source_kind="web")
+    b = SearchResult(url="https://b", title="b", snippet="b", source_kind="web")
+    a.extras["k"] = "v"
+    assert b.extras == {}
+    assert a.extras is not b.extras
+
+
+def test_search_result_round_trip_json() -> None:
+    pub = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+    sr = SearchResult(
+        url="https://e.com",
+        title="t",
+        snippet="s",
+        published_at=pub,
+        source_kind="arxiv",
+        score=0.5,
+        extras={"arxiv_id": "2501.00001"},
+    )
+    parsed = SearchResult.model_validate_json(sr.model_dump_json())
+    assert parsed == sr
+
+
+# ---------------------------------------------------------------------------
+# Source
+# ---------------------------------------------------------------------------
+
+
+def test_source_minimal_construction() -> None:
+    fetched = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+    src = Source(
+        url="https://example.com/x",
+        title="X",
+        cleaned_text="hello world",
+        fetched_at=fetched,
+        source_kind="web",
+    )
+    assert src.url == "https://example.com/x"
+    assert src.cleaned_text == "hello world"
+    assert src.fetched_at == fetched
+    assert src.raw_html is None
+    assert src.archive_url is None
+    assert src.metadata == {}
+
+
+def test_source_full_construction() -> None:
+    fetched = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+    src = Source(
+        url="https://example.com/x",
+        title="X",
+        cleaned_text="cleaned",
+        raw_html="<html>...</html>",
+        fetched_at=fetched,
+        source_kind="pdf",
+        archive_url="https://web.archive.org/web/2025/https://example.com/x",
+        metadata={"sha256": "abc123", "page_count": 7},
+    )
+    assert src.raw_html == "<html>...</html>"
+    assert src.archive_url is not None
+    assert src.metadata["page_count"] == 7
+
+
+def test_source_fetched_at_accepts_iso_string() -> None:
+    src = Source(
+        url="https://e.com",
+        title="t",
+        cleaned_text="body",
+        fetched_at="2025-06-01T12:00:00+00:00",  # type: ignore[arg-type]
+        source_kind="web",
+    )
+    assert src.fetched_at == datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+
+
+def test_source_invalid_source_kind_raises() -> None:
+    with pytest.raises(ValidationError):
+        Source(
+            url="https://e.com",
+            title="t",
+            cleaned_text="body",
+            fetched_at=datetime.now(UTC),
+            source_kind="bogus",  # type: ignore[arg-type]
+        )
+
+
+def test_source_metadata_default_is_independent_dict() -> None:
+    fetched = datetime.now(UTC)
+    a = Source(url="https://a", title="a", cleaned_text="a", fetched_at=fetched, source_kind="web")
+    b = Source(url="https://b", title="b", cleaned_text="b", fetched_at=fetched, source_kind="web")
+    a.metadata["k"] = "v"
+    assert b.metadata == {}
+    assert a.metadata is not b.metadata
+
+
+def test_source_round_trip_json() -> None:
+    fetched = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+    src = Source(
+        url="https://e.com",
+        title="t",
+        cleaned_text="body",
+        raw_html="<p>body</p>",
+        fetched_at=fetched,
+        source_kind="github",
+        archive_url=None,
+        metadata={"repo": "x/y", "stars": 42},
+    )
+    parsed = Source.model_validate_json(src.model_dump_json())
+    assert parsed == src
+
+
+# ---------------------------------------------------------------------------
+# extra="forbid"
+# ---------------------------------------------------------------------------
+
+
+def test_search_result_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        SearchResult(
+            url="https://e.com",
+            title="t",
+            snippet="s",
+            source_kind="web",
+            surprise="boom",  # type: ignore[call-arg]
+        )
+
+
+def test_source_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        Source(
+            url="https://e.com",
+            title="t",
+            cleaned_text="body",
+            fetched_at=datetime.now(UTC),
+            source_kind="web",
+            surprise="boom",  # type: ignore[call-arg]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Re-exports from `research_agent.tools`
+# ---------------------------------------------------------------------------
+
+
+def test_symbols_importable_from_tools_package() -> None:
+    from research_agent import tools
+
+    assert tools.SearchResult is SearchResult
+    assert tools.Source is Source
+    assert tools.SourceKind is SourceKind
+    assert "SearchResult" in tools.__all__
+    assert "Source" in tools.__all__
+    assert "SourceKind" in tools.__all__


### PR DESCRIPTION
Closes #13

## Summary

Automated implementation of **Uniform SearchResult / Source Pydantic models for connectors**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

SearchResult/Source contract matches issue spec and §7 of the guide; 40 new tests + 270 total pass; no critical or warning findings.

- **INFO** [OPEN] `src/research_agent/tools/models.py`: url is typed as str rather than pydantic.HttpUrl. Pragmatic for now (the 'local' source_kind may wrap file paths, and HttpUrl can be too strict), but worth revisiting once connectors land if web/non-web sources can be split.
- **INFO** [OPEN] `src/research_agent/tools/models.py`: datetime fields (published_at, fetched_at) accept naive datetimes. Tests only exercise tz-aware UTC values. Consider enforcing tz-aware later when storage/comparison logic against fetched_at gets wired up.
- **INFO** [OPEN] `src/research_agent/tools/__init__.py`: Acceptance criterion 'each connector exports async search/fetch' is N/A in this issue's scope — TOOL_REGISTRY is intentionally empty until Phase 3 connector issues land. Contract is locked; enforcement is deferred to those issues.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*