### PR TITLE
feat: Interactive intake (intake.py) (closes #31)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 dev = [
     "pytest>=8",
     "pytest-asyncio>=0.23",
+    "pytest-mock>=3.12",
     "ruff>=0.4",
     "mypy>=1.10",
 ]
@@ -51,6 +52,7 @@ web = []
 dev = [
     "pytest>=8",
     "pytest-asyncio>=0.23",
+    "pytest-mock>=3.12",
     "ruff>=0.4",
     "mypy>=1.10",
 ]

--- a/review-issue-31.json
+++ b/review-issue-31.json
@@ -1,0 +1,24 @@
+{
+  "passed": true,
+  "summary": "intake.py meets all AC: 11-step Questionary flow, general-tier follow-ups capped at 3, Rich summary, revise loop, 9-key dict; CLI flags pre-fill defaults; --skip-intake unaffected; 19 intake + 45 CLI tests pass. Fixed one minor doc drift in prompt frontmatter.",
+  "findings": [
+    {
+      "severity": "info",
+      "description": "intake_followup.md frontmatter declared model_tier: fast while the AC and intake.py call the general tier. Loader treats model_tier as metadata only (no routing impact), but the inconsistency was misleading. Updated frontmatter to general.",
+      "fixed": true,
+      "file": "src/research_agent/prompts/intake_followup.md"
+    },
+    {
+      "severity": "info",
+      "description": "Summary panel renders time_cap as '{N}h' when N is an int — '1 week' (168h) shows as 'time=168h' rather than 'time=1 week'. Not a bug per spec; flagging for future polish.",
+      "fixed": false,
+      "file": "src/research_agent/intake.py"
+    },
+    {
+      "severity": "info",
+      "description": "_collect_followups already slices to MAX_FOLLOWUPS, and run_intake slices again with [:MAX_FOLLOWUPS]. Redundant but harmless.",
+      "fixed": false,
+      "file": "src/research_agent/intake.py"
+    }
+  ]
+}

--- a/src/research_agent/cli.py
+++ b/src/research_agent/cli.py
@@ -12,7 +12,7 @@ import typer
 from rich.console import Console
 from rich.live import Live
 
-from research_agent import __version__, config, doctor
+from research_agent import __version__, config, doctor, intake
 from research_agent.storage import db
 from research_agent.storage.jobs import Job, list_jobs
 from research_agent.ui import render
@@ -97,30 +97,31 @@ def start_command(
     ),
 ) -> None:
     """Register a new research job (does NOT spawn the daemon — that's phase 5)."""
-    if not skip_intake:
-        typer.echo(
-            "interactive intake not yet implemented (phase 5) — use --skip-intake",
-            err=True,
-        )
-        raise typer.Exit(code=2)
-
-    if not goal or not goal.strip():
-        typer.echo("--goal is required when --skip-intake is set", err=True)
-        raise typer.Exit(code=2)
-
-    intake: dict[str, object] = {
-        "goal": goal.strip(),
-        "domain": "general",
-        "time_cap_hours": time_cap,
-        "budget_cap_usd": budget_usd,
-    }
-    if corpus:
-        intake["corpus"] = corpus
+    if skip_intake:
+        if not goal or not goal.strip():
+            typer.echo("--goal is required when --skip-intake is set", err=True)
+            raise typer.Exit(code=2)
+        intake_data: dict[str, object] = {
+            "goal": goal.strip(),
+            "domain": "general",
+            "time_cap_hours": time_cap,
+            "budget_cap_usd": budget_usd,
+        }
+        if corpus:
+            intake_data["corpus"] = corpus
+    else:
+        answers = intake.run_intake(corpus=corpus, budget_usd=budget_usd, time_cap=time_cap)
+        intake_data = {
+            **answers,
+            "time_cap_hours": answers["time_cap"],
+            "budget_cap_usd": answers["budget_usd"],
+            "corpus": answers["corpus_path"],
+        }
 
     # Make sure the schema exists so the testing back door is self-bootstrapping.
     db.migrate().close()
 
-    job = Job.create(intake)
+    job = Job.create(intake_data)
     typer.echo(f"Started job {job.id} (status: {job.status})")
     typer.echo("note: the daemon is not yet wired up — register-only for now (phase 5)")
 

