### PR TITLE
feat: Research loop (orchestrator/loop.py) — task runner with retry (closes #26)

### DIFF
--- a/src/research_agent/orchestrator/__init__.py
+++ b/src/research_agent/orchestrator/__init__.py
@@ -1,5 +1,15 @@
 """Orchestrator — job lifecycle, planning, research loop, synthesis, critique, checkpointing."""
 
+from research_agent.orchestrator.errors import FatalError, RetriableError
+from research_agent.orchestrator.loop import (
+    HEURISTIC_CHECK_EVERY_N,
+    MAX_TASKS_PER_JOB,
+    RETRY_MAX_ATTEMPTS,
+    RETRY_WAITS,
+    Handler,
+    default_handlers,
+    run_loop,
+)
 from research_agent.orchestrator.plan import (
     MAX_PLAN_VERSIONS,
     Plan,
@@ -13,13 +23,22 @@ from research_agent.orchestrator.plan import (
 )
 
 __all__ = [
+    "HEURISTIC_CHECK_EVERY_N",
+    "Handler",
     "MAX_PLAN_VERSIONS",
+    "MAX_TASKS_PER_JOB",
     "Plan",
     "PlanVersionCapExceeded",
+    "RETRY_MAX_ATTEMPTS",
+    "RETRY_WAITS",
     "Subgoal",
     "TaskKind",
     "TaskSpec",
+    "FatalError",
+    "RetriableError",
     "cloud_replan",
+    "default_handlers",
     "initial_plan",
+    "run_loop",
     "tactical_replan",
 ]

--- a/src/research_agent/orchestrator/errors.py
+++ b/src/research_agent/orchestrator/errors.py
@@ -1,0 +1,29 @@
+"""Loop-control exceptions shared between the orchestrator and connectors.
+
+Lives in its own module so connectors (which raise these) and the loop
+(which catches them) can both import without producing an import cycle
+through :mod:`research_agent.orchestrator.loop`.
+
+A :class:`RetriableError` is the connector's signal that "this task could
+work — just try again". The loop wraps the handler call in a tenacity
+backoff (1s/2s/4s/8s/16s/30s/60s, 5 attempts) and only marks the task
+``failed`` once the budget is exhausted.
+
+A :class:`FatalError` is the connector's signal that "this task will never
+work as currently shaped". The loop marks the task ``failed`` immediately
+and continues with the next task — *not* the daemon — because v1's job
+state machine treats one bad task as a recoverable event, not a job-killer.
+"""
+
+from __future__ import annotations
+
+
+class RetriableError(Exception):
+    """Connector-level error that the loop should retry with exponential backoff."""
+
+
+class FatalError(Exception):
+    """Connector-level error that should not be retried; mark task failed and continue."""
+
+
+__all__ = ["FatalError", "RetriableError"]

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -1,0 +1,510 @@
+"""Research loop — task runner with retry, follow-ups, and synthesis cadence.
+
+Implements §6.1 of ``research-agent-implementation-guide.md``: a single
+``while not job.should_stop() and not plan.is_complete()`` loop that pulls
+the next pending task from the SQLite queue, dispatches it through a
+``kind → handler`` registry, and records the outcome.
+
+The loop has three resilience boundaries:
+
+* :class:`~research_agent.orchestrator.errors.RetriableError` — handlers
+  raise this for transient failures; the loop applies a tenacity backoff
+  (waits ``RETRY_WAITS`` seconds, ``RETRY_MAX_ATTEMPTS`` total attempts).
+* :class:`~research_agent.orchestrator.errors.FatalError` — the task is
+  marked ``failed`` and the loop continues with the next task. One bad
+  task does not kill the daemon.
+* ``MAX_TASKS_PER_JOB`` hard cap — anti-runaway guard from §6.3. When hit
+  the loop stops and best-effort triggers a final synthesis pass so the
+  user gets *something* back even if the planner went off the rails.
+
+Synthesis and critique cadence is driven by ``HEURISTIC_CHECK_EVERY_N``
+(every 25 tasks) — real heuristics live with the synthesis/critique
+modules; the loop just calls handlers if registered. Failures in those
+heuristic-driven calls are emitted as ``warning`` events but never abort
+the loop.
+
+The single entry point is :func:`run_loop`. It accepts an optional
+``handlers`` registry override (used by tests + for swapping connector
+implementations) and an optional explicit ``plan`` (otherwise the latest
+``plans`` row for the job is loaded).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception_type,
+    stop_after_attempt,
+)
+
+from research_agent.observability.events import emit
+from research_agent.orchestrator.errors import FatalError, RetriableError
+from research_agent.orchestrator.plan import Plan, TaskKind, TaskSpec
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+from research_agent.storage.tasks import (
+    enqueue,
+    mark_done,
+    mark_failed,
+    mark_running,
+    next_pending,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_TASKS_PER_JOB = 10000
+HEURISTIC_CHECK_EVERY_N = 25
+RETRY_WAITS: tuple[int, ...] = (1, 2, 4, 8, 16, 30, 60)
+RETRY_MAX_ATTEMPTS = 5
+
+Handler = Callable[[Job, dict[str, Any]], Awaitable[dict[str, Any] | None]]
+
+
+# ---------------------------------------------------------------------------
+# Default handler registry
+# ---------------------------------------------------------------------------
+
+
+async def _not_implemented_handler(job: Job, task: dict[str, Any]) -> dict[str, Any] | None:
+    """Placeholder for task kinds whose connectors haven't shipped yet.
+
+    Raises :class:`FatalError` so the loop marks the task ``failed`` and
+    continues — this keeps the loop usable end-to-end while individual
+    connector handlers land in their own follow-up issues.
+    """
+    raise FatalError(f"handler not implemented for kind={task['kind']!r}")
+
+
+def default_handlers(router: Any) -> dict[str, Handler]:
+    """Build the standard ``kind → handler`` registry.
+
+    Connector kinds that have a shipping module (``web_search``, ``web_fetch``,
+    ``arxiv_*``, ``news_search``, ``reddit_search``, ``local_corpus_query``)
+    get thin async wrappers that call into the connector. Kinds whose
+    handlers haven't been implemented yet (``github_*``, ``extract_findings``,
+    ``summarize_source``, ``synthesize``, ``critique``) get
+    :func:`_not_implemented_handler` so the loop stays runnable end-to-end.
+    """
+
+    async def _web_search(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        from research_agent.tools import web_search
+
+        payload = task["payload"]
+        results = await web_search.search(
+            payload.get("query", ""),
+            max_results=payload.get("max_results", 10),
+            engine=payload.get("engine", "ddg"),
+        )
+        return {"results": [r.model_dump() for r in results]}
+
+    async def _web_fetch(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        from research_agent.tools import web_fetch
+
+        payload = task["payload"]
+        source = await web_fetch.fetch(payload["url"])
+        return {"source": source.model_dump() if source is not None else None}
+
+    async def _arxiv_search(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        from research_agent.tools import arxiv_tool
+
+        payload = task["payload"]
+        results = await arxiv_tool.search(
+            payload.get("query", ""),
+            max_results=payload.get("max_results", 10),
+        )
+        return {"results": [r.model_dump() for r in results]}
+
+    async def _arxiv_fetch(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        from research_agent.tools import arxiv_tool
+
+        payload = task["payload"]
+        source = await arxiv_tool.fetch(payload["arxiv_id"])
+        return {"source": source.model_dump() if source is not None else None}
+
+    async def _news_search(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        from research_agent.tools import news
+
+        payload = task["payload"]
+        results = await news.search(payload.get("query", ""))
+        return {"results": [r.model_dump() for r in results]}
+
+    async def _reddit_search(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        from research_agent.tools import reddit
+
+        payload = task["payload"]
+        results = await reddit.search(payload.get("query", ""))
+        return {"results": [r.model_dump() for r in results]}
+
+    async def _local_corpus_query(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        from research_agent.tools import local_corpus
+
+        payload = task["payload"]
+        loop = asyncio.get_running_loop()
+        results = await loop.run_in_executor(
+            None,
+            lambda: local_corpus.search(
+                payload.get("query", ""),
+                job,
+                top_k=payload.get("top_k", 10),
+            ),
+        )
+        return {"results": results}
+
+    return {
+        "web_search": _web_search,
+        "web_fetch": _web_fetch,
+        "arxiv_search": _arxiv_search,
+        "arxiv_fetch": _arxiv_fetch,
+        "news_search": _news_search,
+        "reddit_search": _reddit_search,
+        "local_corpus_query": _local_corpus_query,
+        "github_search": _not_implemented_handler,
+        "github_fetch": _not_implemented_handler,
+        "extract_findings": _not_implemented_handler,
+        "summarize_source": _not_implemented_handler,
+        "synthesize": _not_implemented_handler,
+        "critique": _not_implemented_handler,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Loop helpers
+# ---------------------------------------------------------------------------
+
+
+def _should_stop(job: Job) -> bool:
+    """True when the operator dropped a ``STOP`` flag in the job folder."""
+    return (job.root / "STOP").exists()
+
+
+def _checkpoint_hook(job: Job, plan: Plan, task: dict[str, Any]) -> None:
+    """Best-effort call into the (future) ``orchestrator.checkpoint`` module.
+
+    The checkpoint module ships in issue #29; until then the import simply
+    fails and the hook is a no-op so this loop can ship first.
+    """
+    try:
+        from research_agent.orchestrator.checkpoint import (
+            checkpoint,  # type: ignore[import-not-found]
+        )
+    except ImportError:
+        return
+    checkpoint(job, plan, task)
+
+
+def _should_synthesize(plan: Plan, tasks_done: int) -> bool:
+    """v1 synthesis heuristic: every ``HEURISTIC_CHECK_EVERY_N`` tasks.
+
+    The "real" heuristic — only synthesize if there are unsummarized
+    findings — lives with the synthesis module that lands later. The loop
+    just provides the cadence.
+    """
+    return tasks_done > 0 and tasks_done % HEURISTIC_CHECK_EVERY_N == 0
+
+
+def _should_critique(plan: Plan, tasks_done: int) -> bool:
+    """v1 critique heuristic: every 4× the synthesis cadence (default: 100)."""
+    return tasks_done > 0 and tasks_done % (HEURISTIC_CHECK_EVERY_N * 4) == 0
+
+
+def _load_latest_plan(job: Job) -> Plan | None:
+    """Read the highest-version ``plans`` row for ``job`` and return it as :class:`Plan`."""
+    conn = db.connect(job.db_path)
+    try:
+        row = conn.execute(
+            "SELECT payload_json FROM plans WHERE job_id = ? ORDER BY version DESC LIMIT 1",
+            (job.id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return None
+    return Plan.model_validate_json(row["payload_json"])
+
+
+def _make_wait_fn(wait_seq: tuple[int, ...]) -> Callable[[Any], int]:
+    """Build a tenacity wait callable that walks ``wait_seq`` then clamps to its tail."""
+
+    def _wait(retry_state: Any) -> int:
+        idx = min(max(retry_state.attempt_number - 1, 0), len(wait_seq) - 1)
+        return int(wait_seq[idx])
+
+    return _wait
+
+
+async def _run_with_retry(
+    handler: Handler,
+    job: Job,
+    task: dict[str, Any],
+    *,
+    wait_seq: tuple[int, ...] = RETRY_WAITS,
+    max_attempts: int = RETRY_MAX_ATTEMPTS,
+) -> dict[str, Any] | None:
+    """Run ``handler`` with tenacity backoff on :class:`RetriableError`.
+
+    On final exhaustion the underlying :class:`RetriableError` is re-raised
+    (``reraise=True``), which the caller catches to mark the task ``failed``.
+    """
+    result: dict[str, Any] | None = None
+    async for attempt in AsyncRetrying(
+        stop=stop_after_attempt(max_attempts),
+        wait=_make_wait_fn(wait_seq),
+        retry=retry_if_exception_type(RetriableError),
+        reraise=True,
+    ):
+        with attempt:
+            result = await handler(job, task)
+    return result
+
+
+def _enqueue_follow_ups(
+    job: Job,
+    follow_ups: list[Any],
+    plan_version: int,
+) -> list[int]:
+    """Coerce a handler's ``follow_up_tasks`` into :class:`TaskSpec` rows + enqueue.
+
+    Accepts either fully-formed ``TaskSpec`` instances or plain dicts that
+    validate against the model — handlers can return whichever is more
+    natural at their boundary.
+    """
+    coerced: list[TaskSpec] = []
+    for item in follow_ups:
+        if isinstance(item, TaskSpec):
+            coerced.append(item)
+        else:
+            coerced.append(TaskSpec.model_validate(item))
+    if not coerced:
+        return []
+    return enqueue(job, coerced, plan_version)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+async def run_loop(
+    job: Job,
+    router: Any,
+    *,
+    plan: Plan | None = None,
+    handlers: dict[str, Handler] | None = None,
+    max_tasks: int = MAX_TASKS_PER_JOB,
+    retry_waits: tuple[int, ...] = RETRY_WAITS,
+    retry_max_attempts: int = RETRY_MAX_ATTEMPTS,
+) -> dict[str, Any]:
+    """Drain the task queue for ``job`` until the plan is complete or a cap fires.
+
+    Parameters mirror §6.1's pseudocode plus a few testing hooks: an explicit
+    ``plan`` (otherwise the latest persisted plan is loaded), a ``handlers``
+    registry override, and ``retry_waits``/``retry_max_attempts`` so tests
+    can collapse the backoff to zero. Returns a small status dict so callers
+    (CLI, future UI) can render the run's outcome without re-querying the DB.
+    """
+    handlers = handlers if handlers is not None else default_handlers(router)
+    if plan is None:
+        plan = _load_latest_plan(job)
+    if plan is None:
+        raise RuntimeError(
+            f"run_loop: no plan persisted for job {job.id!r}; "
+            "run initial_plan() before entering the loop"
+        )
+
+    tasks_done = 0
+    stopped = False
+    cap_hit = False
+
+    while not _should_stop(job) and not plan.is_complete() and tasks_done < max_tasks:
+        task = next_pending(job)
+        if task is None:
+            break
+
+        mark_running(task["id"], db_path=job.db_path)
+        emit(
+            job,
+            "INFO",
+            "loop",
+            "task_pulled",
+            {"task_id": task["id"], "kind": task["kind"]},
+        )
+        _checkpoint_hook(job, plan, task)
+
+        handler = handlers.get(task["kind"])
+        if handler is None:
+            err = f"no handler registered for kind={task['kind']!r}"
+            mark_failed(task["id"], err, db_path=job.db_path)
+            emit(
+                job,
+                "ERROR",
+                "loop",
+                "error",
+                {"task_id": task["id"], "kind": task["kind"], "error": err},
+            )
+            tasks_done += 1
+            continue
+
+        try:
+            result = await _run_with_retry(
+                handler,
+                job,
+                task,
+                wait_seq=retry_waits,
+                max_attempts=retry_max_attempts,
+            )
+        except FatalError as exc:
+            mark_failed(task["id"], str(exc), db_path=job.db_path)
+            emit(
+                job,
+                "ERROR",
+                "loop",
+                "task_failed",
+                {
+                    "task_id": task["id"],
+                    "kind": task["kind"],
+                    "error": str(exc),
+                    "fatal": True,
+                },
+            )
+            tasks_done += 1
+            continue
+        except RetriableError as exc:
+            mark_failed(task["id"], str(exc), db_path=job.db_path)
+            emit(
+                job,
+                "ERROR",
+                "loop",
+                "task_failed",
+                {
+                    "task_id": task["id"],
+                    "kind": task["kind"],
+                    "error": str(exc),
+                    "retries_exhausted": True,
+                },
+            )
+            tasks_done += 1
+            continue
+
+        follow_ups = (result or {}).get("follow_up_tasks") if isinstance(result, dict) else None
+        # ``result`` is what gets persisted; strip the meta key so it isn't
+        # double-stored (the queue rows for the follow-ups are the canonical
+        # record of what was enqueued).
+        persistable: dict[str, Any] | None
+        if isinstance(result, dict) and "follow_up_tasks" in result:
+            persistable = {k: v for k, v in result.items() if k != "follow_up_tasks"}
+        else:
+            persistable = result
+
+        mark_done(task["id"], persistable, db_path=job.db_path)
+        emit(
+            job,
+            "INFO",
+            "loop",
+            "task_done",
+            {"task_id": task["id"], "kind": task["kind"]},
+        )
+
+        if follow_ups:
+            _enqueue_follow_ups(job, list(follow_ups), task["plan_version"])
+
+        tasks_done += 1
+
+        if tasks_done % HEURISTIC_CHECK_EVERY_N == 0:
+            await _maybe_run_heuristic(job, plan, handlers, tasks_done)
+
+    if tasks_done >= max_tasks and not _should_stop(job):
+        cap_hit = True
+        emit(
+            job,
+            "WARN",
+            "loop",
+            "warning",
+            {"cap_hit": True, "max_tasks": max_tasks, "tasks_done": tasks_done},
+        )
+        await _final_synthesis_best_effort(job, handlers)
+
+    if _should_stop(job):
+        stopped = True
+
+    return {
+        "tasks_done": tasks_done,
+        "stopped": stopped,
+        "completed": plan.is_complete(),
+        "cap_hit": cap_hit,
+    }
+
+
+async def _maybe_run_heuristic(
+    job: Job,
+    plan: Plan,
+    handlers: dict[str, Handler],
+    tasks_done: int,
+) -> None:
+    """Fire synthesize/critique handlers if the cadence heuristics agree.
+
+    Failures here surface as ``warning`` events but never abort the loop —
+    a flaky synth pass shouldn't kill a week-long run.
+    """
+    if _should_synthesize(plan, tasks_done):
+        synth = handlers.get("synthesize")
+        if synth is not None:
+            try:
+                await synth(job, {"kind": "synthesize", "id": -1, "payload": {}})
+            except Exception as exc:  # noqa: BLE001 — heuristic is best-effort
+                emit(
+                    job,
+                    "WARN",
+                    "loop",
+                    "warning",
+                    {"heuristic": "synthesize", "error": str(exc)},
+                )
+    if _should_critique(plan, tasks_done):
+        crit = handlers.get("critique")
+        if crit is not None:
+            try:
+                await crit(job, {"kind": "critique", "id": -1, "payload": {}})
+            except Exception as exc:  # noqa: BLE001 — heuristic is best-effort
+                emit(
+                    job,
+                    "WARN",
+                    "loop",
+                    "warning",
+                    {"heuristic": "critique", "error": str(exc)},
+                )
+
+
+async def _final_synthesis_best_effort(
+    job: Job,
+    handlers: dict[str, Handler],
+) -> None:
+    """On cap-hit, try a final synthesize pass so the user gets *something*."""
+    synth = handlers.get("synthesize")
+    if synth is None:
+        return
+    try:
+        await synth(job, {"kind": "synthesize", "id": -1, "payload": {"final": True}})
+    except Exception as exc:  # noqa: BLE001 — final synth is best-effort
+        emit(
+            job,
+            "WARN",
+            "loop",
+            "warning",
+            {"final_synthesis": "failed", "error": str(exc)},
+        )
+
+
+__all__ = [
+    "HEURISTIC_CHECK_EVERY_N",
+    "Handler",
+    "MAX_TASKS_PER_JOB",
+    "RETRY_MAX_ATTEMPTS",
+    "RETRY_WAITS",
+    "TaskKind",
+    "default_handlers",
+    "run_loop",
+]

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -1,0 +1,428 @@
+"""Tests for ``research_agent.orchestrator.loop``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from research_agent.orchestrator.errors import FatalError, RetriableError
+from research_agent.orchestrator.loop import (
+    HEURISTIC_CHECK_EVERY_N,
+    MAX_TASKS_PER_JOB,
+    RETRY_MAX_ATTEMPTS,
+    Handler,
+    default_handlers,
+    run_loop,
+)
+from research_agent.orchestrator.plan import Plan, Subgoal, TaskSpec
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+from research_agent.storage.markdown import write_plan
+from research_agent.storage.tasks import (
+    STATUS_DONE,
+    STATUS_FAILED,
+    STATUS_PENDING,
+    enqueue,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "index.sqlite"
+    db.migrate(path=path).close()
+    return path
+
+
+@pytest.fixture
+def jobs_root(tmp_path: Path) -> Path:
+    return tmp_path / "jobs"
+
+
+@pytest.fixture
+def job(jobs_root: Path, db_path: Path) -> Job:
+    return Job.create(
+        {"goal": "Investigate Widget Co"},
+        jobs_root=jobs_root,
+        db_path=db_path,
+    )
+
+
+@pytest.fixture
+def plan(job: Job) -> Plan:
+    """Persist a plan whose subgoals are all open so the loop runs to drain."""
+    p = Plan(
+        version=1,
+        objective="Investigate the target",
+        subgoals=[Subgoal(id=1, description="Gather", done=False)],
+        task_template=[TaskSpec(kind="web_search")],
+        expected_iterations=3,
+    )
+    write_plan(job, p.model_dump())
+    return p
+
+
+def _seed_tasks(job: Job, kinds: list[str], plan_version: int = 1) -> list[int]:
+    specs = [TaskSpec(kind=k, payload={"q": f"q-{i}"}) for i, k in enumerate(kinds)]  # type: ignore[arg-type]
+    return enqueue(job, specs, plan_version=plan_version)
+
+
+def _read_task_rows(db_path: Path, job_id: str) -> list[dict[str, Any]]:
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT id, kind, status, error, retry_count, result_json"
+            " FROM tasks WHERE job_id = ? ORDER BY id ASC",
+            (job_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [dict(r) for r in rows]
+
+
+def _read_event_kinds(db_path: Path, job_id: str) -> list[str]:
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT kind FROM events WHERE job_id = ? ORDER BY id ASC",
+            (job_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [r["kind"] for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Stub handler factory
+# ---------------------------------------------------------------------------
+
+
+def _ok_handler(result: dict[str, Any] | None = None) -> Handler:
+    async def _h(job: Job, task: dict[str, Any]) -> dict[str, Any] | None:
+        return result if result is not None else {"hits": 1}
+
+    return _h
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_loop_drains_five_task_plan(job: Job, db_path: Path, plan: Plan) -> None:
+    """A 5-task plan should fully drain with all rows transitioning to ``done``."""
+    kinds = ["web_search", "web_fetch", "arxiv_search", "news_search", "reddit_search"]
+    ids = _seed_tasks(job, kinds)
+
+    handlers: dict[str, Handler] = {k: _ok_handler() for k in kinds}
+
+    result = await run_loop(job, router=None, plan=plan, handlers=handlers, retry_waits=(0,))
+
+    assert result["tasks_done"] == 5
+    assert result["stopped"] is False
+    assert result["cap_hit"] is False
+
+    rows = _read_task_rows(db_path, job.id)
+    assert [r["id"] for r in rows] == ids
+    assert all(r["status"] == STATUS_DONE for r in rows)
+
+    events = _read_event_kinds(db_path, job.id)
+    assert events.count("task_pulled") == 5
+    assert events.count("task_done") == 5
+
+
+@pytest.mark.asyncio
+async def test_retriable_error_retries_then_succeeds(job: Job, db_path: Path, plan: Plan) -> None:
+    """A handler that raises RetriableError twice must succeed on the third try."""
+    _seed_tasks(job, ["web_search"])
+    attempts = {"n": 0}
+
+    async def flaky(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise RetriableError("transient")
+        return {"ok": True}
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": flaky},
+        retry_waits=(0,),
+    )
+
+    assert attempts["n"] == 3
+    assert result["tasks_done"] == 1
+    rows = _read_task_rows(db_path, job.id)
+    assert rows[0]["status"] == STATUS_DONE
+
+
+@pytest.mark.asyncio
+async def test_retriable_error_exhausted_marks_failed(job: Job, db_path: Path, plan: Plan) -> None:
+    """If every retry hits RetriableError, the task ends ``failed`` and the loop continues."""
+    _seed_tasks(job, ["web_search", "web_fetch"])
+    attempts = {"n": 0}
+
+    async def always_retriable(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        attempts["n"] += 1
+        raise RetriableError("never works")
+
+    async def ok(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        return {"ok": True}
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": always_retriable, "web_fetch": ok},
+        retry_waits=(0,),
+    )
+
+    assert attempts["n"] == RETRY_MAX_ATTEMPTS
+    assert result["tasks_done"] == 2
+
+    rows = _read_task_rows(db_path, job.id)
+    assert rows[0]["status"] == STATUS_FAILED
+    assert rows[0]["error"] == "never works"
+    assert rows[1]["status"] == STATUS_DONE
+
+    events = _read_event_kinds(db_path, job.id)
+    assert "task_failed" in events
+
+
+@pytest.mark.asyncio
+async def test_fatal_error_marks_failed_and_continues(job: Job, db_path: Path, plan: Plan) -> None:
+    """A FatalError marks the task failed once (no retry) and the next task still runs."""
+    _seed_tasks(job, ["web_search", "web_fetch"])
+    attempts = {"n": 0}
+
+    async def boom(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        attempts["n"] += 1
+        raise FatalError("structural")
+
+    async def ok(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        return {"ok": True}
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": boom, "web_fetch": ok},
+        retry_waits=(0,),
+    )
+
+    # FatalError must NOT be retried — exactly one call to the boom handler.
+    assert attempts["n"] == 1
+    assert result["tasks_done"] == 2
+
+    rows = _read_task_rows(db_path, job.id)
+    assert rows[0]["status"] == STATUS_FAILED
+    assert rows[0]["error"] == "structural"
+    assert rows[1]["status"] == STATUS_DONE
+
+
+@pytest.mark.asyncio
+async def test_stop_flag_short_circuits(job: Job, db_path: Path, plan: Plan) -> None:
+    """A STOP flag dropped mid-run exits the loop and leaves remaining tasks pending."""
+    _seed_tasks(job, ["web_search", "web_fetch", "arxiv_search"])
+
+    async def stop_after_first(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        # Drop the STOP flag inside the handler to simulate an external request.
+        (job.root / "STOP").write_text("")
+        return {"ok": True}
+
+    handlers: dict[str, Handler] = {
+        "web_search": stop_after_first,
+        "web_fetch": _ok_handler(),
+        "arxiv_search": _ok_handler(),
+    }
+
+    result = await run_loop(job, router=None, plan=plan, handlers=handlers, retry_waits=(0,))
+
+    assert result["stopped"] is True
+    assert result["tasks_done"] == 1
+
+    rows = _read_task_rows(db_path, job.id)
+    assert rows[0]["status"] == STATUS_DONE
+    # Tasks 2 and 3 must remain pending — STOP is not failure.
+    assert rows[1]["status"] == STATUS_PENDING
+    assert rows[2]["status"] == STATUS_PENDING
+
+
+@pytest.mark.asyncio
+async def test_max_tasks_cap_triggers_final_synthesis(job: Job, db_path: Path, plan: Plan) -> None:
+    """When ``max_tasks`` cap fires, the loop best-effort calls the ``synthesize`` handler."""
+    _seed_tasks(job, ["web_search"] * 5)
+    synth_calls = {"n": 0}
+
+    async def synth(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        synth_calls["n"] += 1
+        return {"ok": True}
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": _ok_handler(), "synthesize": synth},
+        max_tasks=3,
+        retry_waits=(0,),
+    )
+
+    assert result["tasks_done"] == 3
+    assert result["cap_hit"] is True
+    assert synth_calls["n"] == 1
+
+    events = _read_event_kinds(db_path, job.id)
+    assert "warning" in events  # cap_hit warning event
+
+    rows = _read_task_rows(db_path, job.id)
+    done_count = sum(1 for r in rows if r["status"] == STATUS_DONE)
+    pending_count = sum(1 for r in rows if r["status"] == STATUS_PENDING)
+    assert done_count == 3
+    assert pending_count == 2
+
+
+@pytest.mark.asyncio
+async def test_follow_up_tasks_get_enqueued(job: Job, db_path: Path, plan: Plan) -> None:
+    """A handler returning ``follow_up_tasks`` must enqueue + process them."""
+    _seed_tasks(job, ["web_search"])
+
+    fetch_calls = {"n": 0}
+
+    async def web_search(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "results": ["a", "b"],
+            "follow_up_tasks": [
+                TaskSpec(kind="web_fetch", payload={"url": "https://a"}),
+                TaskSpec(kind="web_fetch", payload={"url": "https://b"}),
+            ],
+        }
+
+    async def web_fetch(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        fetch_calls["n"] += 1
+        return {"ok": True}
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": web_search, "web_fetch": web_fetch},
+        retry_waits=(0,),
+    )
+
+    assert fetch_calls["n"] == 2
+    assert result["tasks_done"] == 3
+
+    rows = _read_task_rows(db_path, job.id)
+    assert len(rows) == 3
+    assert all(r["status"] == STATUS_DONE for r in rows)
+
+    # The result_json for the parent task must NOT include the follow_up_tasks key
+    # (they're persisted as queue rows, not as a meta-blob).
+    import json as _json
+
+    parent_result = _json.loads(rows[0]["result_json"])
+    assert "follow_up_tasks" not in parent_result
+    assert parent_result["results"] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_kind_marks_failed(job: Job, db_path: Path, plan: Plan) -> None:
+    """A task whose kind has no registered handler ends ``failed``; the loop continues."""
+    _seed_tasks(job, ["web_search", "web_fetch"])
+
+    handlers: dict[str, Handler] = {"web_fetch": _ok_handler()}  # web_search missing
+
+    result = await run_loop(job, router=None, plan=plan, handlers=handlers, retry_waits=(0,))
+
+    assert result["tasks_done"] == 2
+
+    rows = _read_task_rows(db_path, job.id)
+    assert rows[0]["status"] == STATUS_FAILED
+    assert "no handler" in (rows[0]["error"] or "")
+    assert rows[1]["status"] == STATUS_DONE
+
+    events = _read_event_kinds(db_path, job.id)
+    assert "error" in events
+
+
+# ---------------------------------------------------------------------------
+# Constants and registry sanity
+# ---------------------------------------------------------------------------
+
+
+def test_module_constants_match_spec() -> None:
+    assert MAX_TASKS_PER_JOB == 10000
+    assert HEURISTIC_CHECK_EVERY_N == 25
+    assert RETRY_MAX_ATTEMPTS == 5
+
+
+def test_default_handlers_covers_every_task_kind() -> None:
+    handlers = default_handlers(router=None)
+    expected = {
+        "web_search",
+        "web_fetch",
+        "arxiv_search",
+        "arxiv_fetch",
+        "github_search",
+        "github_fetch",
+        "news_search",
+        "reddit_search",
+        "local_corpus_query",
+        "extract_findings",
+        "summarize_source",
+        "synthesize",
+        "critique",
+    }
+    assert set(handlers.keys()) == expected
+
+
+@pytest.mark.asyncio
+async def test_default_not_implemented_handler_raises_fatal(
+    job: Job, db_path: Path, plan: Plan
+) -> None:
+    """The placeholder handlers raise :class:`FatalError`, marking the task failed."""
+    _seed_tasks(job, ["github_search"])
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers=default_handlers(router=None),
+        retry_waits=(0,),
+    )
+
+    assert result["tasks_done"] == 1
+    rows = _read_task_rows(db_path, job.id)
+    assert rows[0]["status"] == STATUS_FAILED
+    assert "not implemented" in (rows[0]["error"] or "")
+
+
+@pytest.mark.asyncio
+async def test_run_loop_loads_plan_from_db_when_not_provided(
+    job: Job, db_path: Path, plan: Plan
+) -> None:
+    """If ``plan`` is omitted, the loop loads the latest persisted plan via DB."""
+    _seed_tasks(job, ["web_search"])
+    handlers: dict[str, Handler] = {"web_search": _ok_handler()}
+
+    result = await run_loop(job, router=None, handlers=handlers, retry_waits=(0,))
+    assert result["tasks_done"] == 1
+
+
+@pytest.mark.asyncio
+async def test_run_loop_raises_when_no_plan_persisted(jobs_root: Path, db_path: Path) -> None:
+    """A job with no plan and no plan kwarg surfaces a clear RuntimeError."""
+    j = Job.create(
+        {"goal": "no plan yet"},
+        jobs_root=jobs_root,
+        db_path=db_path,
+    )
+    with pytest.raises(RuntimeError, match="no plan persisted"):
+        await run_loop(j, router=None, retry_waits=(0,))


### PR DESCRIPTION
Closes #26

## Summary

Automated implementation of **Research loop (orchestrator/loop.py) — task runner with retry**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

All 8 acceptance criteria addressed; orchestrator/loop.py is well-structured with comprehensive tests (13 loop tests + 506 repo-wide tests pass).

- **INFO** [OPEN] `src/research_agent/orchestrator/loop.py`: RETRY_WAITS has 7 entries (1,2,4,8,16,30,60) but RETRY_MAX_ATTEMPTS=5 means only the first 4 wait values are reachable between attempts. Matches the spec's verbatim wording but the spec itself was internally inconsistent. _make_wait_fn correctly clamps so this is harmless.
- **INFO** [OPEN] `src/research_agent/orchestrator/loop.py`: When a handler raises a RetriableError that exhausts retries, mark_failed() is called once at the end so retry_count in DB reflects 1, not the actual number of attempts (5). Minor observability gap; tests do not check retry_count.
- **INFO** [OPEN] `src/research_agent/orchestrator/loop.py`: Unexpected exceptions (not RetriableError or FatalError) raised by a handler will propagate up and abort run_loop. Defensible per spec wording, but a buggy handler could kill the daemon. Could be hardened with a catch-all that maps to FatalError-style behavior.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*