### PR TITLE
feat: OpenRouter network blip handling (tenacity backoff) (closes #37)

### DIFF
--- a/src/research_agent/llm/router.py
+++ b/src/research_agent/llm/router.py
@@ -32,11 +32,19 @@ import time
 from pathlib import Path
 from typing import Any, Literal
 
+import httpx
+import openai
 import yaml  # type: ignore[import-untyped]
 from openai import RateLimitError
 from pydantic_ai import Agent
 from pydantic_ai.models.openai import OpenAIModel
 from pydantic_ai.providers.openai import OpenAIProvider
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception,
+    stop_after_delay,
+    wait_exponential,
+)
 
 from research_agent.config import get as cfg_get
 from research_agent.observability.events import emit
@@ -79,6 +87,39 @@ LMSTUDIO_RETRY_SLEEP_S = 5.0
 # timeouts. Within this window calls reroute to the configured ``fallback_tier``
 # instead of hitting LM Studio again.
 LMSTUDIO_DEGRADED_WINDOW_S = 600.0
+
+# OpenRouter network-blip backoff (§6.3 #2): exponential backoff between
+# attempts (1s, 2s, 4s, 8s, 16s, 30s, 60s, 60s, …) capped at
+# ``OPENROUTER_RETRY_MAX_DELAY`` and giving up after
+# ``OPENROUTER_RETRY_STOP_DELAY`` total seconds. Per-instance overrides on
+# :class:`Router` let tests collapse these to zero.
+OPENROUTER_RETRY_MIN_DELAY = 1.0
+OPENROUTER_RETRY_MAX_DELAY = 60.0
+OPENROUTER_RETRY_STOP_DELAY = 120.0
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    """True for transient OpenRouter failures: 5xx, 429, network, httpx timeout.
+
+    Matches the §6.3 "network blip" contract: 4xx other than 429 (bad request,
+    auth, permission, not found, unprocessable) are immediate failures.
+    Distinguishes by inspecting :attr:`openai.APIStatusError.status_code`
+    rather than the concrete subclass so any future provider 5xx still
+    qualifies and any new 4xx subclass still doesn't.
+    """
+    if isinstance(exc, RateLimitError):
+        return True
+    if isinstance(exc, openai.APIConnectionError):
+        return True
+    if isinstance(exc, openai.APIStatusError):
+        try:
+            status = int(getattr(exc, "status_code", 0) or 0)
+        except (TypeError, ValueError):
+            return False
+        return status >= 500
+    if isinstance(exc, (httpx.NetworkError, httpx.TimeoutException)):
+        return True
+    return False
 
 
 def load_models_config(path: Path | str = "config/models.yaml") -> dict[str, Any]:
@@ -286,6 +327,11 @@ class Router:
         # monkeypatching the global asyncio loop.
         self.retry_sleep_s: float = LMSTUDIO_RETRY_SLEEP_S
         self.degraded_window_s: float = LMSTUDIO_DEGRADED_WINDOW_S
+        # Per-instance OpenRouter retry knobs — tests collapse to 0 to avoid
+        # actually waiting two minutes when simulating retry exhaustion.
+        self.openrouter_retry_min_delay: float = OPENROUTER_RETRY_MIN_DELAY
+        self.openrouter_retry_max_delay: float = OPENROUTER_RETRY_MAX_DELAY
+        self.openrouter_retry_stop_delay: float = OPENROUTER_RETRY_STOP_DELAY
 
     # ---- Provider wiring ---------------------------------------------------
 
@@ -410,13 +456,16 @@ class Router:
 
         t0 = time.perf_counter()
         try:
-            result = await self._run_with_timeout(agent, timeout_s, args, kwargs)
+            if is_cloud:
+                result = await self._run_openrouter_with_retry(agent, args, kwargs, timeout_s)
+            else:
+                result = await self._run_with_timeout(agent, timeout_s, args, kwargs)
         except RateLimitError:
             fallback_model = spec.get("fallback_model")
             if not (is_cloud and fallback_model):
                 raise
             fallback_agent = self._make_fallback_agent(tier, fallback_model)
