### PR TITLE
feat: Live progress bars with Rich (closes #41)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,8 @@ RESEARCH_IGNORE_ROBOTS=
 
 # Optional: override the default LM Studio base URL (http://localhost:1234/v1).
 LMSTUDIO_BASE_URL=
+
+# Optional: set to 0 to suppress the foreground Rich progress bar the daemon
+# writes to stdout when run interactively. Has no effect on `research start`
+# (its daemon redirects stdout to a log file, so the bar stays dormant).
+RESEARCH_DAEMON_PROGRESS=

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ list, so there is no drift.
 | `RESEARCH_HEADFUL` | no | Set to `1` to launch Playwright in headed mode for debugging. |
 | `RESEARCH_IGNORE_ROBOTS` | no | Set to `1` to bypass robots.txt checks in `web_fetch`. |
 | `LMSTUDIO_BASE_URL` | no | Override the default `http://localhost:1234/v1`. |
+| `RESEARCH_DAEMON_PROGRESS` | no | Set to `0` to suppress the foreground Rich progress bar the daemon writes to stdout when run interactively. |
 
 ## CLI
 

--- a/src/research_agent/cli.py
+++ b/src/research_agent/cli.py
@@ -180,6 +180,9 @@ def status_command(
             task_counts=data["task_counts"],
             cost=data["cost"],
             recent_events=data["recent_events"],
+            budget_cap=data["budget_cap"],
+            eta_seconds=data["eta_seconds"],
+            current_task=data["current_task"],
         )
 
     if not watch:

--- a/src/research_agent/config.py
+++ b/src/research_agent/config.py
@@ -51,6 +51,15 @@ EXPECTED_ENV_KEYS: tuple[EnvKey, ...] = (
         description="Override the default LM Studio base URL.",
         default="http://localhost:1234/v1",
     ),
+    EnvKey(
+        name="RESEARCH_DAEMON_PROGRESS",
+        required=False,
+        description=(
+            "Set to '0' to suppress the foreground Rich progress bar that the daemon"
+            " writes to stdout when run interactively. The spawned-daemon path is"
+            " unaffected (its stdout is a log file, so the bar stays dormant)."
+        ),
+    ),
 )
 
 

--- a/src/research_agent/daemon.py
+++ b/src/research_agent/daemon.py
@@ -327,6 +327,10 @@ _STOP_POLL_INTERVAL_S = 2.0
 DISK_CAP_POLL_INTERVAL_S = 300.0
 DEFAULT_DISK_CAP_GB = 10.0
 
