### PR TITLE
feat: Web search via Playwright (DuckDuckGo + Google SERP) + shared  (closes #14)

### DIFF
--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -2,14 +2,33 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 
 from research_agent.tools.models import SearchResult, Source, SourceKind
 
+
+def _smoke_web_search(query: str) -> list[SearchResult]:
+    """Smoke wrapper: run DDG then Google, return top-5 hits from each combined.
+
+    The CLI smoke verb calls this synchronously and prints ``repr`` of the
+    return value, so the output shows results from both engines per AC #14.
+    """
+    from research_agent.tools import web_search
+
+    async def _run() -> list[SearchResult]:
+        ddg = await web_search.search(query, max_results=5, engine="ddg")
+        google = await web_search.search(query, max_results=5, engine="google")
+        return ddg + google
+
+    return asyncio.run(_run())
+
+
 # Registered tool callables, keyed by the name `research _smoke-tool` and the
-# orchestrator dispatch by. Empty until Phase 3 lands the actual connectors;
-# the smoke verb checks against this dict so the dispatch surface is in place
-# from day one.
-TOOL_REGISTRY: dict[str, Callable[[str], object]] = {}
+# orchestrator dispatch by. The smoke verb checks against this dict so the
+# dispatch surface is in place from day one.
+TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
+    "web_search": _smoke_web_search,
+}
 
 __all__ = ["TOOL_REGISTRY", "SearchResult", "Source", "SourceKind"]

--- a/src/research_agent/tools/browser.py
+++ b/src/research_agent/tools/browser.py
@@ -1,0 +1,227 @@
+"""Shared Playwright session manager for browser-driven connectors.
+
+A single Chromium instance is launched lazily on first use and reused across
+all callers (web_search, fetch fallbacks, news, reddit, …). Every request is
+gated by a per-host token bucket so we don't hammer a single SERP/site even
+when multiple connectors run concurrently.
+
+Why a module-level singleton: launching Chromium is ~hundreds of ms and the
+daemon is single-process; opening a fresh browser per ``search()`` call would
+dominate latency for short queries. The lock around init makes concurrent
+``browser_session()`` callers wait for the first to finish bootstrapping.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import os
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from urllib.parse import urlparse
+
+from playwright.async_api import (
+    Browser,
+    BrowserContext,
+    Page,
+    Playwright,
+    Route,
+    async_playwright,
+)
+
+from research_agent import config
+
+_DEFAULT_USER_AGENT = "research-agent/0.1"
+_BLOCKED_RESOURCE_TYPES = {"font", "image", "media"}
+_DEFAULT_HOST_RPS = 1.0
+_NAV_TIMEOUT_MS = 30_000
+
+
+class _HostBucket:
+    """Simple per-host pace limiter.
+
+    Not a true leaky bucket — just enforces a minimum gap between requests
+    to a given host. Sufficient for politeness; the goal is to avoid bursts
+    that look bot-like to public SERPs, not to model bandwidth.
+    """
+
+    __slots__ = ("rps", "_next_allowed_at", "_lock")
+
+    def __init__(self, rps: float) -> None:
+        self.rps = rps
+        self._next_allowed_at = 0.0
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        async with self._lock:
+            now = time.monotonic()
+            min_gap = 1.0 / self.rps if self.rps > 0 else 0.0
+            wait = self._next_allowed_at - now
+            if wait > 0:
+                await asyncio.sleep(wait)
+                now = time.monotonic()
+            self._next_allowed_at = now + min_gap
+
+
+_playwright: Playwright | None = None
+_browser: Browser | None = None
+_context: BrowserContext | None = None
+_init_lock = asyncio.Lock()
+_host_buckets: dict[str, _HostBucket] = {}
+_buckets_lock = asyncio.Lock()
+_atexit_registered = False
+
+
+def _resolve_headful(headful: bool | None) -> bool:
+    if headful is not None:
+        return headful
+    raw = os.environ.get("RESEARCH_HEADFUL") or config.get("RESEARCH_HEADFUL")
+    if raw is None:
+        return False
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _resolve_user_agent() -> str:
+    return config.get("RESEARCH_USER_AGENT") or _DEFAULT_USER_AGENT
+
+
+def set_host_rate(netloc: str, rps: float) -> None:
+    """Override the per-host rate (requests per second).
+
+    Connectors call this at module import or first use to register a stricter
+    limit (e.g. 0.5 rps for SERPs). Subsequent ``throttle()`` calls for the
+    same netloc respect the new rate.
+    """
+    bucket = _host_buckets.get(netloc)
+    if bucket is None:
+        _host_buckets[netloc] = _HostBucket(rps)
+    else:
+        bucket.rps = rps
+
+
+async def _get_bucket(netloc: str) -> _HostBucket:
+    async with _buckets_lock:
+        bucket = _host_buckets.get(netloc)
+        if bucket is None:
+            bucket = _HostBucket(_DEFAULT_HOST_RPS)
+            _host_buckets[netloc] = bucket
+        return bucket
+
+
+async def throttle(url: str) -> None:
+    """Wait until a request to ``url``'s host is permitted by its bucket."""
+    netloc = urlparse(url).netloc
+    bucket = await _get_bucket(netloc)
+    await bucket.acquire()
+
+
+async def navigate(page: Page, url: str, *, timeout_ms: int = _NAV_TIMEOUT_MS) -> None:
+    """Throttle, then navigate. The standard way connectors should call ``page.goto``."""
+    await throttle(url)
+    await page.goto(url, wait_until="domcontentloaded", timeout=timeout_ms)
+
+
+def _make_route_blocker():
+    async def _block(route: Route) -> None:
+        if route.request.resource_type in _BLOCKED_RESOURCE_TYPES:
+            await route.abort()
+        else:
+            await route.continue_()
+
+    return _block
+
+
+async def _ensure_context(*, headful: bool, block_media: bool) -> BrowserContext:
+    """Launch (or return cached) shared browser + context."""
+    global _playwright, _browser, _context, _atexit_registered
+    async with _init_lock:
+        if _context is not None:
+            return _context
+
+        _playwright = await async_playwright().start()
+        _browser = await _playwright.chromium.launch(headless=not headful)
+        _context = await _browser.new_context(user_agent=_resolve_user_agent())
+
+        if block_media:
+            await _context.route("**/*", _make_route_blocker())
+
+        if not _atexit_registered:
+            atexit.register(_atexit_shutdown)
+            _atexit_registered = True
+
+        return _context
+
+
+async def shutdown() -> None:
+    """Close the shared browser/context. Safe to call multiple times."""
+    global _playwright, _browser, _context
+    async with _init_lock:
+        if _context is not None:
+            try:
+                await _context.close()
+            except Exception:  # noqa: BLE001 — best-effort cleanup
+                pass
+            _context = None
+        if _browser is not None:
+            try:
+                await _browser.close()
+            except Exception:  # noqa: BLE001
+                pass
+            _browser = None
+        if _playwright is not None:
+            try:
+                await _playwright.stop()
+            except Exception:  # noqa: BLE001
+                pass
+            _playwright = None
+
+
+def _atexit_shutdown() -> None:
+    """atexit hook — schedules ``shutdown()`` if an event loop is reachable."""
+    if _context is None and _browser is None and _playwright is None:
+        return
+    try:
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(shutdown())
+        finally:
+            loop.close()
+    except Exception:  # noqa: BLE001 — never let atexit raise
+        pass
+
+
+@asynccontextmanager
+async def browser_session(
+    headful: bool | None = None,
+    block_media: bool = True,
+) -> AsyncIterator[BrowserContext]:
+    """Yield the shared :class:`BrowserContext`, lazy-launching if needed.
+
+    The same context is yielded to every caller for the life of the process —
+    not closed on context-manager exit. Call :func:`shutdown` from the daemon's
+    teardown to release Chromium.
+    """
+    resolved_headful = _resolve_headful(headful)
+    context = await _ensure_context(headful=resolved_headful, block_media=block_media)
+    yield context
+
+
+def reset_for_tests() -> None:
+    """Reset module state so tests can re-init cleanly. Test-only."""
+    global _playwright, _browser, _context, _atexit_registered
+    _playwright = None
+    _browser = None
+    _context = None
+    _atexit_registered = False
+    _host_buckets.clear()
+
+
+__all__ = [
+    "browser_session",
+    "navigate",
+    "reset_for_tests",
+    "set_host_rate",
+    "shutdown",
+    "throttle",
+]

