### PR TITLE
feat: Planner module (orchestrator/plan.py) (closes #25)

### DIFF
--- a/src/research_agent/orchestrator/__init__.py
+++ b/src/research_agent/orchestrator/__init__.py
@@ -1,15 +1,25 @@
 """Orchestrator — job lifecycle, planning, research loop, synthesis, critique, checkpointing."""
 
 from research_agent.orchestrator.plan import (
+    MAX_PLAN_VERSIONS,
     Plan,
+    PlanVersionCapExceeded,
     Subgoal,
     TaskKind,
     TaskSpec,
+    cloud_replan,
+    initial_plan,
+    tactical_replan,
 )
 
 __all__ = [
+    "MAX_PLAN_VERSIONS",
     "Plan",
+    "PlanVersionCapExceeded",
     "Subgoal",
     "TaskKind",
     "TaskSpec",
+    "cloud_replan",
+    "initial_plan",
+    "tactical_replan",
 ]

--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -1,4 +1,4 @@
-"""Plan + Task Pydantic models.
+"""Plan + Task Pydantic models and planner orchestration.
 
 The ``Plan`` is the versioned, structured document the planner agent emits
 each iteration of the research loop. It captures the objective, the list of
@@ -13,13 +13,33 @@ parent task pointer) that the planner does not own.
 
 All models use ``extra='forbid'`` so a typo in a planner prompt surfaces as
 a validation error at the boundary rather than silently dropping a field.
