### PR TITLE
feat: Daemon main loop with signal handlers + STOP flag watcher (closes #33)

### DIFF
--- a/src/research_agent/daemon.py
+++ b/src/research_agent/daemon.py
@@ -1,18 +1,32 @@
 """Long-running research process — drives the agent loop per job (impl guide §4, §5.1, §6).
 
-Issue #32 ships the spawn/PID-file lifecycle: ``spawn_daemon`` forks a
-detached child via :func:`subprocess.Popen` with ``start_new_session=True``
-so it survives terminal exit, and ``is_daemon_alive`` checks the process
-behind ``jobs/<id>/daemon.pid``. The actual research loop wired into
-``run_daemon`` is owned by issue #33; this module ships a thin stub that
-delegates to ``orchestrator.loop.run_daemon`` once that lands.
+Issue #32 shipped the spawn/PID-file lifecycle; issue #33 fills in the
+research-loop body. ``spawn_daemon`` forks a detached child via
+:func:`subprocess.Popen` with ``start_new_session=True`` so it survives
+terminal exit, and ``is_daemon_alive`` checks the process behind
+``jobs/<id>/daemon.pid``.
+
+``run_daemon`` is the long-running async coroutine the child enters. It:
+
+1. Loads the :class:`Job`, builds a :class:`Router`/:class:`BudgetTracker`
+   from ``config/models.yaml``, runs the LM Studio + OpenRouter health
+   checks (60 s deadline each), and flips ``status=running``.
+2. Installs SIGTERM/SIGINT handlers via ``loop.add_signal_handler`` that
+   set a single in-memory ``asyncio.Event`` *and* atomically touch
+   ``jobs/<id>/STOP`` so the existing ``orchestrator.loop._should_stop``
+   poll picks the request up.
+3. Starts a 2 s ``STOP``-flag watcher task so a ``research stop --graceful``
+   that drops the file externally also flips the event.
+4. Calls :func:`research_agent.orchestrator.loop.run_loop`, then a
+   best-effort :func:`research_agent.orchestrator.synth.final_synthesis`
+   so ``report.md`` is always rewritten.
+5. Sets ``status=completed``/``stopped``/``failed`` accordingly and exits
+   with ``0`` on graceful shutdown, ``1`` on uncaught exception.
 
 The PID file is written by the *parent* (spawn_daemon) and removed by the
-*child* on clean shutdown (atexit). Both SIGTERM and SIGINT route through
-the same path: raise :class:`KeyboardInterrupt`, the asyncio loop unwinds,
-atexit fires, ``daemon.pid`` is deleted. Per §5.2 the daemon is the
-graceful path — there is no separate "dirty" exit that leaves the file
-behind on a normal signal.
+*child* on shutdown via ``atexit``. Per §5.2 the daemon is the graceful
+path — there is no separate "dirty" exit that leaves the file behind on a
+normal signal.
 """
 
 from __future__ import annotations
@@ -24,11 +38,16 @@ import os
 import signal
 import subprocess
 import sys
+import time
+import traceback
 from pathlib import Path
-from types import FrameType
 from typing import Any
 
-from research_agent.storage.jobs import DEFAULT_JOBS_ROOT
+import httpx
+
+from research_agent.config import get as cfg_get
+from research_agent.observability.events import emit
+from research_agent.storage.jobs import DEFAULT_JOBS_ROOT, Job
 
 logger = logging.getLogger(__name__)
 
@@ -159,45 +178,386 @@ def _remove_pid_file(jobs_root: Path, job_id: str) -> None:
         logger.exception("failed to remove %s", pid_file)
 
 
-async def run_daemon(job_id: str, *, jobs_root: Path | str = DEFAULT_JOBS_ROOT) -> None:
-    """Drive the agent loop for ``job_id`` until completion or stop.
+# ---------------------------------------------------------------------------
+# Health checks (acceptance criterion: 60 s retry deadline at startup)
+# ---------------------------------------------------------------------------
 
-    Stub: issue #33 owns the real implementation. This delegates to
-    ``orchestrator.loop.run_daemon`` if it has shipped, otherwise it logs
-    a warning and returns cleanly so the PID-file lifecycle (write on
-    spawn, remove on shutdown) is exercised end-to-end.
+
+_HEALTH_INITIAL_DELAY_S = 1.0
+_HEALTH_MAX_DELAY_S = 10.0
+_HEALTH_CLIENT_TIMEOUT_S = 10.0
+
+
+async def _retry_until(
+    job: Job | None,
+    *,
+    name: str,
+    probe: Any,
+    deadline_s: float,
+) -> None:
+    """Drive a single async ``probe()`` until it succeeds or ``deadline_s`` expires.
+
+    Backoff doubles from ``_HEALTH_INITIAL_DELAY_S`` and clamps at
+    ``_HEALTH_MAX_DELAY_S`` per the issue spec. The first failure emits a
+    ``warning`` event so an operator tailing logs sees it before the full
+    deadline expires; on deadline we emit ``error`` and re-raise.
     """
-    _ = jobs_root  # kept on the signature for future use; loop.run_daemon owns root resolution
-    from research_agent.orchestrator import loop as _loop
+    start = time.monotonic()
+    deadline = start + deadline_s
+    delay = _HEALTH_INITIAL_DELAY_S
+    last_exc: BaseException | None = None
+    first_failure_emitted = False
 
-    real = getattr(_loop, "run_daemon", None)
-    if real is None:
-        logger.warning("daemon entrypoint stub — run_daemon not implemented yet (issue #33)")
+    while True:
+        try:
+            await probe()
+            return
+        except BaseException as exc:  # noqa: BLE001 — health probes can raise anything
+            last_exc = exc
+            if not first_failure_emitted and job is not None:
+                try:
+                    emit(
+                        job,
+                        "WARN",
+                        "daemon",
+                        "warning",
+                        {"stage": f"{name}_health", "error": str(exc)},
+                    )
+                except Exception:
+                    pass
+                first_failure_emitted = True
+            logger.info(
+                "%s health check failed (%s); retrying in %.1fs",
+                name,
+                exc,
+                delay,
+            )
+        now = time.monotonic()
+        if now + delay >= deadline:
+            break
+        await asyncio.sleep(delay)
+        delay = min(delay * 2.0, _HEALTH_MAX_DELAY_S)
+
+    msg = f"{name} not reachable within {deadline_s:.0f}s: {last_exc}"
+    if job is not None:
+        try:
+            emit(
+                job,
+                "ERROR",
+                "daemon",
+                "error",
+                {"stage": f"{name}_health", "error": str(last_exc)},
+            )
+        except Exception:
+            pass
+    raise RuntimeError(msg)
+
+
+async def ensure_lm_studio_alive(router: Any, *, deadline_s: float = 60.0) -> None:
+    """Block until LM Studio answers ``GET /models`` or 60 s expires.
+
+    The router can't usefully dispatch local-tier calls without LM Studio,
+    so failing fast at startup is friendlier than letting the first
+    in-loop call time out per-tier.
+    """
+    base_url = (cfg_get("LMSTUDIO_BASE_URL") or "http://localhost:1234/v1").rstrip("/")
+    url = f"{base_url}/models"
+
+    async def _probe() -> None:
+        async with httpx.AsyncClient(timeout=_HEALTH_CLIENT_TIMEOUT_S) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+
+    await _retry_until(
+        getattr(router, "job", None),
+        name="lm_studio",
+        probe=_probe,
+        deadline_s=deadline_s,
+    )
+
+
+async def ensure_openrouter_reachable(router: Any, *, deadline_s: float = 60.0) -> None:
+    """Block until OpenRouter answers ``GET /models`` or 60 s expires.
+
+    Authenticated request — a missing ``OPENROUTER_API_KEY`` should raise
+    immediately rather than retry-loop for 60 s.
+    """
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        msg = "OPENROUTER_API_KEY environment variable is required"
+        job = getattr(router, "job", None)
+        if job is not None:
+            try:
+                emit(
+                    job,
+                    "ERROR",
+                    "daemon",
+                    "error",
+                    {"stage": "openrouter_health", "error": msg},
+                )
+            except Exception:
+                pass
+        raise RuntimeError(msg)
+
+    url = "https://openrouter.ai/api/v1/models"
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    async def _probe() -> None:
+        async with httpx.AsyncClient(timeout=_HEALTH_CLIENT_TIMEOUT_S) as client:
+            resp = await client.get(url, headers=headers)
+            resp.raise_for_status()
+
+    await _retry_until(
+        getattr(router, "job", None),
+        name="openrouter",
+        probe=_probe,
+        deadline_s=deadline_s,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Run-daemon: the §6.1 main coroutine
+# ---------------------------------------------------------------------------
+
+
+_STOP_POLL_INTERVAL_S = 2.0
+
+
+def _build_router(job: Job) -> Any:
+    """Build a :class:`Router` + :class:`BudgetTracker` for ``job``.
+
+    Imports are deferred so plain ``daemon.spawn_daemon`` callers don't pay
+    the cost of pulling the LLM stack just to launch a child.
+    """
+    from research_agent.llm.budgets import BudgetTracker
+    from research_agent.llm.router import Router, load_models_config
+
+    config_path = os.environ.get("RESEARCH_MODELS_CONFIG", "config/models.yaml")
+    config = load_models_config(config_path)
+    pricing = config.get("pricing") or {}
+    intake = job.intake or {}
+    cap_usd = intake.get("budget_cap_usd")
+
+    budget = BudgetTracker(job.id, cap_usd, pricing=pricing, db_path=job.db_path)
+    return Router(config, budget, job=job, db_path=job.db_path)
+
+
+def _resolve_db_path() -> Path | None:
+    """Pull ``RESEARCH_DB_PATH`` from the env, if set, else None for the default."""
+    val = os.environ.get("RESEARCH_DB_PATH")
+    return Path(val) if val else None
+
+
+def _install_stop_signal_handlers(
+    aloop: asyncio.AbstractEventLoop,
+    job: Job,
+    should_stop: asyncio.Event,
+) -> None:
+    """Wire SIGTERM/SIGINT through the asyncio loop into a graceful stop.
+
+    The handler does two things: atomically writes ``jobs/<id>/STOP`` so
+    ``orchestrator.loop._should_stop`` picks the request up between tasks,
+    and sets the in-memory event so any non-loop awaiter (e.g. the watcher
+    or future health-check loops) can also bail.
+    """
+    stop_path = job.root / "STOP"
+
+    def _on_signal() -> None:
+        try:
+            tmp = stop_path.with_suffix(".tmp")
+            tmp.write_text("", encoding="utf-8")
+            os.replace(tmp, stop_path)
+        except OSError:
+            logger.exception("failed to write STOP flag for job %s", job.id)
+        should_stop.set()
+
+    aloop.add_signal_handler(signal.SIGTERM, _on_signal)
+    aloop.add_signal_handler(signal.SIGINT, _on_signal)
+
+
+async def _stop_flag_watcher(
+    job: Job,
+    should_stop: asyncio.Event,
+    *,
+    poll_interval_s: float = _STOP_POLL_INTERVAL_S,
+) -> None:
+    """Poll ``jobs/<id>/STOP`` every ``poll_interval_s`` seconds.
+
+    The signal handler also touches the file so this loop is in fact
+    redundant for the SIGTERM/SIGINT path — but ``research stop --graceful``
+    drops the file from a sibling process, and that needs to flip the
+    in-memory event without relying on a signal arriving.
+    """
+    stop_path = job.root / "STOP"
+    try:
+        while not should_stop.is_set():
+            if stop_path.exists():
+                should_stop.set()
+                return
+            try:
+                await asyncio.wait_for(should_stop.wait(), timeout=poll_interval_s)
+            except TimeoutError:
+                continue
+    except asyncio.CancelledError:
         return
-    await real(job_id)
 
 
-def _make_signal_handler() -> Any:
-    """Build a SIGTERM/SIGINT handler that routes through KeyboardInterrupt.
+async def run_daemon(
+    job_id: str,
+    *,
+    jobs_root: Path | str = DEFAULT_JOBS_ROOT,
+    db_path: Path | str | None = None,
+) -> int:
+    """Drive the agent loop for ``job_id`` until completion, stop, or failure.
 
-    Raising :class:`KeyboardInterrupt` from the handler unwinds the
-    :func:`asyncio.run` call cleanly; ``_main`` catches it and exits with
-    status 0 so atexit fires and the PID file is removed.
+    Returns the integer exit code: ``0`` on a graceful run (including
+    SIGTERM/SIGINT or external STOP), ``1`` on an uncaught exception.
+
+    ``db_path`` defaults to the project-relative ``data/index.sqlite`` (via
+    :data:`research_agent.storage.db.DEFAULT_DB_PATH`); tests pass a
+    ``tmp_path`` override so the suite never touches the real index.
     """
+    from research_agent.orchestrator import loop as _loop
+    from research_agent.orchestrator import synth as _synth
+    from research_agent.storage import db as _db
 
-    def _on_signal(signum: int, frame: FrameType | None) -> None:
-        del signum, frame
-        raise KeyboardInterrupt
+    jobs_root_p = Path(jobs_root)
+    db_path_p = Path(db_path) if db_path is not None else _db.DEFAULT_DB_PATH
 
-    return _on_signal
+    try:
+        job = Job.load(job_id, jobs_root=jobs_root_p, db_path=db_path_p)
+    except (FileNotFoundError, KeyError, ValueError) as exc:
+        logger.error("daemon: cannot load job %r: %s", job_id, exc)
+        return 1
+
+    try:
+        router = _build_router(job)
+    except Exception as exc:
+        logger.exception("daemon: failed to build router for job %s", job.id)
+        try:
+            emit(
+                job,
+                "ERROR",
+                "daemon",
+                "error",
+                {
+                    "stage": "router_init",
+                    "error": str(exc),
+                    "traceback": traceback.format_exc(),
+                },
+            )
+        except Exception:
+            pass
+        try:
+            job.set_status("failed")
+        except Exception:
+            pass
+        return 1
+
+    skip_health = os.environ.get("RESEARCH_DAEMON_SKIP_HEALTH_CHECKS") == "1"
+    if not skip_health:
+        try:
+            await ensure_lm_studio_alive(router)
+            await ensure_openrouter_reachable(router)
+        except Exception as exc:
+            logger.error("daemon: health checks failed for job %s: %s", job.id, exc)
+            try:
+                job.set_status("failed")
+            except Exception:
+                pass
+            return 1
+
+    job.set_status("running")
+
+    should_stop = asyncio.Event()
+    aloop = asyncio.get_running_loop()
+    signals_installed = False
+    try:
+        _install_stop_signal_handlers(aloop, job, should_stop)
+        signals_installed = True
+    except (NotImplementedError, ValueError):
+        # Windows / inside a thread: fall back to default signal handling.
+        # The STOP-flag watcher still works, so callers using
+        # ``research stop --graceful`` aren't broken.
+        logger.warning("could not install asyncio signal handlers; relying on STOP flag only")
+
+    watcher_task = aloop.create_task(_stop_flag_watcher(job, should_stop))
+
+    exit_code = 0
+    final_status = "stopped"
+    try:
+        try:
+            await _loop.run_loop(job, router)
+        except Exception as exc:
+            logger.exception("daemon: run_loop crashed for job %s", job.id)
+            try:
+                emit(
+                    job,
+                    "ERROR",
+                    "daemon",
+                    "error",
+                    {
+                        "stage": "run_loop",
+                        "error": str(exc),
+                        "traceback": traceback.format_exc(),
+                    },
+                )
+            except Exception:
+                pass
+            try:
+                job.set_status("failed")
+            except Exception:
+                pass
+            return 1
+
+        plan = _loop._load_latest_plan(job)
+        try:
+            if plan is not None:
+                await _synth.final_synthesis(job, plan, router=router)
+        except Exception as exc:
+            logger.warning("daemon: final synthesis failed for job %s: %s", job.id, exc)
+            try:
+                emit(
+                    job,
+                    "WARN",
+                    "daemon",
+                    "warning",
+                    {"stage": "final_synthesis", "error": str(exc)},
+                )
+            except Exception:
+                pass
+
+        if plan is not None and plan.is_complete():
+            final_status = "completed"
+        else:
+            final_status = "stopped"
+        try:
+            job.set_status(final_status)
+        except Exception:
+            logger.exception("daemon: failed to write final status for job %s", job.id)
+    finally:
+        watcher_task.cancel()
+        try:
+            await watcher_task
+        except (asyncio.CancelledError, Exception):
+            pass
+        if signals_installed:
+            for sig in (signal.SIGTERM, signal.SIGINT):
+                try:
+                    aloop.remove_signal_handler(sig)
+                except (NotImplementedError, ValueError):
+                    pass
+
+    return exit_code
 
 
 def _main(argv: list[str] | None = None) -> int:
     """Module entrypoint for ``python -m research_agent.daemon <job_id>``.
 
-    Wires up the PID-file cleanup, signal handlers, and then runs the
-    research loop via :func:`run_daemon`. Exits 0 on clean shutdown
-    (including SIGTERM/SIGINT), 1 on an unhandled exception, 2 on usage.
+    Wires up the PID-file cleanup, then runs :func:`run_daemon` (which
+    installs its own signal handlers via the asyncio loop). Surfaces the
+    exit code from :func:`run_daemon`: ``0`` on graceful shutdown,
+    ``1`` on an uncaught exception, ``2`` on usage error.
     """
     argv = list(sys.argv if argv is None else argv)
     if len(argv) < 2:
@@ -205,28 +565,29 @@ def _main(argv: list[str] | None = None) -> int:
         return 2
 
     job_id = argv[1]
-    jobs_root = Path(DEFAULT_JOBS_ROOT)
+    jobs_root_env = os.environ.get("RESEARCH_JOBS_ROOT")
+    jobs_root = Path(jobs_root_env) if jobs_root_env else Path(DEFAULT_JOBS_ROOT)
+    db_path = _resolve_db_path()
 
     atexit.register(_remove_pid_file, jobs_root, job_id)
 
-    handler = _make_signal_handler()
-    signal.signal(signal.SIGTERM, handler)
-    signal.signal(signal.SIGINT, handler)
-
     try:
-        asyncio.run(run_daemon(job_id, jobs_root=jobs_root))
+        return asyncio.run(run_daemon(job_id, jobs_root=jobs_root, db_path=db_path))
     except KeyboardInterrupt:
-        # SIGTERM/SIGINT handlers re-raise as KeyboardInterrupt; that's a
-        # graceful shutdown per §5.2.
+        # The asyncio signal handler turns SIGINT into a graceful stop, but
+        # if the handler couldn't be installed (e.g. running on Windows) the
+        # default SIGINT behavior raises here. Treat as graceful so the PID
+        # file is still cleaned up.
         return 0
     except Exception:
         logger.exception("daemon crashed for job %s", job_id)
         return 1
-    return 0
 
 
 __all__ = [
     "DEFAULT_JOBS_ROOT",
+    "ensure_lm_studio_alive",
+    "ensure_openrouter_reachable",
     "is_daemon_alive",
     "run_daemon",
     "spawn_daemon",

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,31 +1,42 @@
-"""Tests for ``daemon.spawn_daemon`` / ``is_daemon_alive`` / module entrypoint.
+"""Tests for ``research_agent.daemon`` — spawn lifecycle + main loop (issues #32, #33).
 
-These tests exercise the §5.1 contract from the implementation guide:
+These tests exercise the §5.1 + §6.1 contract from the implementation guide:
 
 * ``spawn_daemon`` launches a detached child via ``Popen(start_new_session=True)``,
   redirects stdout/stderr to ``daemon.{out,err}.log``, and writes the PID to
   ``daemon.pid`` atomically.
 * ``is_daemon_alive`` reads the PID file and confirms the process exists. It
   returns ``False`` for missing files, garbage contents, and dead PIDs.
+* ``run_daemon`` is the long-running coroutine: loads the job, builds the
+  router, runs the orchestrator loop with signal handlers + STOP watcher,
+  calls a final synthesis pass, and writes ``status=completed/stopped/failed``
+  on the way out.
 * The ``python -m research_agent.daemon <id>`` entrypoint cleans up the PID
-  file on a graceful exit (atexit).
-
-Tests rely on the ``run_daemon`` stub-warning fast path — issue #33 owns the
-real loop, so the child currently logs and returns within milliseconds. That
-makes the suite fast without monkeypatching across the process boundary.
+  file on exit (atexit) regardless of the path taken.
 """
 
 from __future__ import annotations
 
+import asyncio
 import os
+import signal
 import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from research_agent import daemon
+from research_agent.orchestrator.plan import Plan, Subgoal, TaskSpec
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+from research_agent.storage.markdown import write_plan
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -48,7 +59,39 @@ def jobs_root(job_root: Path) -> Path:
     return job_root.parent
 
 
-def _wait_for_proc_exit(pid: int, timeout: float = 5.0) -> None:
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    """Migrated SQLite at a known tmp path for the run-daemon tests."""
+    path = tmp_path / "index.sqlite"
+    db.migrate(path=path).close()
+    return path
+
+
+@pytest.fixture
+def jobs_root_for_run(tmp_path: Path) -> Path:
+    return tmp_path / "jobs"
+
+
+@pytest.fixture
+def seeded_job(jobs_root_for_run: Path, db_path: Path) -> Job:
+    """Job + persisted plan, ready for ``run_daemon`` to drain."""
+    job = Job.create(
+        {"goal": "Investigate Widget Co", "budget_cap_usd": None},
+        jobs_root=jobs_root_for_run,
+        db_path=db_path,
+    )
+    plan = Plan(
+        version=1,
+        objective="Investigate the target",
+        subgoals=[Subgoal(id=1, description="Gather", done=False)],
+        task_template=[TaskSpec(kind="web_search")],
+        expected_iterations=3,
+    )
+    write_plan(job, plan.model_dump())
+    return job
+
+
+def _wait_for_proc_exit(pid: int, timeout: float = 10.0) -> None:
     """Wait for ``pid`` to exit and reap the zombie.
 
     ``spawn_daemon`` does not double-fork (per §5.1's "simple, portable" choice
@@ -204,12 +247,14 @@ def test_is_daemon_alive_true_after_spawn_daemon(jobs_root: Path, job_id: str) -
 
 
 # ---------------------------------------------------------------------------
-# Module entrypoint: clean shutdown removes daemon.pid
+# Module entrypoint
 # ---------------------------------------------------------------------------
 
 
-def test_module_entrypoint_clean_shutdown_removes_pid_file(jobs_root: Path, job_id: str) -> None:
-    """``python -m research_agent.daemon <id>`` deletes the PID file on exit."""
+def test_module_entrypoint_unknown_job_exits_one_and_clears_pid(
+    jobs_root: Path, job_id: str
+) -> None:
+    """An unknown job id is a fatal startup error: returncode 1, PID file removed."""
     pid_file = jobs_root / job_id / "daemon.pid"
     pid_file.write_text("12345\n", encoding="utf-8")
     assert pid_file.exists()
@@ -220,25 +265,12 @@ def test_module_entrypoint_clean_shutdown_removes_pid_file(jobs_root: Path, job_
         capture_output=True,
         text=True,
         timeout=30,
+        env={**os.environ, "RESEARCH_JOBS_ROOT": str(jobs_root)},
     )
-    assert proc.returncode == 0, f"stderr={proc.stderr}"
-    assert not pid_file.exists(), "atexit hook must remove daemon.pid on graceful exit"
-
-
-def test_module_entrypoint_logs_stub_warning(jobs_root: Path, job_id: str) -> None:
-    """Stub fast path emits the warning so future operators know why nothing ran."""
-    proc = subprocess.run(
-        [sys.executable, "-m", "research_agent.daemon", job_id],
-        cwd=jobs_root.parent,
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    assert proc.returncode == 0
-    # Python logging.warning() goes to stderr by default.
-    combined = proc.stdout + proc.stderr
-    assert "daemon entrypoint stub" in combined
-    assert "issue #33" in combined
+    # Job folder lacks job.json → Job.load raises FileNotFoundError → exit 1.
+    assert proc.returncode == 1, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    # atexit must still fire and unlink the (test-seeded) PID file.
+    assert not pid_file.exists(), "atexit hook must remove daemon.pid even on exit 1"
 
 
 def test_module_entrypoint_usage_when_missing_args() -> None:
@@ -250,3 +282,304 @@ def test_module_entrypoint_usage_when_missing_args() -> None:
     )
     assert proc.returncode == 2
     assert "usage" in proc.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# run_daemon: graceful path via STOP flag (no real LLM calls)
+# ---------------------------------------------------------------------------
+
+
+def _patch_run_daemon_for_in_process(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    run_loop_impl: Any,
+) -> dict[str, list[tuple[Any, ...]]]:
+    """Stub out the LLM-touching pieces of ``run_daemon`` for in-process tests.
+
+    Returns a dict of recorded calls so each test can assert what fired.
+    """
+    monkeypatch.setenv("RESEARCH_DAEMON_SKIP_HEALTH_CHECKS", "1")
+
+    calls: dict[str, list[tuple[Any, ...]]] = {"final_synthesis": [], "run_loop": []}
+
+    async def _wrapped_run_loop(job: Job, router: Any, **kwargs: Any) -> Any:
+        calls["run_loop"].append((job.id,))
+        return await run_loop_impl(job, router, **kwargs)
+
+    async def _final_synth_stub(job: Job, plan: Plan, *, router: Any) -> None:
+        calls["final_synthesis"].append((job.id, plan.version))
+        return None
+
+    monkeypatch.setattr(
+        "research_agent.orchestrator.loop.run_loop",
+        _wrapped_run_loop,
+    )
+    monkeypatch.setattr(
+        "research_agent.orchestrator.synth.final_synthesis",
+        _final_synth_stub,
+    )
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_stops_on_stop_flag(
+    seeded_job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An externally-dropped STOP flag triggers a clean shutdown with status=stopped."""
+
+    async def _waiting_run_loop(job: Job, router: Any, **kwargs: Any) -> dict[str, Any]:
+        # Mimic the real run_loop's STOP poll: spin until the flag exists.
+        for _ in range(200):
+            if (job.root / "STOP").exists():
+                return {"tasks_done": 0, "stopped": True, "completed": False, "cap_hit": False}
+            await asyncio.sleep(0.02)
+        return {"tasks_done": 0, "stopped": False, "completed": False, "cap_hit": False}
+
+    calls = _patch_run_daemon_for_in_process(monkeypatch, run_loop_impl=_waiting_run_loop)
+
+    async def _drop_stop() -> None:
+        await asyncio.sleep(0.1)
+        (seeded_job.root / "STOP").write_text("", encoding="utf-8")
+
+    drop_task = asyncio.create_task(_drop_stop())
+    exit_code = await daemon.run_daemon(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    await drop_task
+
+    assert exit_code == 0
+    assert calls["run_loop"], "run_loop must have been called"
+    assert calls["final_synthesis"], "final_synthesis must run after a stop"
+
+    refreshed = Job.load(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    assert refreshed.status == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_sigterm_routes_through_same_graceful_path(
+    seeded_job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SIGTERM must flip the in-memory event AND touch STOP so the loop bails."""
+
+    async def _waiting_run_loop(job: Job, router: Any, **kwargs: Any) -> dict[str, Any]:
+        for _ in range(200):
+            if (job.root / "STOP").exists():
+                return {"tasks_done": 0, "stopped": True, "completed": False, "cap_hit": False}
+            await asyncio.sleep(0.02)
+        return {"tasks_done": 0, "stopped": False, "completed": False, "cap_hit": False}
+
+    calls = _patch_run_daemon_for_in_process(monkeypatch, run_loop_impl=_waiting_run_loop)
+
+    async def _send_sigterm() -> None:
+        await asyncio.sleep(0.1)
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    sig_task = asyncio.create_task(_send_sigterm())
+    exit_code = await daemon.run_daemon(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    await sig_task
+
+    assert exit_code == 0
+    assert (seeded_job.root / "STOP").exists(), "signal handler must touch STOP"
+    assert calls["final_synthesis"], "final_synthesis must run after SIGTERM"
+
+    refreshed = Job.load(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    assert refreshed.status == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_completed_status_when_plan_is_complete(
+    seeded_job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When run_loop returns and plan.is_complete(), status flips to completed."""
+
+    async def _instant_run_loop(job: Job, router: Any, **kwargs: Any) -> dict[str, Any]:
+        # Mark every subgoal done so the post-loop ``plan.is_complete()`` is True.
+        plan_dump = {
+            "version": 2,
+            "objective": "Investigate the target",
+            "subgoals": [{"id": 1, "description": "Gather", "done": True}],
+            "task_template": [{"kind": "web_search"}],
+            "expected_iterations": 3,
+        }
+        write_plan(job, plan_dump)
+        return {"tasks_done": 1, "stopped": False, "completed": True, "cap_hit": False}
+
+    _patch_run_daemon_for_in_process(monkeypatch, run_loop_impl=_instant_run_loop)
+
+    exit_code = await daemon.run_daemon(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    assert exit_code == 0
+
+    refreshed = Job.load(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    assert refreshed.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_uncaught_exception_marks_failed(
+    seeded_job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bubbling exceptions from run_loop produce status=failed + an error event."""
+
+    async def _crashing_run_loop(job: Job, router: Any, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("planner explosion")
+
+    _patch_run_daemon_for_in_process(monkeypatch, run_loop_impl=_crashing_run_loop)
+
+    exit_code = await daemon.run_daemon(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    assert exit_code == 1
+
+    refreshed = Job.load(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    assert refreshed.status == "failed"
+
+    conn = db.connect(seeded_job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT level, kind, payload_json FROM events WHERE job_id = ? AND kind = 'error'",
+            (seeded_job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows, "an error event must be emitted on uncaught exception"
+    payload = rows[-1]["payload_json"]
+    assert "planner explosion" in payload
+    assert "Traceback" in payload, "traceback must be captured in the error payload"
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_health_check_failure_exits_one(
+    seeded_job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreachable LM Studio at startup → status=failed, exit 1."""
+    monkeypatch.delenv("RESEARCH_DAEMON_SKIP_HEALTH_CHECKS", raising=False)
+
+    async def _fast_fail_lm(router: Any, *, deadline_s: float = 60.0) -> None:
+        raise RuntimeError("lm_studio not reachable: connection refused")
+
+    async def _ok_openrouter(router: Any, *, deadline_s: float = 60.0) -> None:
+        return None
+
+    monkeypatch.setattr(daemon, "ensure_lm_studio_alive", _fast_fail_lm)
+    monkeypatch.setattr(daemon, "ensure_openrouter_reachable", _ok_openrouter)
+
+    exit_code = await daemon.run_daemon(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    assert exit_code == 1
+
+    refreshed = Job.load(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    assert refreshed.status == "failed"
+
+
+# ---------------------------------------------------------------------------
+# Health-check helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_lm_studio_alive_succeeds_immediately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One successful probe must short-circuit the retry loop."""
+
+    class _OkResp:
+        def raise_for_status(self) -> None:
+            return None
+
+    class _OkClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _OkClient:
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+        async def get(self, url: str, **kwargs: Any) -> _OkResp:
+            return _OkResp()
+
+    monkeypatch.setattr(daemon.httpx, "AsyncClient", _OkClient)
+
+    class _StubRouter:
+        job = None
+
+    await daemon.ensure_lm_studio_alive(_StubRouter(), deadline_s=1.0)
+
+
+@pytest.mark.asyncio
+async def test_ensure_lm_studio_alive_raises_on_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Persistent failures must raise RuntimeError once the deadline expires."""
+
+    class _BadClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _BadClient:
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+        async def get(self, url: str, **kwargs: Any) -> Any:
+            raise ConnectionError("nope")
+
+    monkeypatch.setattr(daemon.httpx, "AsyncClient", _BadClient)
+    # Compress the backoff so the test finishes fast.
+    monkeypatch.setattr(daemon, "_HEALTH_INITIAL_DELAY_S", 0.01)
+    monkeypatch.setattr(daemon, "_HEALTH_MAX_DELAY_S", 0.02)
+
+    class _StubRouter:
+        job = None
+
+    with pytest.raises(RuntimeError, match="lm_studio not reachable"):
+        await daemon.ensure_lm_studio_alive(_StubRouter(), deadline_s=0.05)
+
+
+@pytest.mark.asyncio
+async def test_ensure_openrouter_reachable_requires_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    class _StubRouter:
+        job = None
+
+    with pytest.raises(RuntimeError, match="OPENROUTER_API_KEY"):
+        await daemon.ensure_openrouter_reachable(_StubRouter(), deadline_s=1.0)


### PR DESCRIPTION
Closes #33

## Summary

Automated implementation of **Daemon main loop with signal handlers + STOP flag watcher**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

All acceptance criteria met: run_daemon loads job, installs SIGTERM/SIGINT handlers wired to a shared asyncio.Event + atomic STOP write, runs the 2s STOP watcher, drives run_loop, calls final_synthesis best-effort, writes status=completed/stopped/failed, and exits 0/1 with PID-file cleanup via atexit. 60s health-check retry deadlines for LM Studio and OpenRouter are correctly configured. 21 daemon tests + 570 total tests pass.

- **INFO** [OPEN] `src/research_agent/daemon.py`: _retry_until catches BaseException, which would swallow asyncio.CancelledError or KeyboardInterrupt during health-check retries. In practice nothing cancels the health-check coroutines (they run before signal handlers are installed), so there is no observable impact, but tightening to `except Exception` would be more idiomatic.
- **INFO** [OPEN] `src/research_agent/daemon.py`: run_daemon reaches into the orchestrator's private _load_latest_plan helper to grab the plan for final_synthesis. Works fine and is the simplest path; if the loop module ever moves the helper, the daemon will need updating.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*