### PR TITLE
feat: Checkpoint save/restore (orchestrator/checkpoint.py) (closes #29)

### DIFF
--- a/src/research_agent/orchestrator/__init__.py
+++ b/src/research_agent/orchestrator/__init__.py
@@ -1,5 +1,11 @@
 """Orchestrator — job lifecycle, planning, research loop, synthesis, critique, checkpointing."""
 
+from research_agent.orchestrator.checkpoint import (
+    CHECKPOINT_KINDS,
+    RestoreState,
+    checkpoint,
+    restore,
+)
 from research_agent.orchestrator.critique import (
     CritiqueOutput,
     Gap,
@@ -35,6 +41,7 @@ from research_agent.orchestrator.synth import (
 )
 
 __all__ = [
+    "CHECKPOINT_KINDS",
     "FINAL_TOP_N",
     "HEURISTIC_CHECK_EVERY_N",
     "CritiqueOutput",
@@ -46,6 +53,7 @@ __all__ = [
     "PlanVersionCapExceeded",
     "RETRY_MAX_ATTEMPTS",
     "RETRY_WAITS",
+    "RestoreState",
     "Subgoal",
     "SynthesisOutput",
     "TOP_N_FINDINGS",
@@ -53,11 +61,13 @@ __all__ = [
     "TaskSpec",
     "FatalError",
     "RetriableError",
+    "checkpoint",
     "cloud_replan",
     "critique",
     "default_handlers",
     "final_synthesis",
     "initial_plan",
+    "restore",
     "run_loop",
     "synthesize",
     "tactical_replan",

--- a/src/research_agent/orchestrator/checkpoint.py
+++ b/src/research_agent/orchestrator/checkpoint.py
@@ -1,0 +1,273 @@
+"""Checkpoint save/restore for the research loop.
+
+Implements §6.2 of the implementation guide: every state transition writes
+a row to the cross-job ``checkpoints`` table, and :func:`restore` reads the
+most recent row to reconstruct ``(plan, queue state, cost-to-date)`` so the
+loop can resume without re-doing completed tasks.
+
+Checkpoint inserts use ``synchronous=FULL`` (the §6.2 belt-and-suspenders
+durability option) — a hard kill between two consecutive transitions can
+still cost the in-flight task, but it cannot lose the prior committed
+checkpoint row. The rest of the read path uses the standard ``NORMAL``
+connection.
+
+Resume is idempotent: any task left in ``running`` (i.e. the worker died
+mid-execution) is reset to ``pending`` so a fresh worker re-pulls it. The
+v1 task surface has no outbound side effects with idempotency keys, so a
+clean re-run of a half-done task is the correct semantics.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from research_agent.observability.events import emit
+from research_agent.orchestrator.plan import Plan
+from research_agent.storage import db
+from research_agent.storage.jobs import DEFAULT_JOBS_ROOT, Job
+
+CheckpointKind = Literal[
+    "job_started",
+    "task_pulled",
+    "task_done",
+    "synthesis_done",
+    "critique_done",
+    "replan_done",
+    "stop_requested",
+]
+
+CHECKPOINT_KINDS: tuple[str, ...] = (
+    "job_started",
+    "task_pulled",
+    "task_done",
+    "synthesis_done",
+    "critique_done",
+    "replan_done",
+    "stop_requested",
+)
+
+
+class RestoreState(BaseModel):
+    """State needed to resume the research loop after a kill or shutdown."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    job_id: str
+    last_checkpoint_kind: str | None = None
+    last_checkpoint_ts: int | None = None
+    last_checkpoint_payload: dict[str, Any] = Field(default_factory=dict)
+    plan: Plan | None = None
+    plan_version: int | None = None
+    pending_task_ids: list[int] = Field(default_factory=list)
+    running_task_ids_reset: list[int] = Field(default_factory=list)
+    cost_to_date_usd: float = 0.0
+    completed_task_count: int = 0
+
+
+def checkpoint(job: Job, kind: str, payload: dict[str, Any]) -> int:
+    """Insert a checkpoint row for ``job`` and return its rowid.
+
+    Validates ``kind`` against :data:`CHECKPOINT_KINDS` and opens the
+    connection at ``synchronous=FULL`` so the insert is durable across a
+    crash even before fsync amortization.
+    """
+    if kind not in CHECKPOINT_KINDS:
+        raise ValueError(f"unknown checkpoint kind {kind!r}; must be one of {CHECKPOINT_KINDS}")
+    if not isinstance(payload, dict):
+        raise TypeError(f"payload must be a dict; got {type(payload).__name__}")
+
+    payload_json = json.dumps(payload, sort_keys=True, default=str)
+    ts = int(time.time())
+
+    conn = db.connect_for_checkpoints(job.db_path)
+    try:
+        with conn:
+            cur = conn.execute(
+                "INSERT INTO checkpoints (job_id, kind, payload_json, ts) VALUES (?, ?, ?, ?)",
+                (job.id, kind, payload_json, ts),
+            )
+            rowid = cur.lastrowid
+        assert rowid is not None  # noqa: S101 — INTEGER PK rowid set after INSERT
+    finally:
+        conn.close()
+
+    emit(
+        job,
+        "DEBUG",
+        "checkpoint",
+        "checkpoint",
+        {"checkpoint_kind": kind, "ts": ts, "rowid": int(rowid)},
+    )
+    return int(rowid)
+
+
+def _load_latest_checkpoint(
+    db_path: Path, job_id: str
+) -> tuple[str | None, int | None, dict[str, Any]]:
+    conn = db.connect(db_path)
+    try:
+        row = conn.execute(
+            """
+            SELECT kind, ts, payload_json
+            FROM checkpoints
+            WHERE job_id = ?
+            ORDER BY ts DESC, id DESC
+            LIMIT 1
+            """,
+            (job_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    if row is None:
+        return None, None, {}
+
+    payload_raw = row["payload_json"]
+    payload = json.loads(payload_raw) if payload_raw else {}
+    return row["kind"], int(row["ts"]), payload
+
+
+def _load_latest_plan(db_path: Path, job_id: str) -> Plan | None:
+    conn = db.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT payload_json FROM plans WHERE job_id = ? ORDER BY version DESC LIMIT 1",
+            (job_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return None
+    return Plan.model_validate_json(row["payload_json"])
+
+
+def _reset_running_tasks(db_path: Path, job_id: str) -> list[int]:
+    """Reset any ``running`` tasks back to ``pending`` and return reset ids."""
+    conn = db.connect(db_path)
+    try:
+        with conn:
+            rows = conn.execute(
+                "SELECT id FROM tasks WHERE job_id = ? AND status = 'running' ORDER BY id ASC",
+                (job_id,),
+            ).fetchall()
+            ids = [int(r["id"]) for r in rows]
+            if ids:
+                conn.execute(
+                    "UPDATE tasks SET status = 'pending', started_at = NULL"
+                    " WHERE job_id = ? AND status = 'running'",
+                    (job_id,),
+                )
+    finally:
+        conn.close()
+    return ids
+
+
+def _cost_to_date(db_path: Path, job_id: str) -> float:
+    conn = db.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT COALESCE(SUM(cost_usd), 0.0) AS total FROM llm_calls WHERE job_id = ?",
+            (job_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return 0.0
+    val = row["total"]
+    return float(val) if val is not None else 0.0
+
+
+def _completed_count(db_path: Path, job_id: str) -> int:
+    conn = db.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) AS c FROM tasks WHERE job_id = ? AND status = 'done'",
+            (job_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    return int(row["c"]) if row is not None else 0
+
+
+def _pending_ids(db_path: Path, job_id: str) -> list[int]:
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE job_id = ? AND status = 'pending' ORDER BY id ASC",
+            (job_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [int(r["id"]) for r in rows]
+
+
+def restore(
+    job_id: str,
+    *,
+    db_path: Path | str = db.DEFAULT_DB_PATH,
+    jobs_root: Path | str = DEFAULT_JOBS_ROOT,
+) -> RestoreState:
+    """Reconstruct the resume state for ``job_id`` from disk + DB.
+
+    Idempotent: a second ``restore()`` after the first returns the same
+    state except its ``running_task_ids_reset`` is empty, since the first
+    call already moved any in-flight rows back to ``pending``.
+    """
+    db_path_p = Path(db_path)
+    jobs_root_p = Path(jobs_root)
+
+    job = Job.load(job_id, jobs_root=jobs_root_p, db_path=db_path_p)
+
+    last_kind, last_ts, last_payload = _load_latest_checkpoint(db_path_p, job_id)
+    plan = _load_latest_plan(db_path_p, job_id)
+    plan_version = plan.version if plan is not None else None
+
+    running_reset = _reset_running_tasks(db_path_p, job_id)
+    cost = _cost_to_date(db_path_p, job_id)
+    completed = _completed_count(db_path_p, job_id)
+    pending = _pending_ids(db_path_p, job_id)
+
+    state = RestoreState(
+        job_id=job_id,
+        last_checkpoint_kind=last_kind,
+        last_checkpoint_ts=last_ts,
+        last_checkpoint_payload=last_payload,
+        plan=plan,
+        plan_version=plan_version,
+        pending_task_ids=pending,
+        running_task_ids_reset=running_reset,
+        cost_to_date_usd=cost,
+        completed_task_count=completed,
+    )
+
+    emit(
+        job,
+        "INFO",
+        "checkpoint",
+        "checkpoint",
+        {
+            "stage": "resume_initialized",
+            "last_checkpoint_kind": last_kind,
+            "plan_version": plan_version,
+            "pending_count": len(pending),
+            "running_reset_count": len(running_reset),
+            "cost_to_date_usd": cost,
+            "completed_task_count": completed,
+        },
+    )
+
+    return state
+
+
+__all__ = [
+    "CHECKPOINT_KINDS",
+    "CheckpointKind",
+    "RestoreState",
+    "checkpoint",
+    "restore",
+]

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -43,6 +43,7 @@ from tenacity import (
 )
 
 from research_agent.observability.events import emit
+from research_agent.orchestrator.checkpoint import checkpoint
 from research_agent.orchestrator.errors import FatalError, RetriableError
 from research_agent.orchestrator.plan import Plan, TaskKind, TaskSpec
 from research_agent.storage import db
@@ -179,7 +180,7 @@ def default_handlers(router: Any) -> dict[str, Handler]:
         result = await critique(job, plan, latest_synth, router=router)
         if result.should_replan:
             critique_md = _load_critique_md(job, result.md_path)
-            await cloud_replan(job, plan, critique_md, router=router)
+            new_plan = await cloud_replan(job, plan, critique_md, router=router)
             emit(
                 job,
                 "INFO",
@@ -187,6 +188,15 @@ def default_handlers(router: Any) -> dict[str, Handler]:
                 "replan_triggered",
                 {
                     "from_version": plan.version,
+                    "critique_version": result.version,
+                },
+            )
+            checkpoint(
+                job,
+                "replan_done",
+                {
+                    "from_version": plan.version,
+                    "to_version": new_plan.version,
                     "critique_version": result.version,
                 },
             )
@@ -217,21 +227,6 @@ def default_handlers(router: Any) -> dict[str, Handler]:
 def _should_stop(job: Job) -> bool:
     """True when the operator dropped a ``STOP`` flag in the job folder."""
     return (job.root / "STOP").exists()
-
-
-def _checkpoint_hook(job: Job, plan: Plan, task: dict[str, Any]) -> None:
-    """Best-effort call into the (future) ``orchestrator.checkpoint`` module.
-
-    The checkpoint module ships in issue #29; until then the import simply
-    fails and the hook is a no-op so this loop can ship first.
-    """
-    try:
-        from research_agent.orchestrator.checkpoint import (
-            checkpoint,  # type: ignore[import-not-found]
-        )
-    except ImportError:
-        return
-    checkpoint(job, plan, task)
 
 
 def _should_synthesize(plan: Plan, tasks_done: int) -> bool:
@@ -381,6 +376,12 @@ async def run_loop(
     stopped = False
     cap_hit = False
 
+    checkpoint(
+        job,
+        "job_started",
+        {"plan_version": plan.version, "objective": plan.objective},
+    )
+
     while not _should_stop(job) and not plan.is_complete() and tasks_done < max_tasks:
         task = next_pending(job)
         if task is None:
@@ -394,7 +395,15 @@ async def run_loop(
             "task_pulled",
             {"task_id": task["id"], "kind": task["kind"]},
         )
-        _checkpoint_hook(job, plan, task)
+        checkpoint(
+            job,
+            "task_pulled",
+            {
+                "task_id": task["id"],
+                "kind": task["kind"],
+                "plan_version": plan.version,
+            },
+        )
 
         handler = handlers.get(task["kind"])
         if handler is None:
@@ -469,6 +478,11 @@ async def run_loop(
             "task_done",
             {"task_id": task["id"], "kind": task["kind"]},
         )
+        checkpoint(
+            job,
+            "task_done",
+            {"task_id": task["id"], "kind": task["kind"]},
+        )
 
         if follow_ups:
             _enqueue_follow_ups(job, list(follow_ups), task["plan_version"])
@@ -491,6 +505,7 @@ async def run_loop(
 
     if _should_stop(job):
         stopped = True
+        checkpoint(job, "stop_requested", {"tasks_done": tasks_done})
 
     return {
         "tasks_done": tasks_done,
@@ -524,6 +539,12 @@ async def _maybe_run_heuristic(
                     "warning",
                     {"heuristic": "synthesize", "error": str(exc)},
                 )
+            else:
+                checkpoint(
+                    job,
+                    "synthesis_done",
+                    {"tasks_done": tasks_done, "plan_version": plan.version},
+                )
     if _should_critique(plan, tasks_done):
         crit = handlers.get("critique")
         if crit is not None:
@@ -536,6 +557,12 @@ async def _maybe_run_heuristic(
                     "loop",
                     "warning",
                     {"heuristic": "critique", "error": str(exc)},
+                )
+            else:
+                checkpoint(
+                    job,
+                    "critique_done",
+                    {"tasks_done": tasks_done, "plan_version": plan.version},
                 )
 
 

--- a/tests/test_orchestrator_checkpoint.py
+++ b/tests/test_orchestrator_checkpoint.py
@@ -1,0 +1,367 @@
+"""Tests for ``research_agent.orchestrator.checkpoint``."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from research_agent.orchestrator.checkpoint import (
+    CHECKPOINT_KINDS,
+    checkpoint,
+    restore,
+)
+from research_agent.orchestrator.loop import Handler, run_loop
+from research_agent.orchestrator.plan import Plan, Subgoal, TaskSpec
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+from research_agent.storage.markdown import write_plan
+from research_agent.storage.tasks import (
+    STATUS_DONE,
+    STATUS_PENDING,
+    STATUS_RUNNING,
+    enqueue,
+    mark_running,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "index.sqlite"
+    db.migrate(path=path).close()
+    return path
+
+
+@pytest.fixture
+def jobs_root(tmp_path: Path) -> Path:
+    return tmp_path / "jobs"
+
+
+@pytest.fixture
+def job(jobs_root: Path, db_path: Path) -> Job:
+    return Job.create(
+        {"goal": "Investigate Widget Co"},
+        jobs_root=jobs_root,
+        db_path=db_path,
+    )
+
+
+@pytest.fixture
+def plan(job: Job) -> Plan:
+    """Persist a plan whose subgoals are all open so the loop runs to drain."""
+    p = Plan(
+        version=1,
+        objective="Investigate the target",
+        subgoals=[Subgoal(id=1, description="Gather", done=False)],
+        task_template=[TaskSpec(kind="web_search")],
+        expected_iterations=3,
+    )
+    write_plan(job, p.model_dump())
+    return p
+
+
+def _read_checkpoint_rows(db_path: Path, job_id: str) -> list[dict[str, Any]]:
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT id, kind, payload_json, ts FROM checkpoints WHERE job_id = ? ORDER BY id ASC",
+            (job_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [dict(r) for r in rows]
+
+
+def _read_task_rows(db_path: Path, job_id: str) -> list[dict[str, Any]]:
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT id, kind, status, started_at, finished_at FROM tasks"
+            " WHERE job_id = ? ORDER BY id ASC",
+            (job_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [dict(r) for r in rows]
+
+
+def _checkpoint_synchronous_pragma(job: Job) -> str:
+    """Open a checkpoint connection and read back its ``synchronous`` pragma.
+
+    SQLite returns ``synchronous`` as an integer code: 0=OFF, 1=NORMAL, 2=FULL,
+    3=EXTRA. We resolve to a string for readable assertions.
+    """
+    conn = db.connect_for_checkpoints(job.db_path)
+    try:
+        row = conn.execute("PRAGMA synchronous").fetchone()
+    finally:
+        conn.close()
+    return {0: "OFF", 1: "NORMAL", 2: "FULL", 3: "EXTRA"}.get(int(row[0]), "UNKNOWN")
+
+
+# ---------------------------------------------------------------------------
+# Direct ``checkpoint()`` tests
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_inserts_row_with_synchronous_full(job: Job, db_path: Path) -> None:
+    """One row per kind, ts is monotonic-ish, payload round-trips, sync=FULL."""
+    assert _checkpoint_synchronous_pragma(job) == "FULL"
+
+    payload = {"plan_version": 1, "task_id": 42, "kind": "web_search"}
+    rowids: list[int] = []
+    for kind in CHECKPOINT_KINDS:
+        rowids.append(checkpoint(job, kind, payload))
+
+    rows = _read_checkpoint_rows(db_path, job.id)
+    assert len(rows) == len(CHECKPOINT_KINDS)
+    assert [r["kind"] for r in rows] == list(CHECKPOINT_KINDS)
+    assert [r["id"] for r in rows] == rowids
+    for r in rows:
+        assert json.loads(r["payload_json"]) == payload
+        assert isinstance(r["ts"], int)
+
+
+def test_checkpoint_rejects_unknown_kind(job: Job) -> None:
+    with pytest.raises(ValueError, match="unknown checkpoint kind"):
+        checkpoint(job, "not_a_real_kind", {})
+
+
+def test_checkpoint_rejects_non_dict_payload(job: Job) -> None:
+    with pytest.raises(TypeError):
+        checkpoint(job, "job_started", "not a dict")  # type: ignore[arg-type]
+
+
+def test_checkpoint_emits_event(job: Job, db_path: Path) -> None:
+    """Each checkpoint() call should write one ``checkpoint`` event."""
+    checkpoint(job, "job_started", {"plan_version": 1})
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT kind, level, payload_json FROM events WHERE job_id = ?",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    kinds = [r["kind"] for r in rows]
+    assert kinds.count("checkpoint") == 1
+
+
+# ---------------------------------------------------------------------------
+# ``restore()`` tests
+# ---------------------------------------------------------------------------
+
+
+def test_restore_returns_none_when_no_checkpoints(
+    job: Job, db_path: Path, plan: Plan, jobs_root: Path
+) -> None:
+    state = restore(job.id, db_path=db_path, jobs_root=jobs_root)
+    assert state.job_id == job.id
+    assert state.last_checkpoint_kind is None
+    assert state.last_checkpoint_ts is None
+    assert state.last_checkpoint_payload == {}
+    assert state.plan is not None
+    assert state.plan_version == 1
+    assert state.pending_task_ids == []
+    assert state.running_task_ids_reset == []
+    assert state.cost_to_date_usd == 0.0
+    assert state.completed_task_count == 0
+
+
+def test_restore_reads_latest_checkpoint(
+    job: Job, db_path: Path, plan: Plan, jobs_root: Path
+) -> None:
+    checkpoint(job, "job_started", {"plan_version": 1})
+    checkpoint(job, "task_pulled", {"task_id": 1, "kind": "web_search"})
+    checkpoint(job, "task_done", {"task_id": 1, "kind": "web_search"})
+
+    state = restore(job.id, db_path=db_path, jobs_root=jobs_root)
+    assert state.last_checkpoint_kind == "task_done"
+    assert state.last_checkpoint_payload == {"task_id": 1, "kind": "web_search"}
+    assert state.last_checkpoint_ts is not None
+
+
+def test_restore_resets_running_tasks_to_pending(
+    job: Job, db_path: Path, plan: Plan, jobs_root: Path
+) -> None:
+    ids = enqueue(
+        job,
+        [
+            TaskSpec(kind="web_search", payload={"q": "a"}),
+            TaskSpec(kind="web_fetch", payload={"url": "https://x"}),
+        ],
+        plan_version=1,
+    )
+    mark_running(ids[0], db_path=db_path)
+
+    rows_before = _read_task_rows(db_path, job.id)
+    by_id_before = {r["id"]: r for r in rows_before}
+    assert by_id_before[ids[0]]["status"] == STATUS_RUNNING
+
+    state = restore(job.id, db_path=db_path, jobs_root=jobs_root)
+    assert state.running_task_ids_reset == [ids[0]]
+
+    rows_after = _read_task_rows(db_path, job.id)
+    by_id_after = {r["id"]: r for r in rows_after}
+    assert by_id_after[ids[0]]["status"] == STATUS_PENDING
+    assert by_id_after[ids[0]]["started_at"] is None
+    assert by_id_after[ids[1]]["status"] == STATUS_PENDING
+
+    # Pending list should now include both since we reset the running one.
+    assert state.pending_task_ids == ids
+
+    # Idempotent: a second call has nothing to reset.
+    state2 = restore(job.id, db_path=db_path, jobs_root=jobs_root)
+    assert state2.running_task_ids_reset == []
+    assert state2.pending_task_ids == ids
+
+
+def test_restore_loads_latest_plan_and_cost(
+    job: Job, db_path: Path, plan: Plan, jobs_root: Path
+) -> None:
+    p2 = plan.model_copy(update={"version": 2})
+    write_plan(job, p2.model_dump())
+
+    conn = db.connect(db_path)
+    try:
+        with conn:
+            conn.execute(
+                """
+                INSERT INTO llm_calls
+                    (job_id, ts, tier, provider, model, cost_usd)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    job.id,
+                    int(time.time()),
+                    "frontier",
+                    "openrouter",
+                    "anthropic/claude-opus-4-7",
+                    0.50,
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO llm_calls
+                    (job_id, ts, tier, provider, model, cost_usd)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    job.id,
+                    int(time.time()),
+                    "general",
+                    "lmstudio",
+                    "llama-3.3",
+                    0.05,
+                ),
+            )
+    finally:
+        conn.close()
+
+    state = restore(job.id, db_path=db_path, jobs_root=jobs_root)
+    assert state.plan_version == 2
+    assert state.plan is not None and state.plan.version == 2
+    assert state.cost_to_date_usd == pytest.approx(0.55)
+
+
+def test_restore_counts_completed_tasks(
+    job: Job, db_path: Path, plan: Plan, jobs_root: Path
+) -> None:
+    ids = enqueue(
+        job,
+        [
+            TaskSpec(kind="web_search", payload={"q": "a"}),
+            TaskSpec(kind="web_search", payload={"q": "b"}),
+        ],
+        plan_version=1,
+    )
+    conn = db.connect(db_path)
+    try:
+        with conn:
+            conn.execute(
+                "UPDATE tasks SET status = ? WHERE id = ?",
+                (STATUS_DONE, ids[0]),
+            )
+    finally:
+        conn.close()
+
+    state = restore(job.id, db_path=db_path, jobs_root=jobs_root)
+    assert state.completed_task_count == 1
+    assert state.pending_task_ids == [ids[1]]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: kill mid-loop, restore, resume
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kill_midloop_resume_e2e(
+    job: Job, db_path: Path, plan: Plan, jobs_root: Path
+) -> None:
+    """Cancel mid-loop, restore, and verify the cancelled task replays."""
+    ids = enqueue(
+        job,
+        [
+            TaskSpec(kind="web_search", payload={"q": "0"}),
+            TaskSpec(kind="web_search", payload={"q": "1"}),
+            TaskSpec(kind="web_search", payload={"q": "2"}),
+        ],
+        plan_version=1,
+    )
+
+    invocations = {"n": 0}
+
+    async def kill_second(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        invocations["n"] += 1
+        if invocations["n"] == 2:
+            raise asyncio.CancelledError()
+        return {"ok": True}
+
+    handlers: dict[str, Handler] = {"web_search": kill_second}
+    with pytest.raises(asyncio.CancelledError):
+        await run_loop(
+            job,
+            router=None,
+            plan=plan,
+            handlers=handlers,
+            retry_waits=(0,),
+        )
+
+    # State after the kill: task[0] done, task[1] running, task[2] pending.
+    rows_mid = _read_task_rows(db_path, job.id)
+    by_id_mid = {r["id"]: r for r in rows_mid}
+    assert by_id_mid[ids[0]]["status"] == STATUS_DONE
+    assert by_id_mid[ids[1]]["status"] == STATUS_RUNNING
+    assert by_id_mid[ids[2]]["status"] == STATUS_PENDING
+
+    state = restore(job.id, db_path=db_path, jobs_root=jobs_root)
+    assert state.running_task_ids_reset == [ids[1]]
+    assert state.completed_task_count == 1
+    assert sorted(state.pending_task_ids) == sorted([ids[1], ids[2]])
+    assert state.last_checkpoint_kind in CHECKPOINT_KINDS
+
+    # Resume: a handler that always succeeds — the cancelled task plus the
+    # remaining tasks should both run to ``done``.
+    async def always_ok(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        return {"ok": True}
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": always_ok},
+        retry_waits=(0,),
+    )
+    assert result["tasks_done"] == 2
+
+    rows_final = _read_task_rows(db_path, job.id)
+    assert all(r["status"] == STATUS_DONE for r in rows_final)


### PR DESCRIPTION
Closes #29

## Summary

Automated implementation of **Checkpoint save/restore (orchestrator/checkpoint.py)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Checkpoint save/restore implementation fully meets all acceptance criteria; 10/10 module tests + 530/530 full suite pass.

- **INFO** [OPEN] `src/research_agent/orchestrator/checkpoint.py`: _load_latest_plan helper is duplicated between checkpoint.py and loop.py. Minor — could be consolidated into a shared storage helper in a future cleanup, but not a bug.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*