--- a/src/research_agent/intake.py
+++ b/src/research_agent/intake.py
@@ -1,1 +1,291 @@
-"""Interactive Q&A intake — captures research goal and constraints (implementation guide §4)."""
+"""Interactive Q&A intake — captures research goal and constraints.
+
+Implements the 11-step Questionary flow from §5.1 of the implementation
+guide. Steps 1–8 collect the structured constraints (goal, domain, caps,
+output orientation, aggressiveness, optional corpus). Step 9 hits the
+local ``general`` tier for up to three adaptive clarifying questions
+(via ``intake_followup.md``). Step 10 prints a Rich summary; on revise
+the loop drops back to step 1 with no preserved state.
+
+The LLM follow-up call is best-effort: any error surfaces as a structlog
+warning and ``followup_qa=[]`` rather than blocking the user behind a
+cloud failure (intake must not block on cloud failure).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import questionary
+import structlog
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic_ai import Agent
+from rich.console import Console
+from rich.panel import Panel
+
+from research_agent.llm.router import _build_model_for_tier, load_models_config
+from research_agent.prompts.loader import load_prompt
+
+_log = structlog.get_logger(__name__)
+
+DOMAIN_CHOICES: tuple[str, ...] = (
+    "Political / corruption",
+    "Corporate / financial",
+    "Legal / regulatory",
+    "Technical / scientific",
+    "Media / public figure",
+    "Other",
+)
+
+TIME_CAP_CHOICES: tuple[str, ...] = ("4h", "12h", "24h", "48h", "1 week", "open-ended")
+_TIME_CAP_HOURS: dict[str, int | None] = {
+    "4h": 4,
+    "12h": 12,
+    "24h": 24,
+    "48h": 48,
+    "1 week": 24 * 7,
+    "open-ended": None,
+}
+
+BUDGET_CHOICES: tuple[str, ...] = ("$5", "$25", "$100", "$500", "no cap")
+_BUDGET_USD: dict[str, float | None] = {
+    "$5": 5.0,
+    "$25": 25.0,
+    "$100": 100.0,
+    "$500": 500.0,
+    "no cap": None,
+}
+
+OUTPUT_CHOICES: tuple[str, ...] = (
+    "Substack-ready long-form",
+    "internal brief",
+    "raw findings dump",
+    "research dossier",
+)
+
+AGGRESSIVENESS_CHOICES: tuple[str, ...] = ("conservative", "balanced", "aggressive")
+
+MAX_FOLLOWUPS = 3
+
+
+class FollowupQuestion(BaseModel):
+    """A single adaptive clarifying question emitted by the intake agent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    question: str = Field(min_length=1)
+    why_it_matters: str = ""
+    suggested_defaults: list[str] = Field(default_factory=list)
+
+
+def _ask_text(prompt: str, *, default: str = "") -> str:
+    """Ask a non-empty text question; ``default`` pre-fills the input."""
+    return questionary.text(prompt, default=default).ask() or ""
+
+
+def _ask_select(prompt: str, choices: tuple[str, ...], *, default: str) -> str:
+    return questionary.select(prompt, choices=list(choices), default=default).ask()
+
+
+def _budget_default(budget_usd: float | None) -> str:
+    if budget_usd is None:
+        return BUDGET_CHOICES[0]
+    for label, val in _BUDGET_USD.items():
+        if val is not None and float(val) == float(budget_usd):
+            return label
+    return BUDGET_CHOICES[0]
+
+
+def _time_cap_default(time_cap: int | None) -> str:
+    if time_cap is None:
+        return TIME_CAP_CHOICES[0]
+    for label, val in _TIME_CAP_HOURS.items():
+        if val == time_cap:
+            return label
+    return TIME_CAP_CHOICES[0]
+
+
+def _generate_followup_questions(answers_so_far: dict[str, Any]) -> list[FollowupQuestion]:
+    """Run the local ``general`` tier to produce 0–N follow-up questions.
+
+    Separated from :func:`_collect_followups` so tests can stub the LLM
+    call independently of the user-facing prompt loop.
+    """
+    cfg = load_models_config(Path("config/models.yaml"))
+    tiers = cfg["tiers"]
+    if "general" not in tiers:
+        raise KeyError("'general' tier missing from config/models.yaml")
+    model = _build_model_for_tier("general", tiers["general"])
+
+    question_text = (
+        f"goal: {answers_so_far.get('goal', '')}\n"
+        f"successful answer: {answers_so_far.get('goal_one_sentence', '')}\n"
+        f"domain: {answers_so_far.get('domain', '')}"
+    )
+    rendered = load_prompt("intake_followup", question=question_text)
+    agent = Agent(model, output_type=list[FollowupQuestion], system_prompt=rendered)
+    result = asyncio.run(agent.run(question_text))
+    output = result.output
+    if not isinstance(output, list):
+        return []
+    return list(output)
+
+
+def _collect_followups(answers_so_far: dict[str, Any]) -> list[dict[str, str]]:
+    """Generate adaptive follow-ups via the local LLM and prompt the user.
+
+    Returns a list of ``{"question", "answer"}`` dicts capped at
+    :data:`MAX_FOLLOWUPS`. Any LLM error is logged at WARN and yields ``[]``
+    so the intake loop never blocks on cloud failure.
+    """
+    try:
+        questions = _generate_followup_questions(answers_so_far)
+    except Exception as e:  # noqa: BLE001 — best-effort; never block intake
+        _log.warning("intake_followup_failed", error=str(e))
+        return []
+
+    qa: list[dict[str, str]] = []
+    for q in questions[:MAX_FOLLOWUPS]:
+        if q.suggested_defaults:
+            answer = questionary.select(
+                q.question,
+                choices=list(q.suggested_defaults),
+            ).ask()
+        else:
+            answer = questionary.text(q.question).ask()
+        qa.append({"question": q.question, "answer": answer or ""})
+    return qa
+
+
+def _render_summary(intake: dict[str, Any]) -> Panel:
+    """Render the 5-line confirmation summary before spawning the daemon."""
+    time_cap = intake.get("time_cap")
+    budget = intake.get("budget_usd")
+    time_str = f"{time_cap}h" if isinstance(time_cap, int) else "open-ended"
+    budget_str = f"${budget:.0f}" if isinstance(budget, (int, float)) else "no cap"
+    lines = [
+        f"Goal: {intake['goal']}",
+        f"Domain: {intake['domain']}",
+        f"Caps: time={time_str}, budget={budget_str}",
+        f"Output: {intake['output_orientation']} ({intake['aggressiveness']})",
+        f"Follow-ups answered: {len(intake.get('followup_qa', []))}",
+    ]
+    return Panel("\n".join(lines), title="Research plan", border_style="cyan")
+
+
+def run_intake(
+    corpus: str | None = None,
+    budget_usd: float | None = None,
+    time_cap: int | None = None,
+) -> dict[str, Any]:
+    """Run the interactive intake flow and return a populated intake dict.
+
+    Loops the 1–10 step flow until the user confirms; on revise we re-prompt
+    every field from scratch (per §5.1, no preserved state). The CLI pre-fills
+    ``time_cap`` / ``budget_usd`` / ``corpus`` defaults; the user can still
+    override any of them inside the flow.
+
+    Returns a dict with exactly nine keys: ``goal``, ``goal_one_sentence``,
+    ``domain``, ``time_cap``, ``budget_usd``, ``output_orientation``,
+    ``aggressiveness``, ``corpus_path``, ``followup_qa``.
+    """
+    console = Console()
+
+    while True:
+        # Step 1 — goal (required, non-empty).
+        goal = ""
+        while not goal.strip():
+            goal = _ask_text("Who or what do you want to research?")
+
+        # Step 2 — clarification.
+        goal_one_sentence = _ask_text(
+            "In one sentence, what would a successful answer look like?",
+        )
+
+        # Step 3 — domain.
+        domain_choice = _ask_select(
+            "Domain?",
+            DOMAIN_CHOICES,
+            default=DOMAIN_CHOICES[0],
+        )
+        if domain_choice == "Other":
+            domain = _ask_text("Describe the domain:") or "other"
+        else:
+            domain = domain_choice
+
+        # Step 4 — time cap.
+        time_cap_label = _ask_select(
+            "Time cap?",
+            TIME_CAP_CHOICES,
+            default=_time_cap_default(time_cap),
+        )
+        time_cap_hours = _TIME_CAP_HOURS[time_cap_label]
+
+        # Step 5 — budget cap.
+        budget_label = _ask_select(
+            "Budget cap (cloud only)?",
+            BUDGET_CHOICES,
+            default=_budget_default(budget_usd),
+        )
+        budget_value = _BUDGET_USD[budget_label]
+
+        # Step 6 — output orientation.
+        output_orientation = _ask_select(
+            "Output orientation?",
+            OUTPUT_CHOICES,
+            default=OUTPUT_CHOICES[0],
+        )
+
+        # Step 7 — aggressiveness.
+        aggressiveness = _ask_select(
+            "Aggressiveness?",
+            AGGRESSIVENESS_CHOICES,
+            default=AGGRESSIVENESS_CHOICES[1],
+        )
+
+        # Step 8 — optional corpus path.
+        corpus_answer = _ask_text(
+            "Any local files I should index first? (default: skip)",
+            default=corpus or "",
+        )
+        corpus_path = corpus_answer.strip() or None
+
+        partial = {
+            "goal": goal.strip(),
+            "goal_one_sentence": goal_one_sentence.strip(),
+            "domain": domain,
+        }
+
+        # Step 9 — adaptive follow-ups (best-effort, capped at 3).
+        followup_qa = _collect_followups(partial)[:MAX_FOLLOWUPS]
+
+        intake: dict[str, Any] = {
+            "goal": partial["goal"],
+            "goal_one_sentence": partial["goal_one_sentence"],
+            "domain": domain,
+            "time_cap": time_cap_hours,
+            "budget_usd": budget_value,
+            "output_orientation": output_orientation,
+            "aggressiveness": aggressiveness,
+            "corpus_path": corpus_path,
+            "followup_qa": followup_qa,
+        }
+
+        # Step 10 — confirm. Revise drops back to step 1.
+        console.print(_render_summary(intake))
+        if questionary.confirm("Proceed with this plan?").ask():
+            return intake
+
+
+__all__ = [
+    "AGGRESSIVENESS_CHOICES",
+    "BUDGET_CHOICES",
+    "DOMAIN_CHOICES",
+    "FollowupQuestion",
+    "MAX_FOLLOWUPS",
+    "OUTPUT_CHOICES",
+    "TIME_CAP_CHOICES",
+    "run_intake",
+]

