### PR TITLE
feat: arXiv connector (tools/arxiv_tool.py) (closes #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ register here) and invokes it with `<query>`. Exits with code 2 and a
 ```bash
 research _smoke-tool web_search "alpha research project"
 research _smoke-tool web_fetch "https://example.com/article"
+research _smoke-tool arxiv "transformer interpretability"
 ```
 
 `web_fetch` prints the resolved title, the path that served the fetch
@@ -146,3 +147,7 @@ research _smoke-tool web_fetch "https://example.com/article"
 archive URL (when Save Page Now completed in time), and the first 200
 characters of cleaned text. Background Wayback archival is fire-and-forget,
 so a missing `archive_url` is not a fetch failure.
+
+`arxiv` prints the top 5 hits as `- <title>\n  <abs URL>\n  <abstract
+preview>`. The connector honours arXiv's 3 s request-spacing recommendation
+and runs the synchronous `arxiv` lib through `asyncio.to_thread`.

--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -54,6 +54,30 @@ def _smoke_local_corpus(corpus_path: str) -> str:
     )
 
 
+def _smoke_arxiv(query: str) -> str:
+    """Smoke wrapper: arXiv search returning the top-5 hits as plain text.
+
+    Each hit shows ``title``, abs URL, and a 200-char snippet of the abstract
+    so AC #5 (`research _smoke-tool arxiv "..."` returns top 5 with abstracts)
+    can be eyeballed against live data.
+    """
+    from research_agent.tools import arxiv_tool
+
+    async def _run() -> str:
+        results = await arxiv_tool.search(query, max_results=5)
+        if not results:
+            return f"arxiv search returned no results for {query!r}"
+        lines: list[str] = []
+        for hit in results:
+            snippet = hit.snippet.replace("\n", " ")
+            if len(snippet) > 200:
+                snippet = snippet[:200] + "…"
+            lines.append(f"- {hit.title}\n  {hit.url}\n  {snippet}")
+        return "\n".join(lines)
+
+    return asyncio.run(_run())
+
+
 def _smoke_web_fetch(url: str) -> str:
     """Smoke wrapper for web_fetch: print word count, path, preview, archive URL.
 
@@ -97,6 +121,7 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "web_search": _smoke_web_search,
     "web_fetch": _smoke_web_fetch,
     "local_corpus": _smoke_local_corpus,
+    "arxiv": _smoke_arxiv,
 }
 
 __all__ = ["TOOL_REGISTRY", "SearchResult", "Source", "SourceKind"]

--- a/src/research_agent/tools/arxiv_tool.py
+++ b/src/research_agent/tools/arxiv_tool.py
@@ -1,0 +1,248 @@
+"""arXiv connector (issue #19).
+
+Wraps the synchronous ``arxiv`` Python lib in an asyncio-friendly surface and
+adds the same per-process rate limiting and PDF-text extraction the rest of
+the pipeline relies on.
+
+Public surface:
+
+* ``async def search(query, max_results=20, sort_by='relevance')`` — return a
+  list of :class:`SearchResult`. Snippet is the arXiv abstract.
+* ``async def fetch(arxiv_id_or_url)`` — download the PDF to
+  ``corpus/.cache/arxiv/<id>.pdf`` (cached) and return a :class:`Source` with
+  ``source_kind='arxiv'`` whose ``cleaned_text`` is the extracted PDF text.
+
+arXiv's API guidelines ask callers to leave at least three seconds between
+requests; both ``search`` and the PDF download go through ``_rate_limit_gate``
+to honour that.
+
+The ``arxiv`` lib is sync, so its ``Client.results`` invocation runs inside
+``asyncio.to_thread``. PDF text extraction reuses
+``local_corpus._extract_pdf`` so the pypdf → unstructured fallback that the
+local indexer uses is shared with arXiv-fetched PDFs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+import arxiv
+import httpx
+
+from research_agent import config
+from research_agent.tools import local_corpus
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_USER_AGENT = "research-agent/0.1"
+_RATE_LIMIT_INTERVAL = 3.0
+_CACHE_DIR = Path("corpus/.cache/arxiv")
+
+# Match either a bare arXiv id (with optional version) or an arxiv.org abs/pdf URL.
+# Modern ids look like ``2401.12345`` or ``2401.12345v2``; legacy ids look like
+# ``quant-ph/0201082`` or ``quant-ph/0201082v1``.
+_ARXIV_ID_RE = re.compile(
+    r"(?:arxiv\.org/(?:abs|pdf)/)?"
+    r"(?P<id>(?:[a-z\-]+(?:\.[A-Z]{2})?/\d{7}|\d{4}\.\d{4,5}))"
+    r"(?P<version>v\d+)?"
+    r"(?:\.pdf)?",
+    re.IGNORECASE,
+)
+
+_SORT_BY_MAP: dict[str, arxiv.SortCriterion] = {
+    "relevance": arxiv.SortCriterion.Relevance,
+    "submittedDate": arxiv.SortCriterion.SubmittedDate,
+    "lastUpdatedDate": arxiv.SortCriterion.LastUpdatedDate,
+}
+
+_rate_lock = asyncio.Lock()
+_last_call_monotonic: float | None = None
+
+
+def _resolve_user_agent() -> str:
+    return config.get("RESEARCH_USER_AGENT") or _DEFAULT_USER_AGENT
+
+
+async def _rate_limit_gate() -> None:
+    """Block until at least ``_RATE_LIMIT_INTERVAL`` has passed since the last call."""
+    global _last_call_monotonic
+    async with _rate_lock:
+        if _last_call_monotonic is not None:
+            elapsed = time.monotonic() - _last_call_monotonic
+            wait = _RATE_LIMIT_INTERVAL - elapsed
+            if wait > 0:
+                await asyncio.sleep(wait)
+        _last_call_monotonic = time.monotonic()
+
+
+def _normalize_id(arxiv_id_or_url: str) -> str:
+    """Extract the bare arXiv id (without version suffix) from any accepted form."""
+    if not arxiv_id_or_url:
+        raise ValueError("arxiv_id_or_url must be non-empty")
+    match = _ARXIV_ID_RE.search(arxiv_id_or_url.strip())
+    if not match:
+        raise ValueError(f"could not parse arXiv id from {arxiv_id_or_url!r}")
+    return match.group("id")
+
+
+def _build_search_result(result: arxiv.Result) -> SearchResult:
+    short_id = result.get_short_id()
+    return SearchResult(
+        url=result.entry_id,
+        title=(result.title or "").strip(),
+        snippet=(result.summary or "").strip(),
+        published_at=result.published,
+        source_kind="arxiv",
+        extras={
+            "arxiv_id": short_id,
+            "authors": [a.name for a in result.authors],
+            "pdf_url": result.pdf_url,
+            "categories": list(result.categories or []),
+            "primary_category": result.primary_category,
+        },
+    )
+
+
+async def search(
+    query: str,
+    max_results: int = 20,
+    sort_by: str = "relevance",
+) -> list[SearchResult]:
+    """Search arXiv and return up to ``max_results`` :class:`SearchResult` hits.
+
+    ``sort_by`` accepts ``'relevance'`` or ``'submittedDate'`` (and the less
+    common ``'lastUpdatedDate'``). The ``arxiv`` lib is synchronous, so the
+    actual HTTP call runs in a worker thread; the rate-limit gate ensures we
+    leave ≥3 s between successive arXiv API calls per process.
+    """
+    if sort_by not in _SORT_BY_MAP:
+        raise ValueError(f"sort_by must be one of {sorted(_SORT_BY_MAP)}; got {sort_by!r}")
+
+    sort_criterion = _SORT_BY_MAP[sort_by]
+    arxiv_search = arxiv.Search(
+        query=query,
+        max_results=max_results,
+        sort_by=sort_criterion,
+    )
+
+    await _rate_limit_gate()
+
+    def _run() -> list[arxiv.Result]:
+        client = arxiv.Client()
+        return list(client.results(arxiv_search))
+
+    try:
+        results = await asyncio.to_thread(_run)
+    except (arxiv.ArxivError, arxiv.HTTPError, arxiv.UnexpectedEmptyPageError) as exc:
+        logger.warning("arxiv search failed for %r: %s", query, exc)
+        return []
+
+    return [_build_search_result(r) for r in results]
+
+
+async def _download_pdf(pdf_url: str, dest: Path, timeout: float) -> bool:
+    """Download ``pdf_url`` to ``dest`` atomically. Returns True on success."""
+    headers = {"User-Agent": _resolve_user_agent()}
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=headers,
+        ) as client:
+            response = await client.get(pdf_url)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("arxiv pdf download failed for %s: %s", pdf_url, exc)
+        return False
+
+    if response.status_code >= 400:
+        logger.warning(
+            "arxiv pdf download returned HTTP %s for %s",
+            response.status_code,
+            pdf_url,
+        )
+        return False
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    tmp.write_bytes(response.content)
+    tmp.replace(dest)
+    return True
+
+
+async def _resolve_title(arxiv_id: str) -> str | None:
+    """Fetch a single result's metadata to recover its title. None on failure."""
+    await _rate_limit_gate()
+
+    def _run() -> arxiv.Result | None:
+        client = arxiv.Client()
+        try:
+            return next(client.results(arxiv.Search(id_list=[arxiv_id])))
+        except StopIteration:
+            return None
+
+    try:
+        result = await asyncio.to_thread(_run)
+    except (arxiv.ArxivError, arxiv.HTTPError, arxiv.UnexpectedEmptyPageError) as exc:
+        logger.debug("arxiv title lookup failed for %s: %s", arxiv_id, exc)
+        return None
+
+    if result is None:
+        return None
+    return (result.title or "").strip() or None
+
+
+async def fetch(arxiv_id_or_url: str, timeout: float = 30.0) -> Source | None:
+    """Download the arXiv PDF for ``arxiv_id_or_url`` and return a :class:`Source`.
+
+    PDF bytes are cached at ``corpus/.cache/arxiv/<id>.pdf`` so repeated calls
+    skip the network entirely. Text extraction reuses
+    ``local_corpus._extract_pdf``. Returns None if the download fails.
+    """
+    try:
+        arxiv_id = _normalize_id(arxiv_id_or_url)
+    except ValueError as exc:
+        logger.warning("arxiv fetch rejected %r: %s", arxiv_id_or_url, exc)
+        return None
+
+    pdf_url = f"https://arxiv.org/pdf/{arxiv_id}.pdf"
+    cache_path = _CACHE_DIR / f"{arxiv_id.replace('/', '_')}.pdf"
+
+    if not cache_path.exists():
+        await _rate_limit_gate()
+        ok = await _download_pdf(pdf_url, cache_path, timeout)
+        if not ok:
+            return None
+
+    cleaned_text = await asyncio.to_thread(local_corpus._extract_pdf, cache_path)
+
+    title = await _resolve_title(arxiv_id) or arxiv_id
+
+    return Source(
+        url=f"https://arxiv.org/abs/{arxiv_id}",
+        title=title,
+        cleaned_text=cleaned_text,
+        raw_html=None,
+        fetched_at=datetime.now(UTC),
+        source_kind="arxiv",
+        metadata={
+            "arxiv_id": arxiv_id,
+            "pdf_path": str(cache_path),
+            "pdf_url": pdf_url,
+        },
+    )
+
+
+def reset_for_tests() -> None:
+    """Clear per-process rate-limit state. Test-only."""
+    global _last_call_monotonic, _rate_lock
+    _last_call_monotonic = None
+    _rate_lock = asyncio.Lock()
+
+
+__all__ = ["fetch", "reset_for_tests", "search"]

