### PR TITLE
feat: Prompt registry — load prompts from prompts/*.md (closes #23)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ research = "research_agent.cli:app"
 where = ["src"]
 include = ["research_agent*"]
 
+[tool.setuptools.package-data]
+research_agent = ["prompts/*.md"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py312"

--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -41,6 +41,7 @@ EventKind = Literal[
     "llm_call",
     "tool_call",
     "checkpoint",
+    "prompt_loaded",
     "error",
     "warning",
 ]

--- a/src/research_agent/prompts/__init__.py
+++ b/src/research_agent/prompts/__init__.py
@@ -1,0 +1,26 @@
+"""Prompt registry — Markdown prompts loaded from disk (implementation guide §16).
+
+Prompt files live next to this module as ``<name>.md`` with YAML frontmatter.
+Use :func:`load_prompt` to render with ``{{var}}`` substitution and
+:func:`load_prompt_meta` for the parsed :class:`Prompt` (version, hash, etc.).
+"""
+
+from research_agent.prompts.loader import (
+    ModelTier,
+    Prompt,
+    PromptNotFoundError,
+    PromptVariableMissing,
+    clear_cache,
+    load_prompt,
+    load_prompt_meta,
+)
+
+__all__ = [
+    "ModelTier",
+    "Prompt",
+    "PromptNotFoundError",
+    "PromptVariableMissing",
+    "clear_cache",
+    "load_prompt",
+    "load_prompt_meta",
+]

--- a/src/research_agent/prompts/critic.md
+++ b/src/research_agent/prompts/critic.md
@@ -1,0 +1,46 @@
+---
+version: "1"
+model_tier: frontier_alt
+description: System prompt for the critic agent that audits a synthesis report against its findings.
+---
+You are the **critic** for an autonomous research agent.
+
+You audit a draft synthesis report against the underlying findings before it
+ships. Your job is to catch unsupported claims, missed disagreements, weak
+sourcing, and logical leaps. You do not rewrite the report; you produce a
+critique the synthesizer (or a follow-up plan) can act on.
+
+## Inputs
+
+- The **draft report**.
+- The **findings corpus** the report was built from (each with source URL,
+  retrieval timestamp, confidence).
+
+## What to check
+
+1. **Sourcing integrity** — does every factual claim trace to a finding,
+   and does that finding actually support the claim as worded?
+2. **Confidence calibration** — is a `low`-confidence finding dressed up as
+   established fact? Are `high`-confidence findings being underused?
+3. **Contradiction handling** — when findings disagree, does the report
+   surface the disagreement or paper over it?
+4. **Scope drift** — does the report answer the original goal, or has it
+   wandered into adjacent topics?
+5. **Inference vs. evidence** — are inferred connections labelled as such,
+   or are they presented as if a source asserted them?
+
+## What to produce
+
+For each issue, return:
+
+- **Severity:** `block` (must fix before shipping), `warn` (worth
+  addressing), or `nit` (minor).
+- **Location:** the report section or claim.
+- **Problem:** what is wrong, in one sentence.
+- **Suggested fix:** what the synthesizer should do (e.g., remove claim,
+  add citation, surface contradiction, narrow scope).
+
+If the report is shippable as-is, return an empty critique with a one-line
+rationale. Do not invent issues.
+
+Return the critique as the structured output the caller requested.

--- a/src/research_agent/prompts/intake_followup.md
+++ b/src/research_agent/prompts/intake_followup.md
@@ -1,0 +1,49 @@
+---
+version: "1"
+model_tier: fast
+description: System prompt for the intake follow-up agent that decides which clarifying questions to ask the user.
+---
+You are the **intake follow-up** for an autonomous research agent.
+
+Given a free-text research request, you decide whether the agent has enough
+to start, and if not, you produce up to three clarifying questions to ask
+the user. The bar is high: every question costs the user time, so only ask
+when the answer would materially change the plan.
+
+## Input
+
+The user's initial request:
+
+{{question}}
+
+## What to produce
+
+If the request is workable as-is, return an empty list of follow-ups with a
+one-line rationale (e.g., "Target and scope are unambiguous").
+
+Otherwise, return up to three follow-up questions, each with:
+
+- **Question** — concise, one sentence, no jargon.
+- **Why it matters** — what the answer changes about the plan.
+- **Suggested defaults** — reasonable answers the user can accept verbatim
+  if they don't want to type. Two or three options.
+
+## What to ask about (in priority order)
+
+1. **Target disambiguation** — multiple people / companies / policies share
+   the name; which one?
+2. **Scope** — geographic, temporal, or organizational bounds.
+3. **Depth vs. breadth** — quick scan or deep investigation?
+4. **Output preference** — narrative report, structured table, raw findings?
+
+## Rules
+
+- **Never ask for information you can derive from the request.**
+- Do not ask the user for sources, URLs, or queries — that's the planner's
+  job.
+- Do not ask more than three questions. Pick the highest-leverage ones.
+- If the request is hostile, illegal, or targets a private individual with
+  no public-interest hook, surface that as a single follow-up flagging the
+  concern and asking the user to confirm intent.
+
+Return the follow-ups as the structured output the caller requested.

--- a/src/research_agent/prompts/loader.py
+++ b/src/research_agent/prompts/loader.py
@@ -1,0 +1,205 @@
+"""Prompt registry — load Markdown prompts from ``src/research_agent/prompts/``.
+
+Per §16 anti-pattern: prompts NEVER live in code. They sit alongside the
+package as ``<name>.md`` files with a YAML frontmatter block carrying
+``version``, ``model_tier``, and ``description``. The body is the prompt
+template with optional ``{{var}}`` placeholders.
+
+Loading is two-step: first call parses frontmatter, computes the file hash,
+caches a :class:`Prompt`, and emits a ``prompt_loaded`` event (or logs).
+Subsequent calls render from the cached template — the hash is computed
+exactly once per ``name``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from importlib.resources import files
+from pathlib import Path
+from typing import Any, Literal
+
+import structlog
+import yaml  # type: ignore[import-untyped]
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from research_agent.observability.events import emit
+from research_agent.storage.jobs import Job
+
+ModelTier = Literal[
+    "fast",
+    "general",
+    "reasoner",
+    "frontier",
+    "frontier_alt",
+    "frontier_speed",
+]
+
+_FRONTMATTER_RE = re.compile(
+    r"\A---\s*\n(?P<fm>.*?)\n---\s*\n?(?P<body>.*)\Z",
+    re.DOTALL,
+)
+_VAR_RE = re.compile(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
+
+_log = structlog.get_logger(__name__)
+
+
+class PromptNotFoundError(FileNotFoundError):
+    """Raised when ``load_prompt(name)`` cannot find ``<name>.md``."""
+
+
+class PromptVariableMissing(KeyError):
+    """Raised when a template references a ``{{var}}`` not provided by the caller."""
+
+
+class _Frontmatter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: str
+    model_tier: ModelTier
+    description: str
+
+
+class Prompt(BaseModel):
+    """Parsed prompt with frontmatter, raw template, and content hash."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str
+    version: str
+    model_tier: ModelTier
+    description: str
+    template: str
+    sha256: str
+    path: Path = Field(...)
+
+
+_CACHE: dict[str, Prompt] = {}
+
+
+def _prompts_dir() -> Path:
+    """Return the on-disk directory holding ``<name>.md`` files.
+
+    Uses :mod:`importlib.resources` so it works for both editable installs
+    (paths under ``src/``) and built wheels (paths under ``site-packages``).
+    """
+    return Path(str(files("research_agent.prompts")))
+
+
+def _available_names() -> list[str]:
+    try:
+        return sorted(p.stem for p in _prompts_dir().glob("*.md"))
+    except (FileNotFoundError, OSError):
+        return []
+
+
+def _parse(name: str, path: Path) -> Prompt:
+    raw_bytes = path.read_bytes()
+    sha = hashlib.sha256(raw_bytes).hexdigest()
+    raw_text = raw_bytes.decode("utf-8")
+
+    match = _FRONTMATTER_RE.match(raw_text)
+    if match is None:
+        raise ValueError(
+            f"prompt {name!r} at {path} is missing a YAML frontmatter block "
+            "(must start with '---' on its own line)"
+        )
+    fm_data = yaml.safe_load(match.group("fm")) or {}
+    if not isinstance(fm_data, dict):
+        raise ValueError(
+            f"prompt {name!r} frontmatter must be a YAML mapping, got {type(fm_data).__name__}"
+        )
+    try:
+        meta = _Frontmatter(**fm_data)
+    except ValidationError as exc:
+        raise ValueError(
+            f"prompt {name!r} has invalid frontmatter: {exc.errors(include_url=False)}"
+        ) from exc
+
+    return Prompt(
+        name=name,
+        version=meta.version,
+        model_tier=meta.model_tier,
+        description=meta.description,
+        template=match.group("body"),
+        sha256=sha,
+        path=path,
+    )
+
+
+def _get_or_load(name: str, *, job: Job | None = None) -> Prompt:
+    cached = _CACHE.get(name)
+    if cached is not None:
+        return cached
+
+    base = _prompts_dir()
+    path = base / f"{name}.md"
+    if not path.exists():
+        available = _available_names()
+        raise PromptNotFoundError(
+            f"prompt {name!r} not found at {path}. "
+            f"Available: {', '.join(available) if available else '(none)'}"
+        )
+
+    prompt = _parse(name, path)
+    _CACHE[name] = prompt
+
+    payload: dict[str, Any] = {
+        "name": prompt.name,
+        "version": prompt.version,
+        "model_tier": prompt.model_tier,
+        "sha256": prompt.sha256,
+        "path": str(prompt.path),
+    }
+    if job is not None:
+        emit(job, "INFO", "prompts", "prompt_loaded", payload)
+    else:
+        _log.info("prompt_loaded", **payload)
+
+    return prompt
+
+
+def load_prompt_meta(name: str, *, job: Job | None = None) -> Prompt:
+    """Return the cached :class:`Prompt` for ``name`` without rendering."""
+    return _get_or_load(name, job=job)
+
+
+def load_prompt(name: str, *, job: Job | None = None, **vars: object) -> str:
+    """Load ``<name>.md`` and render its ``{{var}}`` placeholders.
+
+    On first load, parses frontmatter, computes the SHA-256 of the raw file,
+    caches the :class:`Prompt`, and emits a ``prompt_loaded`` event (when
+    ``job`` is supplied) or logs at INFO. Subsequent calls reuse the cache.
+
+    Substitution is whitespace-tolerant: ``{{ goal }}`` and ``{{goal}}`` both
+    resolve to the same key. Missing keys raise :class:`PromptVariableMissing`.
+    Unused ``vars`` are silently ignored — the caller may pass a superset.
+    """
+    prompt = _get_or_load(name, job=job)
+
+    def _sub(match: re.Match[str]) -> str:
+        key = match.group(1)
+        if key not in vars:
+            raise PromptVariableMissing(
+                f"prompt {name!r} references {{{{{key}}}}} but no value was "
+                f"provided (got: {sorted(vars.keys()) or 'none'})"
+            )
+        return str(vars[key])
+
+    return _VAR_RE.sub(_sub, prompt.template)
+
+
+def clear_cache() -> None:
+    """Reset the in-process prompt cache. For tests."""
+    _CACHE.clear()
+
+
+__all__ = [
+    "ModelTier",
+    "Prompt",
+    "PromptNotFoundError",
+    "PromptVariableMissing",
+    "clear_cache",
+    "load_prompt",
+    "load_prompt_meta",
+]

--- a/src/research_agent/prompts/planner.md
+++ b/src/research_agent/prompts/planner.md
@@ -1,0 +1,40 @@
+---
+version: "1"
+model_tier: reasoner
+description: System prompt for the planner agent that decomposes a research goal into a directed task graph.
+---
+You are the **planner** for an autonomous research agent.
+
+Your job is to take an investigation goal and produce a directed task graph
+that other agents will execute. You do not fetch sources, write findings, or
+draft synthesis — you only plan.
+
+## Goal
+
+{{goal}}
+
+## What to produce
+
+A plan with:
+
+1. **Hypotheses to confirm or refute** — phrased as falsifiable statements.
+2. **Sub-questions** — concrete, narrowly-scoped questions whose answers
+   collectively resolve the hypotheses.
+3. **Tasks** — each task is one of: `web_search`, `web_fetch`, `arxiv_search`,
+   `news_search`, `reddit_search`, `archive_lookup`, `local_corpus_search`,
+   `synthesis`, or `critique`. Tasks declare their dependencies on prior task
+   ids so the orchestrator can schedule them.
+4. **Stop conditions** — what counts as "enough" evidence for each hypothesis.
+
+## Rules
+
+- Prefer breadth-first early (cast a wide net) and depth-first late (drill
+  into the most promising leads).
+- Every fetch task must declare *why* it matters — which sub-question it
+  feeds.
+- Do not invent sources. The connectors will discover them.
+- Never write conclusions in the plan. Conclusions belong to synthesis.
+- If the goal is ambiguous, surface the ambiguity as a `clarification` task
+  rather than guessing.
+
+Return the plan as the structured output the caller requested.

--- a/src/research_agent/prompts/researcher.md
+++ b/src/research_agent/prompts/researcher.md
@@ -1,0 +1,40 @@
+---
+version: "1"
+model_tier: general
+description: System prompt for the researcher agent that executes a single fetch/extract/summarize task.
+---
+You are the **researcher** for an autonomous research agent.
+
+You execute one task from the plan: fetch a source (or several), extract the
+relevant claims, and produce a finding. You do not re-plan, judge the
+investigation as a whole, or write the final report.
+
+## Inputs
+
+- **Sub-question:** the specific question this task is meant to answer.
+- **Tools:** `web_search`, `web_fetch`, `arxiv_search`, `news_search`,
+  `reddit_search`, `archive_lookup`, `local_corpus_search`. Use the tool best
+  suited to the question.
+
+## What to produce
+
+For every claim you record, capture:
+
+- The **claim** in one sentence.
+- The **source URL** and the **retrieval timestamp** (the connector returns
+  both — pass them through).
+- A **direct quote or line range** from the source that supports the claim.
+- A **confidence** rating: `high` (primary, unambiguous), `medium`
+  (secondary, paraphrased), `low` (single source, contested, or inferred).
+
+## Rules
+
+- **Cite everything.** A claim without a source URL is a bug, not a finding.
+- Prefer **primary sources** over commentary. If the source you fetched cites
+  another source, fetch the original where feasible.
+- If a fetch fails (rate-limit, blocked, 404), record the failure as a
+  `tool_call` event and either retry with a different connector or surface
+  the gap. Do not fabricate.
+- Keep findings **short and structured**. The synthesizer will combine them.
+
+Return the finding as the structured output the caller requested.

--- a/src/research_agent/prompts/synthesizer.md
+++ b/src/research_agent/prompts/synthesizer.md
@@ -1,0 +1,42 @@
+---
+version: "1"
+model_tier: frontier
+description: System prompt for the synthesizer agent that turns findings into a sourced narrative report.
+---
+You are the **synthesizer** for an autonomous research agent.
+
+You receive the full set of findings produced by the researchers and the
+original investigation goal. Your job is to produce a report that answers
+the goal, organized by hypothesis, with every factual claim traced to a
+source.
+
+## Inputs
+
+- **Goal:** {{goal}}
+- **Findings:** the canonical record of what was fetched and what was claimed.
+  Each finding carries its source URL, retrieval timestamp, and confidence.
+
+## What to produce
+
+A markdown report with:
+
+1. **Executive summary** — three to six bullets, each ending in inline
+   citations like ``[1]``, ``[2]``.
+2. **Hypotheses** — for each, state confirmed / refuted / inconclusive,
+   with the strongest supporting and contradicting findings cited.
+3. **Connections** — relationships between people, orgs, policies, or
+   events that the findings reveal but no single source spells out.
+4. **Open questions** — what the investigation could not resolve, and why
+   (e.g., source unavailable, contradictory evidence, ambiguous goal).
+5. **Sources** — numbered list mapping ``[N]`` → URL + retrieved-at.
+
+## Rules
+
+- **No unsourced claims.** Every factual statement maps to a finding's
+  source. If you cannot cite it, drop it or label it as inference.
+- Prefer **primary** findings over secondary; flag downgrades.
+- Surface **disagreement** between sources rather than averaging it away.
+- Do not invent dates, names, numbers, or quotes. If a finding is
+  ambiguous, say so.
+
+Return the report as the structured output the caller requested.

--- a/tests/test_prompts_loader.py
+++ b/tests/test_prompts_loader.py
@@ -1,0 +1,344 @@
+"""Tests for `research_agent.prompts.loader`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from research_agent.prompts import loader as prompts_loader
+from research_agent.prompts.loader import (
+    Prompt,
+    PromptNotFoundError,
+    PromptVariableMissing,
+    clear_cache,
+    load_prompt,
+    load_prompt_meta,
+)
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache() -> None:
+    """Each test starts with an empty in-process prompt cache."""
+    clear_cache()
+    yield
+    clear_cache()
+
+
+@pytest.fixture
+def isolated_prompts_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the loader at a writable temp directory of test prompts."""
+    target = tmp_path / "prompts"
+    target.mkdir()
+    monkeypatch.setattr(prompts_loader, "_prompts_dir", lambda: target)
+    return target
+
+
+@pytest.fixture
+def jobs_root(tmp_path: Path) -> Path:
+    return tmp_path / "jobs"
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "index.sqlite"
+    db.migrate(path=path).close()
+    return path
+
+
+@pytest.fixture
+def job(jobs_root: Path, db_path: Path) -> Job:
+    return Job.create(
+        {"goal": "Investigate prompt registry"},
+        jobs_root=jobs_root,
+        db_path=db_path,
+    )
+
+
+def _write_prompt(
+    dir_: Path,
+    name: str,
+    *,
+    version: str = "1",
+    model_tier: str = "general",
+    description: str = "Test prompt.",
+    body: str = "Hello {{who}}!",
+) -> Path:
+    path = dir_ / f"{name}.md"
+    path.write_text(
+        f"---\n"
+        f'version: "{version}"\n'
+        f"model_tier: {model_tier}\n"
+        f'description: "{description}"\n'
+        f"---\n"
+        f"{body}",
+        encoding="utf-8",
+    )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Shipped prompt files
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["planner", "researcher", "synthesizer", "critic", "intake_followup"],
+)
+def test_shipped_prompt_loads_with_valid_frontmatter(name: str) -> None:
+    meta = load_prompt_meta(name)
+    assert meta.name == name
+    assert meta.version  # non-empty
+    assert meta.model_tier in {
+        "fast",
+        "general",
+        "reasoner",
+        "frontier",
+        "frontier_alt",
+        "frontier_speed",
+    }
+    assert meta.description
+    assert len(meta.sha256) == 64
+    assert meta.path.exists()
+    assert meta.template  # body non-empty
+
+
+def test_planner_substitutes_goal_placeholder() -> None:
+    rendered = load_prompt("planner", goal="map who funded ACME Corp 2019-2024")
+    assert "{{goal}}" not in rendered
+    assert "map who funded ACME Corp 2019-2024" in rendered
+
+
+def test_intake_followup_substitutes_question_placeholder() -> None:
+    rendered = load_prompt("intake_followup", question="who is jane doe")
+    assert "{{question}}" not in rendered
+    assert "who is jane doe" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Missing prompt
+# ---------------------------------------------------------------------------
+
+
+def test_missing_prompt_raises_with_helpful_message(
+    isolated_prompts_dir: Path,
+) -> None:
+    _write_prompt(isolated_prompts_dir, "alpha")
+    _write_prompt(isolated_prompts_dir, "beta")
+
+    with pytest.raises(PromptNotFoundError) as excinfo:
+        load_prompt("nonexistent")
+
+    msg = str(excinfo.value)
+    assert "nonexistent" in msg
+    assert "alpha" in msg and "beta" in msg
+    # PromptNotFoundError is also a FileNotFoundError so existing handlers work.
+    assert isinstance(excinfo.value, FileNotFoundError)
+
+
+# ---------------------------------------------------------------------------
+# Substitution
+# ---------------------------------------------------------------------------
+
+
+def test_substitution_renders_value(isolated_prompts_dir: Path) -> None:
+    _write_prompt(isolated_prompts_dir, "greet", body="Hello {{who}}!")
+    assert load_prompt("greet", who="world") == "Hello world!"
+
+
+def test_substitution_is_whitespace_tolerant(isolated_prompts_dir: Path) -> None:
+    _write_prompt(
+        isolated_prompts_dir,
+        "spaced",
+        body="A={{ x }}, B={{y }}, C={{ z}}, D={{w}}",
+    )
+    out = load_prompt("spaced", x="1", y="2", z="3", w="4")
+    assert out == "A=1, B=2, C=3, D=4"
+
+
+def test_substitution_unused_vars_ignored(isolated_prompts_dir: Path) -> None:
+    _write_prompt(isolated_prompts_dir, "greet", body="Hello {{who}}!")
+    # `extra` is not in template — should be silently accepted.
+    assert load_prompt("greet", who="bob", extra="unused") == "Hello bob!"
+
+
+def test_substitution_missing_variable_raises(isolated_prompts_dir: Path) -> None:
+    _write_prompt(isolated_prompts_dir, "greet", body="Hello {{who}}!")
+    with pytest.raises(PromptVariableMissing) as excinfo:
+        load_prompt("greet")
+    assert "who" in str(excinfo.value)
+
+
+def test_substitution_repeated_placeholder(isolated_prompts_dir: Path) -> None:
+    _write_prompt(isolated_prompts_dir, "echo", body="{{x}} and {{x}} again")
+    assert load_prompt("echo", x="ping") == "ping and ping again"
+
+
+def test_template_without_placeholders_returns_body_verbatim(
+    isolated_prompts_dir: Path,
+) -> None:
+    _write_prompt(isolated_prompts_dir, "static", body="No placeholders here.\n")
+    assert load_prompt("static") == "No placeholders here.\n"
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter / metadata
+# ---------------------------------------------------------------------------
+
+
+def test_frontmatter_fields_surface_via_meta(isolated_prompts_dir: Path) -> None:
+    _write_prompt(
+        isolated_prompts_dir,
+        "p",
+        version="3",
+        model_tier="frontier",
+        description="A meaningful prompt.",
+        body="Body.",
+    )
+    meta = load_prompt_meta("p")
+    assert isinstance(meta, Prompt)
+    assert meta.name == "p"
+    assert meta.version == "3"
+    assert meta.model_tier == "frontier"
+    assert meta.description == "A meaningful prompt."
+    assert meta.template == "Body."
+
+
+def test_frontmatter_missing_version_raises(isolated_prompts_dir: Path) -> None:
+    path = isolated_prompts_dir / "bad.md"
+    path.write_text(
+        "---\nmodel_tier: general\ndescription: missing version\n---\nBody.",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError) as excinfo:
+        load_prompt("bad")
+    assert "version" in str(excinfo.value).lower()
+
+
+def test_frontmatter_missing_block_raises(isolated_prompts_dir: Path) -> None:
+    path = isolated_prompts_dir / "raw.md"
+    path.write_text("Just a body, no frontmatter.\n", encoding="utf-8")
+    with pytest.raises(ValueError) as excinfo:
+        load_prompt("raw")
+    assert "frontmatter" in str(excinfo.value).lower()
+
+
+def test_frontmatter_invalid_model_tier_raises(isolated_prompts_dir: Path) -> None:
+    _write_prompt(isolated_prompts_dir, "p", model_tier="hyper-mega-frontier")
+    with pytest.raises(ValueError):
+        load_prompt("p")
+
+
+def test_frontmatter_unknown_field_rejected(isolated_prompts_dir: Path) -> None:
+    path = isolated_prompts_dir / "extra.md"
+    path.write_text(
+        '---\nversion: "1"\nmodel_tier: general\ndescription: x\nsurprise: nope\n---\nBody.',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError):
+        load_prompt("extra")
+
+
+# ---------------------------------------------------------------------------
+# Caching
+# ---------------------------------------------------------------------------
+
+
+def test_cache_returns_same_instance(isolated_prompts_dir: Path) -> None:
+    _write_prompt(isolated_prompts_dir, "cached")
+    a = load_prompt_meta("cached")
+    b = load_prompt_meta("cached")
+    assert a is b
+
+
+def test_cache_hash_computed_once(
+    isolated_prompts_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_prompt(isolated_prompts_dir, "once")
+
+    calls = {"n": 0}
+    real_read_bytes = Path.read_bytes
+
+    def counting_read_bytes(self: Path) -> bytes:
+        if self.name == "once.md":
+            calls["n"] += 1
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", counting_read_bytes)
+
+    load_prompt("once", who="a")
+    load_prompt("once", who="b")
+    load_prompt_meta("once")
+
+    assert calls["n"] == 1
+
+
+def test_clear_cache_forces_reload(
+    isolated_prompts_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_prompt(isolated_prompts_dir, "reload")
+
+    calls = {"n": 0}
+    real_read_bytes = Path.read_bytes
+
+    def counting_read_bytes(self: Path) -> bytes:
+        if self.name == "reload.md":
+            calls["n"] += 1
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", counting_read_bytes)
+
+    load_prompt_meta("reload")
+    clear_cache()
+    load_prompt_meta("reload")
+
+    assert calls["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Event emission
+# ---------------------------------------------------------------------------
+
+
+def test_first_load_with_job_emits_prompt_loaded_event(
+    isolated_prompts_dir: Path, job: Job
+) -> None:
+    _write_prompt(isolated_prompts_dir, "evented")
+
+    load_prompt("evented", who="x", job=job)
+
+    text = (job.root / "events.jsonl").read_text(encoding="utf-8")
+    lines = [line for line in text.splitlines() if line.strip()]
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload["kind"] == "prompt_loaded"
+    assert payload["actor"] == "prompts"
+    assert payload["payload"]["name"] == "evented"
+    assert len(payload["payload"]["sha256"]) == 64
+    assert payload["payload"]["version"] == "1"
+    assert payload["payload"]["model_tier"] == "general"
+
+
+def test_event_emitted_only_on_first_load(isolated_prompts_dir: Path, job: Job) -> None:
+    _write_prompt(isolated_prompts_dir, "evented")
+
+    load_prompt("evented", who="x", job=job)
+    load_prompt("evented", who="y", job=job)
+    load_prompt_meta("evented", job=job)
+
+    text = (job.root / "events.jsonl").read_text(encoding="utf-8")
+    lines = [line for line in text.splitlines() if line.strip()]
+    # Exactly one prompt_loaded event despite three load calls.
+    assert sum(1 for line in lines if json.loads(line)["kind"] == "prompt_loaded") == 1
+
+
+def test_load_without_job_does_not_emit(isolated_prompts_dir: Path, job: Job) -> None:
+    _write_prompt(isolated_prompts_dir, "silent")
+    load_prompt("silent", who="x")  # no job kwarg
+    # Job's events.jsonl is created at Job.create() and starts empty.
+    text = (job.root / "events.jsonl").read_text(encoding="utf-8")
+    assert text == ""


### PR DESCRIPTION
Closes #23

## Summary

Automated implementation of **Prompt registry — load prompts from prompts/*.md**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Prompt registry fully implements all acceptance criteria for #23: 5 prompt files with valid YAML frontmatter, load_prompt with whitespace-tolerant {{var}} substitution, in-process caching, prompt_loaded event with sha256 on first load, comprehensive tests (25 passing). Lint and mypy clean; full suite (448 tests) green.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*