### PR TITLE
feat:  command — FTS over findings/sources (closes #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,23 @@ research view <job-id> --sources   # generated list of recorded sources
 research logs <job-id>             # print existing events.jsonl entries
 research logs <job-id> -f          # follow appended events
 research logs <job-id> --level ERROR
+
+research search "<query>"          # FTS5 over findings + sources (cross-job)
+research search "<query>" --job <job-id>     # scope to one job
+research search "<query>" --kind findings    # findings only (default: both)
+research search "<query>" --kind sources     # sources only
+research search "<query>" --json             # machine-readable list
 ```
+
+`research search` runs the user's query through SQLite FTS5 against
+`findings_fts` (claim text) and `sources_fts` (source titles), ordered by
+the BM25 score (lower is better). Snippet highlights come from the FTS5
+`snippet()` function — the Rich table renders matched terms in bold yellow;
+the `--json` payload preserves them as literal `[`/`]` markers. Source rows
+join through `job_sources`, so the `--job` filter correctly excludes
+sources fetched only by other jobs even when the underlying content is
+shared. FTS5 syntax errors (e.g. unbalanced quotes) exit `1` with a clear
+`FTS5 query error: ...` line on stderr.
 
 ### Config verbs
 

--- a/src/research_agent/cli.py
+++ b/src/research_agent/cli.py
@@ -324,6 +324,60 @@ def smoke_tool_command(
         typer.echo(repr(result))
 
 
+@app.command(name="search")
+def search_command(
+    query: str = typer.Argument(..., help="FTS5 query string."),
+    job: str = typer.Option(None, "--job", help="Scope to a single job id."),
+    all_: bool = typer.Option(  # noqa: ARG001 — explicit flag; --all is the default
+        False,
+        "--all",
+        help="Search across all jobs (default when --job is not set).",
+    ),
+    kind: str = typer.Option(
+        "both",
+        "--kind",
+        help="What to search: findings | sources | both.",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of the Rich table.",
+    ),
+) -> None:
+    """Run FTS5 search over findings and/or sources."""
+    import sqlite3
+
+    from research_agent.storage.search import ALLOWED_KINDS, search_fts
+
+    if kind not in ALLOWED_KINDS:
+        typer.echo(
+            f"--kind must be one of {list(ALLOWED_KINDS)}; got {kind!r}",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    job_id: str | None = None
+    if job is not None:
+        _load_job_or_exit(job)
+        job_id = job
+
+    try:
+        results = search_fts(query, job_id=job_id, kind=kind, db_path=db.DEFAULT_DB_PATH)
+    except sqlite3.OperationalError as e:
+        typer.echo(f"FTS5 query error: {e}", err=True)
+        raise typer.Exit(code=1) from e
+
+    if json_output:
+        typer.echo(render.search_results_to_json(results))
+        return
+
+    if not results:
+        typer.echo("(no results)")
+        return
+
+    Console().print(render.render_search_table(results))
+
+
 @app.command(name="logs")
 def logs_command(
     job_id: str = typer.Argument(..., help="Job id (e.g. 2026-05-02-some-slug)."),

--- a/src/research_agent/storage/__init__.py
+++ b/src/research_agent/storage/__init__.py
@@ -18,6 +18,7 @@ from research_agent.storage.markdown import (
     write_report,
     write_synthesis,
 )
+from research_agent.storage.search import search_fts
 from research_agent.storage.sources import (
     clean_content,
     content_sha256,
@@ -35,6 +36,7 @@ __all__ = [
     "content_sha256",
     "list_jobs",
     "migrate",
+    "search_fts",
     "write_finding",
     "write_plan",
     "write_report",

--- a/src/research_agent/storage/search.py
+++ b/src/research_agent/storage/search.py
@@ -1,0 +1,116 @@
+"""FTS5 search over findings and sources (issue #22).
+
+Pure read-only helper used by the ``research search`` CLI verb. Runs against
+the ``findings_fts`` and ``sources_fts`` virtual tables built in §10 of the
+implementation guide. Scoring uses the FTS5 ``bm25`` function — lower score
+means a better match — and snippets come from the FTS5 ``snippet`` function
+with literal ``[``/``]`` markers around the matched terms (the ``ui.render``
+layer transforms those into Rich markup).
+
+The MATCH string is the user's query verbatim; FTS5 syntax errors propagate
+as :class:`sqlite3.OperationalError` for the CLI to translate into a friendly
+error message.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from research_agent.storage import db
+
+ALLOWED_KINDS = ("findings", "sources", "both")
+
+
+def search_fts(
+    query: str,
+    *,
+    job_id: str | None,
+    kind: str,
+    db_path: Path | str = db.DEFAULT_DB_PATH,
+) -> list[dict[str, Any]]:
+    """Run FTS5 search over findings and/or sources.
+
+    Returns a list of result dicts with keys:
+    ``kind`` (``finding`` or ``source``), ``score`` (bm25 — lower is better),
+    ``job_id``, ``snippet``, ``id``, ``md_path``, ``title_or_claim``.
+
+    Source rows are joined through ``job_sources`` so a source shared by N
+    jobs produces N rows in cross-job mode and is correctly filtered when
+    ``job_id`` is set.
+
+    Raises :class:`ValueError` for empty/whitespace queries or unknown
+    ``kind``. FTS5 MATCH errors surface as :class:`sqlite3.OperationalError`.
+    """
+    if not isinstance(query, str) or not query.strip():
+        raise ValueError("query must be a non-empty string")
+    if kind not in ALLOWED_KINDS:
+        raise ValueError(f"kind must be one of {list(ALLOWED_KINDS)}; got {kind!r}")
+
+    results: list[dict[str, Any]] = []
+    conn = db.connect(Path(db_path))
+    try:
+        if kind in ("findings", "both"):
+            sql = (
+                "SELECT f.id AS id, f.job_id AS job_id, "
+                "bm25(findings_fts) AS score, "
+                "snippet(findings_fts, 0, '[', ']', '…', 12) AS snippet, "
+                "f.md_path AS md_path, f.claim AS title_or_claim "
+                "FROM findings_fts "
+                "JOIN findings f ON f.id = findings_fts.rowid "
+                "WHERE findings_fts MATCH ?"
+            )
+            params: list[Any] = [query]
+            if job_id is not None:
+                sql += " AND f.job_id = ?"
+                params.append(job_id)
+            sql += " ORDER BY score"
+            for row in conn.execute(sql, params).fetchall():
+                results.append(
+                    {
+                        "kind": "finding",
+                        "score": float(row["score"]),
+                        "job_id": row["job_id"],
+                        "snippet": row["snippet"],
+                        "id": int(row["id"]),
+                        "md_path": row["md_path"],
+                        "title_or_claim": row["title_or_claim"],
+                    }
+                )
+
+        if kind in ("sources", "both"):
+            sql = (
+                "SELECT s.id AS id, js.job_id AS job_id, "
+                "bm25(sources_fts) AS score, "
+                "snippet(sources_fts, 0, '[', ']', '…', 12) AS snippet, "
+                "s.md_path AS md_path, s.title AS title_or_claim "
+                "FROM sources_fts "
+                "JOIN sources s ON s.id = sources_fts.rowid "
+                "JOIN job_sources js ON js.source_id = s.id "
+                "WHERE sources_fts MATCH ?"
+            )
+            params = [query]
+            if job_id is not None:
+                sql += " AND js.job_id = ?"
+                params.append(job_id)
+            sql += " ORDER BY score"
+            for row in conn.execute(sql, params).fetchall():
+                results.append(
+                    {
+                        "kind": "source",
+                        "score": float(row["score"]),
+                        "job_id": row["job_id"],
+                        "snippet": row["snippet"],
+                        "id": int(row["id"]),
+                        "md_path": row["md_path"],
+                        "title_or_claim": row["title_or_claim"],
+                    }
+                )
+    finally:
+        conn.close()
+
+    results.sort(key=lambda r: r["score"])
+    return results
+
+
+__all__ = ["ALLOWED_KINDS", "search_fts"]

--- a/src/research_agent/ui/render.py
+++ b/src/research_agent/ui/render.py
@@ -242,6 +242,35 @@ def tail_events_jsonl(
             yield ev
 
 
+def render_search_table(results: list[dict[str, Any]]) -> Table:
+    """Render a Rich table for `research search` results."""
+    table = Table(title="search results", show_lines=False)
+    table.add_column("score")
+    table.add_column("kind")
+    table.add_column("job_id", overflow="fold")
+    table.add_column("snippet", overflow="fold")
+    for row in results:
+        snippet = str(row.get("snippet", ""))
+        snippet = snippet.replace("[", "[bold yellow]").replace("]", "[/]")
+        score = row.get("score")
+        try:
+            score_str = f"{float(score):.2f}"  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            score_str = "—"
+        table.add_row(
+            score_str,
+            str(row.get("kind", "")),
+            str(row.get("job_id") or "—"),
+            snippet,
+        )
+    return table
+
+
+def search_results_to_json(results: list[dict[str, Any]]) -> str:
+    """Serialize search results for `--json` callers."""
+    return json.dumps(results, indent=2, sort_keys=True, default=str)
+
+
 def format_event_line(event: dict[str, Any]) -> str:
     """One-line printable form of an event for `research logs`."""
     ts = event.get("ts", "?")
@@ -260,6 +289,8 @@ __all__ = [
     "jobs_to_json",
     "load_status_data",
     "render_jobs_table",
+    "render_search_table",
     "render_status_panel",
+    "search_results_to_json",
     "tail_events_jsonl",
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -579,3 +579,134 @@ def test_smoke_tool_invokes_registered_callable(smoke_repo, monkeypatch):
         assert "echo:ping" in result.stdout
     finally:
         TOOL_REGISTRY.pop("echo", None)
+
+
+# ---------------------------------------------------------------------------
+# search verb
+# ---------------------------------------------------------------------------
+
+
+def _seed_search_data(repo: Path) -> tuple[Job, Job]:
+    """Create two jobs with seeded findings/sources, then rebuild FTS indexes."""
+    job_a = _make_synthetic_job(repo, goal="alpha quantum job", today=date(2026, 5, 1))
+    job_b = _make_synthetic_job(repo, goal="beta classical job", today=date(2026, 5, 2))
+
+    now = int(time.time())
+    conn = db.connect(repo / "data" / "index.sqlite")
+    try:
+        with conn:
+            conn.execute(
+                "INSERT INTO findings"
+                " (job_id, md_path, claim, confidence, source_ids, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (job_a.id, "findings/000001.md", "quantum mechanics insight", 0.9, "[]", now),
+            )
+            conn.execute(
+                "INSERT INTO findings"
+                " (job_id, md_path, claim, confidence, source_ids, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (job_b.id, "findings/000001.md", "quantum supremacy paper", 0.8, "[]", now),
+            )
+            conn.execute(
+                "INSERT INTO findings"
+                " (job_id, md_path, claim, confidence, source_ids, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (job_a.id, "findings/000002.md", "classical mechanics review", 0.6, "[]", now),
+            )
+
+            cur = conn.execute(
+                "INSERT INTO sources (sha256, url, title, fetched_at, md_path, kind)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                ("a" * 64, "http://x", "Quantum source title", now, "sources/a.md", "web"),
+            )
+            sid = cur.lastrowid
+            conn.execute(
+                "INSERT INTO job_sources (job_id, source_id) VALUES (?, ?)",
+                (job_a.id, sid),
+            )
+
+            conn.execute("INSERT INTO findings_fts(findings_fts) VALUES('rebuild')")
+            conn.execute("INSERT INTO sources_fts(sources_fts) VALUES('rebuild')")
+    finally:
+        conn.close()
+
+    return job_a, job_b
+
+
+def test_search_json_emits_results(isolated_jobs_repo: Path):
+    _seed_search_data(isolated_jobs_repo)
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["search", "quantum", "--json"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, list)
+    assert len(payload) >= 1
+    expected = {"kind", "score", "job_id", "snippet", "id", "md_path", "title_or_claim"}
+    for row in payload:
+        assert expected <= row.keys()
+
+
+def test_search_empty_result_zero_exit(isolated_jobs_repo: Path):
+    _seed_search_data(isolated_jobs_repo)
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["search", "nonexistenttoken", "--json"])
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout) == []
+
+
+def test_search_kind_flag_filters_output(isolated_jobs_repo: Path):
+    _seed_search_data(isolated_jobs_repo)
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["search", "quantum", "--kind", "findings", "--json"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload
+    assert all(r["kind"] == "finding" for r in payload)
+
+
+def test_search_job_flag_scopes_to_job(isolated_jobs_repo: Path):
+    job_a, _job_b = _seed_search_data(isolated_jobs_repo)
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["search", "quantum", "--job", job_a.id, "--json"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload
+    assert all(r["job_id"] == job_a.id for r in payload)
+
+
+def test_search_invalid_kind_exit_code_2(isolated_jobs_repo: Path):
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["search", "quantum", "--kind", "bogus"])
+    assert result.exit_code == 2
+    combined = result.stdout + (result.stderr or "")
+    assert "kind" in combined.lower()
+
+
+def test_search_unknown_job_errors(isolated_jobs_repo: Path):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        ["search", "quantum", "--job", "2026-05-02-does-not-exist", "--json"],
+    )
+    assert result.exit_code == 1
+    combined = result.stdout + (result.stderr or "")
+    assert "job not found" in combined
+    assert "Traceback" not in combined
+
+
+def test_search_no_results_table_message(isolated_jobs_repo: Path):
+    _seed_search_data(isolated_jobs_repo)
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["search", "nonexistenttoken"])
+    assert result.exit_code == 0, result.stdout
+    assert "(no results)" in result.stdout
+
+
+def test_search_malformed_query_exits_one(isolated_jobs_repo: Path):
+    _seed_search_data(isolated_jobs_repo)
+    runner = CliRunner()
+    # Unbalanced quotes are an FTS5 syntax error.
+    result = runner.invoke(cli.app, ["search", '"unterminated', "--json"])
+    assert result.exit_code == 1
+    combined = result.stdout + (result.stderr or "")
+    assert "FTS5 query error" in combined

--- a/tests/test_storage_search.py
+++ b/tests/test_storage_search.py
@@ -1,0 +1,198 @@
+"""Tests for `research_agent.storage.search` (issue #22)."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from research_agent.storage import db
+from research_agent.storage.search import search_fts
+
+JOB_A = "2026-05-01-job-a"
+JOB_B = "2026-05-02-job-b"
+
+
+@pytest.fixture
+def seeded_db(tmp_path: Path) -> Path:
+    """Build a tmp DB with two jobs, several findings, and two sources."""
+    db_path = tmp_path / "data" / "index.sqlite"
+    db.migrate(path=db_path).close()
+
+    now = int(time.time())
+    conn = db.connect(db_path)
+    try:
+        with conn:
+            for jid in (JOB_A, JOB_B):
+                conn.execute(
+                    "INSERT INTO jobs (id, goal, status, intake_json, created_at)"
+                    " VALUES (?, ?, ?, ?, ?)",
+                    (jid, "g", "pending", "{}", now),
+                )
+
+            conn.execute(
+                "INSERT INTO findings"
+                " (job_id, md_path, claim, confidence, source_ids, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    JOB_A,
+                    "findings/000001.md",
+                    "quantum entanglement breakthrough at MIT lab",
+                    0.9,
+                    "[]",
+                    now,
+                ),
+            )
+            conn.execute(
+                "INSERT INTO findings"
+                " (job_id, md_path, claim, confidence, source_ids, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    JOB_B,
+                    "findings/000001.md",
+                    "quantum supremacy benchmark surpassed",
+                    0.8,
+                    "[]",
+                    now,
+                ),
+            )
+            conn.execute(
+                "INSERT INTO findings"
+                " (job_id, md_path, claim, confidence, source_ids, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    JOB_A,
+                    "findings/000002.md",
+                    "unrelated coffee research finding",
+                    0.5,
+                    "[]",
+                    now,
+                ),
+            )
+
+            cur1 = conn.execute(
+                "INSERT INTO sources"
+                " (sha256, url, title, fetched_at, md_path, kind)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    "a" * 64,
+                    "https://example.com/q",
+                    "Quantum computing report",
+                    now,
+                    "sources/a.md",
+                    "web",
+                ),
+            )
+            sid1 = cur1.lastrowid
+            cur2 = conn.execute(
+                "INSERT INTO sources"
+                " (sha256, url, title, fetched_at, md_path, kind)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    "b" * 64,
+                    "https://example.com/c",
+                    "Coffee brewing techniques",
+                    now,
+                    "sources/b.md",
+                    "web",
+                ),
+            )
+            sid2 = cur2.lastrowid
+
+            # sid1 shared by both jobs; sid2 only by JOB_A.
+            conn.execute(
+                "INSERT INTO job_sources (job_id, source_id) VALUES (?, ?)",
+                (JOB_A, sid1),
+            )
+            conn.execute(
+                "INSERT INTO job_sources (job_id, source_id) VALUES (?, ?)",
+                (JOB_B, sid1),
+            )
+            conn.execute(
+                "INSERT INTO job_sources (job_id, source_id) VALUES (?, ?)",
+                (JOB_A, sid2),
+            )
+
+            conn.execute("INSERT INTO findings_fts(findings_fts) VALUES('rebuild')")
+            conn.execute("INSERT INTO sources_fts(sources_fts) VALUES('rebuild')")
+    finally:
+        conn.close()
+
+    return db_path
+
+
+def test_empty_result(seeded_db: Path) -> None:
+    assert search_fts("nonexistenttoken", job_id=None, kind="both", db_path=seeded_db) == []
+
+
+def test_multi_job_hit(seeded_db: Path) -> None:
+    results = search_fts("quantum", job_id=None, kind="findings", db_path=seeded_db)
+    job_ids = {r["job_id"] for r in results}
+    assert JOB_A in job_ids
+    assert JOB_B in job_ids
+
+
+def test_kind_findings_excludes_sources(seeded_db: Path) -> None:
+    results = search_fts("quantum", job_id=None, kind="findings", db_path=seeded_db)
+    assert results
+    assert all(r["kind"] == "finding" for r in results)
+
+
+def test_kind_sources_excludes_findings(seeded_db: Path) -> None:
+    results = search_fts("quantum", job_id=None, kind="sources", db_path=seeded_db)
+    assert results
+    assert all(r["kind"] == "source" for r in results)
+
+
+def test_kind_both_returns_mixed(seeded_db: Path) -> None:
+    results = search_fts("quantum", job_id=None, kind="both", db_path=seeded_db)
+    kinds = {r["kind"] for r in results}
+    assert kinds == {"finding", "source"}
+
+
+def test_job_filter_findings(seeded_db: Path) -> None:
+    results = search_fts("quantum", job_id=JOB_A, kind="findings", db_path=seeded_db)
+    assert results
+    assert all(r["job_id"] == JOB_A for r in results)
+
+
+def test_job_filter_sources_uses_job_sources(seeded_db: Path) -> None:
+    # The "Coffee brewing" source is only linked to JOB_A.
+    a_only = search_fts("coffee", job_id=JOB_A, kind="sources", db_path=seeded_db)
+    assert a_only
+    assert all(r["job_id"] == JOB_A for r in a_only)
+
+    b_only = search_fts("coffee", job_id=JOB_B, kind="sources", db_path=seeded_db)
+    assert b_only == []
+
+
+def test_snippet_highlighting(seeded_db: Path) -> None:
+    results = search_fts("quantum", job_id=None, kind="findings", db_path=seeded_db)
+    assert results
+    snippet = results[0]["snippet"]
+    assert "[" in snippet and "]" in snippet
+
+
+def test_results_sorted_by_score_ascending(seeded_db: Path) -> None:
+    results = search_fts("quantum", job_id=None, kind="both", db_path=seeded_db)
+    scores = [r["score"] for r in results]
+    assert scores == sorted(scores)
+
+
+def test_invalid_kind_raises(seeded_db: Path) -> None:
+    with pytest.raises(ValueError):
+        search_fts("quantum", job_id=None, kind="bogus", db_path=seeded_db)
+
+
+def test_empty_query_raises(seeded_db: Path) -> None:
+    with pytest.raises(ValueError):
+        search_fts("   ", job_id=None, kind="both", db_path=seeded_db)
+
+
+def test_result_dict_has_expected_keys(seeded_db: Path) -> None:
+    results = search_fts("quantum", job_id=None, kind="both", db_path=seeded_db)
+    assert results
+    expected = {"kind", "score", "job_id", "snippet", "id", "md_path", "title_or_claim"}
+    for row in results:
+        assert expected <= row.keys()


### PR DESCRIPTION
Closes #22

## Summary

Automated implementation of **`research search` command — FTS over findings/sources**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

research search command meets all Phase 3 acceptance criteria: FTS5 over findings_fts/sources_fts, --job/--all/--kind/--json flags wired correctly, BM25 scoring, snippet highlighting, friendly errors for unknown job/invalid kind/malformed query. 20 new tests pass; full suite 423/423 green.

- **INFO** [OPEN] `src/research_agent/ui/render.py`: render_search_table does a blanket replace of '[' and ']' to inject Rich markup. If a snippet's source text contains literal brackets (e.g. a finding like 'see [Smith 2024]'), they will be rendered as bold-yellow rather than literal brackets. FTS5's snippet() only adds bracket markers around matched terms, but the surrounding context can still include native brackets. Low impact for Phase 3 since findings/sources rarely contain bracketed text and the JSON path preserves the raw markers; flag for Phase 7 polish along with the semantic+FTS hybrid.
- **INFO** [OPEN] `src/research_agent/cli.py`: --all is implemented as an explicit no-op flag (all_ is unused, --all is the default when --job is unset). This matches the issue spec but means `research search foo --all --job X` silently picks the --job scope. Acceptable since neither option is destructive and Typer help describes the precedence; could harden in a follow-up by raising on the conflict.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*