### PR TITLE
feat: Critique module (orchestrator/critique.py) (closes #28)

### DIFF
--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -39,6 +39,8 @@ EventKind = Literal[
     "synthesis_done",
     "synthesis_written",
     "critique_done",
+    "critique_written",
+    "replan_triggered",
     "llm_call",
     "tool_call",
     "checkpoint",

--- a/src/research_agent/orchestrator/__init__.py
+++ b/src/research_agent/orchestrator/__init__.py
@@ -1,5 +1,10 @@
 """Orchestrator — job lifecycle, planning, research loop, synthesis, critique, checkpointing."""
 
+from research_agent.orchestrator.critique import (
+    CritiqueOutput,
+    Gap,
+    critique,
+)
 from research_agent.orchestrator.errors import FatalError, RetriableError
 from research_agent.orchestrator.loop import (
     HEURISTIC_CHECK_EVERY_N,
@@ -32,6 +37,8 @@ from research_agent.orchestrator.synth import (
 __all__ = [
     "FINAL_TOP_N",
     "HEURISTIC_CHECK_EVERY_N",
+    "CritiqueOutput",
+    "Gap",
     "Handler",
     "MAX_PLAN_VERSIONS",
     "MAX_TASKS_PER_JOB",
@@ -47,6 +54,7 @@ __all__ = [
     "FatalError",
     "RetriableError",
     "cloud_replan",
+    "critique",
     "default_handlers",
     "final_synthesis",
     "initial_plan",

--- a/src/research_agent/orchestrator/critique.py
+++ b/src/research_agent/orchestrator/critique.py
@@ -1,0 +1,354 @@
+"""Critique module — gap analysis on a synthesis report.
+
+Implements the critic pass from the implementation guide: cloud
+``frontier_alt`` tier (a *different* model family than the synthesizer's
+``frontier`` tier) so the synthesizer and critic disagree productively
+instead of agreeing themselves into echo chambers.
+
+The critic reads the top N findings (and the sources they cite), the
+latest synthesis content, and any prior critique, packs them into a JSON
+context payload, and asks the model to emit a structured
+:class:`CritiqueOutput` (gaps, unsupported claims, suggested subgoals,
+confidence concerns, and a ``should_replan`` boolean).
+
+The output drives two things:
+
+* persisted as ``critique/<v>.md`` + ``.json`` and a ``critiques`` DB row
+* when ``should_replan`` is true the loop calls
+  :func:`research_agent.orchestrator.plan.cloud_replan` with the critique
+  attached so the planner can rewrite the next plan version
+
+Budget handling mirrors :mod:`synth`: on :class:`BudgetExceeded` we log
+WARN, emit a ``warning`` event, and return a stub :class:`CritiqueOutput`
+(no DB row, ``should_replan=False``) so a flaky cap never blocks loop
+progress — synth has a fallback ladder, critique just no-ops.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic_ai import Agent
+
+from research_agent.llm.budgets import BudgetExceeded
+from research_agent.observability.events import emit
+from research_agent.prompts.loader import load_prompt
+from research_agent.storage import db
+from research_agent.storage.markdown import write_critique
+
+if TYPE_CHECKING:
+    from research_agent.llm.router import Router
+    from research_agent.orchestrator.plan import Plan
+    from research_agent.storage.jobs import Job
+
+logger = logging.getLogger(__name__)
+
+TOP_N_FINDINGS = 50
+DEFAULT_TIER = "frontier_alt"
+
+
+class Gap(BaseModel):
+    """A single gap the critic flagged in the synthesis."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    description: str = Field(min_length=1)
+    severity: Literal["block", "warn", "nit"]
+    area: str | None = None
+
+
+class CritiqueOutput(BaseModel):
+    """Structured critique consumed by the loop + the planner.
+
+    The ``version``/``model``/``cost_usd``/``md_path`` fields are filled in
+    after the row is persisted so callers can render or log the result
+    without re-querying the DB.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    gaps: list[Gap] = Field(default_factory=list)
+    unsupported_claims: list[str] = Field(default_factory=list)
+    suggested_subgoals: list[str] = Field(default_factory=list)
+    confidence_concerns: list[str] = Field(default_factory=list)
+    should_replan: bool = False
+
+    version: int = 0
+    model: str = ""
+    cost_usd: float | None = None
+    md_path: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mirror synth.py loaders so behavior stays consistent
+# ---------------------------------------------------------------------------
+
+
+def _load_top_findings(job: Job, n: int) -> list[dict[str, Any]]:
+    conn = db.connect(job.db_path)
+    try:
+        rows = conn.execute(
+            """
+            SELECT id, claim, confidence, source_ids, tags
+            FROM findings
+            WHERE job_id = ?
+            ORDER BY confidence DESC, id ASC
+            LIMIT ?
+            """,
+            (job.id, n),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        source_ids_raw = row["source_ids"]
+        tags_raw = row["tags"]
+        out.append(
+            {
+                "id": int(row["id"]),
+                "claim": row["claim"],
+                "confidence": float(row["confidence"]),
+                "source_ids": json.loads(source_ids_raw) if source_ids_raw else [],
+                "tags": json.loads(tags_raw) if tags_raw else [],
+            }
+        )
+    return out
+
+
+def _load_sources_for(job: Job, finding_rows: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
+    ids: set[int] = set()
+    for f in finding_rows:
+        for sid in f.get("source_ids", []):
+            if isinstance(sid, int):
+                ids.add(sid)
+    if not ids:
+        return {}
+
+    placeholders = ",".join("?" for _ in ids)
+    sql = (
+        f"SELECT id, url, title, fetched_at, archive_url FROM sources WHERE id IN ({placeholders})"
+    )
+    conn = db.connect(job.db_path)
+    try:
+        rows = conn.execute(sql, tuple(ids)).fetchall()
+    finally:
+        conn.close()
+
+    return {
+        int(r["id"]): {
+            "id": int(r["id"]),
+            "url": r["url"],
+            "title": r["title"],
+            "fetched_at": int(r["fetched_at"]) if r["fetched_at"] is not None else None,
+            "archive_url": r["archive_url"],
+        }
+        for r in rows
+    }
+
+
+def _load_prior_critique(job: Job) -> str | None:
+    conn = db.connect(job.db_path)
+    try:
+        row = conn.execute(
+            "SELECT md_path FROM critiques WHERE job_id = ? ORDER BY version DESC LIMIT 1",
+            (job.id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return None
+    md_path = job.root / row["md_path"]
+    if not md_path.exists():
+        return None
+    return md_path.read_text(encoding="utf-8")
+
+
+def _build_context(
+    *,
+    goal: str,
+    findings: list[dict[str, Any]],
+    sources: dict[int, dict[str, Any]],
+    synthesis: str | None,
+    prior_critique: str | None,
+) -> str:
+    payload: dict[str, Any] = {
+        "goal": goal,
+        "findings": findings,
+        "sources": {str(k): v for k, v in sources.items()},
+        "synthesis": synthesis,
+        "prior_critique": prior_critique,
+    }
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+def _model_name_for(router: Router, tier: str) -> str:
+    spec = router.tiers.get(tier, {})
+    name = spec.get("model")
+    if not isinstance(name, str) or not name:
+        return tier
+    return name
+
+
+def _render_critique_md(payload: CritiqueOutput) -> str:
+    """Render a human-readable summary for ``critique/<v>.md``."""
+    lines: list[str] = ["# Critique\n"]
+    lines.append(f"**should_replan:** {'yes' if payload.should_replan else 'no'}\n")
+
+    lines.append("\n## Gaps\n")
+    if payload.gaps:
+        for gap in payload.gaps:
+            area = f" [{gap.area}]" if gap.area else ""
+            lines.append(f"- **{gap.severity}**{area}: {gap.description}\n")
+    else:
+        lines.append("- (none)\n")
+
+    lines.append("\n## Unsupported claims\n")
+    if payload.unsupported_claims:
+        for claim in payload.unsupported_claims:
+            lines.append(f"- {claim}\n")
+    else:
+        lines.append("- (none)\n")
+
+    lines.append("\n## Suggested subgoals\n")
+    if payload.suggested_subgoals:
+        for sg in payload.suggested_subgoals:
+            lines.append(f"- {sg}\n")
+    else:
+        lines.append("- (none)\n")
+
+    lines.append("\n## Confidence concerns\n")
+    if payload.confidence_concerns:
+        for cc in payload.confidence_concerns:
+            lines.append(f"- {cc}\n")
+    else:
+        lines.append("- (none)\n")
+
+    return "".join(lines)
+
+
+def _stub_output() -> CritiqueOutput:
+    """Return an empty critique used when the budget cap blocks the call."""
+    return CritiqueOutput(
+        gaps=[],
+        unsupported_claims=[],
+        suggested_subgoals=[],
+        confidence_concerns=[],
+        should_replan=False,
+        version=0,
+        model="budget_capped",
+        cost_usd=None,
+        md_path="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+async def critique(
+    job: Job,
+    plan: Plan,
+    latest_synthesis: str | None,
+    *,
+    router: Router,
+    tier: str = DEFAULT_TIER,
+) -> CritiqueOutput:
+    """Run a critique pass on the cloud ``frontier_alt`` tier by default.
+
+    The critic reads the top :data:`TOP_N_FINDINGS` findings (by confidence),
+    the sources they cite, the latest synthesis, and the prior critique (if
+    any). On budget exhaustion this returns a stub :class:`CritiqueOutput`
+    with ``should_replan=False`` and emits a ``warning`` event — critique is
+    advisory, not load-bearing.
+    """
+    findings = _load_top_findings(job, TOP_N_FINDINGS)
+    sources = _load_sources_for(job, findings)
+    prior = _load_prior_critique(job)
+
+    context = _build_context(
+        goal=job.goal,
+        findings=findings,
+        sources=sources,
+        synthesis=latest_synthesis,
+        prior_critique=prior,
+    )
+
+    rendered = load_prompt("critic", job=job, goal=job.goal)
+    agent = Agent(
+        router.model_for(tier),
+        output_type=CritiqueOutput,
+        system_prompt=rendered,
+    )
+
+    try:
+        result = await router.call(tier, agent, context)
+    except BudgetExceeded as exc:
+        logger.warning("critique: budget exceeded on %s tier: %s", tier, exc)
+        emit(
+            job,
+            "WARN",
+            "critique",
+            "warning",
+            {"stage": tier, "error": str(exc), "budget_capped": True},
+        )
+        return _stub_output()
+
+    output = result.output
+    if not isinstance(output, CritiqueOutput):
+        output = CritiqueOutput.model_validate(output)
+
+    cost_raw = getattr(router.budget, "last_cost", None)
+    cost_val: float | None = float(cost_raw) if isinstance(cost_raw, (int, float)) else None
+    model_name = _model_name_for(router, tier)
+
+    md_body = _render_critique_md(output)
+    payload_dict = output.model_dump(exclude={"version", "model", "cost_usd", "md_path"})
+    version = write_critique(
+        job,
+        payload=payload_dict,
+        content=md_body,
+        model=model_name,
+        cost_usd=cost_val,
+        should_replan=output.should_replan,
+    )
+
+    md_rel = f"critique/{version:04d}.md"
+    enriched = output.model_copy(
+        update={
+            "version": version,
+            "model": model_name,
+            "cost_usd": cost_val,
+            "md_path": md_rel,
+        }
+    )
+
+    emit(
+        job,
+        "INFO",
+        "critique",
+        "critique_written",
+        {
+            "version": version,
+            "tier": tier,
+            "model": model_name,
+            "should_replan": bool(output.should_replan),
+            "gaps_count": len(output.gaps),
+            "replan_triggered": False,
+        },
+    )
+
+    return enriched
+
+
+__all__ = [
+    "DEFAULT_TIER",
+    "TOP_N_FINDINGS",
+    "CritiqueOutput",
+    "Gap",
+    "critique",
+]

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -168,6 +168,30 @@ def default_handlers(router: Any) -> dict[str, Handler]:
             output = await synthesize(job, plan, router=router)
         return output.model_dump()
 
+    async def _critique(job: Job, task: dict[str, Any]) -> dict[str, Any] | None:
+        from research_agent.orchestrator.critique import critique
+        from research_agent.orchestrator.plan import cloud_replan
+
+        plan = _load_latest_plan(job)
+        if plan is None:
+            raise FatalError("critique: no plan persisted for job")
+        latest_synth = _load_latest_synthesis_md(job)
+        result = await critique(job, plan, latest_synth, router=router)
+        if result.should_replan:
+            critique_md = _load_critique_md(job, result.md_path)
+            await cloud_replan(job, plan, critique_md, router=router)
+            emit(
+                job,
+                "INFO",
+                "critique",
+                "replan_triggered",
+                {
+                    "from_version": plan.version,
+                    "critique_version": result.version,
+                },
+            )
+        return result.model_dump()
+
     return {
         "web_search": _web_search,
         "web_fetch": _web_fetch,
@@ -181,7 +205,7 @@ def default_handlers(router: Any) -> dict[str, Handler]:
         "extract_findings": _not_implemented_handler,
         "summarize_source": _not_implemented_handler,
         "synthesize": _synthesize,
-        "critique": _not_implemented_handler,
+        "critique": _critique,
     }
 
 
@@ -238,6 +262,30 @@ def _load_latest_plan(job: Job) -> Plan | None:
     if row is None:
         return None
     return Plan.model_validate_json(row["payload_json"])
+
+
+def _load_latest_synthesis_md(job: Job) -> str | None:
+    """Read the markdown content of the highest-version persisted synthesis."""
+    conn = db.connect(job.db_path)
+    try:
+        row = conn.execute(
+            "SELECT md_path FROM syntheses WHERE job_id = ? ORDER BY version DESC LIMIT 1",
+            (job.id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return None
+    md_path = job.root / row["md_path"]
+    if not md_path.exists():
+        return None
+    return md_path.read_text(encoding="utf-8")
+
+
+def _load_critique_md(job: Job, md_rel: str) -> str:
+    """Read the rendered markdown for a critique that was just written."""
+    md_path = job.root / md_rel
+    return md_path.read_text(encoding="utf-8")
 
 
 def _make_wait_fn(wait_seq: tuple[int, ...]) -> Callable[[Any], int]:

--- a/src/research_agent/storage/db.py
+++ b/src/research_agent/storage/db.py
@@ -112,6 +112,20 @@ CREATE TABLE IF NOT EXISTS syntheses (
     UNIQUE(job_id, version)
 );
 
+-- Critique passes (paired with syntheses; uses a different model tier)
+CREATE TABLE IF NOT EXISTS critiques (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL REFERENCES jobs(id),
+    version INTEGER NOT NULL,
+    md_path TEXT NOT NULL,
+    model TEXT NOT NULL,
+    cost_usd REAL,
+    should_replan INTEGER NOT NULL DEFAULT 0,
+    payload_json TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    UNIQUE(job_id, version)
+);
+
 -- Checkpoints (one per state transition)
 CREATE TABLE IF NOT EXISTS checkpoints (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/research_agent/storage/markdown.py
+++ b/src/research_agent/storage/markdown.py
@@ -260,6 +260,81 @@ def write_synthesis(
     return version
 
 
+def write_critique(
+    job: Job,
+    *,
+    payload: dict[str, Any],
+    content: str,
+    model: str,
+    cost_usd: float | None = None,
+    should_replan: bool = False,
+) -> int:
+    """Write the next critique version (md + json) and insert into ``critiques``.
+
+    The markdown body is the human-readable summary; the JSON sidecar carries
+    the raw structured payload so downstream consumers (planner, future UI)
+    can read the gaps/claims/suggestions without re-parsing markdown.
+    """
+    if not isinstance(content, str) or not content.strip():
+        raise ValueError("content must be a non-empty string")
+    if not isinstance(model, str) or not model:
+        raise ValueError("model must be a non-empty string")
+    if not isinstance(payload, dict):
+        raise ValueError(f"payload must be a dict; got {type(payload).__name__}")
+    if cost_usd is not None and (
+        isinstance(cost_usd, bool) or not isinstance(cost_usd, (int, float))
+    ):
+        raise ValueError(f"cost_usd must be a number or None; got {cost_usd!r}")
+
+    now = _now_epoch()
+    cost = float(cost_usd) if cost_usd is not None else None
+    payload_json = json.dumps(payload, sort_keys=True, default=str)
+
+    conn = db.connect(job.db_path)
+    try:
+        with conn:
+            version = _next_version(conn, "critiques", job.id)
+            md_rel = f"critique/{version:04d}.md"
+            json_rel = f"critique/{version:04d}.json"
+
+            md_body = content if content.endswith("\n") else content + "\n"
+            _atomic_write_text(job.root / md_rel, md_body)
+            _atomic_write_json(
+                job.root / json_rel,
+                {
+                    "version": version,
+                    "model": model,
+                    "cost_usd": cost,
+                    "should_replan": bool(should_replan),
+                    "payload": payload,
+                    "created_at": now,
+                },
+            )
+
+            conn.execute(
+                """
+                INSERT INTO critiques (
+                    job_id, version, md_path, model, cost_usd,
+                    should_replan, payload_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    job.id,
+                    version,
+                    md_rel,
+                    model,
+                    cost,
+                    1 if should_replan else 0,
+                    payload_json,
+                    now,
+                ),
+            )
+    finally:
+        conn.close()
+
+    return version
+
+
 def write_report(job: Job, content: str) -> Path:
     """Rotate any prior ``report.md`` into ``report.history/`` then write fresh content."""
     if not isinstance(content, str):
@@ -286,6 +361,7 @@ def write_report(job: Job, content: str) -> Path:
 
 
 __all__ = [
+    "write_critique",
     "write_finding",
     "write_plan",
     "write_report",

--- a/tests/test_orchestrator_critique.py
+++ b/tests/test_orchestrator_critique.py
@@ -1,0 +1,460 @@
+"""Tests for ``research_agent.orchestrator.critique``."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from research_agent.llm.budgets import BudgetExceeded
+from research_agent.orchestrator import loop as loop_module
+from research_agent.orchestrator.critique import (
+    DEFAULT_TIER,
+    CritiqueOutput,
+    Gap,
+    critique,
+)
+from research_agent.orchestrator.plan import Plan, Subgoal, TaskSpec
+from research_agent.prompts import loader as prompts_loader
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+from research_agent.storage.markdown import write_finding, write_plan, write_synthesis
+from research_agent.storage.sources import write_source
+
+# `from research_agent.orchestrator import critique` would resolve to the
+# re-exported function; grab the actual submodule via importlib so tests
+# can monkeypatch attributes on it.
+critique_module = importlib.import_module("research_agent.orchestrator.critique")
+
+# ---------------------------------------------------------------------------
+# Stub Router / Budget / Agent
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_TIERS: dict[str, dict[str, Any]] = {
+    "frontier": {"provider": "openrouter", "model": "anthropic/claude-opus-4-7"},
+    "frontier_alt": {"provider": "openrouter", "model": "moonshotai/kimi-k2"},
+    "frontier_speed": {"provider": "openrouter", "model": "anthropic/claude-haiku-4-5"},
+}
+
+
+class _StubBudget:
+    def __init__(self, last_cost: float = 0.0091) -> None:
+        self.last_cost = last_cost
+
+
+class _StubAgent:
+    instances: list[_StubAgent] = []
+
+    def __init__(
+        self,
+        model: Any,
+        *,
+        output_type: Any = None,
+        system_prompt: str | None = None,
+    ) -> None:
+        self.model = model
+        self.output_type = output_type
+        self.system_prompt = system_prompt
+        _StubAgent.instances.append(self)
+
+
+class _StubRouter:
+    """Stub Router compatible with :func:`critique`'s call surface."""
+
+    def __init__(
+        self,
+        *,
+        output: CritiqueOutput | None = None,
+        side_effect: dict[str, list[Exception | None]] | None = None,
+        tiers: dict[str, dict[str, Any]] | None = None,
+        budget: _StubBudget | None = None,
+    ) -> None:
+        self.output = output or CritiqueOutput(
+            gaps=[Gap(description="missing analysis of X", severity="warn")],
+            unsupported_claims=["claim about Y has no source"],
+            suggested_subgoals=["dig into X"],
+            confidence_concerns=["low coverage of Z"],
+            should_replan=False,
+        )
+        self.side_effect: dict[str, list[Exception | None]] = side_effect or {}
+        self.tiers: dict[str, dict[str, Any]] = tiers or dict(_DEFAULT_TIERS)
+        self.budget = budget or _StubBudget()
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def model_for(self, tier: str) -> Any:
+        return SimpleNamespace(tier=tier)
+
+    async def call(self, tier: str, agent: Any, *args: Any, **kwargs: Any) -> Any:
+        self.calls.append((tier, args, kwargs))
+        effects = self.side_effect.get(tier) or []
+        if effects:
+            err = effects.pop(0)
+            if err is not None:
+                raise err
+        return SimpleNamespace(output=self.output)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _patch_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _StubAgent.instances = []
+    monkeypatch.setattr(critique_module, "Agent", _StubAgent)
+
+
+@pytest.fixture(autouse=True)
+def _clear_prompt_cache() -> None:
+    prompts_loader.clear_cache()
+    yield
+    prompts_loader.clear_cache()
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "index.sqlite"
+    db.migrate(path=path).close()
+    return path
+
+
+@pytest.fixture
+def jobs_root(tmp_path: Path) -> Path:
+    return tmp_path / "jobs"
+
+
+@pytest.fixture
+def job(jobs_root: Path, db_path: Path) -> Job:
+    return Job.create(
+        {"goal": "Investigate Widget Co critique"},
+        jobs_root=jobs_root,
+        db_path=db_path,
+    )
+
+
+@pytest.fixture
+def plan(job: Job) -> Plan:
+    p = Plan(
+        version=1,
+        objective="Investigate the target",
+        subgoals=[Subgoal(id=1, description="Gather", done=False)],
+        task_template=[TaskSpec(kind="web_search")],
+        expected_iterations=3,
+    )
+    write_plan(job, p.model_dump())
+    return p
+
+
+def _seed_source(job: Job, url: str, content: str) -> int:
+    return write_source(
+        job,
+        url=url,
+        title=f"Title {url}",
+        raw_content=content,
+        kind="web",
+    )
+
+
+def _seed_findings(
+    job: Job,
+    confidences: list[float],
+    *,
+    base_claim: str = "claim",
+) -> tuple[list[int], list[int]]:
+    source_ids: list[int] = []
+    finding_ids: list[int] = []
+    for i, conf in enumerate(confidences):
+        sid = _seed_source(job, f"https://example.com/{i}", f"content body {i}")
+        source_ids.append(sid)
+        fid = write_finding(job, f"{base_claim} {i}", conf, [sid])
+        finding_ids.append(fid)
+    return source_ids, finding_ids
+
+
+def _read_critique_rows(db_path: Path, job_id: str) -> list[dict[str, Any]]:
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT version, md_path, model, cost_usd, should_replan, payload_json"
+            " FROM critiques WHERE job_id = ? ORDER BY version ASC",
+            (job_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [dict(r) for r in rows]
+
+
+def _read_event_rows(db_path: Path, job_id: str) -> list[dict[str, Any]]:
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT level, kind, payload_json FROM events WHERE job_id = ? ORDER BY id ASC",
+            (job_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_critique_writes_md_json_and_db_row(job: Job, db_path: Path, plan: Plan) -> None:
+    _seed_findings(job, [0.9, 0.5])
+    router = _StubRouter()
+
+    out = asyncio.run(critique(job, plan, "# Synthesis\n\nDraft.\n", router=router))
+
+    assert isinstance(out, CritiqueOutput)
+    assert out.version == 1
+    assert out.model == "moonshotai/kimi-k2"
+    assert out.cost_usd == pytest.approx(router.budget.last_cost)
+    assert out.md_path == "critique/0001.md"
+    assert out.should_replan is False
+    assert out.gaps and out.gaps[0].severity == "warn"
+
+    md = (job.root / "critique/0001.md").read_text(encoding="utf-8")
+    assert "# Critique" in md
+    assert "missing analysis of X" in md
+
+    sidecar = json.loads((job.root / "critique/0001.json").read_text(encoding="utf-8"))
+    assert sidecar["version"] == 1
+    assert sidecar["model"] == "moonshotai/kimi-k2"
+    assert sidecar["payload"]["should_replan"] is False
+    assert sidecar["payload"]["gaps"][0]["severity"] == "warn"
+
+    rows = _read_critique_rows(db_path, job.id)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["version"] == 1
+    assert row["md_path"] == "critique/0001.md"
+    assert row["model"] == "moonshotai/kimi-k2"
+    assert row["cost_usd"] == pytest.approx(router.budget.last_cost)
+    assert row["should_replan"] == 0
+    payload = json.loads(row["payload_json"])
+    assert payload["gaps"][0]["description"] == "missing analysis of X"
+
+
+def test_critique_uses_frontier_alt_tier_by_default(job: Job, db_path: Path, plan: Plan) -> None:
+    _seed_findings(job, [0.7])
+    router = _StubRouter()
+
+    asyncio.run(critique(job, plan, "# Synthesis\n", router=router))
+
+    assert router.calls, "critique must invoke router.call"
+    assert router.calls[0][0] == DEFAULT_TIER == "frontier_alt"
+
+
+def test_critique_file_rotation_writes_0002_on_second_call(
+    job: Job, db_path: Path, plan: Plan
+) -> None:
+    _seed_findings(job, [0.7])
+    router = _StubRouter()
+
+    first = asyncio.run(critique(job, plan, "# Synth v1\n", router=router))
+    second = asyncio.run(critique(job, plan, "# Synth v2\n", router=router))
+
+    assert first.version == 1
+    assert second.version == 2
+    assert second.md_path == "critique/0002.md"
+
+    assert (job.root / "critique/0001.md").exists()
+    assert (job.root / "critique/0002.md").exists()
+    assert (job.root / "critique/0001.json").exists()
+    assert (job.root / "critique/0002.json").exists()
+
+    rows = _read_critique_rows(db_path, job.id)
+    versions = [r["version"] for r in rows]
+    assert versions == [1, 2]
+
+
+def test_critique_should_replan_persists_truthy(job: Job, db_path: Path, plan: Plan) -> None:
+    _seed_findings(job, [0.6])
+    output = CritiqueOutput(
+        gaps=[Gap(description="big gap", severity="block", area="evidence")],
+        unsupported_claims=[],
+        suggested_subgoals=["new subgoal"],
+        confidence_concerns=[],
+        should_replan=True,
+    )
+    router = _StubRouter(output=output)
+
+    out = asyncio.run(critique(job, plan, "# Synth\n", router=router))
+
+    assert out.should_replan is True
+    rows = _read_critique_rows(db_path, job.id)
+    assert rows[0]["should_replan"] == 1
+
+    events = _read_event_rows(db_path, job.id)
+    written = [e for e in events if e["kind"] == "critique_written"]
+    assert len(written) == 1
+    payload = json.loads(written[0]["payload_json"])
+    assert payload["should_replan"] is True
+    assert payload["tier"] == "frontier_alt"
+    assert payload["model"] == "moonshotai/kimi-k2"
+    assert payload["gaps_count"] == 1
+
+
+def test_critique_budget_exceeded_returns_stub_no_db_row(
+    job: Job, db_path: Path, plan: Plan
+) -> None:
+    _seed_findings(job, [0.6])
+    router = _StubRouter(
+        side_effect={
+            "frontier_alt": [BudgetExceeded(job.id, spent=10.0, cap=5.0)],
+        },
+    )
+
+    out = asyncio.run(critique(job, plan, "# Synth\n", router=router))
+
+    assert out.should_replan is False
+    assert out.version == 0
+    assert out.model == "budget_capped"
+    assert out.cost_usd is None
+    assert out.gaps == []
+
+    # No critique row should be persisted on the budget-capped path.
+    rows = _read_critique_rows(db_path, job.id)
+    assert rows == []
+
+    # No critique md/json files written either.
+    assert not (job.root / "critique/0001.md").exists()
+    assert not (job.root / "critique/0001.json").exists()
+
+    events = _read_event_rows(db_path, job.id)
+    warns = [e for e in events if e["kind"] == "warning"]
+    assert warns, "budget-capped critique should emit a WARN event"
+    assert any(e["level"] == "WARN" for e in warns)
+    payloads = [json.loads(e["payload_json"]) for e in warns]
+    assert any(p.get("budget_capped") is True for p in payloads)
+
+
+def test_critique_top_n_findings_passed_to_model(job: Job, db_path: Path, plan: Plan) -> None:
+    _seed_findings(job, [0.1, 0.9, 0.5])
+    router = _StubRouter()
+
+    asyncio.run(critique(job, plan, "# Synth\n", router=router))
+
+    tier, args, _kwargs = router.calls[0]
+    assert tier == "frontier_alt"
+    assert args, "context payload must be passed positionally"
+    payload = json.loads(args[0])
+    confs = [f["confidence"] for f in payload["findings"]]
+    assert confs == sorted(confs, reverse=True)
+    assert payload["synthesis"] == "# Synth\n"
+    assert payload["goal"] == job.goal
+
+
+# ---------------------------------------------------------------------------
+# Loop integration test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_critique_handler_triggers_cloud_replan(
+    monkeypatch: pytest.MonkeyPatch,
+    job: Job,
+    db_path: Path,
+    plan: Plan,
+) -> None:
+    """When ``critique.should_replan`` is True the loop calls ``cloud_replan``."""
+
+    write_synthesis(
+        job,
+        "# Existing synthesis\n\nDraft body.\n",
+        model="anthropic/claude-opus-4-7",
+        cost_usd=0.001,
+    )
+    _seed_findings(job, [0.7])
+
+    captured: dict[str, Any] = {}
+    new_plan = plan.model_copy(update={"version": plan.version + 1})
+
+    async def fake_critique(
+        job_arg: Job,
+        plan_arg: Plan,
+        latest_synth: str | None,
+        *,
+        router: Any,
+        tier: str = "frontier_alt",
+    ) -> CritiqueOutput:
+        captured["latest_synth"] = latest_synth
+        captured["plan_version_in"] = plan_arg.version
+        # Persist a real critique row + file so the loop can read it back.
+        from research_agent.storage.markdown import write_critique as _write_critique
+
+        payload = {
+            "gaps": [{"description": "g", "severity": "block", "area": None}],
+            "unsupported_claims": [],
+            "suggested_subgoals": ["new"],
+            "confidence_concerns": [],
+            "should_replan": True,
+        }
+        version = _write_critique(
+            job_arg,
+            payload=payload,
+            content="# Critique\n\nNeeds a replan.\n",
+            model="moonshotai/kimi-k2",
+            cost_usd=0.0042,
+            should_replan=True,
+        )
+        return CritiqueOutput(
+            gaps=[Gap(description="g", severity="block")],
+            unsupported_claims=[],
+            suggested_subgoals=["new"],
+            confidence_concerns=[],
+            should_replan=True,
+            version=version,
+            model="moonshotai/kimi-k2",
+            cost_usd=0.0042,
+            md_path=f"critique/{version:04d}.md",
+        )
+
+    async def fake_cloud_replan(
+        job_arg: Job,
+        plan_arg: Plan,
+        critique_md: str,
+        *,
+        router: Any,
+    ) -> Plan:
+        captured["replan_called"] = True
+        captured["critique_md"] = critique_md
+        captured["plan_version_for_replan"] = plan_arg.version
+        return new_plan
+
+    from research_agent.orchestrator import plan as plan_module
+
+    monkeypatch.setattr(critique_module, "critique", fake_critique)
+    monkeypatch.setattr(plan_module, "cloud_replan", fake_cloud_replan)
+
+    handlers = loop_module.default_handlers(router=object())
+    critique_handler = handlers["critique"]
+
+    result = await critique_handler(
+        job, {"id": -1, "kind": "critique", "payload": {}, "plan_version": plan.version}
+    )
+
+    assert captured.get("replan_called") is True
+    assert "Needs a replan" in captured["critique_md"]
+    assert captured["plan_version_in"] == plan.version
+    assert captured["plan_version_for_replan"] == plan.version
+    assert captured["latest_synth"] == "# Existing synthesis\n\nDraft body.\n"
+
+    assert result is not None
+    assert result["should_replan"] is True
+
+    events = _read_event_rows(db_path, job.id)
+    triggered = [e for e in events if e["kind"] == "replan_triggered"]
+    assert len(triggered) == 1
+    payload = json.loads(triggered[0]["payload_json"])
+    assert payload["from_version"] == plan.version
+    assert payload["critique_version"] == 1


### PR DESCRIPTION
Closes #28

## Summary

Automated implementation of **Critique module (orchestrator/critique.py)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Critique module fully meets all acceptance criteria; 7 critique tests + 520 total tests pass.

- **INFO** [OPEN] `src/research_agent/orchestrator/loop.py`: Loop's _critique handler re-reads the freshly-written critique md from disk to pass to cloud_replan, even though _render_critique_md already produced that text. Minor duplication but keeps the on-disk file as the single source of truth, so leaving as-is.
- **INFO** [OPEN] `src/research_agent/orchestrator/critique.py`: load_prompt("critic", ..., goal=job.goal) passes a goal var that the critic.md template doesn't reference. Loader silently ignores unused vars by design, so this is harmless and consistent with synth.py's call shape.
- **INFO** [OPEN] `src/research_agent/orchestrator/loop.py`: After cloud_replan persists a new plan version, the run_loop's in-memory plan variable is not refreshed. Subsequent tasks still drain the existing queue, and _load_latest_plan picks up the new version on next handler call — but no follow-up tasks are enqueued from the rewritten plan. This is a planner/loop integration concern that pre-dates this issue and belongs in the planner work, not in critique.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*