+# Foreground progress bar (issue #41). 2 s matches `research status --watch`
+# so the operator's two views advance in lockstep.
+FOREGROUND_PROGRESS_INTERVAL_S = 2.0
+
 
 def _build_router(job: Job) -> Any:
     """Build a :class:`Router` + :class:`BudgetTracker` for ``job``.
@@ -420,6 +424,129 @@ async def _disk_cap_watcher(
                 await asyncio.wait_for(should_stop.wait(), timeout=poll_s)
             except TimeoutError:
                 continue
+    except asyncio.CancelledError:
+        return
+
+
+def _should_show_foreground_progress(stream: Any) -> bool:
+    """True when the daemon should drive a Rich Progress bar on ``stream``.
+
+    Active only when stdout is a real TTY (``spawn_daemon`` redirects to a
+    log file, where this stays dormant) and the operator hasn't opted out
+    via ``RESEARCH_DAEMON_PROGRESS=0``. Anything that isn't ``"0"`` is
+    treated as opt-in.
+    """
+    if os.environ.get("RESEARCH_DAEMON_PROGRESS") == "0":
+        return False
+    isatty = getattr(stream, "isatty", None)
+    if isatty is None:
+        return False
+    try:
+        return bool(isatty())
+    except Exception:  # noqa: BLE001 — defensive: never let isatty crash the daemon
+        return False
+
+
+def _plan_completion(job: Job, plan_version: int | None) -> tuple[int, int]:
+    """Return ``(done_count, total_count)`` for the latest plan version's tasks.
+
+    ``plan_version`` is recomputed each tick because a mid-run replan
+    advances ``plans.version`` and the operator wants the bar to track the
+    *current* plan, not stale rows from a prior pass.
+    """
+    from research_agent.storage import db as _db
+
+    conn = _db.connect(job.db_path)
+    try:
+        if plan_version is None:
+            row = conn.execute(
+                "SELECT COALESCE(MAX(version), 0) AS v FROM plans WHERE job_id = ?",
+                (job.id,),
+            ).fetchone()
+            plan_version = int(row["v"]) if row is not None else 0
+
+        rows = conn.execute(
+            "SELECT status, COUNT(*) AS n FROM tasks"
+            " WHERE job_id = ? AND plan_version = ? GROUP BY status",
+            (job.id, plan_version),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    counts = {str(r["status"]): int(r["n"]) for r in rows}
+    done = counts.get("done", 0)
+    total = (
+        counts.get("pending", 0)
+        + counts.get("running", 0)
+        + counts.get("done", 0)
+        + counts.get("failed", 0)
+    )
+    return done, total
+
+
+async def _foreground_progress_task(
+    job: Job,
+    should_stop: asyncio.Event,
+    *,
+    interval_s: float | None = None,
+    stream: Any | None = None,
+    progress_factory: Any | None = None,
+) -> None:
+    """Drive a Rich ``Progress`` bar on stdout while the daemon runs.
+
+    Only runs when the chosen ``stream`` is a TTY and the
+    ``RESEARCH_DAEMON_PROGRESS`` env var is not ``"0"`` — under
+    :func:`spawn_daemon` stdout is the per-job log file (non-TTY), so this
+    coroutine returns immediately and never writes to disk. Tests inject a
+    fake ``progress_factory`` to capture updates without a real terminal.
+    """
+    chosen_stream = stream if stream is not None else sys.stdout
+    if not _should_show_foreground_progress(chosen_stream):
+        return
+
+    poll_s = interval_s if interval_s is not None else FOREGROUND_PROGRESS_INTERVAL_S
+
+    if progress_factory is None:
+        from rich.console import Console
+        from rich.progress import (
+            BarColumn,
+            Progress,
+            TaskProgressColumn,
+            TextColumn,
+            TimeElapsedColumn,
+        )
+
+        def _factory() -> Any:
+            console = Console(file=chosen_stream, force_terminal=True)
+            return Progress(
+                TextColumn(f"[bold]{job.id}[/bold]"),
+                BarColumn(),
+                TaskProgressColumn(),
+                TextColumn("•"),
+                TimeElapsedColumn(),
+                console=console,
+                transient=False,
+            )
+
+        progress = _factory()
+    else:
+        progress = progress_factory()
+
+    bar_id = progress.add_task("plan", total=1, completed=0)
+
+    try:
+        with progress:
+            while not should_stop.is_set():
+                try:
+                    done, total = _plan_completion(job, plan_version=None)
+                except Exception:  # noqa: BLE001 — bar must not crash the daemon
+                    logger.exception("foreground progress tick failed for job %s", job.id)
+                    done, total = 0, 0
+                progress.update(bar_id, total=max(1, total), completed=done)
+                try:
+                    await asyncio.wait_for(should_stop.wait(), timeout=poll_s)
+                except TimeoutError:
+                    continue
     except asyncio.CancelledError:
         return
 
@@ -540,6 +667,7 @@ async def run_daemon(
         disk_cap_gb = DEFAULT_DISK_CAP_GB
     cap_bytes = max(1, int(disk_cap_gb * 1024 * 1024 * 1024))
     disk_cap_task = aloop.create_task(_disk_cap_watcher(job, cap_bytes, should_stop))
+    progress_task = aloop.create_task(_foreground_progress_task(job, should_stop))
 
     from research_agent.llm.budgets import BudgetExceeded
 
@@ -655,6 +783,11 @@ async def run_daemon(
         disk_cap_task.cancel()
         try:
             await disk_cap_task
+        except (asyncio.CancelledError, Exception):
+            pass
+        progress_task.cancel()
+        try:
+            await progress_task
         except (asyncio.CancelledError, Exception):
             pass
         if signals_installed:

--- a/src/research_agent/ui/render.py
+++ b/src/research_agent/ui/render.py
@@ -41,6 +41,20 @@ def _humanize_age(now_epoch: int, then_epoch: int | None) -> str:
     return f"{delta // 86400}d"
 
 
+def _humanize_duration(seconds: float | int | None) -> str:
+    """Format a positive duration as ``Xs`` / ``Ym`` / ``Zh`` (closest unit)."""
+    if seconds is None:
+        return "—"
+    delta = max(0, int(seconds))
+    if delta < 60:
+        return f"{delta}s"
+    if delta < 3600:
+        return f"{delta // 60}m"
+    if delta < 86400:
+        return f"{delta // 3600}h"
+    return f"{delta // 86400}d"
+
+
 def _truncate(text: str, limit: int = _GOAL_TRUNCATE) -> str:
     if len(text) <= limit:
         return text
@@ -94,8 +108,11 @@ def jobs_to_json(jobs: list[dict[str, Any]]) -> str:
     return json.dumps(jobs, indent=2, sort_keys=True, default=str)
 
 
+_ETA_SAMPLE_LIMIT = 5
+
+
 def load_status_data(job: Job, *, db_path: Path | None = None) -> dict[str, Any]:
-    """Pull plan version, task counts, cost, and last 10 events for a job."""
+    """Pull plan version, task counts, cost, ETA, current task, and recent events."""
     path = db_path if db_path is not None else job.db_path
     conn = db.connect(path)
     try:
@@ -118,6 +135,44 @@ def load_status_data(job: Job, *, db_path: Path | None = None) -> dict[str, Any]
         cost_val = cost_row["cost_so_far_usd"] if cost_row else None
         cost = float(cost_val) if cost_val else 0.0
 
+        # Rolling-average ETA from the last few finished tasks. We need both
+        # started_at and finished_at populated to derive a duration; tasks
+        # missing either are skipped.
+        duration_rows = conn.execute(
+            "SELECT started_at, finished_at FROM tasks"
+            " WHERE job_id = ? AND status = 'done'"
+            " AND started_at IS NOT NULL AND finished_at IS NOT NULL"
+            " ORDER BY finished_at DESC LIMIT ?",
+            (job.id, _ETA_SAMPLE_LIMIT),
+        ).fetchall()
+        eta_seconds: float | None = None
+        if duration_rows:
+            durations = [
+                max(0, int(r["finished_at"]) - int(r["started_at"])) for r in duration_rows
+            ]
+            avg = sum(durations) / len(durations)
+            pending = task_counts.get("pending", 0)
+            if pending > 0 and avg > 0:
+                eta_seconds = avg * pending
+
+        current_row = conn.execute(
+            "SELECT id, kind, started_at FROM tasks"
+            " WHERE job_id = ? AND status = 'running'"
+            " ORDER BY started_at DESC LIMIT 1",
+            (job.id,),
+        ).fetchone()
+        current_task: dict[str, Any] | None = None
+        if current_row is not None:
+            current_task = {
+                "id": int(current_row["id"]),
+                "kind": str(current_row["kind"]),
+                "started_at": (
+                    int(current_row["started_at"])
+                    if current_row["started_at"] is not None
+                    else None
+                ),
+            }
+
         event_rows = conn.execute(
             "SELECT ts, level, actor, kind, payload_json FROM events"
             " WHERE job_id = ? ORDER BY ts DESC LIMIT 10",
@@ -136,12 +191,34 @@ def load_status_data(job: Job, *, db_path: Path | None = None) -> dict[str, Any]
     finally:
         conn.close()
 
+    intake = job.intake or {}
+    budget_cap = intake.get("budget_cap_usd")
+
     return {
         "plan_version": plan_version,
         "task_counts": task_counts,
         "cost": cost,
+        "budget_cap": budget_cap,
+        "eta_seconds": eta_seconds,
+        "current_task": current_task,
         "recent_events": recent_events,
     }
+
+
+def _format_task_counts(task_counts: dict[str, int]) -> str:
+    """Render the canonical pending/running/done/failed counter row.
+
+    Always emits all four buckets so the layout doesn't shift between ticks
+    of ``--watch``. Running and failed counts get color cues that match the
+    job-list theme.
+    """
+    pending = int(task_counts.get("pending", 0))
+    running = int(task_counts.get("running", 0))
+    done = int(task_counts.get("done", 0))
+    failed = int(task_counts.get("failed", 0))
+    running_cell = f"[{_STATUS_STYLE['running']}]running={running}[/{_STATUS_STYLE['running']}]"
+    failed_cell = f"[{_STATUS_STYLE['failed']}]failed={failed}[/{_STATUS_STYLE['failed']}]"
+    return f"pending={pending} {running_cell} done={done} {failed_cell}"
 
 
 def render_status_panel(
@@ -150,26 +227,35 @@ def render_status_panel(
     task_counts: dict[str, int],
     cost: float,
     recent_events: list[dict[str, Any]],
+    *,
+    budget_cap: float | None = None,
+    eta_seconds: float | None = None,
+    current_task: dict[str, Any] | None = None,
+    now: int | None = None,
 ) -> Panel:
     """Render the detail panel for `research status <job-id>`."""
     intake = job.intake or {}
+    now_epoch = int(now) if now is not None else int(time.time())
+    cap_for_display = budget_cap if budget_cap is not None else intake.get("budget_cap_usd")
+
     summary_lines = [
         f"[bold]Status:[/bold] {_status_cell(job.status)}",
         f"[bold]Goal:[/bold] {job.goal}",
         f"[bold]Domain:[/bold] {job.domain or '—'}",
         f"[bold]Plan version:[/bold] {plan_version}",
-        f"[bold]Cost so far:[/bold] {_format_cost(cost)}",
-        (
-            f"[bold]Budget cap:[/bold] {_format_cost(intake.get('budget_cap_usd'))} | "
-            f"[bold]Time cap (h):[/bold] {intake.get('time_cap_hours') or '—'}"
-        ),
+        f"[bold]Cost so far:[/bold] {_format_cost(cost)} / {_format_cost(cap_for_display)}",
+        f"[bold]Time cap (h):[/bold] {intake.get('time_cap_hours') or '—'}",
+        f"[bold]Tasks:[/bold] {_format_task_counts(task_counts)}",
+        f"[bold]ETA:[/bold] ~{_humanize_duration(eta_seconds)}",
     ]
 
-    if task_counts:
-        counts_str = ", ".join(f"{k}={v}" for k, v in sorted(task_counts.items()))
+    if current_task is not None:
+        kind = current_task.get("kind") or "?"
+        started_at = current_task.get("started_at")
+        age = _humanize_age(now_epoch, started_at) if started_at is not None else "—"
+        summary_lines.append(f"[bold]Current:[/bold] {kind} (running {age})")
     else:
-        counts_str = "(none)"
-    summary_lines.append(f"[bold]Task counts:[/bold] {counts_str}")
+        summary_lines.append("[bold]Current:[/bold] (idle)")
 
     summary = "\n".join(summary_lines)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -350,6 +350,127 @@ def test_status_renders_panel_for_pending_job(isolated_jobs_repo: Path):
     assert "Plan version" in out
     assert "0" in out
     assert "$2.50" in out
+    # Phase-7 polish (#41): the panel always exposes ETA + current-task lines.
+    assert "ETA" in out
+    assert "Current" in out
+
+
+def _seed_tasks_for_status(
+    db_path: Path,
+    job_id: str,
+    *,
+    plan_version: int = 1,
+    done_specs: list[tuple[int, int]] | None = None,
+    running_kind: str | None = None,
+    running_started_at: int | None = None,
+    pending_count: int = 0,
+) -> None:
+    """Insert synthetic ``tasks`` rows so ``load_status_data`` has stuff to chew."""
+    conn = db.connect(db_path)
+    try:
+        with conn:
+            for started_at, finished_at in done_specs or []:
+                conn.execute(
+                    "INSERT INTO tasks"
+                    " (job_id, plan_version, kind, payload_json, status,"
+                    " started_at, finished_at, retry_count)"
+                    " VALUES (?, ?, ?, ?, 'done', ?, ?, 0)",
+                    (job_id, plan_version, "web_search", "{}", started_at, finished_at),
+                )
+            if running_kind is not None:
+                conn.execute(
+                    "INSERT INTO tasks"
+                    " (job_id, plan_version, kind, payload_json, status, started_at, retry_count)"
+                    " VALUES (?, ?, ?, ?, 'running', ?, 0)",
+                    (job_id, plan_version, running_kind, "{}", running_started_at),
+                )
+            for _ in range(pending_count):
+                conn.execute(
+                    "INSERT INTO tasks"
+                    " (job_id, plan_version, kind, payload_json, status, retry_count)"
+                    " VALUES (?, ?, ?, ?, 'pending', 0)",
+                    (job_id, plan_version, "web_search", "{}"),
+                )
+    finally:
+        conn.close()
+
+
+def test_status_renders_eta_and_current_task(isolated_jobs_repo: Path):
+    """ETA derived from finished-task durations × pending count, plus current-task line."""
+    job = _make_synthetic_job(isolated_jobs_repo, goal="ETA target", cost=0.0)
+    db_path = isolated_jobs_repo / "data" / "index.sqlite"
+
+    now = int(time.time())
+    # Three completed tasks at 30s each → avg 30s; two pending → ETA ~60s = "1m".
+    done_specs = [
+        (now - 1000, now - 970),
+        (now - 900, now - 870),
+        (now - 800, now - 770),
+    ]
+    _seed_tasks_for_status(
+        db_path,
+        job.id,
+        done_specs=done_specs,
+        running_kind="web_fetch",
+        running_started_at=now - 18,
+        pending_count=2,
+    )
+
+    data = render.load_status_data(job, db_path=db_path)
+    assert data["eta_seconds"] == pytest.approx(60.0)
+    assert data["current_task"] is not None
+    assert data["current_task"]["kind"] == "web_fetch"
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["status", job.id])
+    assert result.exit_code == 0, result.stdout
+    out = result.stdout
+    # ETA renders as "~1m" via _humanize_duration; current task as the
+    # task-kind plus an age suffix.
+    assert "~1m" in out
+    assert "web_fetch" in out
+    # Counter row uses the canonical pending/running/done/failed shape.
+    assert "pending=2" in out
+    assert "done=3" in out
+
+
+def test_status_idle_when_no_running_task(isolated_jobs_repo: Path):
+    """No running rows → panel renders the explicit ``(idle)`` line."""
+    job = _make_synthetic_job(isolated_jobs_repo, goal="idle target")
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["status", job.id])
+    assert result.exit_code == 0, result.stdout
+    assert "(idle)" in result.stdout
+
+
+def test_status_color_theme_matches_list(isolated_jobs_repo: Path):
+    """The status badge uses the same _STATUS_STYLE markup as `research list`."""
+    import io
+
+    from rich.console import Console
+
+    job = _make_synthetic_job(isolated_jobs_repo, goal="theme target", status="running")
+
+    data = render.load_status_data(job)
+    panel = render.render_status_panel(
+        job,
+        plan_version=data["plan_version"],
+        task_counts=data["task_counts"],
+        cost=data["cost"],
+        recent_events=data["recent_events"],
+        budget_cap=data["budget_cap"],
+        eta_seconds=data["eta_seconds"],
+        current_task=data["current_task"],
+    )
+    # Render through a forced-terminal Console so SGR escape codes hit the buffer.
+    buf = io.StringIO()
+    Console(file=buf, force_terminal=True, color_system="truecolor", width=200).print(panel)
+    rendered = buf.getvalue()
+    assert "running" in rendered
+    # _STATUS_STYLE['running'] = 'green' → the ANSI 32 sequence must appear,
+    # matching the same theme `research list` uses for running jobs.
+    assert "\x1b[32m" in rendered
 
 
 def test_status_unknown_job_errors(isolated_jobs_repo: Path):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -641,3 +641,197 @@ async def test_ensure_openrouter_reachable_requires_api_key(
 
     with pytest.raises(RuntimeError, match="OPENROUTER_API_KEY"):
         await daemon.ensure_openrouter_reachable(_StubRouter(), deadline_s=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Foreground progress bar (issue #41)
+# ---------------------------------------------------------------------------
+
+
+class _FakeProgress:
+    """In-memory stand-in for ``rich.progress.Progress`` used by daemon tests."""
+
+    def __init__(self) -> None:
+        self.tasks: dict[int, dict[str, Any]] = {}
+        self._next_id = 1
+        self.updates: list[tuple[int, dict[str, Any]]] = []
+        self.entered = False
+        self.exited = False
+
+    def __enter__(self) -> _FakeProgress:
+        self.entered = True
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.exited = True
+
+    def add_task(self, name: str, *, total: int | None = None, completed: int = 0) -> int:
+        tid = self._next_id
+        self._next_id += 1
+        self.tasks[tid] = {"name": name, "total": total, "completed": completed}
+        return tid
+
+    def update(self, task_id: int, **kwargs: Any) -> None:
+        self.tasks[task_id].update(kwargs)
+        self.updates.append((task_id, dict(kwargs)))
+
+
+class _TtyStream:
+    """Stand-in stdout that reports ``isatty() == True``."""
+
+    def isatty(self) -> bool:
+        return True
+
+    def write(self, _: str) -> int:
+        return 0
+
+    def flush(self) -> None:
+        return None
+
+
+class _NonTtyStream:
+    def isatty(self) -> bool:
+        return False
+
+
+def test_should_show_foreground_progress_respects_tty_and_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("RESEARCH_DAEMON_PROGRESS", raising=False)
+    assert daemon._should_show_foreground_progress(_TtyStream()) is True
+    assert daemon._should_show_foreground_progress(_NonTtyStream()) is False
+
+    monkeypatch.setenv("RESEARCH_DAEMON_PROGRESS", "0")
+    assert daemon._should_show_foreground_progress(_TtyStream()) is False
+
+
+@pytest.mark.asyncio
+async def test_foreground_progress_dormant_for_non_tty(
+    seeded_job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-TTY stdout (the spawn_daemon path) → no Progress is ever created."""
+    monkeypatch.delenv("RESEARCH_DAEMON_PROGRESS", raising=False)
+    factory_calls = {"n": 0}
+
+    def _factory() -> _FakeProgress:
+        factory_calls["n"] += 1
+        return _FakeProgress()
+
+    should_stop = asyncio.Event()
+    should_stop.set()  # ensure the task exits even if it somehow enters the loop
+
+    await daemon._foreground_progress_task(
+        seeded_job,
+        should_stop,
+        stream=_NonTtyStream(),
+        progress_factory=_factory,
+    )
+    assert factory_calls["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_foreground_progress_dormant_when_env_zero(
+    seeded_job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Operator opt-out via RESEARCH_DAEMON_PROGRESS=0 keeps the bar quiet."""
+    monkeypatch.setenv("RESEARCH_DAEMON_PROGRESS", "0")
+    factory_calls = {"n": 0}
+
+    def _factory() -> _FakeProgress:
+        factory_calls["n"] += 1
+        return _FakeProgress()
+
+    should_stop = asyncio.Event()
+    should_stop.set()
+
+    await daemon._foreground_progress_task(
+        seeded_job,
+        should_stop,
+        stream=_TtyStream(),
+        progress_factory=_factory,
+    )
+    assert factory_calls["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_foreground_progress_updates_as_tasks_transition(
+    seeded_job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When stdout is a TTY, the bar tracks done/total of the latest plan version."""
+    monkeypatch.delenv("RESEARCH_DAEMON_PROGRESS", raising=False)
+    fake = _FakeProgress()
+
+    # Seed two pending and one done task on the seeded plan version (1).
+    conn = db.connect(seeded_job.db_path)
+    try:
+        with conn:
+            now = int(time.time())
+            conn.execute(
+                "INSERT INTO tasks"
+                " (job_id, plan_version, kind, payload_json, status,"
+                " started_at, finished_at, retry_count)"
+                " VALUES (?, 1, 'web_search', '{}', 'done', ?, ?, 0)",
+                (seeded_job.id, now - 30, now - 10),
+            )
+            conn.execute(
+                "INSERT INTO tasks"
+                " (job_id, plan_version, kind, payload_json, status, retry_count)"
+                " VALUES (?, 1, 'web_search', '{}', 'pending', 0)",
+                (seeded_job.id,),
+            )
+            conn.execute(
+                "INSERT INTO tasks"
+                " (job_id, plan_version, kind, payload_json, status, retry_count)"
+                " VALUES (?, 1, 'web_search', '{}', 'pending', 0)",
+                (seeded_job.id,),
+            )
+    finally:
+        conn.close()
+
+    should_stop = asyncio.Event()
+
+    async def _flip_after_first_tick() -> None:
+        # Wait for the initial tick + a follow-up; the wait_for(timeout=)
+        # branch lets the task settle into a steady state.
+        await asyncio.sleep(0.05)
+        # Mark another task done.
+        conn = db.connect(seeded_job.db_path)
+        try:
+            with conn:
+                row = conn.execute(
+                    "SELECT id FROM tasks WHERE job_id = ? AND status = 'pending'"
+                    " ORDER BY id LIMIT 1",
+                    (seeded_job.id,),
+                ).fetchone()
+                if row is not None:
+                    conn.execute(
+                        "UPDATE tasks SET status = 'done',"
+                        " started_at = ?, finished_at = ? WHERE id = ?",
+                        (int(time.time()) - 5, int(time.time()), int(row["id"])),
+                    )
+        finally:
+            conn.close()
+        await asyncio.sleep(0.05)
+        should_stop.set()
+
+    flip = asyncio.create_task(_flip_after_first_tick())
+    await daemon._foreground_progress_task(
+        seeded_job,
+        should_stop,
+        stream=_TtyStream(),
+        progress_factory=lambda: fake,
+        interval_s=0.02,
+    )
+    await flip
+
+    assert fake.entered and fake.exited
+    assert len(fake.tasks) == 1
+    # Initial state: 1 done out of 3.
+    first_update = fake.updates[0]
+    assert first_update[1]["total"] == 3
+    assert first_update[1]["completed"] == 1
+    # By the time should_stop fires, the bar saw the second done transition.
+    assert any(u[1]["completed"] >= 2 for u in fake.updates)
+    final = fake.updates[-1]
+    assert final[1]["completed"] == 2
+    assert final[1]["total"] == 3


### PR DESCRIPTION
Closes #41

## Summary

Automated implementation of **Live progress bars with Rich**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Issue #41 acceptance criteria fully met; fixed undocumented RESEARCH_DAEMON_PROGRESS env var.

- **WARNING** [FIXED] `src/research_agent/config.py`: New operator-facing env var RESEARCH_DAEMON_PROGRESS was introduced in daemon.py but not added to EXPECTED_ENV_KEYS, .env.example, or README — would have drifted from the parity contract enforced by test_env_example_matches_expected_keys.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*