### PR TITLE
feat: Web fetch connector with trafilatura + Wayback archival (closes #15)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,8 @@ RESEARCH_USER_AGENT=
 # Optional: set to 1 to launch Playwright in headed mode for debugging.
 RESEARCH_HEADFUL=
 
+# Optional: set to 1 to bypass robots.txt checks in web_fetch.
+RESEARCH_IGNORE_ROBOTS=
+
 # Optional: override the default LM Studio base URL (http://localhost:1234/v1).
 LMSTUDIO_BASE_URL=

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ list, so there is no drift.
 | `OPENROUTER_API_KEY` | yes | Cloud synthesis tier (Claude Opus / Haiku via OpenRouter). |
 | `RESEARCH_USER_AGENT` | no | Override default UA sent by httpx + Playwright. |
 | `RESEARCH_HEADFUL` | no | Set to `1` to launch Playwright in headed mode for debugging. |
+| `RESEARCH_IGNORE_ROBOTS` | no | Set to `1` to bypass robots.txt checks in `web_fetch`. |
 | `LMSTUDIO_BASE_URL` | no | Override the default `http://localhost:1234/v1`. |
 
 ## CLI
@@ -137,8 +138,11 @@ register here) and invokes it with `<query>`. Exits with code 2 and a
 
 ```bash
 research _smoke-tool web_search "alpha research project"
+research _smoke-tool web_fetch "https://example.com/article"
 ```
 
-The registry is empty until Phase 3 lands — running the verb today exits
-with `tool not registered: <name> (available: ['(none registered yet)'])`,
-which is the expected pre-Phase-3 baseline.
+`web_fetch` prints the resolved title, the path that served the fetch
+(`httpx` vs `playwright`), HTTP status code, word count, the Wayback
+archive URL (when Save Page Now completed in time), and the first 200
+characters of cleaned text. Background Wayback archival is fire-and-forget,
+so a missing `archive_url` is not a fetch failure.

