### PR TITLE
feat: Cost cap final-pass enforcement (closes #39)

### DIFF
--- a/src/research_agent/daemon.py
+++ b/src/research_agent/daemon.py
@@ -541,11 +541,34 @@ async def run_daemon(
     cap_bytes = max(1, int(disk_cap_gb * 1024 * 1024 * 1024))
     disk_cap_task = aloop.create_task(_disk_cap_watcher(job, cap_bytes, should_stop))
 
+    from research_agent.llm.budgets import BudgetExceeded
+
     exit_code = 0
     final_status = "stopped"
+    completion_reason: str | None = None
     try:
+        loop_result: dict[str, Any] | None = None
+        budget_capped = False
         try:
-            await _loop.run_loop(job, router)
+            loop_result = await _loop.run_loop(job, router)
+        except BudgetExceeded as exc:
+            logger.warning("daemon: budget cap reached mid-loop for job %s: %s", job.id, exc)
+            budget_capped = True
+            try:
+                emit(
+                    job,
+                    "WARN",
+                    "daemon",
+                    "warning",
+                    {
+                        "stage": "run_loop_budget_cap",
+                        "error": str(exc),
+                        "spent": getattr(exc, "spent", None),
+                        "cap": getattr(exc, "cap", None),
+                    },
+                )
+            except Exception:
+                pass
         except Exception as exc:
             logger.exception("daemon: run_loop crashed for job %s", job.id)
             try:
@@ -569,28 +592,58 @@ async def run_daemon(
             return 1
 
         plan = _loop._load_latest_plan(job)
-        try:
-            if plan is not None:
-                await _synth.final_synthesis(job, plan, router=router)
-        except Exception as exc:
-            logger.warning("daemon: final synthesis failed for job %s: %s", job.id, exc)
+        if budget_capped:
             try:
-                emit(
-                    job,
-                    "WARN",
-                    "daemon",
-                    "warning",
-                    {"stage": "final_synthesis", "error": str(exc)},
+                if plan is not None:
+                    await _synth.final_synthesis_after_cap(job, plan, router=router)
+            except Exception as exc:
+                logger.warning(
+                    "daemon: post-cap final synthesis failed for job %s: %s", job.id, exc
                 )
-            except Exception:
-                pass
-
-        if plan is not None and plan.is_complete():
+                try:
+                    emit(
+                        job,
+                        "WARN",
+                        "daemon",
+                        "warning",
+                        {"stage": "final_synthesis_after_cap", "error": str(exc)},
+                    )
+                except Exception:
+                    pass
             final_status = "completed"
+            completion_reason = "budget_cap"
         else:
-            final_status = "stopped"
+            try:
+                if plan is not None:
+                    await _synth.final_synthesis(job, plan, router=router)
+            except Exception as exc:
+                logger.warning("daemon: final synthesis failed for job %s: %s", job.id, exc)
+                try:
+                    emit(
+                        job,
+                        "WARN",
+                        "daemon",
+                        "warning",
+                        {"stage": "final_synthesis", "error": str(exc)},
+                    )
+                except Exception:
+                    pass
+
+            if _loop._should_stop(job):
+                final_status = "stopped"
+                completion_reason = "user_stopped"
+            elif loop_result is not None and loop_result.get("cap_hit"):
+                final_status = "completed"
+                completion_reason = "task_cap"
+            elif plan is not None and plan.is_complete():
+                final_status = "completed"
+                completion_reason = "goal_complete"
+            else:
+                final_status = "stopped"
+                completion_reason = "user_stopped"
+
         try:
-            job.set_status(final_status)
+            job.set_status(final_status, completion_reason=completion_reason)
         except Exception:
             logger.exception("daemon: failed to write final status for job %s", job.id)
     finally:

--- a/src/research_agent/orchestrator/synth.py
+++ b/src/research_agent/orchestrator/synth.py
@@ -388,6 +388,126 @@ def _write_stub_output(job: Job) -> SynthesisOutput:
     )
 
 
+def _confidence_bucket(conf: float) -> str:
+    if conf >= 0.8:
+        return "high"
+    if conf >= 0.5:
+        return "medium"
+    return "low"
+
+
+def _render_template_stub(
+    *,
+    goal: str,
+    findings: list[dict[str, Any]],
+    sources: dict[int, dict[str, Any]],
+) -> str:
+    """Render a no-LLM markdown report from on-disk findings + sources.
+
+    Used when even ``frontier_speed`` precheck blows the cap: every byte
+    here comes from the SQLite mirror, so the user always gets a readable
+    report.md even with $0 left in the budget.
+    """
+    lines: list[str] = [
+        "# Report (budget cap — template stub)",
+        "",
+        "Research budget cap was reached before any synthesis call could run.",
+        "This report is a template-rendered summary of the findings already on",
+        "disk; no LLM call was made.",
+        "",
+        "## Goal",
+        "",
+        goal.strip(),
+        "",
+        "## Findings",
+        "",
+    ]
+
+    if not findings:
+        lines.append("_No findings recorded before the cap was hit._")
+        lines.append("")
+    else:
+        buckets: dict[str, list[dict[str, Any]]] = {"high": [], "medium": [], "low": []}
+        for f in findings:
+            buckets[_confidence_bucket(float(f["confidence"]))].append(f)
+
+        for bucket_name in ("high", "medium", "low"):
+            bucket = buckets[bucket_name]
+            if not bucket:
+                continue
+            lines.append(f"### {bucket_name.capitalize()} confidence")
+            lines.append("")
+            for f in bucket:
+                sids = f.get("source_ids") or []
+                sids_str = (
+                    " (sources: " + ", ".join(f"#{sid}" for sid in sids) + ")" if sids else ""
+                )
+                lines.append(f"- {f['claim']}{sids_str}")
+            lines.append("")
+
+    lines.append("## Sources")
+    lines.append("")
+    if not sources:
+        lines.append("_No sources cited by the findings above._")
+        lines.append("")
+    else:
+        for sid in sorted(sources.keys()):
+            src = sources[sid]
+            title = src.get("title") or "(untitled)"
+            url = src.get("url") or "(no url)"
+            lines.append(f"- [{sid}] {title} — {url}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _write_template_stub_output(job: Job) -> SynthesisOutput:
+    """Build a markdown report from on-disk findings/sources — no LLM call.
+
+    Falls back to :data:`_BUDGET_STUB_REPORT` only when there are zero
+    findings, since rendering an empty bullet list isn't useful.
+    """
+    findings = _load_top_findings(job, FINAL_TOP_N)
+    sources = _load_sources_for(job, findings)
+
+    if not findings:
+        content = _BUDGET_STUB_REPORT
+    else:
+        content = _render_template_stub(
+            goal=job.goal,
+            findings=findings,
+            sources=sources,
+        )
+
+    version = write_synthesis(
+        job,
+        content,
+        model="budget_capped_template",
+        cost_usd=None,
+    )
+    report_path = write_report(job, content)
+    emit(
+        job,
+        "INFO",
+        "synth",
+        "synthesis_written",
+        {
+            "version": version,
+            "tier": "template_stub",
+            "truncated": True,
+            "report_path": str(report_path),
+        },
+    )
+    return SynthesisOutput(
+        version=version,
+        content=content,
+        model="budget_capped_template",
+        cost_usd=None,
+        report_path=str(report_path),
+        truncated=True,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Public entry points
 # ---------------------------------------------------------------------------
@@ -426,10 +546,88 @@ async def final_synthesis(job: Job, plan: Plan, *, router: Router) -> SynthesisO
     )
 
 
+async def final_synthesis_after_cap(
+    job: Job,
+    plan: Plan,  # noqa: ARG001 — plan reserved for future prompt context
+    *,
+    router: Router,
+) -> SynthesisOutput:
+    """Final-pass synthesis triggered after the loop hit the per-job budget cap.
+
+    The ``frontier`` tier is skipped: we already know the cap was tripped, so
+    going straight to ``frontier_speed`` saves the precheck overhead and any
+    misleading "fell back to fallback" event noise. If even ``frontier_speed``
+    blows the precheck (truly $0 left), :func:`_write_template_stub_output`
+    renders a report from on-disk findings without making any LLM call.
+    """
+    findings = _load_top_findings(job, FINAL_TOP_N)
+    sources = _load_sources_for(job, findings)
+    prior = _load_prior_synthesis(job)
+    critique = _load_latest_critique(job)
+
+    context = _build_context(
+        goal=job.goal,
+        findings=findings,
+        sources=sources,
+        prior=prior,
+        critique=critique,
+        final=True,
+    )
+
+    fallback_tier = "frontier_speed"
+    try:
+        content = await _run_synth(job, router, fallback_tier, context)
+    except BudgetExceeded as exc:
+        logger.warning("synth: budget exceeded on %s tier (post-cap): %s", fallback_tier, exc)
+        emit(
+            job,
+            "WARN",
+            "synth",
+            "warning",
+            {"stage": fallback_tier, "error": str(exc), "budget_capped": True},
+        )
+        return _write_template_stub_output(job)
+    except Exception as exc:  # noqa: BLE001 — terminal retry exhaustion
+        logger.warning("synth: %s tier failed after retries (post-cap): %s", fallback_tier, exc)
+        return _write_failed_output(job, tier=fallback_tier, exc=exc, attempt_count=1)
+
+    cost = getattr(router.budget, "last_cost", None)
+    cost_val: float | None = float(cost) if isinstance(cost, (int, float)) else None
+    model_name = _model_name_for(router, fallback_tier)
+
+    version = write_synthesis(job, content, model=model_name, cost_usd=cost_val)
+    synth_md = (job.root / f"synthesis/{version:04d}.md").read_text(encoding="utf-8")
+    report_path = write_report(job, synth_md)
+
+    emit(
+        job,
+        "INFO",
+        "synth",
+        "synthesis_written",
+        {
+            "version": version,
+            "tier": fallback_tier,
+            "truncated": False,
+            "report_path": str(report_path),
+            "post_cap": True,
+        },
+    )
+
+    return SynthesisOutput(
+        version=version,
+        content=content,
+        model=model_name,
+        cost_usd=cost_val,
+        report_path=str(report_path),
+        truncated=False,
+    )
+
+
 __all__ = [
     "FINAL_TOP_N",
     "SynthesisOutput",
     "TOP_N_FINDINGS",
     "final_synthesis",
+    "final_synthesis_after_cap",
     "synthesize",
 ]

--- a/src/research_agent/storage/db.py
+++ b/src/research_agent/storage/db.py
@@ -34,7 +34,8 @@ CREATE TABLE IF NOT EXISTS jobs (
     finished_at INTEGER,
     last_activity_at INTEGER,
     pid INTEGER,
-    cost_so_far_usd REAL DEFAULT 0
+    cost_so_far_usd REAL DEFAULT 0,
+    completion_reason TEXT
 );
 
 -- Plan versions
@@ -261,6 +262,22 @@ def _migrate_sources_md_path_nullable(conn: sqlite3.Connection) -> None:
     )
 
 
+def _migrate_jobs_completion_reason(conn: sqlite3.Connection) -> None:
+    """Add ``jobs.completion_reason`` to legacy DBs that predate issue #39.
+
+    ``ALTER TABLE jobs ADD COLUMN`` is the only safe way to add a nullable
+    column without rebuilding the table; this helper checks
+    ``PRAGMA table_info(jobs)`` first so it is idempotent. Runs inside the
+    caller's transaction.
+    """
+    cols = conn.execute("PRAGMA table_info(jobs)").fetchall()
+    if not cols:
+        return  # table doesn't exist yet; SCHEMA_SQL will create it with the column
+    if any(c["name"] == "completion_reason" for c in cols):
+        return  # already migrated
+    conn.execute("ALTER TABLE jobs ADD COLUMN completion_reason TEXT")
+
+
 def migrate(
     conn: sqlite3.Connection | None = None,
     *,
@@ -276,4 +293,5 @@ def migrate(
     with conn:
         conn.executescript(SCHEMA_SQL)
         _migrate_sources_md_path_nullable(conn)
+        _migrate_jobs_completion_reason(conn)
     return conn

--- a/src/research_agent/storage/jobs.py
+++ b/src/research_agent/storage/jobs.py
@@ -43,6 +43,11 @@ _SUBDIRS = ("plan", "findings", "sources", "synthesis", "critique", "report.hist
 _JOB_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-[a-z0-9][a-z0-9-]{0,59}$")
 _SLUG_FORBIDDEN = ("/", "\\", "..")
 
+# Allowed values for ``completion_reason`` per issue #39 §9.
+ALLOWED_COMPLETION_REASONS = frozenset(
+    {"goal_complete", "time_cap", "budget_cap", "task_cap", "user_stopped"}
+)
+
 
 def _slugify(text: str, max_len: int = 60) -> str:
     """Normalize ``text`` into a safe slug for a job folder name.
@@ -108,6 +113,7 @@ class Job:
     intake: dict[str, Any]
     created_at: int
     db_path: Path = field(default=db.DEFAULT_DB_PATH)
+    completion_reason: str | None = None
 
     # ---- Construction --------------------------------------------------
 
@@ -231,7 +237,8 @@ class Job:
         conn = db.connect(db_path_p)
         try:
             row = conn.execute(
-                "SELECT goal, domain, status, intake_json, created_at FROM jobs WHERE id = ?",
+                "SELECT goal, domain, status, intake_json, created_at, completion_reason"
+                " FROM jobs WHERE id = ?",
                 (job_id,),
             ).fetchone()
         finally:
@@ -249,23 +256,42 @@ class Job:
             intake=json.loads(row["intake_json"]),
             created_at=int(row["created_at"]),
             db_path=db_path_p,
+            completion_reason=row["completion_reason"],
         )
 
     # ---- Lifecycle ops -------------------------------------------------
 
-    def set_status(self, state: str) -> None:
-        """Update ``status`` + ``last_activity_at`` in the DB and mirror to ``job.json``."""
+    def set_status(self, state: str, completion_reason: str | None = None) -> None:
+        """Update ``status`` + ``last_activity_at`` in the DB and mirror to ``job.json``.
+
+        When ``completion_reason`` is provided it is written alongside the
+        status in a single UPDATE and mirrored into ``job.json`` so disk-only
+        consumers see the same value. Allowed reasons live in
+        :data:`ALLOWED_COMPLETION_REASONS`.
+        """
         if not isinstance(state, str) or not state:
             raise ValueError(f"status must be a non-empty string; got {state!r}")
+        if completion_reason is not None and completion_reason not in ALLOWED_COMPLETION_REASONS:
+            raise ValueError(
+                f"completion_reason must be one of {sorted(ALLOWED_COMPLETION_REASONS)};"
+                f" got {completion_reason!r}"
+            )
 
         now = _now_epoch()
         conn = db.connect(self.db_path)
         try:
             with conn:
-                conn.execute(
-                    "UPDATE jobs SET status = ?, last_activity_at = ? WHERE id = ?",
-                    (state, now, self.id),
-                )
+                if completion_reason is not None:
+                    conn.execute(
+                        "UPDATE jobs SET status = ?, last_activity_at = ?,"
+                        " completion_reason = ? WHERE id = ?",
+                        (state, now, completion_reason, self.id),
+                    )
+                else:
+                    conn.execute(
+                        "UPDATE jobs SET status = ?, last_activity_at = ? WHERE id = ?",
+                        (state, now, self.id),
+                    )
         finally:
             conn.close()
 
@@ -275,6 +301,9 @@ class Job:
         meta = json.loads(job_json.read_text(encoding="utf-8"))
         meta["status"] = state
         meta["last_activity_at"] = now
+        if completion_reason is not None:
+            meta["completion_reason"] = completion_reason
+            self.completion_reason = completion_reason
         _atomic_write_json(job_json, meta)
 
     def request_stop(self) -> None:
@@ -326,7 +355,7 @@ def list_jobs(
     try:
         sql = (
             "SELECT id, goal, domain, status, created_at, last_activity_at,"
-            " cost_so_far_usd FROM jobs"
+            " cost_so_far_usd, completion_reason FROM jobs"
         )
         params: tuple[Any, ...] = ()
         if status is not None:

--- a/src/research_agent/ui/render.py
+++ b/src/research_agent/ui/render.py
@@ -69,15 +69,18 @@ def render_jobs_table(jobs: list[dict[str, Any]], *, now: int | None = None) -> 
     table = Table(title="research jobs", show_lines=False)
     table.add_column("id", overflow="fold")
     table.add_column("status")
+    table.add_column("reason")
     table.add_column("goal")
     table.add_column("age")
     table.add_column("cost")
     table.add_column("last activity")
 
     for row in jobs:
+        reason = row.get("completion_reason") or ""
         table.add_row(
             str(row.get("id", "")),
             _status_cell(str(row.get("status", ""))),
+            str(reason),
             _truncate(str(row.get("goal", ""))),
             _humanize_age(now_epoch, row.get("created_at")),
             _format_cost(row.get("cost_so_far_usd")),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -751,6 +751,36 @@ def test_jobs_to_json_round_trips():
     assert payload == rows
 
 
+def test_render_jobs_table_includes_reason_column():
+    """Issue #39: ``research list`` surfaces ``completion_reason`` as its own column."""
+    rows = [
+        {
+            "id": "2026-05-02-x",
+            "status": "completed",
+            "goal": "g",
+            "created_at": 1,
+            "last_activity_at": 2,
+            "cost_so_far_usd": 1.5,
+            "completion_reason": "budget_cap",
+        },
+    ]
+    table = render.render_jobs_table(rows)
+    headers = [str(c.header) for c in table.columns]
+    assert "reason" in headers
+
+
+def test_list_jobs_returns_completion_reason_field(isolated_jobs_repo: Path):
+    """``list_jobs`` SELECT must include ``completion_reason`` so JSON output carries it."""
+    from research_agent.storage.jobs import list_jobs
+
+    job = _make_synthetic_job(isolated_jobs_repo, goal="reason coverage")
+    job.set_status("completed", completion_reason="budget_cap")
+
+    rows = list_jobs(db_path=isolated_jobs_repo / "data" / "index.sqlite")
+    assert rows
+    assert rows[0]["completion_reason"] == "budget_cap"
+
+
 def test_format_event_line_includes_ts_level_kind():
     line = render.format_event_line(
         {"ts": 1700000000, "level": "INFO", "kind": "job_started", "actor": "daemon"}

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -436,6 +436,64 @@ async def test_run_daemon_completed_status_when_plan_is_complete(
 
 
 @pytest.mark.asyncio
+async def test_run_daemon_handles_budget_exceeded_mid_loop(
+    seeded_job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``BudgetExceeded`` raised mid-loop turns into status=completed, reason=budget_cap."""
+    from research_agent.llm.budgets import BudgetExceeded
+    from research_agent.orchestrator import synth as _synth
+
+    async def _capping_run_loop(job: Job, router: Any, **kwargs: Any) -> dict[str, Any]:
+        raise BudgetExceeded(job.id, spent=10.0, cap=5.0)
+
+    captured: dict[str, Any] = {}
+
+    async def _post_cap_synth(job: Job, plan: Plan, *, router: Any):
+        captured["called"] = True
+        captured["plan_version"] = plan.version
+        # Simulate the helper writing a report.
+        (job.root / "report.md").write_text("# Report (post-cap)\n\nstub\n", encoding="utf-8")
+        return None
+
+    monkeypatch.setenv("RESEARCH_DAEMON_SKIP_HEALTH_CHECKS", "1")
+    monkeypatch.setattr(
+        "research_agent.orchestrator.loop.run_loop",
+        _capping_run_loop,
+    )
+    monkeypatch.setattr(_synth, "final_synthesis_after_cap", _post_cap_synth)
+
+    exit_code = await daemon.run_daemon(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    assert exit_code == 0
+    assert captured.get("called"), "final_synthesis_after_cap must run after a cap"
+
+    refreshed = Job.load(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    assert refreshed.status == "completed"
+    assert refreshed.completion_reason == "budget_cap"
+    assert (seeded_job.root / "report.md").exists()
+
+    # A WARN event with stage=run_loop_budget_cap was emitted.
+    conn = db.connect(seeded_job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT level, kind, payload_json FROM events WHERE job_id = ? AND kind = 'warning'",
+            (seeded_job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert any('"stage": "run_loop_budget_cap"' in r["payload_json"] for r in rows), (
+        "expected a run_loop_budget_cap warning event"
+    )
+
+
+@pytest.mark.asyncio
 async def test_run_daemon_uncaught_exception_marks_failed(
     seeded_job: Job, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_llm_budgets.py
+++ b/tests/test_llm_budgets.py
@@ -253,3 +253,133 @@ def test_charge_then_rehydrate_preserves_total(job: Job, db_path: Path) -> None:
 
     bt2 = BudgetTracker(job.id, cap_usd=10.0, pricing=PRICING, db_path=db_path)
     assert bt2.spent == pytest.approx(cost)
+
+
+# ---------------------------------------------------------------------------
+# Post-cap final-pass enforcement (issue #39)
+# ---------------------------------------------------------------------------
+
+
+def test_post_cap_path_runs_template_stub(
+    job: Job, db_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When ``frontier_speed`` precheck also blows the cap, the template stub runs.
+
+    No LLM call must be made: any router.call invocation is configured to
+    raise so the assertion is unambiguous.
+    """
+    import asyncio
+
+    from research_agent.orchestrator import synth as synth_module
+    from research_agent.orchestrator.plan import Plan, Subgoal, TaskSpec
+    from research_agent.storage.markdown import write_finding, write_plan
+    from research_agent.storage.sources import write_source
+
+    plan = Plan(
+        version=1,
+        objective="post-cap goal",
+        subgoals=[Subgoal(id=1, description="x", done=False)],
+        task_template=[TaskSpec(kind="web_search")],
+        expected_iterations=2,
+    )
+    write_plan(job, plan.model_dump())
+
+    sid = write_source(
+        job, url="https://example.com/a", title="src A", raw_content="body", kind="web"
+    )
+    write_finding(job, "claim with high confidence", 0.95, [sid])
+    write_finding(job, "claim with medium confidence", 0.6, [sid])
+    write_finding(job, "claim with low confidence", 0.2, [sid])
+
+    # Drive the BudgetTracker past the cap so any precheck raises.
+    bt = BudgetTracker(job.id, cap_usd=1.0, pricing=PRICING, db_path=db_path)
+    bt.spent = 5.0
+    with pytest.raises(BudgetExceeded):
+        bt.precheck("frontier_speed")
+
+    class _ExplodingRouter:
+        def __init__(self, budget: BudgetTracker) -> None:
+            self.budget = budget
+            self.tiers = {
+                "frontier_speed": {"provider": "openrouter", "model": "haiku"},
+            }
+
+        def model_for(self, tier: str):
+            raise AssertionError(f"model_for must not be invoked post-cap; got {tier!r}")
+
+        async def call(self, *args, **kwargs):
+            raise AssertionError("router.call must not be invoked when precheck fails")
+
+    # Make _run_synth raise BudgetExceeded directly so we don't need pydantic_ai.
+    async def _fake_run_synth(_job, _router, tier, _context):
+        raise BudgetExceeded(_job.id, spent=5.0, cap=1.0)
+
+    monkeypatch.setattr(synth_module, "_run_synth", _fake_run_synth)
+
+    out = asyncio.run(
+        synth_module.final_synthesis_after_cap(job, plan, router=_ExplodingRouter(bt))
+    )
+
+    assert out.truncated is True
+    assert out.model == "budget_capped_template"
+    assert out.cost_usd is None
+
+    report = (job.root / "report.md").read_text(encoding="utf-8")
+    assert "template stub" in report.lower()
+    assert "claim with high confidence" in report
+    assert "claim with medium confidence" in report
+    assert "claim with low confidence" in report
+    assert "src A" in report
+
+
+def test_post_cap_path_runs_frontier_speed_when_budget_remains(
+    job: Job, db_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Partial spend leaves headroom — frontier_speed succeeds and writes a real synthesis."""
+    import asyncio
+
+    from research_agent.orchestrator import synth as synth_module
+    from research_agent.orchestrator.plan import Plan, Subgoal, TaskSpec
+    from research_agent.storage.markdown import write_finding, write_plan
+    from research_agent.storage.sources import write_source
+
+    plan = Plan(
+        version=1,
+        objective="partial-spend goal",
+        subgoals=[Subgoal(id=1, description="x", done=False)],
+        task_template=[TaskSpec(kind="web_search")],
+        expected_iterations=2,
+    )
+    write_plan(job, plan.model_dump())
+    sid = write_source(
+        job, url="https://example.com/a", title="src A", raw_content="body", kind="web"
+    )
+    write_finding(job, "claim", 0.6, [sid])
+
+    class _PartialBudget:
+        def __init__(self) -> None:
+            self.last_cost = 0.001
+
+    class _StubRouter:
+        def __init__(self) -> None:
+            self.budget = _PartialBudget()
+            self.tiers = {"frontier_speed": {"provider": "openrouter", "model": "haiku"}}
+
+        def model_for(self, tier: str):
+            return tier
+
+        async def call(self, *args, **kwargs):
+            raise AssertionError("call must not be reached; _run_synth is stubbed")
+
+    async def _fake_run_synth(_job, _router, tier, _context):
+        assert tier == "frontier_speed"
+        return "# Recovered post-cap synthesis\n\nbody\n"
+
+    monkeypatch.setattr(synth_module, "_run_synth", _fake_run_synth)
+
+    out = asyncio.run(synth_module.final_synthesis_after_cap(job, plan, router=_StubRouter()))
+    assert out.truncated is False
+    assert out.model == "haiku"
+    assert out.cost_usd == pytest.approx(0.001)
+    report = (job.root / "report.md").read_text(encoding="utf-8")
+    assert "Recovered post-cap synthesis" in report

--- a/tests/test_orchestrator_synth.py
+++ b/tests/test_orchestrator_synth.py
@@ -405,3 +405,85 @@ def test_synthesize_emits_synthesis_written_event(job: Job, db_path: Path, plan:
     assert payload["tier"] == "frontier"
     assert payload["truncated"] is False
     assert payload["report_path"] == out.report_path
+
+
+# ---------------------------------------------------------------------------
+# Template-stub renderer (issue #39 — post-cap fallback with no LLM call)
+# ---------------------------------------------------------------------------
+
+
+def test_write_template_stub_output_renders_findings_and_sources(job: Job, db_path: Path) -> None:
+    """With findings on disk, stub renders header + grouped claims + sources."""
+    _seed_findings(job, [0.95, 0.6, 0.2])
+    out = synth_module._write_template_stub_output(job)
+
+    assert out.truncated is True
+    assert out.model == "budget_capped_template"
+    assert out.cost_usd is None
+
+    report = (job.root / "report.md").read_text(encoding="utf-8")
+    assert "template stub" in report.lower()
+    assert job.goal in report
+    assert "High confidence" in report
+    assert "Medium confidence" in report
+    assert "Low confidence" in report
+    assert "claim 0" in report
+    assert "claim 1" in report
+    assert "claim 2" in report
+    # Sources block lists at least one of the seeded sources.
+    assert "https://example.com/0" in report
+
+    rows = _read_synthesis_rows(db_path, job.id)
+    assert len(rows) == 1
+    assert rows[0]["model"] == "budget_capped_template"
+    assert rows[0]["cost_usd"] is None
+
+    events = _read_event_rows(db_path, job.id)
+    written = [e for e in events if e["kind"] == "synthesis_written"]
+    assert len(written) == 1
+    payload = json.loads(written[0]["payload_json"])
+    assert payload["tier"] == "template_stub"
+    assert payload["truncated"] is True
+
+
+def test_write_template_stub_output_empty_findings_falls_back_to_constant(
+    job: Job, db_path: Path
+) -> None:
+    """No findings → fall back to the original ``_BUDGET_STUB_REPORT`` string."""
+    out = synth_module._write_template_stub_output(job)
+
+    assert out.truncated is True
+    assert out.model == "budget_capped_template"
+    report = (job.root / "report.md").read_text(encoding="utf-8")
+    assert "Report (truncated)" in report
+    assert "budget cap was reached" in report.lower()
+
+
+def test_final_synthesis_after_cap_skips_frontier_tier(job: Job, db_path: Path, plan: Plan) -> None:
+    """Post-cap helper must call only ``frontier_speed`` — not the primary tier."""
+    _seed_findings(job, [0.7])
+    router = _StubRouter()
+
+    out = asyncio.run(synth_module.final_synthesis_after_cap(job, plan, router=router))
+    assert out.truncated is False
+    assert [c[0] for c in router.calls] == ["frontier_speed"]
+    assert out.model == "anthropic/claude-haiku-4-5"
+
+
+def test_final_synthesis_after_cap_falls_back_to_template_when_speed_capped(
+    job: Job, db_path: Path, plan: Plan
+) -> None:
+    _seed_findings(job, [0.95, 0.4])
+    router = _StubRouter(
+        side_effect={
+            "frontier_speed": [synth_module.BudgetExceeded(job.id, spent=11.0, cap=5.0)],
+        },
+    )
+
+    out = asyncio.run(synth_module.final_synthesis_after_cap(job, plan, router=router))
+
+    assert out.truncated is True
+    assert out.model == "budget_capped_template"
+    report = (job.root / "report.md").read_text(encoding="utf-8")
+    assert "template stub" in report.lower()
+    assert "claim 0" in report


### PR DESCRIPTION
Closes #39

## Summary

Automated implementation of **Cost cap final-pass enforcement**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Cost cap final-pass enforcement fully implemented per §9: daemon catches BudgetExceeded, runs frontier_speed-only synthesis with template-stub fallback, writes completion_reason to DB+JSON+research-list. All 128 reviewed tests pass.

- **INFO** [OPEN] `src/research_agent/storage/jobs.py`: time_cap is in ALLOWED_COMPLETION_REASONS but no code path emits it yet — wall-clock cap enforcement is out of scope for this issue and will be wired separately. Forward-looking, not a defect.
- **INFO** [OPEN] `src/research_agent/orchestrator/synth.py`: final_synthesis_after_cap takes plan as a parameter but doesn't use it (noqa: ARG001 reserves it for future prompt context). Acceptable — keeps signature parallel to final_synthesis and lets daemon thread the same plan reference.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*