--- a/src/research_agent/prompts/intake_followup.md
+++ b/src/research_agent/prompts/intake_followup.md
@@ -1,6 +1,6 @@
 ---
 version: "1"
-model_tier: fast
+model_tier: general
 description: System prompt for the intake follow-up agent that decides which clarifying questions to ask the user.
 ---
 You are the **intake follow-up** for an autonomous research agent.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -219,12 +219,55 @@ def test_start_skip_intake_creates_job(isolated_jobs_repo: Path):
     assert row["budget_cap_usd"] == 5.0
 
 
-def test_start_without_skip_intake_exits_nonzero(isolated_jobs_repo: Path):
+def test_start_runs_intake_when_not_skipped(isolated_jobs_repo: Path, monkeypatch):
+    canned = {
+        "goal": "Investigate widgets",
+        "goal_one_sentence": "a sourced overview of widget governance",
+        "domain": "Corporate / financial",
+        "time_cap": 12,
+        "budget_usd": 25.0,
+        "output_orientation": "internal brief",
+        "aggressiveness": "balanced",
+        "corpus_path": None,
+        "followup_qa": [],
+    }
+
+    captured: dict[str, object] = {}
+
+    def _fake_run_intake(*, corpus=None, budget_usd=None, time_cap=None):
+        captured["corpus"] = corpus
+        captured["budget_usd"] = budget_usd
+        captured["time_cap"] = time_cap
+        return canned
+
+    monkeypatch.setattr(cli.intake, "run_intake", _fake_run_intake)
+
     runner = CliRunner()