-            result = await self._run_with_timeout(fallback_agent, timeout_s, args, kwargs)
+            result = await self._run_openrouter_with_retry(fallback_agent, args, kwargs, timeout_s)
             fallback_used = True
             model_name = fallback_model
         except TimeoutError:
@@ -505,6 +554,36 @@ class Router:
         if timeout_s is None:
             return await agent.run(*args, **kwargs)
         return await asyncio.wait_for(agent.run(*args, **kwargs), timeout=timeout_s)
+
+    async def _run_openrouter_with_retry(
+        self,
+        agent: Any,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        timeout_s: float | None,
+    ) -> Any:
+        """Run the cloud call with §6.3 exponential backoff on transient errors.
+
+        Retries on 5xx, 429, network errors, and httpx timeouts up to
+        ``openrouter_retry_stop_delay`` total seconds; non-retryable 4xx
+        propagate immediately. ``reraise=True`` surfaces the original
+        exception (not :class:`tenacity.RetryError`) so the caller's
+        ``except RateLimitError`` fallback path keeps working unchanged.
+        """
+        result: Any = None
+        async for attempt in AsyncRetrying(
+            wait=wait_exponential(
+                multiplier=1,
+                min=self.openrouter_retry_min_delay,
+                max=max(self.openrouter_retry_max_delay, self.openrouter_retry_min_delay),
+            ),
+            stop=stop_after_delay(self.openrouter_retry_stop_delay),
+            retry=retry_if_exception(_is_retryable),
+            reraise=True,
+        ):
+            with attempt:
+                result = await self._run_with_timeout(agent, timeout_s, args, kwargs)
+        return result
 
     async def _reroute_to_fallback_tier(
         self,
@@ -687,6 +766,8 @@ __all__ = [
     "LMSTUDIO_DEGRADED_WINDOW_S",
     "LMSTUDIO_RETRY_SLEEP_S",
     "OPENROUTER_BASE_URL",
+    "OPENROUTER_RETRY_MAX_DELAY",
+    "OPENROUTER_RETRY_STOP_DELAY",
     "Router",
     "Tier",
     "load_models_config",

--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -38,6 +38,7 @@ EventKind = Literal[
     "plan_created",
     "synthesis_done",
     "synthesis_written",
+    "synthesis_failed",
     "critique_done",
     "critique_written",
     "replan_triggered",

--- a/src/research_agent/orchestrator/synth.py
+++ b/src/research_agent/orchestrator/synth.py
@@ -39,7 +39,11 @@ from research_agent.llm.budgets import BudgetExceeded
 from research_agent.observability.events import emit
 from research_agent.prompts.loader import load_prompt
 from research_agent.storage import db
-from research_agent.storage.markdown import write_report, write_synthesis
+from research_agent.storage.markdown import (
+    write_report,
+    write_synthesis,
+    write_synthesis_partial,
+)
 
 if TYPE_CHECKING:
     from research_agent.llm.router import Router
@@ -277,6 +281,12 @@ async def _do_synthesis(
                 {"stage": fallback_tier, "error": str(exc2), "budget_capped": True},
             )
             return _write_stub_output(job)
+        except Exception as exc2:  # noqa: BLE001 — terminal retry exhaustion
+            logger.warning("synth: %s tier failed after retries: %s", fallback_tier, exc2)
+            return _write_failed_output(job, tier=fallback_tier, exc=exc2, attempt_count=2)
+    except Exception as exc:  # noqa: BLE001 — terminal retry exhaustion
+        logger.warning("synth: %s tier failed after retries: %s", primary_tier, exc)
+        return _write_failed_output(job, tier=primary_tier, exc=exc, attempt_count=1)
 
     cost = getattr(router.budget, "last_cost", None)
     cost_val: float | None = float(cost) if isinstance(cost, (int, float)) else None
@@ -306,6 +316,45 @@ async def _do_synthesis(
         cost_usd=cost_val,
         report_path=str(report_path),
         truncated=False,
+    )
+
+
+def _write_failed_output(
+    job: Job,
+    *,
+    tier: str,
+    exc: BaseException,
+    attempt_count: int,
+    partial_content: str = "",
+) -> SynthesisOutput:
+    """Persist whatever content we managed to assemble + emit ``synthesis_failed``.
+
+    The current call path is non-streaming so ``partial_content`` is "" — the
+    file is still written so the next attempt can spot it as prior context.
+    Returns a degraded :class:`SynthesisOutput` (``model='synthesis_failed'``,
+    ``truncated=True``) so callers don't have to thread an exception type.
+    """
+    partial_version = write_synthesis_partial(job, partial_content, model="synthesis_failed")
+    partial_path = job.root / f"synthesis/{partial_version:04d}.partial.md"
+    emit(
+        job,
+        "ERROR",
+        "synth",
+        "synthesis_failed",
+        {
+            "tier": tier,
+            "reason": str(exc),
+            "attempt_count": attempt_count,
+            "partial_path": str(partial_path),
+        },
+    )
+    return SynthesisOutput(
+        version=partial_version,
+        content=partial_content,
+        model="synthesis_failed",
+        cost_usd=None,
+        report_path=str(partial_path),
+        truncated=True,
     )
 
 

--- a/src/research_agent/storage/markdown.py
+++ b/src/research_agent/storage/markdown.py
@@ -260,6 +260,32 @@ def write_synthesis(
     return version
 
 
+def write_synthesis_partial(job: Job, content: str, model: str) -> int:
+    """Write ``synthesis/<next_version>.partial.md`` for a failed synthesis.
+
+    Used when a synthesis call exhausts retries: the (possibly empty) partial
+    output is salvaged so the next attempt can include it as context. No DB
+    row and no JSON sidecar are written — the partial file lives outside the
+    canonical ``syntheses`` table on purpose so a future successful run can
+    claim the same version number.
+    """
+    if not isinstance(content, str):
+        raise ValueError(f"content must be a string; got {type(content).__name__}")
+    if not isinstance(model, str) or not model:
+        raise ValueError("model must be a non-empty string")
+
+    conn = db.connect(job.db_path)
+    try:
+        version = _next_version(conn, "syntheses", job.id)
+    finally:
+        conn.close()
+
+    md_rel = f"synthesis/{version:04d}.partial.md"
+    md_body = content if (not content or content.endswith("\n")) else content + "\n"
+    _atomic_write_text(job.root / md_rel, md_body)
+    return version
+
+
 def write_critique(
     job: Job,
     *,
@@ -366,4 +392,5 @@ __all__ = [
     "write_plan",
     "write_report",
     "write_synthesis",
+    "write_synthesis_partial",
 ]

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import httpx
+import openai
 import pytest
 import yaml
 from openai import RateLimitError
@@ -18,6 +19,7 @@ from research_agent.llm.router import (
     LMSTUDIO_DEFAULT_BASE_URL,
     OPENROUTER_BASE_URL,
     Router,
+    _is_retryable,
     load_models_config,
 )
 from research_agent.storage import db
@@ -79,7 +81,13 @@ def make_router(models_config: dict[str, Any], db_path: Path):
                 db_path=db_path,
             )
         )
-        return Router(models_config, b, job=job, db_path=db_path)
+        router = Router(models_config, b, job=job, db_path=db_path)
+        # Default tests off the OpenRouter retry loop so transient failure
+        # tests don't burn two minutes of wall clock per attempt.
+        router.openrouter_retry_min_delay = 0.0
+        router.openrouter_retry_max_delay = 0.0
+        router.openrouter_retry_stop_delay = 0.0
+        return router
 
     return _factory
 
@@ -403,6 +411,11 @@ async def test_ratelimit_falls_back_to_fallback_model_for_cloud(
         db_path=db_path,
     )
     router = Router(models_config, budget, job=job, db_path=db_path)
+    # Disable the OpenRouter retry loop so the rate-limit fallback test
+    # doesn't loop for two minutes before the fallback_model path runs.
+    router.openrouter_retry_min_delay = 0.0
+    router.openrouter_retry_max_delay = 0.0
+    router.openrouter_retry_stop_delay = 0.0
 
     fallback_agent = _FakeAgent(result=_FakeResult())
     monkeypatch.setattr(
@@ -914,6 +927,12 @@ def _make_lmstudio_router(
     budget = _RecordingBudget(cost_per_call=0.42, db_path=db_path, job_id=job.id)
     router = Router(cfg, budget, job=job, db_path=db_path)  # type: ignore[arg-type]
     router.retry_sleep_s = 0.0
+    # Reroute target is a cloud tier — keep its retry loop short so a
+    # transient cloud failure inside a degrade-and-reroute test doesn't
+    # stall for two minutes.
+    router.openrouter_retry_min_delay = 0.0
+    router.openrouter_retry_max_delay = 0.0
+    router.openrouter_retry_stop_delay = 0.0
     return router, budget
 
 
@@ -1086,3 +1105,198 @@ async def test_first_timeout_then_retry_succeeds_does_not_degrade(
     assert "fast" not in router._tier_degraded_until
     assert _read_events_by_kind(job, "lmstudio_degraded") == []
     assert _read_events_by_kind(job, "lmstudio_rerouted") == []
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter network-blip handling (#37)
+# ---------------------------------------------------------------------------
+
+
+def _api_status_error(status: int) -> openai.APIStatusError:
+    request = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+    response = httpx.Response(status, request=request)
+    return openai.APIStatusError("boom", response=response, body=None)
+
+
+def _bad_request_error() -> openai.BadRequestError:
+    request = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+    response = httpx.Response(400, request=request)
+    return openai.BadRequestError("bad request", response=response, body=None)
+
+
+def _api_connection_error() -> openai.APIConnectionError:
+    request = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+    return openai.APIConnectionError(request=request)
+
+
+def _fast_retry_router(
+    models_config: dict[str, Any],
+    db_path: Path,
+    job: Job,
+) -> tuple[Router, _RecordingBudget]:
+    """Build a router with retry collapsed to ~zero so retry tests are <1s."""
+    budget = _RecordingBudget(cost_per_call=0.0, db_path=db_path, job_id=job.id)
+    router = Router(models_config, budget, job=job, db_path=db_path)  # type: ignore[arg-type]
+    # Allow several retries inside a tight wall-clock window so tests can
+    # observe the loop iterating without actually waiting.
+    router.openrouter_retry_min_delay = 0.0
+    router.openrouter_retry_max_delay = 0.0
+    router.openrouter_retry_stop_delay = 0.5
+    return router, budget
+
+
+def test_is_retryable_classifies_transient_vs_terminal() -> None:
+    # Transient — should retry.
+    assert _is_retryable(_rate_limit_error()) is True
+    assert _is_retryable(_api_status_error(503)) is True
+    assert _is_retryable(_api_status_error(500)) is True
+    assert _is_retryable(_api_connection_error()) is True
+    assert _is_retryable(httpx.ConnectError("nope")) is True
+    assert _is_retryable(httpx.ReadTimeout("slow")) is True
+
+    # Terminal — must not retry.
+    assert _is_retryable(_bad_request_error()) is False
+    assert _is_retryable(_api_status_error(404)) is False
+    assert _is_retryable(_api_status_error(401)) is False
+    assert _is_retryable(_api_status_error(422)) is False
+    assert _is_retryable(RuntimeError("nope")) is False
+
+
+@pytest.mark.asyncio
+async def test_openrouter_retries_on_connect_error_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+    models_config: dict[str, Any],
+    db_path: Path,
+    job: Job,
+) -> None:
+    """Two transient httpx.ConnectError followed by success → one charged call."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    router, budget = _fast_retry_router(models_config, db_path, job)
+
+    agent = _FakeAgent(
+        result=_FakeResult(),
+        raises=[httpx.ConnectError("blip 1"), httpx.ConnectError("blip 2")],
+    )
+    result = await router.call("frontier_speed", agent, "summarize")
+
+    assert result is agent.result
+    # Three .run() invocations: two failures + one success.
+    assert len(agent.calls) == 3
+    # Single ledger row for the eventual success (no charge for failed attempts).
+    assert len(budget.charge_calls) == 1
+
+    llm_calls = _read_events_by_kind(job, "llm_call")
+    assert len(llm_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_openrouter_retries_on_503_until_stop_delay(
+    monkeypatch: pytest.MonkeyPatch,
+    models_config: dict[str, Any],
+    db_path: Path,
+    job: Job,
+) -> None:
+    """Continuous 503s → retry until stop_after_delay fires, then APIStatusError propagates."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    router, budget = _fast_retry_router(models_config, db_path, job)
+
+    class _Always503Agent:
+        """Pydantic AI agent stand-in that always raises an APIStatusError(503)."""
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def run(self, *args: Any, **kwargs: Any) -> Any:
+            self.calls += 1
+            raise _api_status_error(503)
+
+    agent = _Always503Agent()
+    with pytest.raises(openai.APIStatusError) as excinfo:
+        await router.call("frontier_speed", agent, "summarize")
+    assert excinfo.value.status_code == 503
+
+    # The loop must have actually retried (otherwise we'd have a single
+    # attempt and the retry contract isn't met).
+    assert agent.calls >= 2
+    # No success → no charge, no llm_call event.
+    assert budget.charge_calls == []
+    assert _read_events_by_kind(job, "llm_call") == []
+
+
+@pytest.mark.asyncio
+async def test_openrouter_retries_on_rate_limit_until_fallback_kicks_in(
+    monkeypatch: pytest.MonkeyPatch,
+    models_config: dict[str, Any],
+    db_path: Path,
+    job: Job,
+) -> None:
+    """RateLimitError survives retries, then the fallback_model branch runs once."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    router, budget = _fast_retry_router(models_config, db_path, job)
+
+    # Override fallback_model construction so we can observe a single call on it.
+    fallback_agent = _FakeAgent(result=_FakeResult(output="fb"))
+    monkeypatch.setattr(router, "_make_fallback_agent", lambda *_a, **_k: fallback_agent)
+
+    class _AlwaysRateLimitedAgent:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def run(self, *args: Any, **kwargs: Any) -> Any:
+            self.calls += 1
+            raise _rate_limit_error()
+
+    primary = _AlwaysRateLimitedAgent()
+    result = await router.call("frontier", primary, "synthesize")
+
+    assert result is fallback_agent.result
+    # Primary was retried at least twice (proves the retry loop ran) before
+    # the stop_delay fired and the fallback path kicked in.
+    assert primary.calls >= 2
+    assert len(fallback_agent.calls) == 1
+    # Fallback charged exactly once.
+    assert len(budget.charge_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_openrouter_does_not_retry_on_bad_request(
+    monkeypatch: pytest.MonkeyPatch,
+    models_config: dict[str, Any],
+    db_path: Path,
+    job: Job,
+) -> None:
+    """A 400 BadRequestError is terminal — propagates after a single attempt."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    router, budget = _fast_retry_router(models_config, db_path, job)
+
+    agent = _FakeAgent(raises=[_bad_request_error()])
+
+    with pytest.raises(openai.BadRequestError):
+        await router.call("frontier_speed", agent, "summarize")
+
+    # Exactly one attempt — no retry.
+    assert len(agent.calls) == 1
+    assert budget.charge_calls == []
+
+
+@pytest.mark.asyncio
+async def test_lmstudio_path_is_not_wrapped_in_openrouter_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    models_config: dict[str, Any],
+    db_path: Path,
+    job: Job,
+) -> None:
+    """A transient httpx error on a local tier must propagate (no cloud retry)."""
+    monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
+    router, budget = _fast_retry_router(models_config, db_path, job)
+
+    agent = _FakeAgent(raises=[httpx.ConnectError("local blip")])
+
+    with pytest.raises(httpx.ConnectError):
+        await router.call("general", agent, "x")
+
+    # Exactly one attempt — local-tier failures are not silently retried by
+    # the OpenRouter retry wrapper. The §16 rule is loud failures, not silent
+    # reroutes.
+    assert len(agent.calls) == 1
+    assert budget.charge_calls == []

--- a/tests/test_orchestrator_synth.py
+++ b/tests/test_orchestrator_synth.py
@@ -352,6 +352,45 @@ def test_final_synthesis_uses_larger_top_n_and_final_flag(
     assert len(payload["findings"]) <= FINAL_TOP_N
 
 
+def test_synthesize_retry_exhaustion_writes_partial_and_emits_failed(
+    job: Job, db_path: Path, plan: Plan
+) -> None:
+    """Terminal retry exhaustion → partial md + ``synthesis_failed`` ERROR event."""
+    _seed_findings(job, [0.6])
+    router = _StubRouter(
+        side_effect={
+            "frontier": [RuntimeError("openrouter: connection reset after 6 retries")],
+        },
+    )
+
+    out = asyncio.run(synthesize(job, plan, router=router))
+
+    # SynthesisOutput marks the failure shape so the loop can distinguish it.
+    assert out.truncated is True
+    assert out.model == "synthesis_failed"
+    assert out.cost_usd is None
+
+    # Partial md exists at the synthesis/<v>.partial.md path (no DB row written).
+    partial = job.root / f"synthesis/{out.version:04d}.partial.md"
+    assert partial.exists()
+    # Non-streaming call path — the partial is empty but its presence lets
+    # the next attempt know a prior failure happened.
+    assert partial.read_text(encoding="utf-8") == ""
+
+    rows = _read_synthesis_rows(db_path, job.id)
+    assert rows == [], "partial writes must not insert a syntheses row"
+
+    events = _read_event_rows(db_path, job.id)
+    failed = [e for e in events if e["kind"] == "synthesis_failed"]
+    assert len(failed) == 1
+    assert failed[0]["level"] == "ERROR"
+    payload = json.loads(failed[0]["payload_json"])
+    assert payload["tier"] == "frontier"
+    assert "connection reset" in payload["reason"]
+    assert payload["attempt_count"] == 1
+    assert payload["partial_path"].endswith(".partial.md")
+
+
 def test_synthesize_emits_synthesis_written_event(job: Job, db_path: Path, plan: Plan) -> None:
     _seed_findings(job, [0.8])
     router = _StubRouter()


### PR DESCRIPTION
Closes #37

## Summary

Automated implementation of **OpenRouter network blip handling (tenacity backoff)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Implementation of #37 meets all acceptance criteria: tenacity AsyncRetrying wraps every OpenRouter call (1s/2s/4s/8s/16s/30s/60s capped, stop_after_delay=120s), transient-vs-terminal classification is correct (5xx/429/network/timeout retried, other 4xx propagate immediately), synthesis exhaustion writes synthesis/<v>.partial.md and emits ERROR synthesis_failed event with reason+attempt_count+partial_path, and the lmstudio path is intentionally excluded from cloud retry. 594 tests pass.

- **INFO** [OPEN] `src/research_agent/orchestrator/synth.py`: Partial-as-context plumbing is half-built: write_synthesis_partial creates synthesis/<v>.partial.md, but _load_prior_synthesis only reads from the syntheses DB table so the next attempt does not actually pull the partial in as context. Currently moot because the call path is non-streaming and partial_content is always empty; the file exists as a marker. When streaming lands, _load_prior_synthesis will need a partial-aware variant.
- **INFO** [OPEN] `tests/test_llm_router.py`: Tests use _FakeAgent(raises=[...]) and direct openai.APIStatusError construction rather than httpx.MockTransport. Functionally exercises the same code paths and the same exception types specified in the AC (429/503/connection-reset), but is a style-only deviation from the literal 'httpx mock' wording in the issue.
- **INFO** [OPEN] `src/research_agent/orchestrator/loop.py`: When _write_failed_output returns a SynthesisOutput instead of raising, _maybe_run_heuristic in loop.py records checkpoint('synthesis_done', ...) even though the synthesis ERROR event was emitted. The synthesis_failed event is the canonical signal so downstream consumers can still distinguish success/failure, but the checkpoint name is now slightly misleading on the failure branch.
- **INFO** [OPEN] `src/research_agent/orchestrator/synth.py`: synthesis_failed payload's attempt_count counts tier attempts (1 = primary only, 2 = primary+fallback) rather than HTTP retry attempts. Field name could be more specific (e.g. tier_attempt_count) but it is an internal observability detail and is consistent across tests.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*