### PR TITLE
feat: Plan + Task Pydantic models and queue operations (closes #24)

### DIFF
--- a/src/research_agent/orchestrator/__init__.py
+++ b/src/research_agent/orchestrator/__init__.py
@@ -1,1 +1,15 @@
 """Orchestrator — job lifecycle, planning, research loop, synthesis, critique, checkpointing."""
+
+from research_agent.orchestrator.plan import (
+    Plan,
+    Subgoal,
+    TaskKind,
+    TaskSpec,
+)
+
+__all__ = [
+    "Plan",
+    "Subgoal",
+    "TaskKind",
+    "TaskSpec",
+]

--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -1,0 +1,96 @@
+"""Plan + Task Pydantic models.
+
+The ``Plan`` is the versioned, structured document the planner agent emits
+each iteration of the research loop. It captures the objective, the list of
+subgoals (which drive completion), a template of tasks to enqueue, and the
+expected number of loop iterations.
+
+A ``TaskSpec`` is the typed shape that the planner emits and that
+:mod:`research_agent.storage.tasks` persists into the ``tasks`` queue. It is
+deliberately a *spec* — not the queue row itself — because the row also
+carries lifecycle state (``status``, ``retry_count``, timestamps, the
+parent task pointer) that the planner does not own.
+
+All models use ``extra='forbid'`` so a typo in a planner prompt surfaces as
+a validation error at the boundary rather than silently dropping a field.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+TaskKind = Literal[
+    "web_search",
+    "web_fetch",
+    "arxiv_search",
+    "arxiv_fetch",
+    "github_search",
+    "github_fetch",
+    "news_search",
+    "reddit_search",
+    "local_corpus_query",
+    "extract_findings",
+    "summarize_source",
+    "synthesize",
+    "critique",
+]
+
+
+class Subgoal(BaseModel):
+    """A single subgoal within a Plan. ``done=True`` retires it from the loop."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: int
+    description: str = Field(min_length=1)
+    done: bool = False
+
+
+class TaskSpec(BaseModel):
+    """A planner-emitted task to enqueue.
+
+    ``depends_on`` references other ``TaskSpec`` entries by their *index*
+    inside the same ``Plan.task_template`` list — this is intentionally
+    decoupled from DB rowids so a plan can be validated before any rows
+    exist.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: TaskKind
+    payload: dict[str, Any] = Field(default_factory=dict)
+    priority: int = 0
+    depends_on: list[int] = Field(default_factory=list)
+
+
+class Plan(BaseModel):
+    """A versioned planning document.
+
+    ``is_complete()`` is the single source of truth for "should the loop
+    stop?" — it returns True only when at least one subgoal exists and all
+    are marked done. An empty ``subgoals`` list returns False so a planner
+    that emits no subgoals never accidentally terminates the loop.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = Field(ge=1)
+    objective: str = Field(min_length=1)
+    subgoals: list[Subgoal]
+    task_template: list[TaskSpec]
+    expected_iterations: int = Field(ge=1)
+
+    def is_complete(self) -> bool:
+        if not self.subgoals:
+            return False
+        return all(sg.done for sg in self.subgoals)
+
+
+__all__ = [
+    "Plan",
+    "Subgoal",
+    "TaskKind",
+    "TaskSpec",
+]

--- a/src/research_agent/storage/tasks.py
+++ b/src/research_agent/storage/tasks.py
@@ -1,0 +1,194 @@
+"""Task queue operations against the ``tasks`` table.
+
+Implements the queue half of §10 of ``research-agent-implementation-guide.md``.
+The orchestrator runs as a single daemon per job, so we deliberately do NOT
+take a ``SELECT ... FOR UPDATE`` (SQLite has no row-level lock anyway) — the
+single-writer assumption is the locking story. Atomicity for state
+transitions comes from each write helper running its ``UPDATE`` inside a
+``with conn:`` block (the implicit BEGIN/COMMIT pair).
+
+Each helper opens its own connection via :func:`research_agent.storage.db.connect`
+and closes it on exit; callers don't share a connection across operations.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from research_agent.orchestrator.plan import TaskSpec
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+
+STATUS_PENDING = "pending"
+STATUS_RUNNING = "running"
+STATUS_DONE = "done"
+STATUS_FAILED = "failed"
+
+
+def _now_epoch() -> int:
+    return int(time.time())
+
+
+def enqueue(job: Job, task_specs: list[TaskSpec], plan_version: int) -> list[int]:
+    """Insert one ``tasks`` row per spec; return rowids in submission order.
+
+    All inserts run inside a single ``with conn:`` transaction so a partial
+    enqueue cannot leave half a plan's worth of rows behind.
+    """
+    if not isinstance(plan_version, int) or plan_version < 1:
+        raise ValueError(f"plan_version must be an int >= 1; got {plan_version!r}")
+    if not isinstance(task_specs, list) or not task_specs:
+        raise ValueError("task_specs must be a non-empty list of TaskSpec")
+    for i, spec in enumerate(task_specs):
+        if not isinstance(spec, TaskSpec):
+            raise TypeError(f"task_specs[{i}] must be a TaskSpec; got {type(spec).__name__}")
+
+    inserted: list[int] = []
+    conn = db.connect(job.db_path)
+    try:
+        with conn:
+            for spec in task_specs:
+                cur = conn.execute(
+                    """
+                    INSERT INTO tasks (
+                        job_id, plan_version, kind, payload_json, status, retry_count
+                    ) VALUES (?, ?, ?, ?, ?, 0)
+                    """,
+                    (
+                        job.id,
+                        plan_version,
+                        spec.kind,
+                        json.dumps(spec.payload, sort_keys=True),
+                        STATUS_PENDING,
+                    ),
+                )
+                rowid = cur.lastrowid
+                assert rowid is not None  # noqa: S101 — INTEGER PK rowid always set after INSERT
+                inserted.append(int(rowid))
+    finally:
+        conn.close()
+
+    return inserted
+
+
+def next_pending(job: Job) -> dict | None:
+    """Return the oldest pending task for ``job`` (by ``id`` ascending) or ``None``.
+
+    Does NOT mutate state — the caller is responsible for transitioning the
+    row to ``running`` via :func:`mark_running` once it commits to executing
+    it. Keeping the read non-mutating means a daemon can peek without
+    locking itself out of a clean shutdown.
+    """
+    conn = db.connect(job.db_path)
+    try:
+        row = conn.execute(
+            """
+            SELECT id, job_id, plan_version, kind, payload_json, status, retry_count
+            FROM tasks
+            WHERE job_id = ? AND status = ?
+            ORDER BY id ASC
+            LIMIT 1
+            """,
+            (job.id, STATUS_PENDING),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    if row is None:
+        return None
+
+    return {
+        "id": int(row["id"]),
+        "job_id": row["job_id"],
+        "plan_version": int(row["plan_version"]),
+        "kind": row["kind"],
+        "payload": json.loads(row["payload_json"]),
+        "status": row["status"],
+        "retry_count": int(row["retry_count"]),
+    }
+
+
+def mark_running(task_id: int, *, db_path: Path | str = db.DEFAULT_DB_PATH) -> None:
+    """Atomically transition ``pending`` → ``running`` and stamp ``started_at``.
+
+    The ``status='pending'`` guard in the WHERE clause prevents accidentally
+    re-starting a task that another caller already advanced, which keeps the
+    state machine honest even though the single-daemon assumption means
+    contention shouldn't happen in practice.
+    """
+    now = _now_epoch()
+    conn = db.connect(db_path)
+    try:
+        with conn:
+            conn.execute(
+                """
+                UPDATE tasks
+                SET status = ?, started_at = ?
+                WHERE id = ? AND status = ?
+                """,
+                (STATUS_RUNNING, now, task_id, STATUS_PENDING),
+            )
+    finally:
+        conn.close()
+
+
+def mark_done(
+    task_id: int,
+    result: dict | None,
+    *,
+    db_path: Path | str = db.DEFAULT_DB_PATH,
+) -> None:
+    """Mark a task done with optional ``result`` payload (single atomic UPDATE)."""
+    now = _now_epoch()
+    result_json = None if result is None else json.dumps(result, sort_keys=True)
+    conn = db.connect(db_path)
+    try:
+        with conn:
+            conn.execute(
+                """
+                UPDATE tasks
+                SET status = ?, finished_at = ?, result_json = ?
+                WHERE id = ?
+                """,
+                (STATUS_DONE, now, result_json, task_id),
+            )
+    finally:
+        conn.close()
+
+
+def mark_failed(
+    task_id: int,
+    error: str,
+    *,
+    db_path: Path | str = db.DEFAULT_DB_PATH,
+) -> None:
+    """Mark a task failed, record the error, and bump ``retry_count`` atomically."""
+    now = _now_epoch()
+    conn = db.connect(db_path)
+    try:
+        with conn:
+            conn.execute(
+                """
+                UPDATE tasks
+                SET status = ?, finished_at = ?, error = ?, retry_count = retry_count + 1
+                WHERE id = ?
+                """,
+                (STATUS_FAILED, now, error, task_id),
+            )
+    finally:
+        conn.close()
+
+
+__all__ = [
+    "STATUS_DONE",
+    "STATUS_FAILED",
+    "STATUS_PENDING",
+    "STATUS_RUNNING",
+    "enqueue",
+    "mark_done",
+    "mark_failed",
+    "mark_running",
+    "next_pending",
+]

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -1,0 +1,165 @@
+"""Tests for `research_agent.orchestrator.plan`."""
+
+from __future__ import annotations
+
+from typing import get_args
+
+import pytest
+from pydantic import ValidationError
+
+from research_agent.orchestrator.plan import Plan, Subgoal, TaskKind, TaskSpec
+
+ALL_TASK_KINDS: tuple[str, ...] = get_args(TaskKind)
+
+
+# ---------------------------------------------------------------------------
+# TaskKind enumeration
+# ---------------------------------------------------------------------------
+
+
+def test_task_kind_covers_expected_set() -> None:
+    expected = {
+        "web_search",
+        "web_fetch",
+        "arxiv_search",
+        "arxiv_fetch",
+        "github_search",
+        "github_fetch",
+        "news_search",
+        "reddit_search",
+        "local_corpus_query",
+        "extract_findings",
+        "summarize_source",
+        "synthesize",
+        "critique",
+    }
+    assert set(ALL_TASK_KINDS) == expected
+
+
+@pytest.mark.parametrize("kind", ALL_TASK_KINDS)
+def test_task_spec_accepts_each_enumerated_kind(kind: str) -> None:
+    spec = TaskSpec(kind=kind)  # type: ignore[arg-type]
+    assert spec.kind == kind
+
+
+def test_task_spec_rejects_unknown_kind() -> None:
+    with pytest.raises(ValidationError):
+        TaskSpec(kind="not_a_real_kind")  # type: ignore[arg-type]
+
+
+def test_task_spec_defaults() -> None:
+    spec = TaskSpec(kind="web_search")
+    assert spec.payload == {}
+    assert spec.priority == 0
+    assert spec.depends_on == []
+
+
+def test_task_spec_round_trip() -> None:
+    spec = TaskSpec(
+        kind="web_fetch",
+        payload={"url": "https://example.com"},
+        priority=5,
+        depends_on=[1, 2],
+    )
+    dumped = spec.model_dump()
+    again = TaskSpec.model_validate(dumped)
+    assert again == spec
+
+
+def test_task_spec_forbids_extra_keys() -> None:
+    with pytest.raises(ValidationError):
+        TaskSpec.model_validate(
+            {"kind": "web_search", "unknown": "boom"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Subgoal
+# ---------------------------------------------------------------------------
+
+
+def test_subgoal_requires_non_empty_description() -> None:
+    with pytest.raises(ValidationError):
+        Subgoal(id=1, description="")
+
+
+def test_subgoal_forbids_extra_keys() -> None:
+    with pytest.raises(ValidationError):
+        Subgoal.model_validate({"id": 1, "description": "do thing", "extra": True})
+
+
+# ---------------------------------------------------------------------------
+# Plan
+# ---------------------------------------------------------------------------
+
+
+def _sample_plan(**overrides) -> Plan:
+    base = {
+        "version": 1,
+        "objective": "Investigate the target",
+        "subgoals": [
+            Subgoal(id=1, description="Gather background"),
+            Subgoal(id=2, description="Cross-reference sources"),
+        ],
+        "task_template": [
+            TaskSpec(kind="web_search", payload={"q": "target"}),
+            TaskSpec(kind="arxiv_search", payload={"q": "target"}, depends_on=[0]),
+        ],
+        "expected_iterations": 3,
+    }
+    base.update(overrides)
+    return Plan(**base)
+
+
+def test_plan_round_trip_through_model_dump_and_validate() -> None:
+    plan = _sample_plan()
+    dumped = plan.model_dump()
+    rebuilt = Plan.model_validate(dumped)
+    assert rebuilt == plan
+
+
+def test_plan_is_complete_false_when_subgoals_empty() -> None:
+    plan = _sample_plan(subgoals=[])
+    assert plan.is_complete() is False
+
+
+def test_plan_is_complete_false_when_any_not_done() -> None:
+    plan = _sample_plan(
+        subgoals=[
+            Subgoal(id=1, description="a", done=True),
+            Subgoal(id=2, description="b", done=False),
+        ]
+    )
+    assert plan.is_complete() is False
+
+
+def test_plan_is_complete_true_when_all_done() -> None:
+    plan = _sample_plan(
+        subgoals=[
+            Subgoal(id=1, description="a", done=True),
+            Subgoal(id=2, description="b", done=True),
+        ]
+    )
+    assert plan.is_complete() is True
+
+
+def test_plan_rejects_version_below_one() -> None:
+    with pytest.raises(ValidationError):
+        _sample_plan(version=0)
+
+
+def test_plan_rejects_empty_objective() -> None:
+    with pytest.raises(ValidationError):
+        _sample_plan(objective="")
+
+
+def test_plan_rejects_expected_iterations_below_one() -> None:
+    with pytest.raises(ValidationError):
+        _sample_plan(expected_iterations=0)
+
+
+def test_plan_forbids_extra_keys() -> None:
+    payload = _sample_plan().model_dump()
+    payload["surprise"] = "boom"
+    with pytest.raises(ValidationError):
+        Plan.model_validate(payload)

--- a/tests/test_storage_tasks.py
+++ b/tests/test_storage_tasks.py
@@ -1,0 +1,224 @@
+"""Tests for `research_agent.storage.tasks`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from research_agent.orchestrator.plan import TaskSpec
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+from research_agent.storage.tasks import (
+    STATUS_DONE,
+    STATUS_FAILED,
+    STATUS_PENDING,
+    STATUS_RUNNING,
+    enqueue,
+    mark_done,
+    mark_failed,
+    mark_running,
+    next_pending,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def jobs_root(tmp_path: Path) -> Path:
+    return tmp_path / "jobs"
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "index.sqlite"
+    db.migrate(path=path).close()
+    return path
+
+
+@pytest.fixture
+def job(jobs_root: Path, db_path: Path) -> Job:
+    return Job.create(
+        {"goal": "Investigate Widget Co"},
+        jobs_root=jobs_root,
+        db_path=db_path,
+    )
+
+
+def _specs(n: int) -> list[TaskSpec]:
+    kinds = [
+        "web_search",
+        "web_fetch",
+        "arxiv_search",
+        "github_search",
+        "news_search",
+    ]
+    return [
+        TaskSpec(kind=kinds[i % len(kinds)], payload={"i": i, "q": f"query-{i}"})  # type: ignore[arg-type]
+        for i in range(n)
+    ]
+
+
+def _all_rows(db_path: Path, job_id: str) -> list[dict]:
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT * FROM tasks WHERE job_id = ? ORDER BY id ASC",
+            (job_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# enqueue
+# ---------------------------------------------------------------------------
+
+
+def test_enqueue_inserts_rows(job: Job, db_path: Path) -> None:
+    specs = _specs(5)
+    ids = enqueue(job, specs, plan_version=1)
+
+    assert len(ids) == 5
+    assert ids == sorted(ids), "rowids should come back in submission order"
+
+    rows = _all_rows(db_path, job.id)
+    assert len(rows) == 5
+    for row, spec in zip(rows, specs, strict=True):
+        assert row["status"] == STATUS_PENDING
+        assert row["kind"] == spec.kind
+        assert row["plan_version"] == 1
+        assert row["retry_count"] == 0
+        assert row["started_at"] is None
+        assert row["finished_at"] is None
+        assert json.loads(row["payload_json"]) == spec.payload
+
+
+def test_enqueue_rejects_empty_list(job: Job) -> None:
+    with pytest.raises(ValueError):
+        enqueue(job, [], plan_version=1)
+
+
+def test_enqueue_rejects_non_taskspec_items(job: Job) -> None:
+    with pytest.raises(TypeError):
+        enqueue(job, [{"kind": "web_search"}], plan_version=1)  # type: ignore[list-item]
+
+
+def test_enqueue_rejects_invalid_plan_version(job: Job) -> None:
+    with pytest.raises(ValueError):
+        enqueue(job, _specs(1), plan_version=0)
+    with pytest.raises(ValueError):
+        enqueue(job, _specs(1), plan_version=-1)
+
+
+# ---------------------------------------------------------------------------
+# next_pending
+# ---------------------------------------------------------------------------
+
+
+def test_next_pending_returns_oldest_first(job: Job, db_path: Path) -> None:
+    specs = _specs(5)
+    ids = enqueue(job, specs, plan_version=1)
+
+    seen: list[int] = []
+    for _ in range(5):
+        row = next_pending(job)
+        assert row is not None
+        seen.append(row["id"])
+        # Round-trip the payload.
+        assert isinstance(row["payload"], dict)
+        assert row["payload"]["i"] == ids.index(row["id"])
+        assert row["status"] == STATUS_PENDING
+        mark_done(row["id"], {"ok": True}, db_path=db_path)
+
+    assert seen == ids
+    assert next_pending(job) is None
+
+
+def test_next_pending_returns_none_when_empty(job: Job) -> None:
+    assert next_pending(job) is None
+
+
+def test_next_pending_skips_non_pending(job: Job, db_path: Path) -> None:
+    ids = enqueue(job, _specs(3), plan_version=1)
+    # row 0 -> done, row 1 -> running, row 2 -> failed (then back to pending? no, failed)
+    mark_done(ids[0], None, db_path=db_path)
+    mark_running(ids[1], db_path=db_path)
+    mark_failed(ids[2], "boom", db_path=db_path)
+
+    assert next_pending(job) is None
+
+    # Now enqueue a fresh pending row; it must be picked up.
+    new_ids = enqueue(job, _specs(1), plan_version=1)
+    row = next_pending(job)
+    assert row is not None
+    assert row["id"] == new_ids[0]
+
+
+# ---------------------------------------------------------------------------
+# mark_running
+# ---------------------------------------------------------------------------
+
+
+def test_mark_running_only_advances_pending_rows(job: Job, db_path: Path) -> None:
+    [task_id] = enqueue(job, _specs(1), plan_version=1)
+    mark_running(task_id, db_path=db_path)
+
+    rows = _all_rows(db_path, job.id)
+    assert rows[0]["status"] == STATUS_RUNNING
+    assert rows[0]["started_at"] is not None
+
+    # Calling again must not re-stamp started_at (guarded by status='pending').
+    started_first = rows[0]["started_at"]
+    mark_running(task_id, db_path=db_path)
+    rows2 = _all_rows(db_path, job.id)
+    assert rows2[0]["started_at"] == started_first
+
+
+# ---------------------------------------------------------------------------
+# mark_done
+# ---------------------------------------------------------------------------
+
+
+def test_mark_done_is_atomic_and_sets_result(job: Job, db_path: Path) -> None:
+    [task_id] = enqueue(job, _specs(1), plan_version=1)
+    mark_done(task_id, {"hits": 3, "ok": True}, db_path=db_path)
+
+    rows = _all_rows(db_path, job.id)
+    assert rows[0]["status"] == STATUS_DONE
+    assert rows[0]["finished_at"] is not None
+    assert json.loads(rows[0]["result_json"]) == {"hits": 3, "ok": True}
+
+
+def test_mark_done_accepts_none_result(job: Job, db_path: Path) -> None:
+    [task_id] = enqueue(job, _specs(1), plan_version=1)
+    mark_done(task_id, None, db_path=db_path)
+
+    rows = _all_rows(db_path, job.id)
+    assert rows[0]["status"] == STATUS_DONE
+    assert rows[0]["result_json"] is None
+
+
+# ---------------------------------------------------------------------------
+# mark_failed
+# ---------------------------------------------------------------------------
+
+
+def test_mark_failed_increments_retry_and_sets_error(job: Job, db_path: Path) -> None:
+    [task_id] = enqueue(job, _specs(1), plan_version=1)
+
+    mark_failed(task_id, "first failure", db_path=db_path)
+    rows = _all_rows(db_path, job.id)
+    assert rows[0]["status"] == STATUS_FAILED
+    assert rows[0]["error"] == "first failure"
+    assert rows[0]["retry_count"] == 1
+    assert rows[0]["finished_at"] is not None
+
+    mark_failed(task_id, "second failure", db_path=db_path)
+    rows = _all_rows(db_path, job.id)
+    assert rows[0]["error"] == "second failure"
+    assert rows[0]["retry_count"] == 2


### PR DESCRIPTION
Closes #24

## Summary

Automated implementation of **Plan + Task Pydantic models and queue operations**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

All acceptance criteria met. Plan/TaskSpec/Subgoal Pydantic models with extra='forbid', exhaustive 13-kind TaskKind Literal, single-transaction enqueue, FIFO next_pending with LIMIT 1, atomic mark_running/mark_done/mark_failed (retry_count bumped on failure). 39 new tests pass; full suite 487/487 green.

- **INFO** [OPEN] `src/research_agent/storage/tasks.py`: TaskSpec.priority and TaskSpec.depends_on are not persisted to the tasks table (no columns exist for them). The plan.py docstring explicitly notes depends_on is plan-template-level metadata referenced by index, decoupled from DB rowids — so this is intentional. priority is similarly accepted by the model but unused by next_pending (which orders by id ASC = FIFO). Acceptable for this issue; flagging so future work knows where the dependency graph and priority scheduler will need to live (likely in the planner emitting tasks in the desired order, or a future tasks-table migration).
- **INFO** [OPEN] `src/research_agent/storage/tasks.py`: mark_done and mark_failed do not guard on current status (they UPDATE unconditionally on id), while mark_running guards WHERE status='pending'. Asymmetric but acceptable under the documented single-daemon model — a terminal transition firing twice would be a logic bug elsewhere, not a race.
- **INFO** [OPEN] `src/research_agent/storage/tasks.py`: mark_* helpers default db_path to db.DEFAULT_DB_PATH while enqueue/next_pending derive it from Job.db_path — callers must remember to pass the job's db_path explicitly when using a non-default DB. Tests do this correctly. A future ergonomics pass could thread the Job through these helpers for symmetry.
- **INFO** [OPEN] `src/research_agent/storage/__init__.py`: research_agent.storage.__init__ does not re-export tasks.* symbols (enqueue, next_pending, mark_*, STATUS_*). Direct submodule import works (tests use it) and other modules like db/jobs are also re-exported only selectively, so this is a minor consistency note, not a defect.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*