--- a/src/research_agent/tools/web_search.py
+++ b/src/research_agent/tools/web_search.py
@@ -1,0 +1,379 @@
+"""Web search via headless DuckDuckGo / Google SERPs (no paid APIs).
+
+Issue #14 — first browser-driven connector. DDG's ``html.duckduckgo.com``
+SERP is the default because it doesn't aggressively bot-block; Google is
+the fallback when DDG misses. Both go through the shared
+:mod:`research_agent.tools.browser` so per-host rate limits stick.
+
+Selectors live in inline constants near the parsers — when the SERP HTML
+inevitably drifts, the screenshot fail-soft path drops a PNG under
+``data/diagnostics/web_search/`` and logs a single WARN; the operator
+fixes the constant.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import UTC, datetime
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Literal
+from urllib.parse import parse_qs, quote_plus
+
+from playwright.async_api import Error as PlaywrightError
+
+from research_agent.tools import browser
+from research_agent.tools.models import SearchResult
+
+logger = logging.getLogger(__name__)
+
+Engine = Literal["ddg", "google"]
+
+DDG_HOST = "html.duckduckgo.com"
+GOOGLE_HOST = "www.google.com"
+_SERP_RPS = 0.5  # 1 query per 2 seconds — public SERPs notice bursts.
+
+DIAGNOSTICS_DIR = Path("data/diagnostics/web_search")
+
+
+def _ensure_serp_rates() -> None:
+    """Register conservative per-host rates for both SERPs.
+
+    Idempotent — safe to call on every ``search()`` invocation. We re-apply
+    on each call (rather than at module import) so a test that resets the
+    shared bucket dict still gets the limits back.
+    """
+    browser.set_host_rate(DDG_HOST, _SERP_RPS)
+    browser.set_host_rate(GOOGLE_HOST, _SERP_RPS)
+
+
+_ensure_serp_rates()
+
+
+# ---------------------------------------------------------------------------
+# Parsers — pure functions over HTML so they can be unit-tested without
+# Playwright. Keep selectors documented inline so future drift is repairable.
+# ---------------------------------------------------------------------------
+
+
+class _DDGParser(HTMLParser):
+    """Extract result rows from html.duckduckgo.com.
+
+    DDG HTML SERP shape (last verified 2026-05):
+      <div class="result__body">
+        <a class="result__a" href="/l/?uddg=<encoded url>">Title</a>
+        <a class="result__snippet">Snippet text</a>
+      </div>
+    DDG wraps the destination URL in a redirect; we unwrap the ``uddg`` param.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.results: list[dict[str, str]] = []
+        self._depth_in_body = 0
+        self._current: dict[str, str] | None = None
+        self._capture: str | None = None  # "title" | "snippet" | None
+        self._buf: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attrd = {k: (v or "") for k, v in attrs}
+        cls = attrd.get("class", "")
+        if tag == "div" and "result__body" in cls.split():
+            self._current = {"url": "", "title": "", "snippet": ""}
+            self._depth_in_body = 1
+            return
+        if self._depth_in_body > 0 and tag == "div":
+            self._depth_in_body += 1
+        if self._current is None:
+            return
+        if tag == "a" and "result__a" in cls.split():
+            href = attrd.get("href", "")
+            self._current["url"] = _unwrap_ddg_href(href)
+            self._capture = "title"
+            self._buf = []
+        elif tag == "a" and "result__snippet" in cls.split():
+            self._capture = "snippet"
+            self._buf = []
+        elif self._capture == "snippet" and tag == "div" and "result__snippet" in cls.split():
+            # Snippet is occasionally a <div>, not <a>.
+            self._buf = []
+
+    def handle_endtag(self, tag: str) -> None:
+        if self._capture == "title" and tag == "a":
+            assert self._current is not None
+            self._current["title"] = "".join(self._buf).strip()
+            self._capture = None
+            self._buf = []
+            return
+        if self._capture == "snippet" and tag in ("a", "div"):
+            assert self._current is not None
+            self._current["snippet"] = "".join(self._buf).strip()
+            self._capture = None
+            self._buf = []
+            return
+        if self._depth_in_body > 0 and tag == "div":
+            self._depth_in_body -= 1
+            if self._depth_in_body == 0 and self._current is not None:
+                if self._current.get("url"):
+                    self.results.append(self._current)
+                self._current = None
+
+    def handle_data(self, data: str) -> None:
+        if self._capture is not None:
+            self._buf.append(data)
+
+
+def _unwrap_ddg_href(href: str) -> str:
+    """DDG wraps result links as ``/l/?uddg=<urlencoded>``; pull the inner URL out."""
+    if not href:
+        return ""
+    if href.startswith("/l/") or href.startswith("//duckduckgo.com/l/"):
+        # parse_qs handles the ``uddg`` param regardless of leading scheme.
+        qs = href.split("?", 1)[1] if "?" in href else ""
+        params = parse_qs(qs)
+        uddg = params.get("uddg")
+        if uddg:
+            return uddg[0]
+    return href
+
+
+def _parse_ddg(html: str) -> list[dict[str, str]]:
+    parser = _DDGParser()
+    try:
+        parser.feed(html)
+    except Exception:  # noqa: BLE001 — malformed HTML must never crash search
+        return parser.results
+    return [r for r in parser.results if r.get("url") and r.get("title")]
+
+
+# Google SERP shape (last verified 2026-05): organic results contain a
+# top-level anchor with an <h3> inside, e.g.:
+#   <div class="g">
+#     <a href="https://example.com/x"><h3>Title</h3></a>
+#     <div class="VwiC3b">snippet</div>
+#   </div>
+# Skip:
+#   - ad blocks (ancestor div with ``data-text-ad`` or
+#     ``commercial-unit-desktop-top`` class),
+#   - knowledge panels (``.ULSxyf`` / ``.kp-blk``),
+#   - "people also ask" (``.related-question-pair``),
+#   - ad redirector URLs (``/aclk?`` or ``/url?...adurl=``).
+_GOOGLE_AD_CLASSES = frozenset(
+    {
+        "commercial-unit-desktop-top",
+        "ULSxyf",
+        "kp-blk",
+        "related-question-pair",
+    }
+)
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _strip_tags(html: str) -> str:
+    return re.sub(r"\s+", " ", _TAG_RE.sub("", html)).strip()
+
+
+class _GoogleParser(HTMLParser):
+    """Walk the DOM and collect organic anchor → h3 → snippet triples."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.results: list[dict[str, str]] = []
+        # Ad-container nesting depth counter. Increment when entering a div
+        # marked as ad/panel; decrement on its close. While >0, skip results.
+        self._ad_stack: list[int] = []  # depth of div nesting at each "in-ad" entry
+        self._div_depth = 0
+
+        self._current_url: str | None = None
+        self._capturing_title = False
+        self._title_buf: list[str] = []
+        # Snippet capture (.VwiC3b div); enabled after we successfully record
+        # an organic result, captures next snippet.
+        self._snippet_pending: bool = False
+        self._capturing_snippet = False
+        self._snippet_buf: list[str] = []
+        self._snippet_div_depth = 0
+
+    @staticmethod
+    def _is_ad_container(attrd: dict[str, str]) -> bool:
+        if "data-text-ad" in attrd:
+            return True
+        cls = set(attrd.get("class", "").split())
+        return bool(cls & _GOOGLE_AD_CLASSES)
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attrd = {k: (v or "") for k, v in attrs}
+
+        if tag == "div":
+            self._div_depth += 1
+            if self._is_ad_container(attrd):
+                self._ad_stack.append(self._div_depth)
+            if self._snippet_pending and "VwiC3b" in attrd.get("class", "").split():
+                self._capturing_snippet = True
+                self._snippet_div_depth = self._div_depth
+                self._snippet_buf = []
+                self._snippet_pending = False
+            return
+
+        if self._ad_stack:
+            return  # Skip everything inside an ad/panel container.
+
+        if tag == "a" and self._current_url is None:
+            href = attrd.get("href", "")
+            if not href.startswith(("http://", "https://")):
+                return
+            if "/aclk?" in href:
+                return
+            if "/url?" in href and "adurl=" in href:
+                return
+            if href.startswith(("https://www.google.com/", "https://accounts.google.com/")):
+                return
+            self._current_url = href
+            return
+
+        if tag == "h3" and self._current_url is not None:
+            self._capturing_title = True
+            self._title_buf = []
+
+    def handle_endtag(self, tag: str) -> None:
+        if self._capturing_snippet and tag == "div":
+            # We may close inner divs; only stop when the snippet div itself closes.
+            if self._div_depth == self._snippet_div_depth:
+                snippet = _strip_tags("".join(self._snippet_buf))
+                if self.results:
+                    self.results[-1]["snippet"] = snippet
+                self._capturing_snippet = False
+                self._snippet_buf = []
+            self._div_depth -= 1
+            if self._ad_stack and self._ad_stack[-1] > self._div_depth:
+                self._ad_stack.pop()
+            return
+
+        if tag == "div":
+            if self._ad_stack and self._ad_stack[-1] == self._div_depth:
+                self._ad_stack.pop()
+            self._div_depth -= 1
+            return
+
+        if self._capturing_title and tag == "h3":
+            title = _strip_tags("".join(self._title_buf))
+            self._capturing_title = False
+            self._title_buf = []
+            if self._current_url and title:
+                self.results.append({"url": self._current_url, "title": title, "snippet": ""})
+                self._snippet_pending = True
+            return
+
+        if tag == "a":
+            self._current_url = None
+            self._capturing_title = False
+            self._title_buf = []
+
+    def handle_data(self, data: str) -> None:
+        if self._capturing_title:
+            self._title_buf.append(data)
+        elif self._capturing_snippet:
+            self._snippet_buf.append(data)
+
+
+def _parse_google(html: str) -> list[dict[str, str]]:
+    """Pull organic results from a Google SERP, skipping ads/knowledge panels."""
+    parser = _GoogleParser()
+    try:
+        parser.feed(html)
+    except Exception:  # noqa: BLE001 — malformed HTML must never crash search
+        return parser.results
+    # Dedupe by URL while preserving order.
+    seen: set[str] = set()
+    out: list[dict[str, str]] = []
+    for row in parser.results:
+        if row["url"] in seen:
+            continue
+        seen.add(row["url"])
+        out.append(row)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+async def _capture_diagnostic(page, engine: str) -> Path:
+    DIAGNOSTICS_DIR.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    path = DIAGNOSTICS_DIR / f"{ts}-{engine}.png"
+    try:
+        await page.screenshot(path=str(path))
+    except PlaywrightError:
+        # If we can't even screenshot, write an empty marker so the path is
+        # still surfaced in the WARN — the operator can grep for the engine.
+        path.write_bytes(b"")
+    return path
+
+
+async def search(
+    query: str,
+    max_results: int = 10,
+    engine: Engine = "ddg",
+) -> list[SearchResult]:
+    """Search ``query`` against ``engine`` and return up to ``max_results`` hits.
+
+    ``score`` and ``published_at`` are intentionally left unset — public SERPs
+    don't expose either consistently, so any value would be made up. Callers
+    that need ranking can re-rank these later.
+    """
+    if not query.strip():
+        return []
+
+    _ensure_serp_rates()
+
+    if engine == "ddg":
+        url = f"https://{DDG_HOST}/html/?q={quote_plus(query)}"
+        parser = _parse_ddg
+    elif engine == "google":
+        url = f"https://{GOOGLE_HOST}/search?q={quote_plus(query)}&hl=en"
+        parser = _parse_google
+    else:  # pragma: no cover — Literal type covers this
+        raise ValueError(f"unknown engine: {engine!r}")
+
+    async with browser.browser_session() as ctx:
+        page = await ctx.new_page()
+        try:
+            try:
+                await browser.navigate(page, url)
+                html = await page.content()
+            except PlaywrightError as exc:
+                logger.warning("web_search %s navigation failed: %s", engine, exc)
+                return []
+
+            parsed = parser(html)
+
+            if not parsed:
+                screenshot = await _capture_diagnostic(page, engine)
+                logger.warning(
+                    "web_search %s returned 0 results for %r — selector drift? screenshot=%s",
+                    engine,
+                    query,
+                    screenshot,
+                )
+                return []
+        finally:
+            await page.close()
+
+    results: list[SearchResult] = []
+    for row in parsed[:max_results]:
+        results.append(
+            SearchResult(
+                url=row["url"],
+                title=row["title"],
+                snippet=row.get("snippet", ""),
+                source_kind="web",
+                extras={"source_engine": engine},
+            )
+        )
+    return results
+
+
+__all__ = ["DIAGNOSTICS_DIR", "search"]

--- a/tests/fixtures/web_search_ddg.html
+++ b/tests/fixtures/web_search_ddg.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head><title>example results</title></head>
+<body>
+<div class="results">
+  <div class="result__body">
+    <h2 class="result__title">
+      <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fopenai.com%2Fblog%2Fexample-one">First Example Result</a>
+    </h2>
+    <a class="result__snippet" href="https://openai.com/blog/example-one">First snippet about <b>OpenAI</b> example one.</a>
+  </div>
+  <div class="result__body">
+    <h2 class="result__title">
+      <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Ftwo">Second Example Result</a>
+    </h2>
+    <a class="result__snippet" href="https://example.com/two">Second snippet content goes here.</a>
+  </div>
+  <div class="result__body">
+    <h2 class="result__title">
+      <a class="result__a" href="https://plain.example/three">Third Example Result</a>
+    </h2>
+    <a class="result__snippet" href="https://plain.example/three">Third snippet without a redirect wrapper.</a>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/fixtures/web_search_google.html
+++ b/tests/fixtures/web_search_google.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head><title>google results</title></head>
+<body>
+<div id="search">
+  <!-- An ad block (must be skipped) -->
+  <div data-text-ad="1" class="commercial-unit-desktop-top">
+    <a href="https://www.googleadservices.com/aclk?adurl=https%3A%2F%2Fads.example%2Fbuy"><h3>Sponsored Ad Title</h3></a>
+    <div class="VwiC3b">Ad description text.</div>
+  </div>
+
+  <!-- Organic result 1 -->
+  <div class="g">
+    <a href="https://example.com/one"><h3>Organic Result One</h3><span>extra</span></a>
+    <div class="VwiC3b">Snippet for organic result one.</div>
+  </div>
+
+  <!-- A "people also ask" block (must be skipped) -->
+  <div class="related-question-pair">
+    <a href="https://example.com/related"><h3>People also ask</h3></a>
+    <div class="VwiC3b">Related question snippet.</div>
+  </div>
+
+  <!-- Organic result 2 -->
+  <div class="g">
+    <a href="https://anothersite.example/page-two"><h3>Organic Result Two</h3></a>
+    <div class="VwiC3b">Snippet for organic result two has <em>some</em> markup.</div>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/test_tools_browser.py
+++ b/tests/test_tools_browser.py
@@ -1,0 +1,312 @@
+"""Tests for the shared Playwright session manager (`tools/browser.py`)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from research_agent.tools import browser
+
+# ---------------------------------------------------------------------------
+# Fakes — enough surface area for browser.py to drive without real Chromium.
+# ---------------------------------------------------------------------------
+
+
+class FakeRoute:
+    def __init__(self, request: FakeRequest) -> None:
+        self.request = request
+        self.aborted = False
+        self.continued = False
+
+    async def abort(self) -> None:
+        self.aborted = True
+
+    async def continue_(self) -> None:
+        self.continued = True
+
+
+class FakeRequest:
+    def __init__(self, resource_type: str) -> None:
+        self.resource_type = resource_type
+
+
+class FakeContext:
+    def __init__(self, ua: str) -> None:
+        self.ua = ua
+        self.routes: list[tuple[str, Any]] = []
+        self.closed = False
+        self.pages_opened = 0
+
+    async def route(self, pattern: str, handler) -> None:
+        self.routes.append((pattern, handler))
+
+    async def new_page(self):
+        self.pages_opened += 1
+        return object()
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeBrowser:
+    def __init__(self) -> None:
+        self.contexts_created: list[FakeContext] = []
+        self.closed = False
+
+    async def new_context(self, *, user_agent: str) -> FakeContext:
+        ctx = FakeContext(user_agent)
+        self.contexts_created.append(ctx)
+        return ctx
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeChromium:
+    def __init__(self) -> None:
+        self.launches: list[dict[str, Any]] = []
+        self.browser = FakeBrowser()
+
+    async def launch(self, *, headless: bool = True):
+        self.launches.append({"headless": headless})
+        return self.browser
+
+
+class FakePlaywright:
+    def __init__(self) -> None:
+        self.chromium = FakeChromium()
+        self.stopped = False
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+class FakePlaywrightStarter:
+    """Mimics the object returned by ``async_playwright()``."""
+
+    def __init__(self) -> None:
+        self.pw = FakePlaywright()
+
+    async def start(self) -> FakePlaywright:
+        return self.pw
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_browser_module(monkeypatch):
+    browser.reset_for_tests()
+    monkeypatch.delenv("RESEARCH_HEADFUL", raising=False)
+    monkeypatch.delenv("RESEARCH_USER_AGENT", raising=False)
+    yield
+    browser.reset_for_tests()
+
+
+@pytest.fixture
+def fake_playwright(monkeypatch):
+    starter = FakePlaywrightStarter()
+
+    def _factory():
+        return starter
+
+    monkeypatch.setattr(browser, "async_playwright", _factory)
+    return starter
+
+
+# ---------------------------------------------------------------------------
+# Session reuse
+# ---------------------------------------------------------------------------
+
+
+async def test_browser_session_reuses_context_across_calls(fake_playwright):
+    async with browser.browser_session() as ctx1:
+        pass
+    async with browser.browser_session() as ctx2:
+        pass
+    assert ctx1 is ctx2
+    # Single launch, single context.
+    assert len(fake_playwright.pw.chromium.launches) == 1
+    assert len(fake_playwright.pw.chromium.browser.contexts_created) == 1
+
+
+async def test_browser_session_blocks_media_by_default(fake_playwright):
+    async with browser.browser_session() as ctx:
+        pass
+    # One route was registered.
+    assert len(ctx.routes) == 1
+    pattern, handler = ctx.routes[0]
+    assert pattern == "**/*"
+
+    for resource_type in ("font", "image", "media"):
+        route = FakeRoute(FakeRequest(resource_type))
+        await handler(route)
+        assert route.aborted, f"{resource_type} should be aborted"
+        assert not route.continued
+
+    for resource_type in ("document", "script", "xhr"):
+        route = FakeRoute(FakeRequest(resource_type))
+        await handler(route)
+        assert not route.aborted, f"{resource_type} should pass"
+        assert route.continued
+
+
+async def test_browser_session_block_media_false_skips_route(fake_playwright):
+    async with browser.browser_session(block_media=False) as ctx:
+        pass
+    assert ctx.routes == []
+
+
+async def test_browser_session_honors_research_headful_env(fake_playwright, monkeypatch):
+    monkeypatch.setenv("RESEARCH_HEADFUL", "1")
+    async with browser.browser_session() as _ctx:
+        pass
+    assert fake_playwright.pw.chromium.launches[0]["headless"] is False
+
+
+async def test_browser_session_default_is_headless(fake_playwright):
+    async with browser.browser_session() as _ctx:
+        pass
+    assert fake_playwright.pw.chromium.launches[0]["headless"] is True
+
+
+async def test_browser_session_explicit_headful_overrides_env(fake_playwright, monkeypatch):
+    monkeypatch.setenv("RESEARCH_HEADFUL", "0")
+    async with browser.browser_session(headful=True) as _ctx:
+        pass
+    assert fake_playwright.pw.chromium.launches[0]["headless"] is False
+
+
+async def test_browser_session_user_agent_falls_back_to_default(fake_playwright, monkeypatch):
+    # Strip both env and config default by monkeypatching config.get.
+    monkeypatch.setattr(browser.config, "get", lambda name: None)
+    async with browser.browser_session() as ctx:
+        pass
+    assert ctx.ua == "research-agent/0.1"
+
+
+async def test_browser_session_uses_research_user_agent_env(fake_playwright, monkeypatch):
+    monkeypatch.setenv("RESEARCH_USER_AGENT", "my-custom-ua/2.0")
+    # config.get reads from os.environ first.
+    async with browser.browser_session() as ctx:
+        pass
+    assert ctx.ua == "my-custom-ua/2.0"
+
+
+# ---------------------------------------------------------------------------
+# Per-host throttling
+# ---------------------------------------------------------------------------
+
+
+async def test_throttle_enforces_minimum_spacing_per_host(monkeypatch):
+    """Two calls in quick succession must result in a sleep of ~1/rps seconds."""
+    sleeps: list[float] = []
+    fake_now = [1000.0]
+
+    def _monotonic():
+        return fake_now[0]
+
+    async def _sleep(d):
+        sleeps.append(d)
+        fake_now[0] += d
+
+    monkeypatch.setattr(browser.time, "monotonic", _monotonic)
+    monkeypatch.setattr(browser.asyncio, "sleep", _sleep)
+
+    browser.set_host_rate("example.com", 1.0)
+
+    await browser.throttle("https://example.com/a")
+    await browser.throttle("https://example.com/b")
+
+    # First call: no wait. Second call: ~1.0 seconds.
+    assert sleeps == pytest.approx([1.0])
+
+
+async def test_throttle_independent_hosts_do_not_block_each_other(monkeypatch):
+    sleeps: list[float] = []
+    fake_now = [2000.0]
+
+    def _monotonic():
+        return fake_now[0]
+
+    async def _sleep(d):
+        sleeps.append(d)
+        fake_now[0] += d
+
+    monkeypatch.setattr(browser.time, "monotonic", _monotonic)
+    monkeypatch.setattr(browser.asyncio, "sleep", _sleep)
+
+    browser.set_host_rate("a.example", 1.0)
+    browser.set_host_rate("b.example", 1.0)
+
+    await browser.throttle("https://a.example/x")
+    await browser.throttle("https://b.example/y")
+
+    # Different hosts share no bucket → no waits.
+    assert sleeps == []
+
+
+async def test_throttle_uses_default_rate_for_unregistered_host(monkeypatch):
+    sleeps: list[float] = []
+    fake_now = [3000.0]
+    monkeypatch.setattr(browser.time, "monotonic", lambda: fake_now[0])
+
+    async def _sleep(d):
+        sleeps.append(d)
+        fake_now[0] += d
+
+    monkeypatch.setattr(browser.asyncio, "sleep", _sleep)
+
+    await browser.throttle("https://unknown.host/x")
+    await browser.throttle("https://unknown.host/y")
+
+    # Default is 1 rps → second call waits ~1s.
+    assert sleeps == pytest.approx([1.0])
+
+
+async def test_set_host_rate_updates_existing_bucket(monkeypatch):
+    sleeps: list[float] = []
+    fake_now = [4000.0]
+    monkeypatch.setattr(browser.time, "monotonic", lambda: fake_now[0])
+
+    async def _sleep(d):
+        sleeps.append(d)
+        fake_now[0] += d
+
+    monkeypatch.setattr(browser.asyncio, "sleep", _sleep)
+
+    # Start with 1 rps, tighten to 0.5 rps (one per 2s) before the first use,
+    # then verify subsequent gaps reflect the tighter rate.
+    browser.set_host_rate("rate.example", 1.0)
+    browser.set_host_rate("rate.example", 0.5)
+
+    await browser.throttle("https://rate.example/x")
+    await browser.throttle("https://rate.example/y")
+    await browser.throttle("https://rate.example/z")
+
+    assert sleeps == pytest.approx([2.0, 2.0])
+
+
+# ---------------------------------------------------------------------------
+# Shutdown
+# ---------------------------------------------------------------------------
+
+
+async def test_shutdown_closes_browser_and_context(fake_playwright):
+    async with browser.browser_session() as ctx:
+        pass
+    await browser.shutdown()
+    assert ctx.closed
+    assert fake_playwright.pw.chromium.browser.closed
+    assert fake_playwright.pw.stopped
+
+
+async def test_shutdown_is_idempotent(fake_playwright):
+    async with browser.browser_session() as _ctx:
+        pass
+    await browser.shutdown()
+    # Second call should not raise even though everything's already torn down.
+    await browser.shutdown()

