### PR TITLE
feat: Wayback archive connector (tools/archive.py) (closes #16)

### DIFF
--- a/src/research_agent/tools/archive.py
+++ b/src/research_agent/tools/archive.py
@@ -1,30 +1,53 @@
 """Wayback Save Page Now (best-effort).
 
-Issue #15 — `web_fetch` fires a non-blocking call to :func:`save` after every
+`web_fetch` (issue #15) fires a non-blocking call to :func:`save` after every
 successful retrieval so we have a durable snapshot of the page at the time of
 research. The Save Page Now endpoint is famously flaky: timeouts, 429s, 500s,
 and silent capture failures are all routine. We treat it as fire-and-forget
 and never raise — the worst case is ``archive_url=None`` on the returned
 :class:`Source`.
 
+Issue #16 layers in two contracts on top of issue #15's hand-rolled call:
+
+* Per-process rate limiting — Wayback's SPN is sensitive to bursts, so all
+  callers in this process serialise through a shared lock that enforces at
+  least ``_RATE_LIMIT_INTERVAL`` seconds between submissions. Concurrent
+  ``save()`` calls queue rather than overlap.
+* Tenacity-driven retries with exponential backoff for transient failures
+  (network errors, timeouts, 408/425/429/5xx) — bounded to three attempts
+  total so a degraded SPN doesn't pin a worker forever.
+
 Why a hand-rolled httpx call over ``waybackpy.WaybackMachineSaveAPI``: the
 latter is synchronous and retry-heavy (8 tries by default) which would block
-the event loop for tens of seconds when SPN is degraded. A single async POST
-with a tight timeout fits the "best-effort, never block" contract.
+the event loop for tens of seconds when SPN is degraded. A single async GET
+with explicit retry/backoff fits the "best-effort, never block long" contract.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 
 import httpx
+import tenacity
 
 from research_agent import config
 
 _DEFAULT_USER_AGENT = "research-agent/0.1"
 _WAYBACK_BASE = "https://web.archive.org"
 
+_RATE_LIMIT_INTERVAL = 5.0
+_RETRYABLE_STATUSES = frozenset({408, 425, 429, 500, 502, 503, 504})
+
 logger = logging.getLogger(__name__)
+
+_rate_lock = asyncio.Lock()
+_last_save_monotonic: float | None = None
+
+
+class _TransientError(Exception):
+    """Internal marker for failures the retry policy should consider retryable."""
 
 
 def _resolve_user_agent() -> str:
@@ -40,20 +63,25 @@ def _absolutise(location: str) -> str:
     return _WAYBACK_BASE + location
 
 
-async def save(url: str, timeout: float = 30.0) -> str | None:
-    """Submit ``url`` to Wayback Save Page Now and return the archive URL.
+async def _rate_limit_gate() -> None:
+    """Block until at least ``_RATE_LIMIT_INTERVAL`` has passed since the last save.
 
-    Returns None on any error/timeout/non-2xx. Never raises — this is invoked
-    as a background task and a crash here would surface as an unhandled
-    exception in the daemon's event loop.
+    Acquired serially via ``_rate_lock`` so concurrent callers queue instead
+    of all firing simultaneously and tripping SPN's per-IP limits.
     """
-    if not url:
-        return None
+    global _last_save_monotonic
+    async with _rate_lock:
+        if _last_save_monotonic is not None:
+            elapsed = time.monotonic() - _last_save_monotonic
+            wait = _RATE_LIMIT_INTERVAL - elapsed
+            if wait > 0:
+                await asyncio.sleep(wait)
+        _last_save_monotonic = time.monotonic()
 
-    user_agent = _resolve_user_agent()
+
+async def _attempt(url: str, headers: dict[str, str], timeout: float) -> str | None:
+    """Single SPN submission. Raises ``_TransientError`` on retryable failures."""
     save_url = f"{_WAYBACK_BASE}/save/{url}"
-    headers = {"User-Agent": user_agent}
-
     try:
         async with httpx.AsyncClient(
             follow_redirects=True,
@@ -61,12 +89,17 @@ async def save(url: str, timeout: float = 30.0) -> str | None:
             headers=headers,
         ) as client:
             response = await client.get(save_url)
+    except (httpx.TimeoutException, httpx.NetworkError) as exc:
+        raise _TransientError(f"transport error: {exc}") from exc
     except (httpx.HTTPError, OSError) as exc:
-        logger.debug("wayback save failed for %s: %s", url, exc)
+        logger.warning("wayback save failed for %s: %s", url, exc)
         return None
 
+    if response.status_code in _RETRYABLE_STATUSES:
+        raise _TransientError(f"wayback HTTP {response.status_code}")
+
     if response.status_code >= 400:
-        logger.debug(
+        logger.warning(
             "wayback save returned HTTP %s for %s",
             response.status_code,
             url,
@@ -88,4 +121,43 @@ async def save(url: str, timeout: float = 30.0) -> str | None:
     return None
 
 
-__all__ = ["save"]
+async def save(url: str, timeout: float = 30.0) -> str | None:
+    """Submit ``url`` to Wayback Save Page Now and return the archive URL.
+
+    Returns None on any error/timeout/non-2xx after retries are exhausted.
+    Never raises — this is invoked as a background task and a crash here
+    would surface as an unhandled exception in the daemon's event loop.
+    """
+    if not url:
+        return None
+
+    headers = {"User-Agent": _resolve_user_agent()}
+
+    await _rate_limit_gate()
+
+    try:
+        async for attempt in tenacity.AsyncRetrying(
+            stop=tenacity.stop_after_attempt(3),
+            wait=tenacity.wait_exponential(multiplier=1, min=1, max=8),
+            retry=tenacity.retry_if_exception_type(_TransientError),
+            reraise=False,
+        ):
+            with attempt:
+                return await _attempt(url, headers, timeout)
+    except tenacity.RetryError as exc:
+        underlying: BaseException | tenacity.RetryError = exc
+        if exc.last_attempt is not None and exc.last_attempt.failed:
+            underlying = exc.last_attempt.exception() or exc
+        logger.warning("wayback save failed after retries for %s: %s", url, underlying)
+
+    return None
+
+
+def reset_for_tests() -> None:
+    """Clear per-process rate-limit state. Test-only."""
+    global _last_save_monotonic, _rate_lock
+    _last_save_monotonic = None
+    _rate_lock = asyncio.Lock()
+
+
+__all__ = ["save", "reset_for_tests"]

--- a/tests/test_tools_archive.py
+++ b/tests/test_tools_archive.py
@@ -1,8 +1,11 @@
-"""Tests for `research_agent.tools.archive` (issue #15)."""
+"""Tests for `research_agent.tools.archive` (issues #15 and #16)."""
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -29,7 +32,7 @@ def _patch_client(monkeypatch, on_get):
     Headers are captured from the ``AsyncClient(headers=...)`` init kwargs
     because that's where archive.py sets them.
     """
-    captured: dict[str, object] = {}
+    captured: dict[str, object] = {"call_count": 0}
 
     @asynccontextmanager
     async def _client_factory(*args, **kwargs):
@@ -38,6 +41,7 @@ def _patch_client(monkeypatch, on_get):
 
         class _Client:
             async def get(self, url, *args, **kwargs):
+                captured["call_count"] = int(captured["call_count"]) + 1
                 captured["last_url"] = url
                 merged = dict(init_headers)
                 merged.update(kwargs.get("headers", {}))
@@ -53,6 +57,20 @@ def _patch_client(monkeypatch, on_get):
 def _scrub_env(monkeypatch):
     monkeypatch.delenv("RESEARCH_USER_AGENT", raising=False)
     yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_archive_state(monkeypatch):
+    """Reset per-process rate-limit state and silence backoff sleeps.
+
+    Tests that need to inspect or override ``asyncio.sleep`` re-patch it
+    explicitly; this default keeps the suite fast even when tenacity is
+    iterating its retry loop.
+    """
+    archive.reset_for_tests()
+    monkeypatch.setattr(archive.asyncio, "sleep", AsyncMock())
+    yield
+    archive.reset_for_tests()
 
 
 # ---------------------------------------------------------------------------
@@ -137,7 +155,7 @@ async def test_save_uses_default_user_agent_when_unset(monkeypatch):
 
 
 async def test_save_returns_none_on_4xx(monkeypatch):
-    _patch_client(monkeypatch, lambda url, _h: _FakeResponse(status_code=429))
+    _patch_client(monkeypatch, lambda url, _h: _FakeResponse(status_code=404))
     assert await archive.save("https://x.example/y") is None
 
 
@@ -193,3 +211,108 @@ async def test_save_returns_none_when_no_archive_pointer(monkeypatch):
         ),
     )
     assert await archive.save("https://x.example/y") is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #16 — retry/backoff and rate-limit behaviour
+# ---------------------------------------------------------------------------
+
+
+async def test_save_logs_warning_on_failure(monkeypatch, caplog):
+    _patch_client(monkeypatch, lambda url, _h: _FakeResponse(status_code=500))
+    with caplog.at_level(logging.WARNING, logger=archive.logger.name):
+        result = await archive.save("https://x.example/y")
+    assert result is None
+    assert any(rec.levelno == logging.WARNING for rec in caplog.records)
+
+
+async def test_save_retries_on_transient_error(monkeypatch):
+    """503 twice, then a 200 with Content-Location succeeds on the 3rd try."""
+    responses = iter(
+        [
+            _FakeResponse(status_code=503),
+            _FakeResponse(status_code=503),
+            _FakeResponse(headers={"Content-Location": "/web/2026/https://x.example/y"}),
+        ]
+    )
+    captured = _patch_client(monkeypatch, lambda url, _h: next(responses))
+
+    result = await archive.save("https://x.example/y")
+    assert result == "https://web.archive.org/web/2026/https://x.example/y"
+    assert captured["call_count"] == 3
+
+
+async def test_save_retries_on_timeout_then_succeeds(monkeypatch):
+    """First call raises TimeoutException; second returns 200."""
+    calls = {"n": 0}
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, url, *args, **kwargs):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    raise archive.httpx.TimeoutException("slow")
+                return _FakeResponse(
+                    headers={"Content-Location": "/web/2026/https://x.example/y"},
+                )
+
+        yield _Client()
+
+    monkeypatch.setattr(archive.httpx, "AsyncClient", _client_factory)
+
+    result = await archive.save("https://x.example/y")
+    assert result == "https://web.archive.org/web/2026/https://x.example/y"
+    assert calls["n"] == 2
+
+
+async def test_save_gives_up_after_max_attempts(monkeypatch, caplog):
+    captured = _patch_client(monkeypatch, lambda url, _h: _FakeResponse(status_code=503))
+    with caplog.at_level(logging.WARNING, logger=archive.logger.name):
+        result = await archive.save("https://x.example/y")
+    assert result is None
+    assert captured["call_count"] == 3
+    assert any(
+        "wayback save failed after retries" in rec.getMessage()
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING
+    )
+
+
+async def test_save_rate_limits_concurrent_calls(monkeypatch):
+    """Two concurrent ``save()`` calls must be serialised: the second one
+    sleeps at least the rate-limit interval before its submission."""
+    clock = [100.0]
+
+    def fake_monotonic() -> float:
+        return clock[0]
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        # Advance the fake clock so subsequent monotonic() reads reflect
+        # that time has "passed."
+        clock[0] += seconds
+
+    monkeypatch.setattr(archive.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(archive.asyncio, "sleep", fake_sleep)
+
+    _patch_client(
+        monkeypatch,
+        lambda url, _h: _FakeResponse(
+            headers={"Content-Location": "/web/2026/" + url},
+        ),
+    )
+
+    results = await asyncio.gather(
+        archive.save("https://a.example"),
+        archive.save("https://b.example"),
+    )
+
+    assert all(r is not None for r in results)
+    # The second call to enter the gate must have slept at least the full
+    # rate-limit interval (no real time passed between the two acquires).
+    assert any(s >= archive._RATE_LIMIT_INTERVAL for s in sleep_calls), (
+        f"expected a sleep ≥ {archive._RATE_LIMIT_INTERVAL}s, got {sleep_calls!r}"
+    )


### PR DESCRIPTION
Closes #16

## Summary

Automated implementation of **Wayback archive connector (tools/archive.py)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Wayback archive connector meets all acceptance criteria; 17 dedicated tests pass and full suite (345 tests) is green.

- **INFO** [OPEN] `src/research_agent/tools/archive.py`: Implementation deviates from issue text 'thin wrapper around waybackpy' — uses a hand-rolled async httpx call instead. Rationale is documented in the module docstring (waybackpy is synchronous and would block the event loop with up to 8 retries by default). Tests correctly mock httpx.AsyncClient rather than waybackpy. The deviation produces a strictly better implementation for the async, fire-and-forget contract required by web_fetch.
- **INFO** [OPEN] `src/research_agent/tools/archive.py`: Retries (up to 3 attempts with 1–8s exponential backoff) fire within a single save() call without re-entering the rate-limit gate, so one URL can produce 2–3 SPN requests within ~10s. This is consistent with treating a save+retries as one logical operation, but means the literal '1 per 5s' invariant only holds across distinct save() invocations, not across retries within one. Acceptable given retries cap at 3 and the same URL is being submitted.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*