--- a/src/research_agent/cli.py
+++ b/src/research_agent/cli.py
@@ -318,7 +318,10 @@ def smoke_tool_command(
         raise typer.Exit(code=2)
 
     result = fn(query)
-    typer.echo(repr(result))
+    if isinstance(result, str):
+        typer.echo(result)
+    else:
+        typer.echo(repr(result))
 
 
 @app.command(name="logs")

--- a/src/research_agent/config.py
+++ b/src/research_agent/config.py
@@ -41,6 +41,11 @@ EXPECTED_ENV_KEYS: tuple[EnvKey, ...] = (
         description="Set to '1' to launch Playwright in headed mode for debugging.",
     ),
     EnvKey(
+        name="RESEARCH_IGNORE_ROBOTS",
+        required=False,
+        description="Set to 1 to bypass robots.txt checks in web_fetch.",
+    ),
+    EnvKey(
         name="LMSTUDIO_BASE_URL",
         required=False,
         description="Override the default LM Studio base URL.",

--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -24,11 +24,48 @@ def _smoke_web_search(query: str) -> list[SearchResult]:
     return asyncio.run(_run())
 
 
+def _smoke_web_fetch(url: str) -> str:
+    """Smoke wrapper for web_fetch: print word count, path, preview, archive URL.
+
+    Returns a multi-line plain string so the CLI can print it verbatim.
+    """
+    from research_agent.tools import web_fetch
+
+    async def _run() -> str:
+        source = await web_fetch.fetch(url)
+        if source is None:
+            return f"web_fetch returned None for {url}"
+        # Best-effort: give the archive task a brief window to finish so the
+        # smoke output shows the URL when SPN is fast. We don't wait long;
+        # callers in the live agent never block on archive at all.
+        await asyncio.sleep(0)
+
+        text = source.cleaned_text or ""
+        word_count = len(text.split())
+        preview = text[:200].replace("\n", " ")
+        if len(text) > 200:
+            preview += "…"
+        fetched_via = source.metadata.get("fetched_via", "?")
+        status = source.metadata.get("status_code")
+        return (
+            f"url: {source.url}\n"
+            f"title: {source.title}\n"
+            f"fetched_via: {fetched_via}\n"
+            f"status_code: {status}\n"
+            f"word_count: {word_count}\n"
+            f"archive_url: {source.archive_url}\n"
+            f"preview: {preview}"
+        )
+
+    return asyncio.run(_run())
+
+
 # Registered tool callables, keyed by the name `research _smoke-tool` and the
 # orchestrator dispatch by. The smoke verb checks against this dict so the
 # dispatch surface is in place from day one.
 TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "web_search": _smoke_web_search,
+    "web_fetch": _smoke_web_fetch,
 }
 
 __all__ = ["TOOL_REGISTRY", "SearchResult", "Source", "SourceKind"]

--- a/src/research_agent/tools/archive.py
+++ b/src/research_agent/tools/archive.py
@@ -1,0 +1,91 @@
+"""Wayback Save Page Now (best-effort).
+
+Issue #15 — `web_fetch` fires a non-blocking call to :func:`save` after every
+successful retrieval so we have a durable snapshot of the page at the time of
+research. The Save Page Now endpoint is famously flaky: timeouts, 429s, 500s,
+and silent capture failures are all routine. We treat it as fire-and-forget
+and never raise — the worst case is ``archive_url=None`` on the returned
+:class:`Source`.
+
+Why a hand-rolled httpx call over ``waybackpy.WaybackMachineSaveAPI``: the
+latter is synchronous and retry-heavy (8 tries by default) which would block
+the event loop for tens of seconds when SPN is degraded. A single async POST
+with a tight timeout fits the "best-effort, never block" contract.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from research_agent import config
+
+_DEFAULT_USER_AGENT = "research-agent/0.1"
+_WAYBACK_BASE = "https://web.archive.org"
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_user_agent() -> str:
+    return config.get("RESEARCH_USER_AGENT") or _DEFAULT_USER_AGENT
+
+
+def _absolutise(location: str) -> str:
+    """Wayback returns ``Content-Location: /web/<ts>/<url>`` — prepend host."""
+    if location.startswith(("http://", "https://")):
+        return location
+    if not location.startswith("/"):
+        location = "/" + location
+    return _WAYBACK_BASE + location
+
+
+async def save(url: str, timeout: float = 30.0) -> str | None:
+    """Submit ``url`` to Wayback Save Page Now and return the archive URL.
+
+    Returns None on any error/timeout/non-2xx. Never raises — this is invoked
+    as a background task and a crash here would surface as an unhandled
+    exception in the daemon's event loop.
+    """
+    if not url:
+        return None
+
+    user_agent = _resolve_user_agent()
+    save_url = f"{_WAYBACK_BASE}/save/{url}"
+    headers = {"User-Agent": user_agent}
+
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=headers,
+        ) as client:
+            response = await client.get(save_url)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.debug("wayback save failed for %s: %s", url, exc)
+        return None
+
+    if response.status_code >= 400:
+        logger.debug(
+            "wayback save returned HTTP %s for %s",
+            response.status_code,
+            url,
+        )
+        return None
+
+    # SPN reports the archive URL in either Content-Location or Location;
+    # if it followed redirects, the final response.url is the canonical
+    # ``/web/<timestamp>/<url>`` page. Try them in priority order.
+    for header in ("Content-Location", "Location"):
+        value = response.headers.get(header)
+        if value:
+            return _absolutise(value)
+
+    final_url = str(response.url)
+    if "/web/" in final_url and final_url != save_url:
+        return final_url
+
+    return None
+
+
+__all__ = ["save"]

--- a/src/research_agent/tools/web_fetch.py
+++ b/src/research_agent/tools/web_fetch.py
@@ -1,0 +1,338 @@
+"""HTTP fetch + content extraction connector (issue #15).
+
+Pipeline per call:
+
+1. Robots.txt check (skipped if ``RESEARCH_IGNORE_ROBOTS=1``).
+2. ``httpx`` GET — unless the planner already declared ``requires_js=True``.
+3. Run trafilatura over the HTML; if the cleaned text is too short, retry
+   with ``readability-lxml`` for academic sites where trafilatura under-
+   extracts.
+4. If the result is still tiny (< 500 chars), or the server replied with a
+   classic anti-bot status (403/429/503), or the planner asked for JS up
+   front, fall back to the shared Playwright session and re-extract.
+5. Spawn a background Wayback Save Page Now task — failures never block the
+   return value.
+
+We deliberately do NOT spawn Playwright per-call: the shared
+``tools/browser.py`` session is reused so we don't pay a Chromium launch on
+every fetch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import urllib.robotparser
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+import trafilatura
+from readability import Document
+
+from research_agent import config
+from research_agent.tools import archive, browser
+from research_agent.tools.models import Source
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_USER_AGENT = "research-agent/0.1"
+_MIN_TRAFILATURA_CHARS = 200
+_MIN_TEXT_CHARS = 500
+_BROWSER_FALLBACK_STATUSES = frozenset({403, 429, 503})
+_ROBOTS_TIMEOUT = 5.0
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+
+# Per-host robots cache. Keyed by ``scheme://host`` so http/https are
+# treated separately (they are technically different "origins" for robots).
+_robots_cache: dict[str, urllib.robotparser.RobotFileParser | None] = {}
+_robots_lock = asyncio.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_user_agent() -> str:
+    return config.get("RESEARCH_USER_AGENT") or _DEFAULT_USER_AGENT
+
+
+def _ignore_robots() -> bool:
+    raw = config.get("RESEARCH_IGNORE_ROBOTS")
+    if raw is None:
+        return False
+    return raw.strip().lower() in _TRUTHY
+
+
+# ---------------------------------------------------------------------------
+# robots.txt
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_robots_text(robots_url: str, user_agent: str) -> str | None:
+    headers = {"User-Agent": user_agent}
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=_ROBOTS_TIMEOUT,
+            headers=headers,
+        ) as client:
+            response = await client.get(robots_url)
+    except (httpx.HTTPError, OSError):
+        return None
+    if response.status_code >= 400:
+        # RFC 9309: a 4xx generally means "no robots.txt, allow everything."
+        return ""
+    return response.text
+
+
+async def _robots_allows(url: str, user_agent: str) -> bool:
+    """Return True when ``url`` is fetchable per the host's robots.txt.
+
+    On any fetch error we default to "allow" (the RFC-recommended behaviour
+    when robots.txt is unreachable). Cached per scheme+host so we don't
+    re-fetch for every page on a site.
+    """
+    parsed = urlparse(url)
+    if not parsed.netloc:
+        return True
+    cache_key = f"{parsed.scheme}://{parsed.netloc}"
+
+    async with _robots_lock:
+        if cache_key in _robots_cache:
+            parser = _robots_cache[cache_key]
+        else:
+            parser = None
+            text = await _fetch_robots_text(f"{cache_key}/robots.txt", user_agent)
+            if text is not None:
+                parser = urllib.robotparser.RobotFileParser()
+                parser.parse(text.splitlines())
+            _robots_cache[cache_key] = parser
+
+    if parser is None:
+        return True
+    return parser.can_fetch(user_agent, url)
+
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+
+def _strip_html(html: str) -> str:
+    return _WS_RE.sub(" ", _TAG_RE.sub(" ", html)).strip()
+
+
+def _extract(html: str) -> tuple[str, str]:
+    """Return ``(title, cleaned_text)``.
+
+    Trafilatura first; if it returns suspiciously little (<200 chars) we
+    fall back to readability-lxml's ``Document.summary()`` and strip tags.
+    Pure function — no I/O — so unit tests can hit it directly.
+    """
+    if not html:
+        return "", ""
+
+    title = ""
+    text = ""
+
+    # Trafilatura's metadata extractor is best for the title; the extracted
+    # body itself rarely contains the page <title>.
+    try:
+        meta = trafilatura.extract_metadata(html)
+        if meta and getattr(meta, "title", None):
+            title = (meta.title or "").strip()
+    except Exception:  # noqa: BLE001 — metadata parsing must never crash
+        title = ""
+
+    try:
+        extracted = trafilatura.extract(
+            html,
+            include_comments=False,
+            include_tables=True,
+            favor_recall=True,
+        )
+    except Exception:  # noqa: BLE001
+        extracted = None
+    if extracted:
+        text = extracted.strip()
+
+    if len(text) < _MIN_TRAFILATURA_CHARS:
+        # readability tends to win on academic pages with heavy boilerplate
+        # that trafilatura over-prunes.
+        try:
+            doc = Document(html)
+            summary_html = doc.summary() or ""
+            readable_text = _strip_html(summary_html)
+            if len(readable_text) > len(text):
+                text = readable_text
+            if not title:
+                title = (doc.short_title() or doc.title() or "").strip()
+        except Exception:  # noqa: BLE001
+            pass
+
+    return title, text
+
+
+def _should_use_browser(text_len: int, status_code: int | None, requires_js: bool) -> bool:
+    if requires_js:
+        return True
+    if status_code is not None and status_code in _BROWSER_FALLBACK_STATUSES:
+        return True
+    return text_len < _MIN_TEXT_CHARS
+
+
+# ---------------------------------------------------------------------------
+# Fetchers
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_via_httpx(
+    url: str,
+    timeout: float,
+    user_agent: str,
+) -> tuple[int | None, str | None]:
+    """Return ``(status_code, html)``. ``status_code`` is None on transport error."""
+    headers = {"User-Agent": user_agent}
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=headers,
+        ) as client:
+            response = await client.get(url)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.debug("httpx fetch failed for %s: %s", url, exc)
+        return None, None
+
+    if response.status_code >= 400:
+        return response.status_code, None
+    return response.status_code, response.text
+
+
+async def _fetch_via_playwright(url: str, timeout: float) -> str | None:
+    """Render ``url`` through the shared Chromium session, return HTML."""
+    try:
+        async with browser.browser_session() as ctx:
+            page = await ctx.new_page()
+            try:
+                await browser.navigate(page, url, timeout_ms=int(timeout * 1000))
+                return await page.content()
+            finally:
+                await page.close()
+    except Exception as exc:  # noqa: BLE001 — never crash the pipeline
+        logger.warning("playwright fetch failed for %s: %s", url, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Background Wayback save
+# ---------------------------------------------------------------------------
+
+
+def _spawn_archive_task(source: Source) -> asyncio.Task[None] | None:
+    """Kick off ``archive.save`` and write the result back onto ``source``.
+
+    Returns the spawned task so callers (and tests) can opt into awaiting it,
+    but the standard contract is fire-and-forget — Wayback failure never
+    blocks ``fetch`` from returning.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return None
+
+    async def _runner() -> None:
+        try:
+            archive_url = await archive.save(source.url)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("wayback save raised for %s: %s", source.url, exc)
+            return
+        if archive_url:
+            source.archive_url = archive_url
+
+    return loop.create_task(_runner())
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+async def fetch(
+    url: str,
+    requires_js: bool = False,
+    timeout: float = 30.0,
+) -> Source | None:
+    """Fetch ``url``, extract its content, and return a :class:`Source`.
+
+    Returns None when robots.txt forbids the fetch, both fetch paths fail to
+    yield enough text, or the URL is malformed. Wayback archival happens in
+    a background task; the returned ``Source.archive_url`` is None unless the
+    save completes before the consumer reads it.
+    """
+    if not url or not urlparse(url).netloc:
+        return None
+
+    user_agent = _resolve_user_agent()
+
+    if not _ignore_robots():
+        if not await _robots_allows(url, user_agent):
+            logger.info("web_fetch skipped %s — disallowed by robots.txt", url)
+            return None
+
+    html: str | None = None
+    status_code: int | None = None
+    fetched_via: str = "httpx"
+
+    if not requires_js:
+        status_code, html = await _fetch_via_httpx(url, timeout, user_agent)
+
+    title, text = _extract(html or "")
+
+    if _should_use_browser(len(text), status_code, requires_js):
+        rendered = await _fetch_via_playwright(url, timeout)
+        if rendered:
+            html = rendered
+            title, text = _extract(rendered)
+            fetched_via = "playwright"
+        elif requires_js or html is None:
+            # We needed JS or had no httpx html and Playwright also failed —
+            # nothing to return.
+            return None
+
+    if len(text) < _MIN_TEXT_CHARS and not html:
+        return None
+
+    metadata: dict[str, Any] = {
+        "fetched_via": fetched_via,
+        "status_code": status_code,
+    }
+
+    source = Source(
+        url=url,
+        title=title or url,
+        cleaned_text=text,
+        raw_html=html,
+        fetched_at=datetime.now(UTC),
+        source_kind="web",
+        metadata=metadata,
+    )
+
+    _spawn_archive_task(source)
+
+    return source
+
+
+def reset_for_tests() -> None:
+    """Clear the per-host robots cache. Test-only."""
+    _robots_cache.clear()
+
+
+__all__ = ["fetch", "reset_for_tests"]

--- a/tests/fixtures/web_fetch_article.html
+++ b/tests/fixtures/web_fetch_article.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>The Great Boilerplate Detour - Example Times</title>
+  <meta property="og:title" content="The Great Boilerplate Detour">
+  <meta name="description" content="A test fixture article with realistic boilerplate around the body content.">
+</head>
+<body>
+  <header class="site-header">
+    <nav>
+      <ul class="nav-list">
+        <li><a href="/">Home</a></li>
+        <li><a href="/news">News</a></li>
+        <li><a href="/opinion">Opinion</a></li>
+        <li><a href="/sports">Sports</a></li>
+        <li><a href="/weather">Weather</a></li>
+        <li><a href="/login">Sign in</a></li>
+      </ul>
+    </nav>
+    <div class="ad ad-leaderboard">Advertisement: Buy widgets at WidgetCo!</div>
+  </header>
+  <aside class="sidebar">
+    <h3>Most Popular</h3>
+    <ul>
+      <li><a href="/a">Top stocks of 2026</a></li>
+      <li><a href="/b">10 ways to save money</a></li>
+      <li><a href="/c">Cooking with cabbage</a></li>
+      <li><a href="/d">Why Mondays are like that</a></li>
+    </ul>
+    <div class="newsletter-signup">
+      <p>Sign up for our daily newsletter!</p>
+      <input type="email" placeholder="Your email">
+      <button>Subscribe</button>
+    </div>
+  </aside>
+  <main>
+    <article>
+      <h1>The Great Boilerplate Detour</h1>
+      <p class="byline">By A. Reporter, May 2, 2026</p>
+      <p>
+        In a stunning development for content extraction researchers, a long-form
+        article surfaced today that was almost entirely buried under navigation
+        menus, advertising slots, and reader-engagement widgets. The article,
+        which appeared on the front page of a popular news site, was widely
+        praised for being a useful test fixture rather than for any particular
+        editorial merit.
+      </p>
+      <p>
+        Speaking at a press conference held in a small windowless conference
+        room, the lead engineer for the extraction system explained that the
+        purpose of the fixture is to demonstrate the difference between raw
+        HTML and the cleaned-text output that downstream language models will
+        actually consume. "If we hand the model the navigation bar, the cookie
+        banner, and the related-articles list," she said, "we will burn our
+        token budget on text that has nothing to do with the user's question."
+      </p>
+      <p>
+        The article continues with several more paragraphs, all of which are
+        genuine prose intended to push the cleaned text well past the five
+        hundred character minimum that the fetch pipeline enforces before it
+        decides to escalate to a JavaScript-rendered fallback. Without this
+        body of content, the test would mistakenly trigger the Playwright
+        path on a page that did not actually require browser execution.
+      </p>
+      <p>
+        Industry observers noted that the fixture goes out of its way to
+        include a sidebar, a footer, and a leaderboard advertisement, all of
+        which are common boilerplate elements that boilerpipe-style extractors
+        are specifically designed to remove. A successful extraction should
+        contain the article body, including this paragraph, and exclude the
+        navigation menu, the newsletter signup form, and the legal notices in
+        the footer.
+      </p>
+      <p>
+        Asked whether the fixture would be updated for future releases, the
+        engineer noted that the fixture is intentionally stable so that
+        regressions in the extraction pipeline can be detected by simple
+        substring assertions. "We don't want this thing to drift," she said.
+        "If the extractor stops finding the byline or the dateline, that's a
+        bug, and we want a deterministic test to catch it."
+      </p>
+    </article>
+    <section class="related-articles">
+      <h3>Related Articles</h3>
+      <ul>
+        <li><a href="/r1">Related story one</a></li>
+        <li><a href="/r2">Related story two</a></li>
+        <li><a href="/r3">Related story three</a></li>
+      </ul>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2026 Example Times. All rights reserved.</p>
+    <p>
+      <a href="/terms">Terms of Service</a> |
+      <a href="/privacy">Privacy Policy</a> |
+      <a href="/contact">Contact Us</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/tests/test_tools_archive.py
+++ b/tests/test_tools_archive.py
@@ -1,0 +1,195 @@
+"""Tests for `research_agent.tools.archive` (issue #15)."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import pytest
+
+from research_agent.tools import archive
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        *,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+        url: str = "",
+    ) -> None:
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.url = url
+
+
+def _patch_client(monkeypatch, on_get):
+    """Replace ``httpx.AsyncClient`` with a fake whose ``get`` is ``on_get``.
+
+    ``on_get`` receives ``(url, headers)`` and returns a :class:`_FakeResponse`.
+    Headers are captured from the ``AsyncClient(headers=...)`` init kwargs
+    because that's where archive.py sets them.
+    """
+    captured: dict[str, object] = {}
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        captured["init_kwargs"] = kwargs
+        init_headers = kwargs.get("headers", {})
+
+        class _Client:
+            async def get(self, url, *args, **kwargs):
+                captured["last_url"] = url
+                merged = dict(init_headers)
+                merged.update(kwargs.get("headers", {}))
+                return on_get(url, merged)
+
+        yield _Client()
+
+    monkeypatch.setattr(archive.httpx, "AsyncClient", _client_factory)
+    return captured
+
+
+@pytest.fixture(autouse=True)
+def _scrub_env(monkeypatch):
+    monkeypatch.delenv("RESEARCH_USER_AGENT", raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+async def test_save_returns_archive_url_from_content_location(monkeypatch):
+    captured = _patch_client(
+        monkeypatch,
+        lambda url, _h: _FakeResponse(
+            headers={"Content-Location": "/web/20260502/https://x.example/y"},
+        ),
+    )
+
+    result = await archive.save("https://x.example/y")
+    assert result == "https://web.archive.org/web/20260502/https://x.example/y"
+    assert captured["last_url"] == "https://web.archive.org/save/https://x.example/y"
+
+
+async def test_save_returns_archive_url_from_location_header(monkeypatch):
+    _patch_client(
+        monkeypatch,
+        lambda url, _h: _FakeResponse(
+            headers={"Location": "/web/20260502/https://x.example/y"},
+        ),
+    )
+    assert (
+        await archive.save("https://x.example/y")
+        == "https://web.archive.org/web/20260502/https://x.example/y"
+    )
+
+
+async def test_save_returns_absolute_archive_url_passthrough(monkeypatch):
+    _patch_client(
+        monkeypatch,
+        lambda url, _h: _FakeResponse(
+            headers={"Content-Location": "https://web.archive.org/web/2026/x.example"},
+        ),
+    )
+    assert await archive.save("https://x.example/") == "https://web.archive.org/web/2026/x.example"
+
+
+async def test_save_uses_response_url_when_no_headers(monkeypatch):
+    final = "https://web.archive.org/web/20260502/https://x.example/y"
+    _patch_client(
+        monkeypatch,
+        lambda url, _h: _FakeResponse(headers={}, url=final),
+    )
+    assert await archive.save("https://x.example/y") == final
+
+
+async def test_save_sends_user_agent_header(monkeypatch):
+    monkeypatch.setenv("RESEARCH_USER_AGENT", "custom-bot/3.0")
+    seen_headers: dict[str, str] = {}
+
+    def _on_get(url, headers):
+        seen_headers.update(headers)
+        return _FakeResponse(headers={"Content-Location": "/web/x/https://x.example"})
+
+    _patch_client(monkeypatch, _on_get)
+    await archive.save("https://x.example")
+    assert seen_headers.get("User-Agent") == "custom-bot/3.0"
+
+
+async def test_save_uses_default_user_agent_when_unset(monkeypatch):
+    monkeypatch.setattr(archive.config, "get", lambda name: None)
+    seen_headers: dict[str, str] = {}
+
+    def _on_get(url, headers):
+        seen_headers.update(headers)
+        return _FakeResponse(headers={"Content-Location": "/web/x/https://x.example"})
+
+    _patch_client(monkeypatch, _on_get)
+    await archive.save("https://x.example")
+    assert seen_headers["User-Agent"] == "research-agent/0.1"
+
+
+# ---------------------------------------------------------------------------
+# Failure modes — every one of these must return None, never raise.
+# ---------------------------------------------------------------------------
+
+
+async def test_save_returns_none_on_4xx(monkeypatch):
+    _patch_client(monkeypatch, lambda url, _h: _FakeResponse(status_code=429))
+    assert await archive.save("https://x.example/y") is None
+
+
+async def test_save_returns_none_on_5xx(monkeypatch):
+    _patch_client(monkeypatch, lambda url, _h: _FakeResponse(status_code=500))
+    assert await archive.save("https://x.example/y") is None
+
+
+async def test_save_returns_none_on_timeout(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, url, *args, **kwargs):
+                raise archive.httpx.TimeoutException("slow")
+
+        yield _Client()
+
+    monkeypatch.setattr(archive.httpx, "AsyncClient", _client_factory)
+    assert await archive.save("https://x.example/y") is None
+
+
+async def test_save_returns_none_on_connection_error(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, url, *args, **kwargs):
+                raise archive.httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(archive.httpx, "AsyncClient", _client_factory)
+    assert await archive.save("https://x.example/y") is None
+
+
+async def test_save_returns_none_for_empty_url(monkeypatch):
+    # No client should be invoked for an empty URL.
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        raise AssertionError("client should not be created for empty URL")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(archive.httpx, "AsyncClient", _client_factory)
+    assert await archive.save("") is None
+
+
+async def test_save_returns_none_when_no_archive_pointer(monkeypatch):
+    """200 OK with no Location/Content-Location and a non-archive URL."""
+    _patch_client(
+        monkeypatch,
+        lambda url, _h: _FakeResponse(
+            headers={},
+            url="https://web.archive.org/save/https://x.example/y",
+        ),
+    )
+    assert await archive.save("https://x.example/y") is None

--- a/tests/test_tools_web_fetch.py
+++ b/tests/test_tools_web_fetch.py
@@ -1,0 +1,435 @@
+"""Tests for `research_agent.tools.web_fetch` (issue #15)."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+from research_agent.tools import browser, web_fetch
+from research_agent.tools.models import Source
+
+FIXTURES = Path(__file__).parent / "fixtures"
+ARTICLE_HTML = (FIXTURES / "web_fetch_article.html").read_text(encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _scrub_env(monkeypatch):
+    for key in (
+        "RESEARCH_USER_AGENT",
+        "RESEARCH_IGNORE_ROBOTS",
+        "RESEARCH_HEADFUL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    web_fetch.reset_for_tests()
+    yield
+    web_fetch.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# _extract — pure parser tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_pulls_article_body_and_title():
+    title, text = web_fetch._extract(ARTICLE_HTML)
+    assert title == "The Great Boilerplate Detour"
+    # Body content is included.
+    assert "boilerpipe-style extractors" in text
+    assert "five hundred character minimum" in text
+    # Boilerplate is excluded.
+    assert "Subscribe" not in text
+    assert "Privacy Policy" not in text
+    assert "Sign in" not in text
+    # Comfortably above the 500-char threshold for the fixture.
+    assert len(text) > 1000
+
+
+def test_extract_empty_html_returns_empty():
+    assert web_fetch._extract("") == ("", "")
+
+
+def test_extract_falls_back_to_readability_when_trafilatura_short(monkeypatch):
+    """If trafilatura yields < _MIN_TRAFILATURA_CHARS, readability fills in."""
+
+    # Force trafilatura to return a tiny string so the readability branch runs.
+    def _short(*_args, **_kwargs):
+        return "tiny"
+
+    monkeypatch.setattr(web_fetch.trafilatura, "extract", _short)
+    title, text = web_fetch._extract(ARTICLE_HTML)
+    # readability strips tags from .summary() — we should get more than the
+    # 4-char trafilatura return.
+    assert len(text) > 200
+    assert "boilerpipe-style extractors" in text
+    # Title still resolves (from trafilatura metadata, then readability).
+    assert title == "The Great Boilerplate Detour"
+
+
+# ---------------------------------------------------------------------------
+# _should_use_browser — branching logic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text_len", "status", "requires_js", "expected"),
+    [
+        (10_000, 200, False, False),  # plenty of text, no escalation
+        (100, 200, False, True),  # too short → escalate
+        (10_000, 403, False, True),  # 403 → escalate
+        (10_000, 429, False, True),  # 429 → escalate
+        (10_000, 503, False, True),  # 503 → escalate
+        (10_000, 200, True, True),  # explicit JS request → escalate
+        (0, None, False, True),  # transport error (no status) + no text
+    ],
+)
+def test_should_use_browser(text_len, status, requires_js, expected):
+    assert web_fetch._should_use_browser(text_len, status, requires_js) is expected
+
+
+# ---------------------------------------------------------------------------
+# robots.txt
+# ---------------------------------------------------------------------------
+
+
+def _make_robots_response(text: str, status_code: int = 200):
+    class _Response:
+        def __init__(self) -> None:
+            self.text = text
+            self.status_code = status_code
+
+    return _Response()
+
+
+@asynccontextmanager
+async def _fake_async_client(get_response):
+    class _Client:
+        async def get(self, url, *args, **kwargs):
+            return get_response(url)
+
+        async def aclose(self) -> None:
+            pass
+
+    yield _Client()
+
+
+def _patch_httpx_for_robots(monkeypatch, robots_text: str, *, status: int = 200):
+    """Replace httpx.AsyncClient so robots.txt fetches return ``robots_text``."""
+
+    def _get(url):
+        if url.endswith("/robots.txt"):
+            return _make_robots_response(robots_text, status_code=status)
+        return _make_robots_response("", status_code=200)
+
+    def _client_factory(*args, **kwargs):
+        return _fake_async_client(_get)
+
+    monkeypatch.setattr(web_fetch.httpx, "AsyncClient", _client_factory)
+
+
+async def test_robots_allow_caches_per_host(monkeypatch):
+    calls: list[str] = []
+
+    def _get(url):
+        calls.append(url)
+        return _make_robots_response("User-agent: *\nAllow: /\n")
+
+    def _client_factory(*args, **kwargs):
+        return _fake_async_client(_get)
+
+    monkeypatch.setattr(web_fetch.httpx, "AsyncClient", _client_factory)
+
+    assert await web_fetch._robots_allows("https://example.com/a", "ua/1") is True
+    assert await web_fetch._robots_allows("https://example.com/b", "ua/1") is True
+    # Robots fetched exactly once for the same host.
+    robots_calls = [c for c in calls if c.endswith("/robots.txt")]
+    assert robots_calls == ["https://example.com/robots.txt"]
+
+
+async def test_robots_disallow_blocks_url(monkeypatch):
+    _patch_httpx_for_robots(monkeypatch, "User-agent: *\nDisallow: /private\n")
+    assert await web_fetch._robots_allows("https://x.example/private/page", "ua/1") is False
+    assert await web_fetch._robots_allows("https://x.example/public/page", "ua/1") is True
+
+
+async def test_robots_unreachable_treated_as_allow(monkeypatch):
+    """If robots.txt fetch raises, default-allow per RFC 9309."""
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, url, *args, **kwargs):
+                raise web_fetch.httpx.ConnectError("boom")
+
+        yield _Client()
+
+    monkeypatch.setattr(web_fetch.httpx, "AsyncClient", _client_factory)
+    assert await web_fetch._robots_allows("https://nope.example/x", "ua/1") is True
+
+
+async def test_fetch_skipped_when_robots_disallows(monkeypatch):
+    _patch_httpx_for_robots(monkeypatch, "User-agent: *\nDisallow: /\n")
+    result = await web_fetch.fetch("https://blocked.example/page")
+    assert result is None
+
+
+async def test_fetch_ignores_robots_when_env_set(monkeypatch):
+    """RESEARCH_IGNORE_ROBOTS=1 must skip the robots.txt check entirely."""
+    monkeypatch.setenv("RESEARCH_IGNORE_ROBOTS", "1")
+
+    # Robots disallow everything — but we should NOT consult robots at all.
+    # Make robots fetch raise loudly so a leak would show up as a test failure.
+    def _client_factory(*args, **kwargs):
+        raise AssertionError("robots.txt should not be fetched")
+
+    monkeypatch.setattr(web_fetch.httpx, "AsyncClient", _client_factory)
+
+    captured_calls: list[str] = []
+
+    async def _fake_httpx(url, timeout, user_agent):
+        captured_calls.append(url)
+        return 200, ARTICLE_HTML
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _fake_httpx)
+
+    source = await web_fetch.fetch("https://anywhere.example/page")
+    assert source is not None
+    assert captured_calls == ["https://anywhere.example/page"]
+
+
+# ---------------------------------------------------------------------------
+# Full fetch() pipeline — httpx + browser fallback wiring
+# ---------------------------------------------------------------------------
+
+
+def _disable_robots(monkeypatch):
+    """Bypass robots in tests that focus on the fetch/extract path."""
+    monkeypatch.setenv("RESEARCH_IGNORE_ROBOTS", "1")
+
+
+def _stub_archive(monkeypatch, archive_url: str | None = None):
+    """Replace the Wayback save with an instant no-op (or a fixed return)."""
+
+    async def _save(url, timeout: float = 30.0):
+        return archive_url
+
+    monkeypatch.setattr(web_fetch.archive, "save", _save)
+
+
+async def test_fetch_returns_source_via_httpx(monkeypatch):
+    _disable_robots(monkeypatch)
+    _stub_archive(monkeypatch)
+
+    async def _fake_httpx(url, timeout, user_agent):
+        # config.get returns the declared EXPECTED_ENV_KEYS default when the
+        # env var is unset.
+        assert user_agent.startswith("research-agent/0.1")
+        return 200, ARTICLE_HTML
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _fake_httpx)
+
+    # Browser path must NOT be invoked when text is plentiful and status is 2xx.
+    async def _no_browser(*args, **kwargs):
+        raise AssertionError("playwright should not be invoked")
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_playwright", _no_browser)
+
+    source = await web_fetch.fetch("https://news.example/article")
+    assert isinstance(source, Source)
+    assert source.url == "https://news.example/article"
+    assert source.source_kind == "web"
+    assert source.metadata["fetched_via"] == "httpx"
+    assert source.metadata["status_code"] == 200
+    assert source.title == "The Great Boilerplate Detour"
+    assert "boilerpipe-style extractors" in source.cleaned_text
+
+
+@pytest.mark.parametrize("status", [403, 429, 503])
+async def test_fetch_falls_back_to_browser_on_blocking_status(monkeypatch, status):
+    _disable_robots(monkeypatch)
+    _stub_archive(monkeypatch)
+
+    async def _fake_httpx(url, timeout, user_agent):
+        return status, None
+
+    pw_calls: list[str] = []
+
+    async def _fake_pw(url, timeout):
+        pw_calls.append(url)
+        return ARTICLE_HTML
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _fake_httpx)
+    monkeypatch.setattr(web_fetch, "_fetch_via_playwright", _fake_pw)
+
+    source = await web_fetch.fetch("https://blocked.example/x")
+    assert source is not None
+    assert pw_calls == ["https://blocked.example/x"]
+    assert source.metadata["fetched_via"] == "playwright"
+    assert source.metadata["status_code"] == status
+
+
+async def test_fetch_falls_back_to_browser_when_text_too_short(monkeypatch):
+    _disable_robots(monkeypatch)
+    _stub_archive(monkeypatch)
+
+    short_html = "<html><head><title>Stub</title></head><body><p>too short</p></body></html>"
+
+    async def _fake_httpx(url, timeout, user_agent):
+        return 200, short_html
+
+    pw_calls: list[str] = []
+
+    async def _fake_pw(url, timeout):
+        pw_calls.append(url)
+        return ARTICLE_HTML
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _fake_httpx)
+    monkeypatch.setattr(web_fetch, "_fetch_via_playwright", _fake_pw)
+
+    source = await web_fetch.fetch("https://thin.example/x")
+    assert source is not None
+    assert pw_calls == ["https://thin.example/x"]
+    assert source.metadata["fetched_via"] == "playwright"
+
+
+async def test_fetch_uses_browser_when_requires_js_true(monkeypatch):
+    _disable_robots(monkeypatch)
+    _stub_archive(monkeypatch)
+
+    async def _fake_httpx(url, timeout, user_agent):
+        raise AssertionError("httpx should be skipped when requires_js=True")
+
+    pw_calls: list[str] = []
+
+    async def _fake_pw(url, timeout):
+        pw_calls.append(url)
+        return ARTICLE_HTML
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _fake_httpx)
+    monkeypatch.setattr(web_fetch, "_fetch_via_playwright", _fake_pw)
+
+    source = await web_fetch.fetch("https://spa.example/x", requires_js=True)
+    assert source is not None
+    assert pw_calls == ["https://spa.example/x"]
+    assert source.metadata["fetched_via"] == "playwright"
+    # status_code is None when we never made the httpx request.
+    assert source.metadata["status_code"] is None
+
+
+async def test_fetch_returns_none_when_both_paths_fail(monkeypatch):
+    _disable_robots(monkeypatch)
+    _stub_archive(monkeypatch)
+
+    async def _fake_httpx(url, timeout, user_agent):
+        return None, None  # transport error
+
+    async def _fake_pw(url, timeout):
+        return None  # browser also failed
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _fake_httpx)
+    monkeypatch.setattr(web_fetch, "_fetch_via_playwright", _fake_pw)
+
+    assert await web_fetch.fetch("https://gone.example/x") is None
+
+
+async def test_fetch_returns_none_for_malformed_url(monkeypatch):
+    _disable_robots(monkeypatch)
+    assert await web_fetch.fetch("") is None
+    assert await web_fetch.fetch("not-a-url") is None
+
+
+# ---------------------------------------------------------------------------
+# Wayback archival — fire-and-forget contract
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_spawns_archive_task_without_blocking(monkeypatch):
+    """The archive call runs in a background task — fetch returns immediately."""
+    _disable_robots(monkeypatch)
+
+    archive_started = asyncio.Event()
+    archive_completed = asyncio.Event()
+
+    async def _slow_save(url, timeout: float = 30.0):
+        archive_started.set()
+        await asyncio.sleep(0)
+        archive_completed.set()
+        return "https://web.archive.org/web/2026/https://x.example/y"
+
+    monkeypatch.setattr(web_fetch.archive, "save", _slow_save)
+
+    async def _fake_httpx(url, timeout, user_agent):
+        return 200, ARTICLE_HTML
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _fake_httpx)
+
+    source = await web_fetch.fetch("https://x.example/y")
+    assert source is not None
+    # fetch returns before the archive coroutine has finished its work — at
+    # most it has scheduled the task and yielded.
+    assert source.archive_url is None or source.archive_url.startswith("https://web.archive.org/")
+
+    # Now drain the loop so the archive task gets a chance to complete.
+    await archive_completed.wait()
+    # After the background task finishes, the source should be tagged.
+    assert source.archive_url == "https://web.archive.org/web/2026/https://x.example/y"
+
+
+async def test_fetch_does_not_crash_when_archive_save_raises(monkeypatch):
+    _disable_robots(monkeypatch)
+
+    async def _boom(url, timeout: float = 30.0):
+        raise RuntimeError("wayback exploded")
+
+    monkeypatch.setattr(web_fetch.archive, "save", _boom)
+
+    async def _fake_httpx(url, timeout, user_agent):
+        return 200, ARTICLE_HTML
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _fake_httpx)
+
+    source = await web_fetch.fetch("https://x.example/y")
+    assert source is not None
+    # Drain background tasks so we observe the swallowed exception didn't escape.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert source.archive_url is None
+
+
+# ---------------------------------------------------------------------------
+# User-Agent resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_user_agent_uses_env(monkeypatch):
+    monkeypatch.setenv("RESEARCH_USER_AGENT", "custom-agent/9")
+    assert web_fetch._resolve_user_agent() == "custom-agent/9"
+
+
+def test_resolve_user_agent_falls_back_to_default(monkeypatch):
+    monkeypatch.setattr(web_fetch.config, "get", lambda name: None)
+    assert web_fetch._resolve_user_agent() == "research-agent/0.1"
+
+
+# ---------------------------------------------------------------------------
+# Module wiring
+# ---------------------------------------------------------------------------
+
+
+def test_tool_registry_has_web_fetch():
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "web_fetch" in TOOL_REGISTRY
+    assert callable(TOOL_REGISTRY["web_fetch"])
+
+
+def test_browser_module_imported_lazily(monkeypatch):
+    """We should reach for `browser` only when the playwright path runs.
+
+    Loading `tools/browser.py` is cheap, but verifying the symbol is present
+    keeps the dependency graph documented for future reviewers.
+    """
+    assert hasattr(web_fetch, "browser")
+    assert web_fetch.browser is browser


### PR DESCRIPTION
Closes #15

## Summary

Automated implementation of **Web fetch connector with trafilatura + Wayback archival**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Implementation meets all acceptance criteria; fixed README drift for new RESEARCH_IGNORE_ROBOTS env var and stale TOOL_REGISTRY note. All 340 tests pass.

- **WARNING** [FIXED] `README.md`: README env var table omitted RESEARCH_IGNORE_ROBOTS, which is a new public config knob added by #15. The README explicitly claims '.env.example and research doctor both read from EXPECTED_ENV_KEYS so there is no drift', so the missing row breaks that contract.
- **WARNING** [FIXED] `README.md`: README troubleshooting section still said 'The registry is empty until Phase 3 lands' even though web_search (#14) and web_fetch (#15) are both registered in TOOL_REGISTRY. Replaced the stale note with a web_fetch smoke example and explanation of its output.
- **INFO** [OPEN] `src/research_agent/tools/web_fetch.py`: Acceptance criteria phrased fetched_via as belonging to Source.extras, but the Source model defined in #13 only has a metadata field (extras lives on SearchResult). Implementation correctly uses metadata; this is a wording-vs-model discrepancy in the issue text, not an implementation gap.
- **INFO** [OPEN] `src/research_agent/tools/web_fetch.py`: Acceptance criteria mentioned an --ignore-robots config flag, but the implementation uses the RESEARCH_IGNORE_ROBOTS env var. This is consistent with the project's '.env is the only config surface' convention documented in README and config.py, so the env var is the right interpretation.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*