-    result = runner.invoke(cli.app, ["start", "--goal", "x"])
-    assert result.exit_code != 0
-    # Combined output should mention the missing flag.
-    assert "skip-intake" in (result.stdout + (result.stderr or ""))
+    result = runner.invoke(
+        cli.app,
+        ["start", "--budget-usd", "25.0", "--time-cap", "12"],
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "Started job" in result.stdout
+
+    today = time.strftime("%Y-%m-%d")
+    job_id = f"{today}-investigate-widgets"
+    conn = db.connect(isolated_jobs_repo / "data" / "index.sqlite")
+    try:
+        row = conn.execute(
+            "SELECT status, budget_cap_usd, time_cap_hours FROM jobs WHERE id = ?",
+            (job_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    assert row["status"] == "pending"
+    assert row["budget_cap_usd"] == 25.0
+    assert row["time_cap_hours"] == 12
+
+    # CLI flags must be forwarded to the intake helper as defaults.
+    assert captured["budget_usd"] == 25.0
+    assert captured["time_cap"] == 12
 
 
 def test_start_skip_intake_requires_goal(isolated_jobs_repo: Path):

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -1,0 +1,297 @@
+"""Tests for the interactive intake flow (`research start`'s 11-step flow)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from research_agent import intake
+
+
+class _Scripted:
+    """Helper: build a fake questionary Question whose ``.ask()`` pops scripted values."""
+
+    def __init__(self, values: list[Any]) -> None:
+        self._values = values
+        self._calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def factory(self, *args: Any, **kwargs: Any):  # type: ignore[no-untyped-def]
+        self._calls.append((args, kwargs))
+        if not self._values:
+            raise AssertionError(
+                f"no scripted answer left for call args={args!r} kwargs={kwargs!r}"
+            )
+        value = self._values.pop(0)
+
+        class _Q:
+            def ask(self_inner) -> Any:  # noqa: N805
+                return value
+
+        return _Q()
+
+    @property
+    def calls(self) -> list[tuple[tuple[Any, ...], dict[str, Any]]]:
+        return self._calls
+
+
+def _patch_questionary(
+    mocker,
+    *,
+    text: list[Any],
+    select: list[Any],
+    confirm: list[Any],
+) -> tuple[_Scripted, _Scripted, _Scripted]:
+    """Patch questionary's text/select/confirm with scripted scripts."""
+    text_s = _Scripted(text)
+    select_s = _Scripted(select)
+    confirm_s = _Scripted(confirm)
+    mocker.patch("research_agent.intake.questionary.text", side_effect=text_s.factory)
+    mocker.patch("research_agent.intake.questionary.select", side_effect=select_s.factory)
+    mocker.patch("research_agent.intake.questionary.confirm", side_effect=confirm_s.factory)
+    return text_s, select_s, confirm_s
+
+
+def test_run_intake_happy_path(mocker):
+    mocker.patch("research_agent.intake._collect_followups", return_value=[])
+    _patch_questionary(
+        mocker,
+        text=[
+            "ABC Corp",  # step 1 goal
+            "a sourced overview of governance issues",  # step 2 goal_one_sentence
+            "",  # step 8 corpus (skip)
+        ],
+        select=[
+            "Corporate / financial",  # step 3 domain
+            "12h",  # step 4 time cap
+            "$25",  # step 5 budget
+            "internal brief",  # step 6 output
+            "balanced",  # step 7 aggressiveness
+        ],
+        confirm=[True],  # step 10 confirm
+    )
+
+    result = intake.run_intake()
+
+    assert set(result.keys()) == {
+        "goal",
+        "goal_one_sentence",
+        "domain",
+        "time_cap",
+        "budget_usd",
+        "output_orientation",
+        "aggressiveness",
+        "corpus_path",
+        "followup_qa",
+    }
+    assert result["goal"] == "ABC Corp"
+    assert result["goal_one_sentence"] == "a sourced overview of governance issues"
+    assert result["domain"] == "Corporate / financial"
+    assert result["time_cap"] == 12
+    assert result["budget_usd"] == 25.0
+    assert result["output_orientation"] == "internal brief"
+    assert result["aggressiveness"] == "balanced"
+    assert result["corpus_path"] is None
+    assert result["followup_qa"] == []
+
+
+def test_run_intake_revise_loops_back_to_step_1(mocker):
+    mocker.patch("research_agent.intake._collect_followups", return_value=[])
+    text_s, _, _ = _patch_questionary(
+        mocker,
+        text=[
+            "First goal",  # round 1 step 1
+            "first answer",  # round 1 step 2
+            "",  # round 1 step 8
+            "Second goal",  # round 2 step 1
+            "second answer",  # round 2 step 2
+            "",  # round 2 step 8
+        ],
+        select=[
+            "Political / corruption",
+            "4h",
+            "$5",
+            "internal brief",
+            "balanced",
+            "Political / corruption",
+            "4h",
+            "$5",
+            "internal brief",
+            "balanced",
+        ],
+        confirm=[False, True],  # revise once, then accept
+    )
+
+    result = intake.run_intake()
+
+    # Step 1 is the very first text prompt each round; we should see two rounds.
+    step_1_prompts = [c for c in text_s.calls if c[0] and "Who or what" in c[0][0]]
+    assert len(step_1_prompts) == 2
+    assert result["goal"] == "Second goal"
+
+
+def test_run_intake_followups_max_three(mocker):
+    five_qa = [{"question": f"q{i}", "answer": f"a{i}"} for i in range(5)]
+    mocker.patch("research_agent.intake._collect_followups", return_value=five_qa)
+    _patch_questionary(
+        mocker,
+        text=["goal", "answer", ""],
+        select=[
+            "Political / corruption",
+            "4h",
+            "$5",
+            "internal brief",
+            "balanced",
+        ],
+        confirm=[True],
+    )
+
+    result = intake.run_intake()
+    assert len(result["followup_qa"]) == 3
+    assert [qa["question"] for qa in result["followup_qa"]] == ["q0", "q1", "q2"]
+
+
+def test_run_intake_followups_swallow_llm_error(mocker):
+    mocker.patch(
+        "research_agent.intake._generate_followup_questions",
+        side_effect=RuntimeError("LM Studio offline"),
+    )
+    _patch_questionary(
+        mocker,
+        text=["goal", "answer", ""],
+        select=[
+            "Political / corruption",
+            "4h",
+            "$5",
+            "internal brief",
+            "balanced",
+        ],
+        confirm=[True],
+    )
+
+    result = intake.run_intake()
+    assert result["followup_qa"] == []
+
+
+def test_run_intake_prefills_from_cli_flags(mocker):
+    mocker.patch("research_agent.intake._collect_followups", return_value=[])
+    text_s, select_s, _ = _patch_questionary(
+        mocker,
+        text=["goal", "answer", "./x"],
+        select=[
+            "Political / corruption",
+            "12h",
+            "$25",
+            "internal brief",
+            "balanced",
+        ],
+        confirm=[True],
+    )
+
+    result = intake.run_intake(corpus="./x", budget_usd=25.0, time_cap=12)
+
+    # Time cap select default came from time_cap=12 → "12h".
+    time_cap_call = next(c for c in select_s.calls if c[0] and "Time cap" in c[0][0])
+    assert time_cap_call[1].get("default") == "12h"
+
+    # Budget select default came from budget_usd=25.0 → "$25".
+    budget_call = next(c for c in select_s.calls if c[0] and "Budget" in c[0][0])
+    assert budget_call[1].get("default") == "$25"
+
+    # Corpus text default came from corpus="./x".
+    corpus_call = next(c for c in text_s.calls if c[0] and "local files" in c[0][0])
+    assert corpus_call[1].get("default") == "./x"
+
+    assert result["corpus_path"] == "./x"
+    assert result["time_cap"] == 12
+    assert result["budget_usd"] == 25.0
+
+
+def test_run_intake_other_domain_prompts_freetext(mocker):
+    mocker.patch("research_agent.intake._collect_followups", return_value=[])
+    text_s, _, _ = _patch_questionary(
+        mocker,
+        text=[
+            "goal",  # step 1
+            "answer",  # step 2
+            "ornithology",  # step 3 free-text domain
+            "",  # step 8 corpus skip
+        ],
+        select=[
+            "Other",  # step 3
+            "4h",
+            "$5",
+            "internal brief",
+            "balanced",
+        ],
+        confirm=[True],
+    )
+
+    result = intake.run_intake()
+    assert result["domain"] == "ornithology"
+    # The free-text domain prompt should have been triggered.
+    assert any("domain" in (c[0][0].lower() if c[0] else "") for c in text_s.calls)
+
+
+def test_module_constants_match_spec():
+    """Lock the §5.1 choice tuples so future edits are intentional."""
+    assert intake.DOMAIN_CHOICES == (
+        "Political / corruption",
+        "Corporate / financial",
+        "Legal / regulatory",
+        "Technical / scientific",
+        "Media / public figure",
+        "Other",
+    )
+    assert intake.TIME_CAP_CHOICES == ("4h", "12h", "24h", "48h", "1 week", "open-ended")
+    assert intake.BUDGET_CHOICES == ("$5", "$25", "$100", "$500", "no cap")
+    assert intake.OUTPUT_CHOICES == (
+        "Substack-ready long-form",
+        "internal brief",
+        "raw findings dump",
+        "research dossier",
+    )
+    assert intake.AGGRESSIVENESS_CHOICES == ("conservative", "balanced", "aggressive")
+    assert intake.MAX_FOLLOWUPS == 3
+
+
+def test_run_intake_step_1_rejects_empty_goal(mocker):
+    """Step 1 must re-prompt until the user enters a non-empty goal."""
+    mocker.patch("research_agent.intake._collect_followups", return_value=[])
+    _patch_questionary(
+        mocker,
+        text=[
+            "",  # first attempt — empty
+            "   ",  # second attempt — whitespace
+            "Real goal",  # third — accepted
+            "answer",  # step 2
+            "",  # step 8
+        ],
+        select=[
+            "Political / corruption",
+            "4h",
+            "$5",
+            "internal brief",
+            "balanced",
+        ],
+        confirm=[True],
+    )
+
+    result = intake.run_intake()
+    assert result["goal"] == "Real goal"
+
+
+@pytest.mark.parametrize(
+    "label,hours",
+    [("4h", 4), ("12h", 12), ("24h", 24), ("48h", 48), ("1 week", 168), ("open-ended", None)],
+)
+def test_time_cap_label_to_hours(label, hours):
+    assert intake._TIME_CAP_HOURS[label] == hours
+
+
+@pytest.mark.parametrize(
+    "label,usd",
+    [("$5", 5.0), ("$25", 25.0), ("$100", 100.0), ("$500", 500.0), ("no cap", None)],
+)
+def test_budget_label_to_usd(label, usd):
+    assert intake._BUDGET_USD[label] == usd

--- a/uv.lock
+++ b/uv.lock
@@ -3127,6 +3127,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3519,6 +3531,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
     { name = "ruff" },
 ]
 
@@ -3527,6 +3540,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
     { name = "ruff" },
 ]
 
@@ -3543,6 +3557,7 @@ requires-dist = [
     { name = "pypdf", specifier = ">=4.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "questionary", specifier = ">=2.0" },
@@ -3565,6 +3580,7 @@ dev = [
     { name = "mypy", specifier = ">=1.10" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "pytest-mock", specifier = ">=3.12" },
     { name = "ruff", specifier = ">=0.4" },
 ]
 


### PR DESCRIPTION
Closes #31

## Summary

Automated implementation of **Interactive intake (intake.py)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

intake.py meets all AC: 11-step Questionary flow, general-tier follow-ups capped at 3, Rich summary, revise loop, 9-key dict; CLI flags pre-fill defaults; --skip-intake unaffected; 19 intake + 45 CLI tests pass. Fixed one minor doc drift in prompt frontmatter.

- **INFO** [FIXED] `src/research_agent/prompts/intake_followup.md`: intake_followup.md frontmatter declared model_tier: fast while the AC and intake.py call the general tier. Loader treats model_tier as metadata only (no routing impact), but the inconsistency was misleading. Updated frontmatter to general.
- **INFO** [OPEN] `src/research_agent/intake.py`: Summary panel renders time_cap as '{N}h' when N is an int — '1 week' (168h) shows as 'time=168h' rather than 'time=1 week'. Not a bug per spec; flagging for future polish.
- **INFO** [OPEN] `src/research_agent/intake.py`: _collect_followups already slices to MAX_FOLLOWUPS, and run_intake slices again with [:MAX_FOLLOWUPS]. Redundant but harmless.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*