+
+This module also exposes the three planner entry points: :func:`initial_plan`
+(cloud / ``frontier`` tier — first plan from intake), :func:`tactical_replan`
+(local / ``general`` tier — small in-loop adjustments), and
+:func:`cloud_replan` (cloud / ``frontier`` tier — big rewrites driven by a
+critique). Each persists the new plan via :func:`write_plan` and emits a
+``plan_created`` event. A hard cap of :data:`MAX_PLAN_VERSIONS` versions per
+job (per implementation guide §6.3 anti-infinite-loop) guards against runaway
+replanning.
 """
 
 from __future__ import annotations
 
-from typing import Any, Literal
+import json
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
+from pydantic_ai import Agent
+
+from research_agent.observability.events import emit
+from research_agent.prompts.loader import load_prompt
+from research_agent.storage import db
+from research_agent.storage.markdown import write_plan
+
+if TYPE_CHECKING:
+    from research_agent.llm.router import Router
+    from research_agent.storage.jobs import Job
 
 TaskKind = Literal[
     "web_search",
@@ -88,9 +108,144 @@ class Plan(BaseModel):
         return all(sg.done for sg in self.subgoals)
 
 
+MAX_PLAN_VERSIONS = 200
+
+
+class PlanVersionCapExceeded(RuntimeError):
+    """Raised when a job has hit the §6.3 hard cap of plan versions.
+
+    The cap exists to short-circuit a planner that is stuck rewriting itself
+    instead of making progress — without it a tactical-replan loop could
+    silently burn local-tier time forever.
+    """
+
+
+def _plan_count(job: Job) -> int:
+    """Count persisted plan rows for ``job`` via the cross-job index."""
+    conn = db.connect(job.db_path)
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) AS c FROM plans WHERE job_id = ?",
+            (job.id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    return int(row["c"]) if row is not None else 0
+
+
+def _assert_under_cap(job: Job) -> None:
+    if _plan_count(job) >= MAX_PLAN_VERSIONS:
+        raise PlanVersionCapExceeded(
+            f"plan version cap of {MAX_PLAN_VERSIONS} reached for job {job.id!r}"
+        )
+
+
+def _emit_plan_created(job: Job, plan: Plan, *, tier: str, kind: str) -> None:
+    emit(
+        job,
+        "INFO",
+        "planner",
+        "plan_created",
+        {
+            "version": plan.version,
+            "tier": tier,
+            "kind": kind,
+            "subgoals": len(plan.subgoals),
+            "tasks": len(plan.task_template),
+        },
+    )
+
+
+async def initial_plan(job: Job, *, router: Router) -> Plan:
+    """Build the v1 plan for a fresh job using the cloud ``frontier`` tier.
+
+    Renders the ``planner.md`` system prompt with the job goal, runs a
+    Pydantic AI :class:`Agent` with ``output_type=Plan`` against the frontier
+    model, forces ``version = 1`` on the structured output, persists via
+    :func:`write_plan`, and emits ``plan_created``.
+    """
+    _assert_under_cap(job)
+    rendered = load_prompt("planner", job=job, goal=job.goal)
+    agent = Agent(router.model_for("frontier"), output_type=Plan, system_prompt=rendered)
+    result = await router.call("frontier", agent, job.goal)
+    plan: Plan = result.output
+    plan = plan.model_copy(update={"version": 1})
+    write_plan(job, plan.model_dump())
+    _emit_plan_created(job, plan, tier="frontier", kind="initial")
+    return plan
+
+
+async def tactical_replan(
+    job: Job,
+    plan: Plan,
+    recent_results: list[dict[str, Any]],
+    *,
+    router: Router,
+) -> Plan:
+    """Run a small in-loop replan on the local ``general`` tier.
+
+    The prior plan + recent task results are serialized into the run-prompt
+    payload so the planner can adjust without a full cloud rewrite. The
+    returned plan's version is set to ``plan.version + 1`` and persisted.
+    """
+    _assert_under_cap(job)
+    rendered = load_prompt("planner", job=job, goal=job.goal)
+    agent = Agent(router.model_for("general"), output_type=Plan, system_prompt=rendered)
+    context = json.dumps(
+        {
+            "prior_plan": plan.model_dump(),
+            "recent_results": recent_results,
+        },
+        sort_keys=True,
+        default=str,
+    )
+    result = await router.call("general", agent, context)
+    new_plan: Plan = result.output
+    new_plan = new_plan.model_copy(update={"version": plan.version + 1})
+    write_plan(job, new_plan.model_dump())
+    _emit_plan_created(job, new_plan, tier="general", kind="tactical_replan")
+    return new_plan
+
+
+async def cloud_replan(
+    job: Job,
+    plan: Plan,
+    critique: str,
+    *,
+    router: Router,
+) -> Plan:
+    """Run a major plan rewrite on the cloud ``frontier`` tier.
+
+    Used when a critique flags structural gaps that a local tactical replan
+    can't address. Increments the plan version, persists, emits.
+    """
+    _assert_under_cap(job)
+    rendered = load_prompt("planner", job=job, goal=job.goal)
+    agent = Agent(router.model_for("frontier"), output_type=Plan, system_prompt=rendered)
+    context = json.dumps(
+        {
+            "prior_plan": plan.model_dump(),
+            "critique": critique,
+        },
+        sort_keys=True,
+        default=str,
+    )
+    result = await router.call("frontier", agent, context)
+    new_plan: Plan = result.output
+    new_plan = new_plan.model_copy(update={"version": plan.version + 1})
+    write_plan(job, new_plan.model_dump())
+    _emit_plan_created(job, new_plan, tier="frontier", kind="cloud_replan")
+    return new_plan
+
+
 __all__ = [
+    "MAX_PLAN_VERSIONS",
     "Plan",
+    "PlanVersionCapExceeded",
     "Subgoal",
     "TaskKind",
     "TaskSpec",
+    "cloud_replan",
+    "initial_plan",
+    "tactical_replan",
 ]

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -2,12 +2,32 @@
 
 from __future__ import annotations
 
-from typing import get_args
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import Any, get_args
 
 import pytest
 from pydantic import ValidationError
 
-from research_agent.orchestrator.plan import Plan, Subgoal, TaskKind, TaskSpec
+from research_agent.llm.budgets import BudgetTracker
+from research_agent.llm.router import Router, load_models_config
+from research_agent.orchestrator import plan as plan_module
+from research_agent.orchestrator.plan import (
+    MAX_PLAN_VERSIONS,
+    Plan,
+    PlanVersionCapExceeded,
+    Subgoal,
+    TaskKind,
+    TaskSpec,
+    cloud_replan,
+    initial_plan,
+    tactical_replan,
+)
+from research_agent.prompts import loader as prompts_loader
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
 
 ALL_TASK_KINDS: tuple[str, ...] = get_args(TaskKind)
 
@@ -163,3 +183,302 @@ def test_plan_forbids_extra_keys() -> None:
     payload["surprise"] = "boom"
     with pytest.raises(ValidationError):
         Plan.model_validate(payload)
+
+
+# ---------------------------------------------------------------------------
+# Planner orchestration: initial_plan / tactical_replan / cloud_replan
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SHIPPED_MODELS_YAML = REPO_ROOT / "config" / "models.yaml"
+
+
+class _StubUsage:
+    """Mimics a Pydantic AI usage object for ``_extract_usage`` to consume."""
+
+    input_tokens = 0
+    output_tokens = 0
+    cache_read_tokens = 0
+
+
+class _StubResult:
+    """Mimics ``AgentRunResult`` — exposes ``output``/``usage()``/``finish_reason``."""
+
+    def __init__(self, output: Plan) -> None:
+        self.output = output
+        self.finish_reason = "stop"
+
+    def usage(self) -> _StubUsage:
+        return _StubUsage()
+
+
+class _StubAgent:
+    """Stub stand-in for :class:`pydantic_ai.Agent`.
+
+    Captures construction kwargs (so tests can verify ``output_type`` and the
+    rendered ``system_prompt``) and returns a configurable :class:`Plan` from
+    :meth:`run`. Each test resets the class-level ``next_plan`` before
+    triggering the planner.
+    """
+
+    instances: list[_StubAgent] = []
+    next_plan: Plan | None = None
+
+    def __init__(
+        self,
+        model: Any,
+        *,
+        output_type: Any = None,
+        system_prompt: str | None = None,
+        **extra: Any,
+    ) -> None:
+        self.model = model
+        self.output_type = output_type
+        self.system_prompt = system_prompt
+        self.extra = extra
+        self.run_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        _StubAgent.instances.append(self)
+
+    async def run(self, *args: Any, **kwargs: Any) -> _StubResult:
+        self.run_calls.append((args, kwargs))
+        plan = _StubAgent.next_plan
+        assert plan is not None, "test forgot to set _StubAgent.next_plan"
+        return _StubResult(output=plan)
+
+
+@pytest.fixture(autouse=True)
+def _clear_prompt_cache() -> None:
+    """Per-test reset of the prompt loader cache to avoid cross-test bleed."""
+    prompts_loader.clear_cache()
+    yield
+    prompts_loader.clear_cache()
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "index.sqlite"
+    db.migrate(path=path).close()
+    return path
+
+
+@pytest.fixture
+def jobs_root(tmp_path: Path) -> Path:
+    return tmp_path / "jobs"
+
+
+@pytest.fixture
+def job(jobs_root: Path, db_path: Path) -> Job:
+    return Job.create(
+        {"goal": "Investigate planner module"},
+        jobs_root=jobs_root,
+        db_path=db_path,
+    )
+
+
+@pytest.fixture
+def router_with_spy(
+    monkeypatch: pytest.MonkeyPatch,
+    job: Job,
+    db_path: Path,
+) -> tuple[Router, list[tuple[str, Any, tuple[Any, ...], dict[str, Any]]]]:
+    """Build a Router whose ``call`` is replaced with a spy that drives the stub.
+
+    The spy records ``(tier, agent, args, kwargs)`` on every call and returns
+    whatever the stub agent produces — this avoids any HTTP traffic while
+    still exercising the planner's tier-selection contract.
+    """
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test-planner")
+    monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
+
+    cfg = load_models_config(SHIPPED_MODELS_YAML)
+    budget = BudgetTracker(job.id, cap_usd=None, db_path=db_path)
+    router = Router(cfg, budget, job=job, db_path=db_path)
+
+    calls: list[tuple[str, Any, tuple[Any, ...], dict[str, Any]]] = []
+
+    async def _spy_call(tier: str, agent: Any, *args: Any, **kwargs: Any) -> Any:
+        calls.append((tier, agent, args, kwargs))
+        return await agent.run(*args, **kwargs)
+
+    monkeypatch.setattr(router, "call", _spy_call)
+    monkeypatch.setattr(plan_module, "Agent", _StubAgent)
+    _StubAgent.instances = []
+    _StubAgent.next_plan = None
+    return router, calls
+
+
+def _read_plan_rows(db_path: Path, job_id: str) -> list[dict[str, Any]]:
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT version, payload_json, created_at FROM plans"
+            " WHERE job_id = ? ORDER BY version ASC",
+            (job_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [dict(r) for r in rows]
+
+
+def _read_event_kinds(db_path: Path, job_id: str) -> list[str]:
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT kind FROM events WHERE job_id = ? ORDER BY id ASC",
+            (job_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [r["kind"] for r in rows]
+
+
+def test_initial_plan_writes_v1_row_and_emits_event(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    router, calls = router_with_spy
+    # Stub returns a plan claiming version=99; initial_plan must force it to 1.
+    _StubAgent.next_plan = _sample_plan(version=99)
+
+    result = asyncio.run(initial_plan(job, router=router))
+
+    assert result.version == 1
+    assert calls and calls[0][0] == "frontier"
+
+    rows = _read_plan_rows(db_path, job.id)
+    assert len(rows) == 1
+    assert rows[0]["version"] == 1
+    persisted = json.loads(rows[0]["payload_json"])
+    assert persisted["version"] == 1
+    assert persisted["objective"] == result.objective
+
+    assert "plan_created" in _read_event_kinds(db_path, job.id)
+
+
+def test_initial_plan_renders_planner_prompt_with_goal(
+    job: Job,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    _router, _calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+
+    asyncio.run(initial_plan(job, router=_router))
+
+    assert _StubAgent.instances, "Agent was never constructed"
+    constructed = _StubAgent.instances[0]
+    assert constructed.output_type is Plan
+    # The planner prompt template contains the goal literal once rendered.
+    assert constructed.system_prompt is not None
+    assert job.goal in constructed.system_prompt
+
+
+def test_tactical_replan_increments_version_and_uses_general_tier(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    router, calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+    assert v1.version == 1
+
+    # Stub returns whatever version it likes — tactical_replan must overwrite
+    # to ``prior + 1`` regardless.
+    _StubAgent.next_plan = _sample_plan(version=42)
+    recent_results = [{"task_id": 7, "kind": "web_search", "status": "done"}]
+    v2 = asyncio.run(
+        tactical_replan(job, v1, recent_results, router=router),
+    )
+
+    assert v2.version == 2
+    rows = _read_plan_rows(db_path, job.id)
+    assert [r["version"] for r in rows] == [1, 2]
+
+    # Spy captured the tier on the second call.
+    assert [c[0] for c in calls] == ["frontier", "general"]
+    # And the tactical run input embedded the prior plan + recent results.
+    args = calls[1][2]
+    assert args, "tactical_replan should pass run-input to router.call"
+    payload = json.loads(args[0])
+    assert payload["recent_results"] == recent_results
+    assert payload["prior_plan"]["version"] == 1
+
+
+def test_cloud_replan_increments_version_and_routes_through_frontier(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    router, calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    _StubAgent.next_plan = _sample_plan(version=7)
+    critique = "Plan misses contradicting evidence; broaden subgoal 2."
+    v2 = asyncio.run(cloud_replan(job, v1, critique, router=router))
+
+    assert v2.version == 2
+    assert [c[0] for c in calls] == ["frontier", "frontier"]
+
+    args = calls[1][2]
+    payload = json.loads(args[0])
+    assert payload["critique"] == critique
+    assert payload["prior_plan"]["version"] == 1
+
+    rows = _read_plan_rows(db_path, job.id)
+    assert [r["version"] for r in rows] == [1, 2]
+
+
+def test_max_plan_versions_cap_raises_when_full(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    router, _calls = router_with_spy
+    # Pre-populate 200 plan rows directly so the cap check fires before the
+    # planner ever calls into the stub agent.
+    now = int(time.time())
+    conn = db.connect(db_path)
+    try:
+        with conn:
+            for v in range(1, MAX_PLAN_VERSIONS + 1):
+                conn.execute(
+                    "INSERT INTO plans (job_id, version, payload_json, created_at)"
+                    " VALUES (?, ?, ?, ?)",
+                    (job.id, v, json.dumps({"version": v}), now),
+                )
+    finally:
+        conn.close()
+
+    _StubAgent.next_plan = _sample_plan()
+
+    with pytest.raises(PlanVersionCapExceeded):
+        asyncio.run(initial_plan(job, router=router))
+
+    prior = _sample_plan(version=MAX_PLAN_VERSIONS)
+    with pytest.raises(PlanVersionCapExceeded):
+        asyncio.run(tactical_replan(job, prior, [], router=router))
+    with pytest.raises(PlanVersionCapExceeded):
+        asyncio.run(cloud_replan(job, prior, "x", router=router))
+
+
+def test_persisted_plan_round_trips_via_db(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """The stored ``payload_json`` parses back into the same Plan we returned."""
+    router, _calls = router_with_spy
+    stub = _sample_plan(version=99)
+    _StubAgent.next_plan = stub
+
+    returned = asyncio.run(initial_plan(job, router=router))
+
+    rows = _read_plan_rows(db_path, job.id)
+    assert len(rows) == 1
+    rebuilt = Plan.model_validate(json.loads(rows[0]["payload_json"]))
+    # Version is forced to 1; everything else matches the stub payload.
+    assert rebuilt == returned
+    expected = stub.model_copy(update={"version": 1})
+    assert rebuilt == expected


### PR DESCRIPTION
Closes #25

## Summary

Automated implementation of **Planner module (orchestrator/plan.py)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Planner module fully meets issue #25 acceptance criteria; all 493 tests pass.

- **INFO** [OPEN] `src/research_agent/orchestrator/plan.py`: Plan.version (set via model_copy in tactical_replan/cloud_replan) is decoupled from the DB row's version column (computed independently by write_plan._next_version). In normal flow they match, but a stale prior-plan argument would diverge JSON payload version from row version. Pre-existing design from issue #6, not new in this PR; flagging for future awareness.
- **INFO** [OPEN] `src/research_agent/orchestrator/plan.py`: tactical_replan/cloud_replan render the system prompt with only `goal=job.goal`; prior plan + recent_results / critique are passed as the user-message context via router.call. This is a deliberate split, but worth documenting in the planner.md prompt if behavior diverges later.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*