--- a/tests/test_tools_web_search.py
+++ b/tests/test_tools_web_search.py
@@ -1,0 +1,231 @@
+"""Tests for `research_agent.tools.web_search` (issue #14)."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+from research_agent.tools import browser, web_search
+from research_agent.tools.models import SearchResult
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Fixture loaders + parser-level tests (no Playwright)
+# ---------------------------------------------------------------------------
+
+
+def _load(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def test_parse_ddg_extracts_three_results_and_unwraps_redirect():
+    rows = web_search._parse_ddg(_load("web_search_ddg.html"))
+    assert len(rows) == 3
+    assert rows[0]["url"] == "https://openai.com/blog/example-one"
+    assert rows[0]["title"] == "First Example Result"
+    assert "First snippet" in rows[0]["snippet"]
+    assert "OpenAI" in rows[0]["snippet"]
+    # Plain hrefs (no /l/?uddg=) are passed through.
+    assert rows[2]["url"] == "https://plain.example/three"
+
+
+def test_parse_google_drops_ads_and_keeps_organic():
+    rows = web_search._parse_google(_load("web_search_google.html"))
+    assert [r["url"] for r in rows] == [
+        "https://example.com/one",
+        "https://anothersite.example/page-two",
+    ]
+    assert rows[0]["title"] == "Organic Result One"
+    assert "organic result one" in rows[0]["snippet"].lower()
+
+
+def test_parse_ddg_empty_html_returns_empty_list():
+    assert web_search._parse_ddg("<html><body>nothing</body></html>") == []
+
+
+def test_parse_google_empty_html_returns_empty_list():
+    assert web_search._parse_google("<html><body>nothing</body></html>") == []
+
+
+def test_unwrap_ddg_href_handles_plain_url():
+    assert web_search._unwrap_ddg_href("https://plain.example/x") == "https://plain.example/x"
+
+
+def test_unwrap_ddg_href_unwraps_redirect():
+    href = "//duckduckgo.com/l/?uddg=https%3A%2F%2Ftarget.example%2Fpath&rut=foo"
+    assert web_search._unwrap_ddg_href(href) == "https://target.example/path"
+
+
+# ---------------------------------------------------------------------------
+# Full search() flow with a stub browser session
+# ---------------------------------------------------------------------------
+
+
+class FakePage:
+    def __init__(self, html: str, *, screenshot_path_holder: list[Path] | None = None) -> None:
+        self._html = html
+        self.closed = False
+        self.goto_calls: list[str] = []
+        self.screenshot_calls: list[Path] = []
+        self._sp_holder = screenshot_path_holder
+
+    async def goto(self, url: str, *, wait_until: str = "load", timeout: int = 30000) -> None:
+        self.goto_calls.append(url)
+
+    async def content(self) -> str:
+        return self._html
+
+    async def screenshot(self, *, path: str) -> None:
+        p = Path(path)
+        self.screenshot_calls.append(p)
+        # Touch the file so the diagnostics dir exists with the marker file.
+        p.write_bytes(b"\x89PNG-fake")
+        if self._sp_holder is not None:
+            self._sp_holder.append(p)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeContext:
+    def __init__(self, page: FakePage) -> None:
+        self._page = page
+        self.pages_handed_out: list[FakePage] = []
+
+    async def new_page(self):
+        self.pages_handed_out.append(self._page)
+        return self._page
+
+
+def _patch_browser_session(monkeypatch, page: FakePage) -> FakeContext:
+    fake_ctx = FakeContext(page)
+
+    @asynccontextmanager
+    async def _fake_session(headful=None, block_media=True):
+        yield fake_ctx
+
+    monkeypatch.setattr(browser, "browser_session", _fake_session)
+
+    # Skip throttling — tests should not actually sleep.
+    async def _no_throttle(url: str) -> None:
+        return None
+
+    async def _fake_navigate(p, url, *, timeout_ms=30000):
+        await p.goto(url)
+
+    monkeypatch.setattr(browser, "throttle", _no_throttle)
+    monkeypatch.setattr(browser, "navigate", _fake_navigate)
+    return fake_ctx
+
+
+async def test_search_ddg_returns_search_results_with_engine_extras(monkeypatch):
+    page = FakePage(_load("web_search_ddg.html"))
+    _patch_browser_session(monkeypatch, page)
+
+    results = await web_search.search("openai gpt-5", max_results=10, engine="ddg")
+    assert len(results) == 3
+    assert all(isinstance(r, SearchResult) for r in results)
+    assert all(r.source_kind == "web" for r in results)
+    assert all(r.extras.get("source_engine") == "ddg" for r in results)
+    assert results[0].url == "https://openai.com/blog/example-one"
+    assert results[0].title == "First Example Result"
+    assert results[0].score is None
+    assert results[0].published_at is None
+    # Page was closed after use.
+    assert page.closed
+
+
+async def test_search_ddg_truncates_to_max_results(monkeypatch):
+    page = FakePage(_load("web_search_ddg.html"))
+    _patch_browser_session(monkeypatch, page)
+
+    results = await web_search.search("foo", max_results=2, engine="ddg")
+    assert len(results) == 2
+
+
+async def test_search_google_drops_ads(monkeypatch):
+    page = FakePage(_load("web_search_google.html"))
+    _patch_browser_session(monkeypatch, page)
+
+    results = await web_search.search("widgets", max_results=10, engine="google")
+    urls = [r.url for r in results]
+    assert urls == ["https://example.com/one", "https://anothersite.example/page-two"]
+    assert all(r.extras["source_engine"] == "google" for r in results)
+
+
+async def test_search_empty_query_returns_empty_without_navigation(monkeypatch):
+    page = FakePage("(should not be read)")
+    _patch_browser_session(monkeypatch, page)
+
+    results = await web_search.search("   ", engine="ddg")
+    assert results == []
+    assert page.goto_calls == []
+
+
+async def test_search_zero_results_writes_screenshot_and_warns(monkeypatch, tmp_path, caplog):
+    """Selector drift fail-soft: 0 results for a non-empty query → screenshot + WARN."""
+    monkeypatch.chdir(tmp_path)
+    page = FakePage("<html><body>no matches here</body></html>")
+    _patch_browser_session(monkeypatch, page)
+
+    caplog.set_level(logging.WARNING, logger="research_agent.tools.web_search")
+    results = await web_search.search("openai gpt-5", engine="ddg")
+    assert results == []
+    # Screenshot saved under data/diagnostics/web_search/.
+    diag_dir = tmp_path / "data" / "diagnostics" / "web_search"
+    saved = list(diag_dir.glob("*.png"))
+    assert len(saved) == 1
+    assert "ddg" in saved[0].name
+    # WARN logged once with engine + path.
+    matches = [r for r in caplog.records if "selector drift" in r.getMessage()]
+    assert len(matches) == 1
+    assert "ddg" in matches[0].getMessage()
+    # Path appears in the WARN message (relative form, since DIAGNOSTICS_DIR
+    # is a relative Path).
+    assert saved[0].name in matches[0].getMessage()
+
+
+async def test_search_navigation_url_includes_query(monkeypatch):
+    page = FakePage(_load("web_search_ddg.html"))
+    _patch_browser_session(monkeypatch, page)
+
+    await web_search.search("hello world", engine="ddg")
+    assert page.goto_calls
+    assert "html.duckduckgo.com/html/?q=hello+world" in page.goto_calls[0]
+
+
+async def test_search_google_navigation_url_includes_hl(monkeypatch):
+    page = FakePage(_load("web_search_google.html"))
+    _patch_browser_session(monkeypatch, page)
+
+    await web_search.search("hello", engine="google")
+    assert "google.com/search?q=hello&hl=en" in page.goto_calls[0]
+
+
+# ---------------------------------------------------------------------------
+# Module wiring
+# ---------------------------------------------------------------------------
+
+
+def test_tool_registry_has_web_search():
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "web_search" in TOOL_REGISTRY
+    assert callable(TOOL_REGISTRY["web_search"])
+
+
+def test_serp_rate_buckets_set_to_one_per_two_seconds():
+    """Every ``search()`` call applies the 0.5 rps SERP rate (1 query/2s)."""
+    browser.reset_for_tests()
+    web_search._ensure_serp_rates()
+    ddg_bucket = browser._host_buckets.get(web_search.DDG_HOST)
+    google_bucket = browser._host_buckets.get(web_search.GOOGLE_HOST)
+    assert ddg_bucket is not None
+    assert google_bucket is not None
+    assert ddg_bucket.rps == pytest.approx(0.5)
+    assert google_bucket.rps == pytest.approx(0.5)


### PR DESCRIPTION
Closes #14

## Summary

Automated implementation of **Web search via Playwright (DuckDuckGo + Google SERP) + shared `tools/browser.py`**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

All acceptance criteria met. tools/browser.py and tools/web_search.py implemented per spec, wired into TOOL_REGISTRY, fail-soft on selector drift, 29 new tests + 299 total pass.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*