--- a/tests/fixtures/arxiv_paper.pdf
+++ b/tests/fixtures/arxiv_paper.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<</Type /Catalog /Pages 2 0 R>>
+endobj
+2 0 obj
+<</Type /Pages /Kids [3 0 R] /Count 1>>
+endobj
+3 0 obj
+<</Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources <</Font <</F1 5 0 R>>>>>>
+endobj
+4 0 obj
+<</Length 63>>
+stream
+BT
+/F1 12 Tf
+72 720 Td
+(Hello arxiv research paper text) Tj
+ET
+endstream
+endobj
+5 0 obj
+<</Type /Font /Subtype /Type1 /BaseFont /Helvetica>>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000056 00000 n 
+0000000111 00000 n 
+0000000231 00000 n 
+0000000341 00000 n 
+trailer
+<</Size 6 /Root 1 0 R>>
+startxref
+409
+%%EOF

--- a/tests/test_tools_arxiv.py
+++ b/tests/test_tools_arxiv.py
@@ -1,0 +1,303 @@
+"""Tests for `research_agent.tools.arxiv_tool` (issue #19)."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import arxiv
+import pytest
+
+from research_agent.tools import arxiv_tool
+
+FIXTURE_PDF = Path(__file__).parent / "fixtures" / "arxiv_paper.pdf"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_result(
+    *,
+    arxiv_id: str = "2401.12345",
+    title: str = "A Sample arXiv Paper",
+    summary: str = "We study transformer interpretability via probing.",
+    published: datetime | None = None,
+    authors: list[str] | None = None,
+    categories: list[str] | None = None,
+) -> arxiv.Result:
+    """Construct a minimal `arxiv.Result` mirroring `_from_feed_entry` shape."""
+    entry_id = f"https://arxiv.org/abs/{arxiv_id}"
+    pdf_link = arxiv.Result.Link(
+        href=f"https://arxiv.org/pdf/{arxiv_id}",
+        title="pdf",
+        rel="related",
+        content_type="application/pdf",
+    )
+    abs_link = arxiv.Result.Link(
+        href=entry_id, title=None, rel="alternate", content_type="text/html"
+    )
+    return arxiv.Result(
+        entry_id=entry_id,
+        updated=published or datetime(2026, 1, 15, tzinfo=UTC),
+        published=published or datetime(2026, 1, 15, tzinfo=UTC),
+        title=title,
+        authors=[arxiv.Result.Author(name) for name in (authors or ["Ada Lovelace"])],
+        summary=summary,
+        primary_category=(categories or ["cs.LG"])[0],
+        categories=categories or ["cs.LG"],
+        links=[abs_link, pdf_link],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _scrub_env(monkeypatch):
+    monkeypatch.delenv("RESEARCH_USER_AGENT", raising=False)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_arxiv_state(monkeypatch):
+    arxiv_tool.reset_for_tests()
+    monkeypatch.setattr(arxiv_tool.asyncio, "sleep", AsyncMock())
+    yield
+    arxiv_tool.reset_for_tests()
+
+
+@pytest.fixture
+def cache_dir(tmp_path: Path, monkeypatch) -> Path:
+    target = tmp_path / "arxiv-cache"
+    monkeypatch.setattr(arxiv_tool, "_CACHE_DIR", target)
+    return target
+
+
+def _patch_client_results(monkeypatch, results: list[arxiv.Result]):
+    """Replace `arxiv.Client.results` with a stub that yields `results`."""
+    captured: dict[str, object] = {"call_count": 0, "searches": []}
+
+    def _fake_results(self, search, offset=0):  # noqa: ARG001
+        captured["call_count"] = int(captured["call_count"]) + 1
+        captured["searches"].append(search)
+        return iter(results)
+
+    monkeypatch.setattr(arxiv_tool.arxiv.Client, "results", _fake_results)
+    return captured
+
+
+def _patch_httpx(monkeypatch, *, body: bytes, status_code: int = 200):
+    """Replace `httpx.AsyncClient` with a fake whose ``get`` returns ``body``."""
+    captured: dict[str, object] = {"call_count": 0, "urls": []}
+
+    class _FakeResp:
+        def __init__(self, body: bytes, status_code: int) -> None:
+            self.content = body
+            self.status_code = status_code
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):  # noqa: ARG001
+        captured["init_kwargs"] = kwargs
+
+        class _Client:
+            async def get(self, url, *_args, **_kwargs):
+                captured["call_count"] = int(captured["call_count"]) + 1
+                captured["urls"].append(url)
+                return _FakeResp(body, status_code)
+
+        yield _Client()
+
+    monkeypatch.setattr(arxiv_tool.httpx, "AsyncClient", _client_factory)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def test_search_returns_search_results_with_arxiv_kind(monkeypatch):
+    fake = _make_result(
+        title="Transformer Interpretability via Probing",
+        summary="We probe attention heads in GPT-style models.",
+    )
+    _patch_client_results(monkeypatch, [fake, _make_result(arxiv_id="2402.99999")])
+
+    results = await arxiv_tool.search("transformer interpretability", max_results=5)
+
+    assert len(results) == 2
+    assert all(r.source_kind == "arxiv" for r in results)
+    assert results[0].title == "Transformer Interpretability via Probing"
+    assert "attention heads" in results[0].snippet
+    assert results[0].url == "https://arxiv.org/abs/2401.12345"
+    assert results[0].extras["arxiv_id"] == "2401.12345"
+    assert results[0].extras["authors"] == ["Ada Lovelace"]
+    assert results[0].extras["pdf_url"] == "https://arxiv.org/pdf/2401.12345"
+    assert results[0].extras["categories"] == ["cs.LG"]
+
+
+async def test_search_honors_sort_by_submitted_date(monkeypatch):
+    captured = _patch_client_results(monkeypatch, [_make_result()])
+    await arxiv_tool.search("foo", max_results=3, sort_by="submittedDate")
+
+    assert captured["call_count"] == 1
+    search_obj = captured["searches"][0]
+    assert search_obj.sort_by == arxiv.SortCriterion.SubmittedDate
+    assert search_obj.max_results == 3
+    assert search_obj.query == "foo"
+
+
+async def test_search_rejects_invalid_sort_by(monkeypatch):
+    _patch_client_results(monkeypatch, [])
+    with pytest.raises(ValueError, match="sort_by"):
+        await arxiv_tool.search("foo", sort_by="bogus")
+
+
+async def test_search_returns_empty_list_on_arxiv_error(monkeypatch):
+    def _raise(self, search, offset=0):  # noqa: ARG001
+        raise arxiv.HTTPError("https://arxiv.org/api", 0, 503)
+
+    monkeypatch.setattr(arxiv_tool.arxiv.Client, "results", _raise)
+
+    assert await arxiv_tool.search("foo") == []
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_downloads_and_extracts_pdf(monkeypatch, cache_dir: Path):
+    pdf_bytes = FIXTURE_PDF.read_bytes()
+    _patch_httpx(monkeypatch, body=pdf_bytes)
+    # Stub title lookup to avoid a second arxiv.Client call path.
+    _patch_client_results(monkeypatch, [_make_result(title="My Paper")])
+
+    source = await arxiv_tool.fetch("2401.12345")
+
+    assert source is not None
+    assert source.source_kind == "arxiv"
+    assert source.url == "https://arxiv.org/abs/2401.12345"
+    assert source.cleaned_text  # non-empty
+    assert "Hello arxiv research paper text" in source.cleaned_text
+    assert source.title == "My Paper"
+    assert source.metadata["arxiv_id"] == "2401.12345"
+    assert source.metadata["pdf_url"] == "https://arxiv.org/pdf/2401.12345.pdf"
+    assert (cache_dir / "2401.12345.pdf").exists()
+
+
+async def test_fetch_is_idempotent_and_uses_cache(monkeypatch, cache_dir: Path):
+    pdf_bytes = FIXTURE_PDF.read_bytes()
+    captured = _patch_httpx(monkeypatch, body=pdf_bytes)
+    _patch_client_results(monkeypatch, [_make_result()])
+
+    s1 = await arxiv_tool.fetch("2401.12345")
+    s2 = await arxiv_tool.fetch("2401.12345")
+
+    assert s1 is not None and s2 is not None
+    # HTTP download fired only once; the second call hits the cache.
+    assert captured["call_count"] == 1
+
+
+async def test_fetch_accepts_abs_url(monkeypatch, cache_dir: Path):
+    _patch_httpx(monkeypatch, body=FIXTURE_PDF.read_bytes())
+    _patch_client_results(monkeypatch, [_make_result()])
+
+    source = await arxiv_tool.fetch("https://arxiv.org/abs/2401.12345v2")
+
+    assert source is not None
+    assert source.metadata["arxiv_id"] == "2401.12345"
+    assert source.url == "https://arxiv.org/abs/2401.12345"
+
+
+async def test_fetch_accepts_pdf_url(monkeypatch, cache_dir: Path):
+    _patch_httpx(monkeypatch, body=FIXTURE_PDF.read_bytes())
+    _patch_client_results(monkeypatch, [_make_result()])
+
+    source = await arxiv_tool.fetch("https://arxiv.org/pdf/2401.12345.pdf")
+
+    assert source is not None
+    assert source.metadata["arxiv_id"] == "2401.12345"
+
+
+async def test_fetch_returns_none_on_http_error(monkeypatch, cache_dir: Path):
+    _patch_httpx(monkeypatch, body=b"", status_code=500)
+    _patch_client_results(monkeypatch, [])
+
+    assert await arxiv_tool.fetch("2401.12345") is None
+    assert not (cache_dir / "2401.12345.pdf").exists()
+
+
+async def test_fetch_returns_none_on_transport_error(monkeypatch, cache_dir: Path):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):  # noqa: ARG001
+        class _Client:
+            async def get(self, url, *_a, **_k):
+                raise arxiv_tool.httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(arxiv_tool.httpx, "AsyncClient", _client_factory)
+
+    assert await arxiv_tool.fetch("2401.12345") is None
+
+
+async def test_fetch_returns_none_on_unparseable_id(monkeypatch, cache_dir: Path):
+    assert await arxiv_tool.fetch("not-an-arxiv-id") is None
+
+
+async def test_fetch_falls_back_to_id_as_title(monkeypatch, cache_dir: Path):
+    """When the title lookup yields nothing, fall back to the bare id."""
+    _patch_httpx(monkeypatch, body=FIXTURE_PDF.read_bytes())
+    _patch_client_results(monkeypatch, [])  # title lookup returns no results
+
+    source = await arxiv_tool.fetch("2401.12345")
+
+    assert source is not None
+    assert source.title == "2401.12345"
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit gate
+# ---------------------------------------------------------------------------
+
+
+async def test_rate_limits_concurrent_calls(monkeypatch):
+    """Two concurrent ``search`` calls must be serialised by the 3 s gate."""
+    clock = [100.0]
+
+    def fake_monotonic() -> float:
+        return clock[0]
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        clock[0] += seconds
+
+    monkeypatch.setattr(arxiv_tool.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(arxiv_tool.asyncio, "sleep", fake_sleep)
+
+    _patch_client_results(monkeypatch, [_make_result()])
+
+    await asyncio.gather(
+        arxiv_tool.search("foo"),
+        arxiv_tool.search("bar"),
+    )
+
+    assert any(s >= arxiv_tool._RATE_LIMIT_INTERVAL for s in sleep_calls), (
+        f"expected a sleep ≥ {arxiv_tool._RATE_LIMIT_INTERVAL}s, got {sleep_calls!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Smoke registration
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_registry_includes_arxiv():
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "arxiv" in TOOL_REGISTRY


### PR DESCRIPTION
Closes #19

## Summary

Automated implementation of **arXiv connector (tools/arxiv_tool.py)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

arXiv connector fully meets all 5 acceptance criteria; all 378 tests pass; smoke verb wired via TOOL_REGISTRY; rate-limit gate, atomic PDF cache, and shared PDF extractor all correct.

- **INFO** [OPEN] `src/research_agent/tools/arxiv_tool.py`: _normalize_id strips version suffix (e.g. v2), so the cache key collapses all versions of a paper to a single file. Documented by test_fetch_accepts_abs_url and likely the desired default — worth revisiting only if version-pinned fetches become a requirement.
- **INFO** [OPEN] `src/research_agent/tools/arxiv_tool.py`: arxiv.Client already enforces a 3s delay internally, so the explicit _rate_limit_gate is belt-and-suspenders for the search path. It is still load-bearing for the direct httpx PDF download path, so leaving it in place is correct.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*