### PR TITLE
feat:  — zip + md-bundle (closes #42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ research search "<query>" --job <job-id>     # scope to one job
 research search "<query>" --kind findings    # findings only (default: both)
 research search "<query>" --kind sources     # sources only
 research search "<query>" --json             # machine-readable list
+
+research export <job-id> --zip               # bundle jobs/<id>/ into <job-id>.zip in cwd
+research export <job-id> --md-bundle         # one markdown file: report + findings + sources
+research export <job-id> --zip --out PATH    # write to PATH (file) or PATH/<job-id>.zip (dir)
+research export <job-id> --md-bundle --include-history   # also inline report.history/
 ```
 
 `research search` runs the user's query through SQLite FTS5 against
@@ -101,6 +106,19 @@ join through `job_sources`, so the `--job` filter correctly excludes
 sources fetched only by other jobs even when the underlying content is
 shared. FTS5 syntax errors (e.g. unbalanced quotes) exit `1` with a clear
 `FTS5 query error: ...` line on stderr.
+
+`research export` bundles a job for sharing. `--zip` walks
+`jobs/<job-id>/` and emits a single `ZIP_DEFLATED` archive whose entries
+are rooted at `<job-id>/...` so unzipping reproduces the full folder.
+`--md-bundle` concatenates the intake front matter, `report.md`, every
+finding (ordered by id), and the source list (with `archive_url` links)
+into one navigable markdown file. Exactly one mode flag is required —
+omitting both, or passing both, exits `2`. `--out` accepts either a file
+path or an existing directory (in which case `<job-id>.{zip,md}` is
+appended); when omitted the file lands in the current working directory.
+`--include-history` adds `report.history/` to either format. Both writes
+use the project's atomic `*.tmp` + `os.replace` convention, so a crash
+mid-export never leaves a half-written archive on disk.
 
 ### Config verbs
 

--- a/src/research_agent/cli.py
+++ b/src/research_agent/cli.py
@@ -480,5 +480,50 @@ def logs_command(
         return
 
 
+@app.command(name="export")
+def export_command(
+    job_id: str = typer.Argument(..., help="Job id (e.g. 2026-05-02-some-slug)."),
+    zip_: bool = typer.Option(False, "--zip", help="Bundle the job folder into a zip archive."),
+    md_bundle: bool = typer.Option(
+        False,
+        "--md-bundle",
+        help="Concatenate report + findings + sources into one markdown file.",
+    ),
+    out: Path = typer.Option(  # noqa: B008 — Typer captures defaults at decoration time
+        None,
+        "--out",
+        help="Output path (file or directory). Defaults to <job-id>.{zip,md} in the cwd.",
+    ),
+    include_history: bool = typer.Option(
+        False,
+        "--include-history",
+        help="Include report.history/ in the export.",
+    ),
+) -> None:
+    """Export a job as a shareable bundle (zip archive or single markdown file)."""
+    from research_agent.storage.export import export_md_bundle, export_zip
+
+    if zip_ == md_bundle:
+        typer.echo("exactly one of --zip or --md-bundle must be set", err=True)
+        raise typer.Exit(code=2)
+
+    job = _load_job_or_exit(job_id)
+    suffix = ".zip" if zip_ else ".md"
+    default_name = f"{job.id}{suffix}"
+
+    if out is None:
+        out_path = Path.cwd() / default_name
+    elif out.exists() and out.is_dir():
+        out_path = out / default_name
+    else:
+        out_path = out
+
+    if zip_:
+        written = export_zip(job, out_path, include_history=include_history)
+    else:
+        written = export_md_bundle(job, out_path, include_history=include_history)
+    typer.echo(str(written))
+
+
 if __name__ == "__main__":
     app()

--- a/src/research_agent/storage/__init__.py
+++ b/src/research_agent/storage/__init__.py
@@ -7,6 +7,10 @@ from research_agent.storage.db import (
     connect_for_checkpoints,
     migrate,
 )
+from research_agent.storage.export import (
+    export_md_bundle,
+    export_zip,
+)
 from research_agent.storage.jobs import (
     DEFAULT_JOBS_ROOT,
     Job,
@@ -34,6 +38,8 @@ __all__ = [
     "connect",
     "connect_for_checkpoints",
     "content_sha256",
+    "export_md_bundle",
+    "export_zip",
     "list_jobs",
     "migrate",
     "search_fts",

--- a/src/research_agent/storage/export.py
+++ b/src/research_agent/storage/export.py
@@ -1,0 +1,196 @@
+"""Export helpers for shareable job bundles (issue #42).
+
+Two pure helpers operate on a :class:`Job`:
+
+* :func:`export_zip` — walks ``job.root`` recursively and writes a
+  ``ZipFile`` whose entries are rooted at ``<job-id>/<relpath>`` so that
+  unzipping yields the full job folder.
+* :func:`export_md_bundle` — concatenates intake metadata, ``report.md``,
+  every finding (ordered by id), and the source list (with ``archive_url``)
+  into a single navigable markdown file.
+
+Both helpers write through the project's atomic-write convention
+(``*.tmp`` + :func:`os.replace`) so a tail-watching reader never observes
+half-written output.
+"""
+
+from __future__ import annotations
+
+import os
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+
+_HISTORY_DIRNAME = "report.history"
+
+
+def _atomic_replace(tmp_path: Path, final_path: Path) -> None:
+    final_path.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(tmp_path, final_path)
+
+
+def export_zip(job: Job, out_path: Path, *, include_history: bool) -> Path:
+    """Bundle ``job.root`` into a zip archive at ``out_path``.
+
+    Each archive entry is rooted at ``<job-id>/<relpath>`` so unzipping
+    reproduces the full job folder. When ``include_history`` is False,
+    paths under ``report.history/`` are skipped.
+    """
+    out_path = Path(out_path)
+    tmp_path = out_path.with_suffix(out_path.suffix + ".tmp")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(tmp_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for path in sorted(job.root.rglob("*")):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(job.root)
+            if not include_history and rel.parts and rel.parts[0] == _HISTORY_DIRNAME:
+                continue
+            arcname = f"{job.id}/{rel.as_posix()}"
+            zf.write(path, arcname)
+
+    _atomic_replace(tmp_path, out_path)
+    return out_path
+
+
+def _format_intake_block(job: Job) -> str:
+    intake = job.intake or {}
+    created_iso = datetime.fromtimestamp(job.created_at, UTC).isoformat()
+    fields = [
+        ("goal", intake.get("goal", job.goal)),
+        ("domain", intake.get("domain", job.domain)),
+        ("time_cap_hours", intake.get("time_cap_hours")),
+        ("budget_cap_usd", intake.get("budget_cap_usd")),
+        ("created_at", created_iso),
+    ]
+    lines = ["---"]
+    for key, value in fields:
+        lines.append(f"{key}: {value if value is not None else ''}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _format_report_section(job: Job) -> str:
+    report_path = job.root / "report.md"
+    if not report_path.exists():
+        return "## Report\n\n(no report.md present)\n"
+    body = report_path.read_text(encoding="utf-8").rstrip("\n")
+    return f"## Report\n\n{body}\n"
+
+
+def _format_findings_section(job: Job) -> str:
+    conn = db.connect(job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT id FROM findings WHERE job_id = ? ORDER BY id ASC",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    if not rows:
+        return "## Findings\n\n(no findings recorded)\n"
+
+    parts = ["## Findings", ""]
+    for row in rows:
+        fid = int(row["id"])
+        md_rel = f"findings/{fid:06d}.md"
+        md_path = job.root / md_rel
+        body = (
+            md_path.read_text(encoding="utf-8").rstrip("\n")
+            if md_path.exists()
+            else f"(missing {md_rel})"
+        )
+        parts.append(f"### Finding {fid:06d}")
+        parts.append("")
+        parts.append(body)
+        parts.append("")
+    return "\n".join(parts).rstrip("\n") + "\n"
+
+
+def _format_sources_section(job: Job) -> str:
+    conn = db.connect(job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT s.id, s.url, s.title, s.archive_url"
+            " FROM job_sources js JOIN sources s ON js.source_id = s.id"
+            " WHERE js.job_id = ?"
+            " ORDER BY s.id ASC",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    if not rows:
+        return "## Sources\n\n(no sources recorded)\n"
+
+    lines = ["## Sources", ""]
+    for r in rows:
+        title = r["title"] or "(untitled)"
+        url = r["url"] or ""
+        archive = r["archive_url"] or "(none)"
+        url_md = f"[{url}]({url})" if url else "(no url)"
+        lines.append(f"- [{r['id']}] {title} — {url_md} — archive: {archive}")
+    return "\n".join(lines) + "\n"
+
+
+def _format_history_section(job: Job) -> str:
+    history_dir = job.root / _HISTORY_DIRNAME
+    if not history_dir.is_dir():
+        return ""
+    files = sorted(p for p in history_dir.iterdir() if p.is_file() and p.suffix == ".md")
+    if not files:
+        return ""
+
+    parts = ["## Report History", ""]
+    for path in files:
+        stamp = path.stem
+        body = path.read_text(encoding="utf-8").rstrip("\n")
+        parts.append(f"### {stamp}")
+        parts.append("")
+        parts.append(body)
+        parts.append("")
+    return "\n".join(parts).rstrip("\n") + "\n"
+
+
+def export_md_bundle(job: Job, out_path: Path, *, include_history: bool) -> Path:
+    """Assemble a single navigable markdown bundle for ``job`` at ``out_path``.
+
+    Sections in order: H1 ``# {job.id}`` + intake front matter, ``## Report``,
+    ``## Findings`` (one ``### Finding {id:06d}`` per row, ordered by id),
+    ``## Sources`` (one bullet per source with ``archive_url``), and — when
+    ``include_history`` is True — ``## Report History`` with each archived
+    rotation inlined under its UTC timestamp stem.
+    """
+    out_path = Path(out_path)
+    tmp_path = out_path.with_suffix(out_path.suffix + ".tmp")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    sections = [
+        f"# {job.id}",
+        "",
+        _format_intake_block(job),
+        "",
+        _format_report_section(job),
+        _format_findings_section(job),
+        _format_sources_section(job),
+    ]
+    if include_history:
+        history = _format_history_section(job)
+        if history:
+            sections.append(history)
+
+    body = "\n".join(s.rstrip("\n") for s in sections).rstrip("\n") + "\n"
+    tmp_path.write_text(body, encoding="utf-8")
+    _atomic_replace(tmp_path, out_path)
+    return out_path
+
+
+__all__ = [
+    "export_md_bundle",
+    "export_zip",
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1203,3 +1203,176 @@ def test_search_malformed_query_exits_one(isolated_jobs_repo: Path):
     assert result.exit_code == 1
     combined = result.stdout + (result.stderr or "")
     assert "FTS5 query error" in combined
+
+
+# ---------------------------------------------------------------------------
+# export verb
+# ---------------------------------------------------------------------------
+
+
+def _seed_export_job(repo: Path) -> Job:
+    """Create a job with a report, two findings, one source, and a history file."""
+    import zipfile  # noqa: F401 — exercised via callers
+
+    job = _make_synthetic_job(repo, goal="Export target", today=date(2026, 5, 2))
+    (job.root / "report.md").write_text("# Final\n\nbody\n", encoding="utf-8")
+    (job.root / "findings" / "000001.md").write_text(
+        "# Finding 000001\n\nclaim one\n", encoding="utf-8"
+    )
+    (job.root / "findings" / "000002.md").write_text(
+        "# Finding 000002\n\nclaim two\n", encoding="utf-8"
+    )
+    (job.root / "report.history").mkdir(exist_ok=True)
+    (job.root / "report.history" / "20260501T000000Z.md").write_text(
+        "# Prior\n\narchived\n", encoding="utf-8"
+    )
+
+    now = int(time.time())
+    conn = db.connect(repo / "data" / "index.sqlite")
+    try:
+        with conn:
+            conn.execute(
+                "INSERT INTO findings"
+                " (job_id, md_path, claim, confidence, source_ids, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (job.id, "findings/000001.md", "claim one", 0.9, "[1]", now),
+            )
+            conn.execute(
+                "INSERT INTO findings"
+                " (job_id, md_path, claim, confidence, source_ids, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (job.id, "findings/000002.md", "claim two", 0.8, "[1]", now),
+            )
+            cur = conn.execute(
+                "INSERT INTO sources"
+                " (sha256, url, title, fetched_at, archive_url, md_path, kind)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "b" * 64,
+                    "https://example.com/x",
+                    "Example X",
+                    now,
+                    "https://web.archive.org/web/2026/x",
+                    "sources/bbb.md",
+                    "web",
+                ),
+            )
+            sid = cur.lastrowid
+            conn.execute(
+                "INSERT INTO job_sources (job_id, source_id) VALUES (?, ?)",
+                (job.id, sid),
+            )
+    finally:
+        conn.close()
+
+    return job
+
+
+def test_export_zip_writes_archive(isolated_jobs_repo: Path):
+    import zipfile
+
+    job = _seed_export_job(isolated_jobs_repo)
+    out_path = isolated_jobs_repo / "bundle.zip"
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["export", job.id, "--zip", "--out", str(out_path)])
+    assert result.exit_code == 0, result.stdout
+    assert out_path.exists()
+
+    with zipfile.ZipFile(out_path) as zf:
+        names = set(zf.namelist())
+    assert f"{job.id}/job.json" in names
+    assert f"{job.id}/report.md" in names
+    assert f"{job.id}/findings/000001.md" in names
+
+
+def test_export_md_bundle_writes_markdown(isolated_jobs_repo: Path):
+    job = _seed_export_job(isolated_jobs_repo)
+    out_path = isolated_jobs_repo / "bundle.md"
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["export", job.id, "--md-bundle", "--out", str(out_path)])
+    assert result.exit_code == 0, result.stdout
+    body = out_path.read_text(encoding="utf-8")
+    assert body.startswith(f"# {job.id}\n")
+    assert "## Report" in body
+    assert "## Findings" in body
+    assert "### Finding 000001" in body
+    assert "## Sources" in body
+    assert "https://web.archive.org/web/2026/x" in body
+
+
+def test_export_requires_a_mode(isolated_jobs_repo: Path):
+    job = _seed_export_job(isolated_jobs_repo)
+    runner = CliRunner()
+
+    no_flag = runner.invoke(cli.app, ["export", job.id])
+    assert no_flag.exit_code == 2
+    combined = no_flag.stdout + (no_flag.stderr or "")
+    assert "exactly one" in combined
+
+    both_flags = runner.invoke(cli.app, ["export", job.id, "--zip", "--md-bundle"])
+    assert both_flags.exit_code == 2
+
+
+def test_export_unknown_job_errors(isolated_jobs_repo: Path):
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["export", "2026-05-02-does-not-exist", "--zip"])
+    assert result.exit_code == 1
+    combined = result.stdout + (result.stderr or "")
+    assert "job not found" in combined
+    assert "Traceback" not in combined
+
+
+def test_export_include_history_flag(isolated_jobs_repo: Path):
+    import zipfile
+
+    job = _seed_export_job(isolated_jobs_repo)
+    runner = CliRunner()
+
+    md_with = isolated_jobs_repo / "with.md"
+    md_no = isolated_jobs_repo / "no.md"
+    runner.invoke(
+        cli.app,
+        ["export", job.id, "--md-bundle", "--include-history", "--out", str(md_with)],
+    )
+    runner.invoke(cli.app, ["export", job.id, "--md-bundle", "--out", str(md_no)])
+    assert "## Report History" in md_with.read_text(encoding="utf-8")
+    assert "## Report History" not in md_no.read_text(encoding="utf-8")
+
+    zip_with = isolated_jobs_repo / "with.zip"
+    zip_no = isolated_jobs_repo / "no.zip"
+    runner.invoke(
+        cli.app,
+        ["export", job.id, "--zip", "--include-history", "--out", str(zip_with)],
+    )
+    runner.invoke(cli.app, ["export", job.id, "--zip", "--out", str(zip_no)])
+
+    with zipfile.ZipFile(zip_with) as zf:
+        names_with = set(zf.namelist())
+    with zipfile.ZipFile(zip_no) as zf:
+        names_no = set(zf.namelist())
+
+    assert f"{job.id}/report.history/20260501T000000Z.md" in names_with
+    assert not any("report.history/" in n for n in names_no)
+
+
+def test_export_default_out_uses_cwd(isolated_jobs_repo: Path):
+    job = _seed_export_job(isolated_jobs_repo)
+    runner = CliRunner()
+    # CliRunner inherits cwd from the test (chdir'd by isolated_jobs_repo).
+    result = runner.invoke(cli.app, ["export", job.id, "--zip"])
+    assert result.exit_code == 0, result.stdout
+    expected = isolated_jobs_repo / f"{job.id}.zip"
+    assert expected.exists()
+
+
+def test_export_out_directory_appends_default_name(isolated_jobs_repo: Path):
+    job = _seed_export_job(isolated_jobs_repo)
+    target_dir = isolated_jobs_repo / "exports"
+    target_dir.mkdir()
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["export", job.id, "--md-bundle", "--out", str(target_dir)])
+    assert result.exit_code == 0, result.stdout
+    assert (target_dir / f"{job.id}.md").exists()

--- a/tests/test_storage_export.py
+++ b/tests/test_storage_export.py
@@ -1,0 +1,210 @@
+"""Tests for `research_agent.storage.export` (issue #42)."""
+
+from __future__ import annotations
+
+import time
+import zipfile
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from research_agent.storage import db
+from research_agent.storage.export import export_md_bundle, export_zip
+from research_agent.storage.jobs import Job
+
+
+@pytest.fixture
+def jobs_root(tmp_path: Path) -> Path:
+    return tmp_path / "jobs"
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "index.sqlite"
+    db.migrate(path=path).close()
+    return path
+
+
+@pytest.fixture
+def seeded_job(jobs_root: Path, db_path: Path) -> Job:
+    """Build a job with a report, two findings, one source, and a history file."""
+    job = Job.create(
+        {
+            "goal": "Investigate exports",
+            "domain": "general",
+            "time_cap_hours": 4,
+            "budget_cap_usd": 7.5,
+        },
+        jobs_root=jobs_root,
+        db_path=db_path,
+        today=date(2026, 5, 2),
+    )
+
+    (job.root / "report.md").write_text("# Final Report\n\nReport body.\n", encoding="utf-8")
+    (job.root / "findings" / "000001.md").write_text(
+        "# Finding 000001\n\nFirst claim.\n", encoding="utf-8"
+    )
+    (job.root / "findings" / "000002.md").write_text(
+        "# Finding 000002\n\nSecond claim.\n", encoding="utf-8"
+    )
+    (job.root / "report.history").mkdir(exist_ok=True)
+    (job.root / "report.history" / "20260501T000000Z.md").write_text(
+        "# Prior Report\n\nArchived body.\n", encoding="utf-8"
+    )
+
+    now = int(time.time())
+    conn = db.connect(db_path)
+    try:
+        with conn:
+            conn.execute(
+                "INSERT INTO findings"
+                " (job_id, md_path, claim, confidence, source_ids, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (job.id, "findings/000001.md", "First claim.", 0.9, "[1]", now),
+            )
+            conn.execute(
+                "INSERT INTO findings"
+                " (job_id, md_path, claim, confidence, source_ids, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (job.id, "findings/000002.md", "Second claim.", 0.7, "[1]", now),
+            )
+            cur = conn.execute(
+                "INSERT INTO sources"
+                " (sha256, url, title, fetched_at, archive_url, md_path, kind)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "a" * 64,
+                    "https://example.com/article",
+                    "Example article",
+                    now,
+                    "https://web.archive.org/web/2026/example",
+                    "sources/aaa.md",
+                    "web",
+                ),
+            )
+            sid = cur.lastrowid
+            conn.execute(
+                "INSERT INTO job_sources (job_id, source_id) VALUES (?, ?)",
+                (job.id, sid),
+            )
+    finally:
+        conn.close()
+
+    return job
+
+
+# ---------------------------------------------------------------------------
+# export_zip
+# ---------------------------------------------------------------------------
+
+
+def test_export_zip_includes_expected_paths(seeded_job: Job, tmp_path: Path) -> None:
+    out = tmp_path / "out.zip"
+    written = export_zip(seeded_job, out, include_history=False)
+    assert written == out
+    assert out.exists()
+
+    with zipfile.ZipFile(out) as zf:
+        names = set(zf.namelist())
+
+    assert f"{seeded_job.id}/job.json" in names
+    assert f"{seeded_job.id}/report.md" in names
+    assert f"{seeded_job.id}/findings/000001.md" in names
+    assert f"{seeded_job.id}/findings/000002.md" in names
+
+
+def test_export_zip_excludes_history_by_default(seeded_job: Job, tmp_path: Path) -> None:
+    out = tmp_path / "out.zip"
+    export_zip(seeded_job, out, include_history=False)
+
+    with zipfile.ZipFile(out) as zf:
+        names = zf.namelist()
+
+    assert not any("report.history/" in n for n in names)
+
+
+def test_export_zip_includes_history_when_requested(seeded_job: Job, tmp_path: Path) -> None:
+    out = tmp_path / "out.zip"
+    export_zip(seeded_job, out, include_history=True)
+
+    with zipfile.ZipFile(out) as zf:
+        names = set(zf.namelist())
+
+    assert f"{seeded_job.id}/report.history/20260501T000000Z.md" in names
+
+
+def test_export_zip_does_not_leave_tmp_file(seeded_job: Job, tmp_path: Path) -> None:
+    out = tmp_path / "out.zip"
+    export_zip(seeded_job, out, include_history=False)
+    siblings = sorted(p.name for p in tmp_path.iterdir())
+    assert "out.zip" in siblings
+    assert not any(s.endswith(".tmp") for s in siblings)
+
+
+# ---------------------------------------------------------------------------
+# export_md_bundle
+# ---------------------------------------------------------------------------
+
+
+def test_export_md_bundle_renders_expected_structure(seeded_job: Job, tmp_path: Path) -> None:
+    out = tmp_path / "bundle.md"
+    written = export_md_bundle(seeded_job, out, include_history=False)
+    assert written == out
+
+    body = out.read_text(encoding="utf-8")
+    assert body.startswith(f"# {seeded_job.id}\n")
+    assert "## Report" in body
+    assert "Report body." in body
+    assert "## Findings" in body
+    assert "### Finding 000001" in body
+    assert "### Finding 000002" in body
+    assert "First claim." in body
+    assert "Second claim." in body
+    assert "## Sources" in body
+
+
+def test_export_md_bundle_includes_archive_url(seeded_job: Job, tmp_path: Path) -> None:
+    out = tmp_path / "bundle.md"
+    export_md_bundle(seeded_job, out, include_history=False)
+    body = out.read_text(encoding="utf-8")
+    assert "https://web.archive.org/web/2026/example" in body
+    assert "https://example.com/article" in body
+
+
+def test_export_md_bundle_history_gated_by_flag(seeded_job: Job, tmp_path: Path) -> None:
+    no_hist = tmp_path / "no_hist.md"
+    export_md_bundle(seeded_job, no_hist, include_history=False)
+    assert "## Report History" not in no_hist.read_text(encoding="utf-8")
+
+    with_hist = tmp_path / "with_hist.md"
+    export_md_bundle(seeded_job, with_hist, include_history=True)
+    body = with_hist.read_text(encoding="utf-8")
+    assert "## Report History" in body
+    assert "### 20260501T000000Z" in body
+    assert "Archived body." in body
+
+
+def test_export_md_bundle_handles_missing_report(jobs_root: Path, db_path: Path) -> None:
+    job = Job.create(
+        {"goal": "no report yet"},
+        jobs_root=jobs_root,
+        db_path=db_path,
+        today=date(2026, 5, 3),
+    )
+    out = jobs_root.parent / "bundle.md"
+    export_md_bundle(job, out, include_history=False)
+    body = out.read_text(encoding="utf-8")
+    assert "## Report" in body
+    assert "(no report.md present)" in body
+    assert "(no findings recorded)" in body
+    assert "(no sources recorded)" in body
+
+
+def test_export_md_bundle_intake_block_includes_caps(seeded_job: Job, tmp_path: Path) -> None:
+    out = tmp_path / "bundle.md"
+    export_md_bundle(seeded_job, out, include_history=False)
+    body = out.read_text(encoding="utf-8")
+    assert "goal: Investigate exports" in body
+    assert "time_cap_hours: 4" in body
+    assert "budget_cap_usd: 7.5" in body


### PR DESCRIPTION
Closes #42

## Summary

Automated implementation of **`research export` — zip + md-bundle**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Export command (zip + md-bundle) fully implements all acceptance criteria; tests pass (636/636); README docs gap fixed.

- **WARNING** [FIXED] `README.md`: README listed every other research verb (start/list/status/view/logs/stop/resume/search/config) but had no entry for the new `research export` command. Added the four common invocations to the command block and a paragraph covering mode selection, --out resolution, --include-history, and the atomic-write guarantee.
- **INFO** [FIXED] `src/research_agent/storage/export.py`: Acceptance criteria all met: --zip writes <job-id>.zip with entries rooted at <job-id>/<relpath>; --md-bundle emits H1 job id + YAML front matter (goal/domain/caps/created_at) + ## Report + ## Findings (ordered by id) + ## Sources (with archive_url); --include-history gates report.history/ in both formats; both writes are atomic via *.tmp + os.replace; default --out lands in cwd, dir paths get the default name appended; mutually exclusive mode flags exit 2.
- **INFO** [FIXED] `tests/test_storage_export.py`: Test coverage: 9 storage tests (zip path manifest, history gating both directions, no-tmp-leftover, md-bundle structure, archive_url presence, missing-report fallback, intake caps in front matter) and 7 CLI tests (zip, md-bundle, mode validation, unknown job, --include-history, default --out, --out as directory). All 16 pass.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*