### PR TITLE
feat: Hybrid semantic + FTS search (closes #43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ research stop <job-id> --kill      # hard: SIGTERM then SIGKILL after 10s, unlin
 research resume <job-id>           # respawn the daemon; restores from last checkpoint
 research resume <job-id> --force   # resume even when job is completed/failed
 
-research search "<query>"          # FTS5 over findings + sources (cross-job)
+research search "<query>"          # hybrid FTS5 + semantic (cross-job, default)
+research search "<query>" --fts-only         # legacy FTS5-only escape hatch
 research search "<query>" --job <job-id>     # scope to one job
 research search "<query>" --kind findings    # findings only (default: both)
 research search "<query>" --kind sources     # sources only
@@ -97,15 +98,24 @@ research export <job-id> --zip --out PATH    # write to PATH (file) or PATH/<job
 research export <job-id> --md-bundle --include-history   # also inline report.history/
 ```
 
-`research search` runs the user's query through SQLite FTS5 against
-`findings_fts` (claim text) and `sources_fts` (source titles), ordered by
-the BM25 score (lower is better). Snippet highlights come from the FTS5
-`snippet()` function — the Rich table renders matched terms in bold yellow;
-the `--json` payload preserves them as literal `[`/`]` markers. Source rows
-join through `job_sources`, so the `--job` filter correctly excludes
-sources fetched only by other jobs even when the underlying content is
-shared. FTS5 syntax errors (e.g. unbalanced quotes) exit `1` with a clear
-`FTS5 query error: ...` line on stderr.
+`research search` defaults to a hybrid pass: it runs the query through
+SQLite FTS5 against `findings_fts` (claim text) and `sources_fts` (source
+titles), embeds the same query through the `embeddings` tier, and scores
+every embedded `findings.embedding` / `sources.embedding` blob by cosine
+similarity. The two top-50 lists are deduped on `(kind, id)` and combined
+via reciprocal-rank fusion (k=60). The Rich table surfaces both the fused
+`score` and the underlying `fts` / `cosine` components so it is obvious
+why a row ranked where it did. When the visible source count exceeds 5000,
+the cosine pass tries the optional `sqlite-vec` extension to run KNN in
+SQL; any load or execution error falls back to numpy cosine, so the hybrid
+path is always available. Pass `--fts-only` to skip the semantic pass
+(useful for FTS-syntax debugging or when LM Studio is offline). Snippet
+highlights come from the FTS5 `snippet()` function — the table renders
+matched terms in bold yellow; the `--json` payload preserves them as
+literal `[`/`]` markers. Source rows join through `job_sources`, so the
+`--job` filter correctly excludes sources fetched only by other jobs even
+when the underlying content is shared. FTS5 syntax errors (e.g. unbalanced
+quotes) exit `1` with a clear `FTS5 query error: ...` line on stderr.
 
 `research export` bundles a job for sharing. `--zip` walks
 `jobs/<job-id>/` and emits a single `ZIP_DEFLATED` archive whose entries

--- a/src/research_agent/cli.py
+++ b/src/research_agent/cli.py
@@ -340,7 +340,7 @@ def smoke_tool_command(
 
 @app.command(name="search")
 def search_command(
-    query: str = typer.Argument(..., help="FTS5 query string."),
+    query: str = typer.Argument(..., help="Search query string."),
     job: str = typer.Option(None, "--job", help="Scope to a single job id."),
     all_: bool = typer.Option(  # noqa: ARG001 — explicit flag; --all is the default
         False,
@@ -352,16 +352,26 @@ def search_command(
         "--kind",
         help="What to search: findings | sources | both.",
     ),
+    fts_only: bool = typer.Option(
+        False,
+        "--fts-only",
+        help="Skip the semantic pass and run FTS5 only (legacy / escape hatch).",
+    ),
     json_output: bool = typer.Option(
         False,
         "--json",
         help="Emit machine-readable JSON instead of the Rich table.",
     ),
 ) -> None:
-    """Run FTS5 search over findings and/or sources."""
+    """Hybrid FTS5 + semantic search over findings and/or sources."""
     import sqlite3
 
-    from research_agent.storage.search import ALLOWED_KINDS, search_fts
+    from research_agent.llm.router import load_models_config
+    from research_agent.storage.search import (
+        ALLOWED_KINDS,
+        search_fts,
+        search_hybrid,
+    )
 
     if kind not in ALLOWED_KINDS:
         typer.echo(
@@ -376,7 +386,17 @@ def search_command(
         job_id = job
 
     try:
-        results = search_fts(query, job_id=job_id, kind=kind, db_path=db.DEFAULT_DB_PATH)
+        if fts_only:
+            results = search_fts(query, job_id=job_id, kind=kind, db_path=db.DEFAULT_DB_PATH)
+        else:
+            models_cfg = load_models_config(Path("config/models.yaml"))
+            results = search_hybrid(
+                query,
+                job_id=job_id,
+                kind=kind,
+                db_path=db.DEFAULT_DB_PATH,
+                models_config=models_cfg,
+            )
     except sqlite3.OperationalError as e:
         typer.echo(f"FTS5 query error: {e}", err=True)
         raise typer.Exit(code=1) from e

--- a/src/research_agent/storage/search.py
+++ b/src/research_agent/storage/search.py
@@ -1,11 +1,13 @@
-"""FTS5 search over findings and sources (issue #22).
+"""FTS5 + semantic hybrid search over findings and sources.
 
-Pure read-only helper used by the ``research search`` CLI verb. Runs against
-the ``findings_fts`` and ``sources_fts`` virtual tables built in §10 of the
-implementation guide. Scoring uses the FTS5 ``bm25`` function — lower score
-means a better match — and snippets come from the FTS5 ``snippet`` function
-with literal ``[``/``]`` markers around the matched terms (the ``ui.render``
-layer transforms those into Rich markup).
+Issue #22 introduced ``search_fts`` (BM25 over ``findings_fts`` /
+``sources_fts``); issue #43 layers a cosine-similarity pass over the packed
+float32 ``findings.embedding`` / ``sources.embedding`` BLOBs on top and fuses
+the two ranked lists via reciprocal-rank fusion (RRF). When the cross-job
+source count exceeds :data:`SQLITE_VEC_THRESHOLD`, the cosine pass tries to
+load the optional ``sqlite-vec`` extension and runs the KNN in SQL; any load
+or execution error falls back to numpy cosine, so the hybrid path is always
+available even without the extension.
 
 The MATCH string is the user's query verbatim; FTS5 syntax errors propagate
 as :class:`sqlite3.OperationalError` for the CLI to translate into a friendly
@@ -14,12 +16,31 @@ error message.
 
 from __future__ import annotations
 
+import logging
+import sqlite3
 from pathlib import Path
 from typing import Any
 
+import numpy as np
+
 from research_agent.storage import db
 
+logger = logging.getLogger(__name__)
+
 ALLOWED_KINDS = ("findings", "sources", "both")
+
+# Above this source count the cosine pass prefers the sqlite-vec KNN path.
+SQLITE_VEC_THRESHOLD = 5000
+
+# Default RRF constant from the original Cormack et al. paper.
+DEFAULT_RRF_K = 60
+
+# Default per-list result cap (FTS top-N and cosine top-N before fusion).
+DEFAULT_TOP_K = 50
+
+# Module-level cache for sqlite-vec availability per connection process.
+# True/False once we've probed; None means "not yet attempted".
+_SQLITE_VEC_LOADED: bool | None = None
 
 
 def search_fts(
@@ -113,4 +134,384 @@ def search_fts(
     return results
 
 
-__all__ = ["ALLOWED_KINDS", "search_fts"]
+# ---------------------------------------------------------------------------
+# Embedding + cosine helpers
+# ---------------------------------------------------------------------------
+
+
+def _embed_query(
+    query: str,
+    models_config: dict[str, Any] | None = None,
+) -> np.ndarray:
+    """Embed ``query`` via the LM Studio ``embeddings`` tier.
+
+    Reuses the wiring from :mod:`research_agent.tools.local_corpus` so the
+    hybrid path goes through exactly the same endpoint and model that the
+    indexer uses. Returns a float32 numpy vector.
+    """
+    # Local import to avoid a circular dependency at module import time
+    # (``local_corpus`` imports from this package's storage layer too).
+    from research_agent.tools.local_corpus import (
+        _embed_chunks_sync,
+        _resolve_embedding_endpoint,
+    )
+
+    base_url, model_name = _resolve_embedding_endpoint(models_config)
+    vectors = _embed_chunks_sync([query], base_url, model_name)
+    if not vectors:
+        raise RuntimeError("embeddings tier returned no vectors for the query")
+    return vectors[0]
+
+
+def _count_sources(conn: sqlite3.Connection, job_id: str | None) -> int:
+    """Return the number of sources visible to the search.
+
+    When ``job_id`` is set the count is scoped to that job's ``job_sources``
+    rows; otherwise it counts every row in ``sources``. Used to gate the
+    sqlite-vec path against the :data:`SQLITE_VEC_THRESHOLD` cutoff.
+    """
+    if job_id is None:
+        row = conn.execute("SELECT COUNT(*) AS n FROM sources").fetchone()
+    else:
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM job_sources WHERE job_id = ?",
+            (job_id,),
+        ).fetchone()
+    return int(row["n"]) if row is not None else 0
+
+
+def _try_load_sqlite_vec(conn: sqlite3.Connection) -> bool:
+    """Try to load the ``sqlite-vec`` extension on ``conn``. Cached per process.
+
+    Tries the python ``sqlite_vec`` package first (the official install
+    pattern), then falls back to ``conn.load_extension('vec0')``. Returns
+    True on success and False on any failure — callers must use the numpy
+    fallback path when this returns False.
+    """
+    global _SQLITE_VEC_LOADED
+    if _SQLITE_VEC_LOADED is not None:
+        return _SQLITE_VEC_LOADED
+
+    try:
+        conn.enable_load_extension(True)
+    except (AttributeError, sqlite3.OperationalError) as exc:
+        logger.debug("sqlite extension loading not supported on this build: %s", exc)
+        _SQLITE_VEC_LOADED = False
+        return False
+
+    try:
+        import sqlite_vec  # type: ignore[import-not-found]
+
+        sqlite_vec.load(conn)
+    except Exception as pkg_exc:  # noqa: BLE001 — fall through to direct load
+        logger.debug("sqlite_vec python package unavailable: %s", pkg_exc)
+        try:
+            conn.load_extension("vec0")
+        except Exception as load_exc:  # noqa: BLE001
+            logger.debug("conn.load_extension('vec0') failed: %s", load_exc)
+            try:
+                conn.enable_load_extension(False)
+            except sqlite3.OperationalError:
+                pass
+            _SQLITE_VEC_LOADED = False
+            return False
+
+    try:
+        conn.execute("SELECT vec_distance_cosine(X'00000000', X'00000000')").fetchone()
+    except sqlite3.OperationalError as exc:
+        logger.debug("sqlite-vec loaded but vec_distance_cosine missing: %s", exc)
+        _SQLITE_VEC_LOADED = False
+        return False
+
+    _SQLITE_VEC_LOADED = True
+    return True
+
+
+def _reset_sqlite_vec_cache() -> None:
+    """Reset the module-level sqlite-vec availability cache. Used by tests."""
+    global _SQLITE_VEC_LOADED
+    _SQLITE_VEC_LOADED = None
+
+
+def _unpack_embedding(blob: bytes) -> np.ndarray:
+    return np.frombuffer(blob, dtype="<f4")
+
+
+def _pack_query_vec(qvec: np.ndarray) -> bytes:
+    return np.asarray(qvec, dtype="<f4").tobytes()
+
+
+def _cosine_search_numpy(
+    conn: sqlite3.Connection,
+    qvec: np.ndarray,
+    job_id: str | None,
+    kind: str,
+    top_k: int = DEFAULT_TOP_K,
+) -> list[dict[str, Any]]:
+    """Score every embedded row by cosine similarity in numpy. Returns top-k."""
+    qnorm = float(np.linalg.norm(qvec))
+    if qnorm == 0.0:
+        return []
+
+    scored: list[dict[str, Any]] = []
+
+    if kind in ("findings", "both"):
+        sql = (
+            "SELECT f.id AS id, f.job_id AS job_id, f.md_path AS md_path, "
+            "f.claim AS title_or_claim, f.embedding AS embedding "
+            "FROM findings f WHERE f.embedding IS NOT NULL"
+        )
+        params: list[Any] = []
+        if job_id is not None:
+            sql += " AND f.job_id = ?"
+            params.append(job_id)
+        for row in conn.execute(sql, params).fetchall():
+            vec = _unpack_embedding(row["embedding"])
+            if vec.shape[0] != qvec.shape[0]:
+                continue
+            vnorm = float(np.linalg.norm(vec))
+            if vnorm == 0.0:
+                continue
+            score = float(np.dot(qvec, vec) / (qnorm * vnorm))
+            scored.append(
+                {
+                    "kind": "finding",
+                    "id": int(row["id"]),
+                    "job_id": row["job_id"],
+                    "md_path": row["md_path"],
+                    "title_or_claim": row["title_or_claim"],
+                    "score": score,
+                }
+            )
+
+    if kind in ("sources", "both"):
+        sql = (
+            "SELECT s.id AS id, js.job_id AS job_id, s.md_path AS md_path, "
+            "s.title AS title_or_claim, s.embedding AS embedding "
+            "FROM sources s JOIN job_sources js ON js.source_id = s.id "
+            "WHERE s.embedding IS NOT NULL"
+        )
+        params = []
+        if job_id is not None:
+            sql += " AND js.job_id = ?"
+            params.append(job_id)
+        for row in conn.execute(sql, params).fetchall():
+            vec = _unpack_embedding(row["embedding"])
+            if vec.shape[0] != qvec.shape[0]:
+                continue
+            vnorm = float(np.linalg.norm(vec))
+            if vnorm == 0.0:
+                continue
+            score = float(np.dot(qvec, vec) / (qnorm * vnorm))
+            scored.append(
+                {
+                    "kind": "source",
+                    "id": int(row["id"]),
+                    "job_id": row["job_id"],
+                    "md_path": row["md_path"],
+                    "title_or_claim": row["title_or_claim"],
+                    "score": score,
+                }
+            )
+
+    scored.sort(key=lambda r: r["score"], reverse=True)
+    return scored[:top_k]
+
+
+def _cosine_search_sqlite_vec(
+    conn: sqlite3.Connection,
+    qvec: np.ndarray,
+    job_id: str | None,
+    kind: str,
+    top_k: int = DEFAULT_TOP_K,
+) -> list[dict[str, Any]]:
+    """Score every embedded row using the sqlite-vec ``vec_distance_cosine``.
+
+    Returns the same dict shape as :func:`_cosine_search_numpy`. Cosine
+    *distance* is converted back to *similarity* (``1 - distance``) so the
+    score axis matches the numpy path and downstream RRF logic.
+    """
+    qblob = _pack_query_vec(qvec)
+    rows: list[dict[str, Any]] = []
+
+    if kind in ("findings", "both"):
+        sql = (
+            "SELECT f.id AS id, f.job_id AS job_id, f.md_path AS md_path, "
+            "f.claim AS title_or_claim, "
+            "vec_distance_cosine(f.embedding, ?) AS distance "
+            "FROM findings f WHERE f.embedding IS NOT NULL"
+        )
+        params: list[Any] = [qblob]
+        if job_id is not None:
+            sql += " AND f.job_id = ?"
+            params.append(job_id)
+        sql += " ORDER BY distance ASC LIMIT ?"
+        params.append(top_k)
+        for row in conn.execute(sql, params).fetchall():
+            rows.append(
+                {
+                    "kind": "finding",
+                    "id": int(row["id"]),
+                    "job_id": row["job_id"],
+                    "md_path": row["md_path"],
+                    "title_or_claim": row["title_or_claim"],
+                    "score": 1.0 - float(row["distance"]),
+                }
+            )
+
+    if kind in ("sources", "both"):
+        sql = (
+            "SELECT s.id AS id, js.job_id AS job_id, s.md_path AS md_path, "
+            "s.title AS title_or_claim, "
+            "vec_distance_cosine(s.embedding, ?) AS distance "
+            "FROM sources s JOIN job_sources js ON js.source_id = s.id "
+            "WHERE s.embedding IS NOT NULL"
+        )
+        params = [qblob]
+        if job_id is not None:
+            sql += " AND js.job_id = ?"
+            params.append(job_id)
+        sql += " ORDER BY distance ASC LIMIT ?"
+        params.append(top_k)
+        for row in conn.execute(sql, params).fetchall():
+            rows.append(
+                {
+                    "kind": "source",
+                    "id": int(row["id"]),
+                    "job_id": row["job_id"],
+                    "md_path": row["md_path"],
+                    "title_or_claim": row["title_or_claim"],
+                    "score": 1.0 - float(row["distance"]),
+                }
+            )
+
+    rows.sort(key=lambda r: r["score"], reverse=True)
+    return rows[:top_k]
+
+
+def _rrf_fuse(
+    fts_results: list[dict[str, Any]],
+    cosine_results: list[dict[str, Any]],
+    k: int = DEFAULT_RRF_K,
+) -> list[dict[str, Any]]:
+    """Reciprocal-rank-fuse two ranked lists into a deduped, sorted list.
+
+    Each item appears at most once, keyed by ``(kind, id)``. Its fused
+    ``score`` is ``sum(1/(k + rank))`` over the lists in which it appears,
+    where ``rank`` is its 1-based position. Items missing from a list
+    contribute zero for that list. The returned list is sorted by fused
+    score descending; metadata from the FTS hit (snippet, etc.) is kept
+    when present, with the cosine hit's metadata used as a fallback.
+    """
+    if k <= 0:
+        raise ValueError(f"k must be positive; got {k}")
+
+    fused: dict[tuple[str, int], dict[str, Any]] = {}
+
+    for rank_idx, item in enumerate(fts_results, start=1):
+        key = (item["kind"], int(item["id"]))
+        contribution = 1.0 / (k + rank_idx)
+        entry = fused.setdefault(
+            key,
+            {
+                "kind": item["kind"],
+                "id": int(item["id"]),
+                "job_id": item.get("job_id"),
+                "md_path": item.get("md_path"),
+                "title_or_claim": item.get("title_or_claim"),
+                "snippet": item.get("snippet"),
+                "score": 0.0,
+                "fts_score": item.get("score"),
+                "cosine_score": None,
+            },
+        )
+        # Preserve FTS-only fields if this is a re-merge from cosine-first.
+        if entry.get("snippet") is None and item.get("snippet") is not None:
+            entry["snippet"] = item.get("snippet")
+        if entry.get("fts_score") is None:
+            entry["fts_score"] = item.get("score")
+        entry["score"] += contribution
+
+    for rank_idx, item in enumerate(cosine_results, start=1):
+        key = (item["kind"], int(item["id"]))
+        contribution = 1.0 / (k + rank_idx)
+        entry = fused.setdefault(
+            key,
+            {
+                "kind": item["kind"],
+                "id": int(item["id"]),
+                "job_id": item.get("job_id"),
+                "md_path": item.get("md_path"),
+                "title_or_claim": item.get("title_or_claim"),
+                "snippet": None,
+                "score": 0.0,
+                "fts_score": None,
+                "cosine_score": item.get("score"),
+            },
+        )
+        if entry.get("cosine_score") is None:
+            entry["cosine_score"] = item.get("score")
+        entry["score"] += contribution
+
+    out = list(fused.values())
+    out.sort(key=lambda r: r["score"], reverse=True)
+    return out
+
+
+def search_hybrid(
+    query: str,
+    *,
+    job_id: str | None,
+    kind: str,
+    db_path: Path | str = db.DEFAULT_DB_PATH,
+    models_config: dict[str, Any] | None = None,
+    top_k: int = DEFAULT_TOP_K,
+    rrf_k: int = DEFAULT_RRF_K,
+) -> list[dict[str, Any]]:
+    """Hybrid FTS5 + cosine search with reciprocal-rank fusion.
+
+    Embeds ``query`` through the embeddings tier, runs FTS and cosine in
+    parallel paths (each capped at ``top_k``), and fuses the rankings via
+    :func:`_rrf_fuse`. Above :data:`SQLITE_VEC_THRESHOLD` cross-job sources
+    the cosine pass tries the sqlite-vec extension and falls back to numpy
+    on any error.
+    """
+    if not isinstance(query, str) or not query.strip():
+        raise ValueError("query must be a non-empty string")
+    if kind not in ALLOWED_KINDS:
+        raise ValueError(f"kind must be one of {list(ALLOWED_KINDS)}; got {kind!r}")
+    if top_k <= 0:
+        raise ValueError(f"top_k must be positive; got {top_k}")
+
+    fts_results = search_fts(query, job_id=job_id, kind=kind, db_path=db_path)[:top_k]
+
+    qvec = _embed_query(query, models_config)
+
+    conn = db.connect(Path(db_path))
+    try:
+        source_count = _count_sources(conn, job_id)
+        cosine_results: list[dict[str, Any]] = []
+        used_sqlite_vec = False
+        if source_count > SQLITE_VEC_THRESHOLD and _try_load_sqlite_vec(conn):
+            try:
+                cosine_results = _cosine_search_sqlite_vec(conn, qvec, job_id, kind, top_k=top_k)
+                used_sqlite_vec = True
+            except sqlite3.OperationalError as exc:
+                logger.warning("sqlite-vec cosine path failed; falling back to numpy: %s", exc)
+                cosine_results = []
+        if not used_sqlite_vec:
+            cosine_results = _cosine_search_numpy(conn, qvec, job_id, kind, top_k=top_k)
+    finally:
+        conn.close()
+
+    return _rrf_fuse(fts_results, cosine_results, k=rrf_k)
+
+
+__all__ = [
+    "ALLOWED_KINDS",
+    "DEFAULT_RRF_K",
+    "DEFAULT_TOP_K",
+    "SQLITE_VEC_THRESHOLD",
+    "search_fts",
+    "search_hybrid",
+]

--- a/src/research_agent/storage/search.py
+++ b/src/research_agent/storage/search.py
@@ -38,8 +38,12 @@ DEFAULT_RRF_K = 60
 # Default per-list result cap (FTS top-N and cosine top-N before fusion).
 DEFAULT_TOP_K = 50
 
-# Module-level cache for sqlite-vec availability per connection process.
-# True/False once we've probed; None means "not yet attempted".
+# Module-level cache for sqlite-vec *availability* in this process.
+# True means a prior load succeeded (so the package is importable and the
+# extension works); we still have to call ``sqlite_vec.load(conn)`` on every
+# new connection because SQLite extensions are connection-local. False is a
+# negative cache: we already tried and the extension is unavailable, so we
+# skip the load attempt and fall back to numpy. None means "not yet probed".
 _SQLITE_VEC_LOADED: bool | None = None
 
 
@@ -181,16 +185,22 @@ def _count_sources(conn: sqlite3.Connection, job_id: str | None) -> int:
 
 
 def _try_load_sqlite_vec(conn: sqlite3.Connection) -> bool:
-    """Try to load the ``sqlite-vec`` extension on ``conn``. Cached per process.
+    """Try to load the ``sqlite-vec`` extension on ``conn``.
 
     Tries the python ``sqlite_vec`` package first (the official install
     pattern), then falls back to ``conn.load_extension('vec0')``. Returns
     True on success and False on any failure — callers must use the numpy
     fallback path when this returns False.
+
+    SQLite loads extensions *per-connection*, so this function always runs
+    the load attempt on ``conn``; the module-level :data:`_SQLITE_VEC_LOADED`
+    cache is only used as a *negative* short-circuit (skip the work when we
+    already know the extension is unavailable in this process) and to skip
+    the one-time function probe after the first successful load.
     """
     global _SQLITE_VEC_LOADED
-    if _SQLITE_VEC_LOADED is not None:
-        return _SQLITE_VEC_LOADED
+    if _SQLITE_VEC_LOADED is False:
+        return False
 
     try:
         conn.enable_load_extension(True)
@@ -216,12 +226,15 @@ def _try_load_sqlite_vec(conn: sqlite3.Connection) -> bool:
             _SQLITE_VEC_LOADED = False
             return False
 
-    try:
-        conn.execute("SELECT vec_distance_cosine(X'00000000', X'00000000')").fetchone()
-    except sqlite3.OperationalError as exc:
-        logger.debug("sqlite-vec loaded but vec_distance_cosine missing: %s", exc)
-        _SQLITE_VEC_LOADED = False
-        return False
+    if _SQLITE_VEC_LOADED is None:
+        # First time we've gotten this far in the process — confirm the
+        # cosine helper is actually registered before we commit to it.
+        try:
+            conn.execute("SELECT vec_distance_cosine(X'00000000', X'00000000')").fetchone()
+        except sqlite3.OperationalError as exc:
+            logger.debug("sqlite-vec loaded but vec_distance_cosine missing: %s", exc)
+            _SQLITE_VEC_LOADED = False
+            return False
 
     _SQLITE_VEC_LOADED = True
     return True

--- a/src/research_agent/ui/render.py
+++ b/src/research_agent/ui/render.py
@@ -331,27 +331,47 @@ def tail_events_jsonl(
             yield ev
 
 
+def _format_score(value: Any, *, digits: int = 2) -> str:
+    if value is None:
+        return "—"
+    try:
+        return f"{float(value):.{digits}f}"
+    except (TypeError, ValueError):
+        return "—"
+
+
 def render_search_table(results: list[dict[str, Any]]) -> Table:
-    """Render a Rich table for `research search` results."""
+    """Render a Rich table for `research search` results.
+
+    Hybrid results expose ``fts_score`` / ``cosine_score`` alongside the
+    fused ``score``; if any row carries those keys we surface them as
+    additional columns so operators can see why an item ranked where it did.
+    """
+    show_components = any(("fts_score" in row) or ("cosine_score" in row) for row in results)
+
     table = Table(title="search results", show_lines=False)
     table.add_column("score")
+    if show_components:
+        table.add_column("fts")
+        table.add_column("cosine")
     table.add_column("kind")
     table.add_column("job_id", overflow="fold")
     table.add_column("snippet", overflow="fold")
     for row in results:
-        snippet = str(row.get("snippet", ""))
+        snippet = str(row.get("snippet") or "")
         snippet = snippet.replace("[", "[bold yellow]").replace("]", "[/]")
-        score = row.get("score")
-        try:
-            score_str = f"{float(score):.2f}"  # type: ignore[arg-type]
-        except (TypeError, ValueError):
-            score_str = "—"
-        table.add_row(
-            score_str,
-            str(row.get("kind", "")),
-            str(row.get("job_id") or "—"),
-            snippet,
+        cells = [_format_score(row.get("score"), digits=4)]
+        if show_components:
+            cells.append(_format_score(row.get("fts_score")))
+            cells.append(_format_score(row.get("cosine_score")))
+        cells.extend(
+            [
+                str(row.get("kind", "")),
+                str(row.get("job_id") or "—"),
+                snippet,
+            ]
         )
+        table.add_row(*cells)
     return table
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1129,7 +1129,7 @@ def _seed_search_data(repo: Path) -> tuple[Job, Job]:
 def test_search_json_emits_results(isolated_jobs_repo: Path):
     _seed_search_data(isolated_jobs_repo)
     runner = CliRunner()
-    result = runner.invoke(cli.app, ["search", "quantum", "--json"])
+    result = runner.invoke(cli.app, ["search", "quantum", "--fts-only", "--json"])
     assert result.exit_code == 0, result.stdout
     payload = json.loads(result.stdout)
     assert isinstance(payload, list)
@@ -1142,7 +1142,7 @@ def test_search_json_emits_results(isolated_jobs_repo: Path):
 def test_search_empty_result_zero_exit(isolated_jobs_repo: Path):
     _seed_search_data(isolated_jobs_repo)
     runner = CliRunner()
-    result = runner.invoke(cli.app, ["search", "nonexistenttoken", "--json"])
+    result = runner.invoke(cli.app, ["search", "nonexistenttoken", "--fts-only", "--json"])
     assert result.exit_code == 0, result.stdout
     assert json.loads(result.stdout) == []
 
@@ -1150,7 +1150,10 @@ def test_search_empty_result_zero_exit(isolated_jobs_repo: Path):
 def test_search_kind_flag_filters_output(isolated_jobs_repo: Path):
     _seed_search_data(isolated_jobs_repo)
     runner = CliRunner()
-    result = runner.invoke(cli.app, ["search", "quantum", "--kind", "findings", "--json"])
+    result = runner.invoke(
+        cli.app,
+        ["search", "quantum", "--fts-only", "--kind", "findings", "--json"],
+    )
     assert result.exit_code == 0, result.stdout
     payload = json.loads(result.stdout)
     assert payload
@@ -1160,7 +1163,10 @@ def test_search_kind_flag_filters_output(isolated_jobs_repo: Path):
 def test_search_job_flag_scopes_to_job(isolated_jobs_repo: Path):
     job_a, _job_b = _seed_search_data(isolated_jobs_repo)
     runner = CliRunner()
-    result = runner.invoke(cli.app, ["search", "quantum", "--job", job_a.id, "--json"])
+    result = runner.invoke(
+        cli.app,
+        ["search", "quantum", "--fts-only", "--job", job_a.id, "--json"],
+    )
     assert result.exit_code == 0, result.stdout
     payload = json.loads(result.stdout)
     assert payload
@@ -1179,7 +1185,14 @@ def test_search_unknown_job_errors(isolated_jobs_repo: Path):
     runner = CliRunner()
     result = runner.invoke(
         cli.app,
-        ["search", "quantum", "--job", "2026-05-02-does-not-exist", "--json"],
+        [
+            "search",
+            "quantum",
+            "--fts-only",
+            "--job",
+            "2026-05-02-does-not-exist",
+            "--json",
+        ],
     )
     assert result.exit_code == 1
     combined = result.stdout + (result.stderr or "")
@@ -1190,7 +1203,7 @@ def test_search_unknown_job_errors(isolated_jobs_repo: Path):
 def test_search_no_results_table_message(isolated_jobs_repo: Path):
     _seed_search_data(isolated_jobs_repo)
     runner = CliRunner()
-    result = runner.invoke(cli.app, ["search", "nonexistenttoken"])
+    result = runner.invoke(cli.app, ["search", "nonexistenttoken", "--fts-only"])
     assert result.exit_code == 0, result.stdout
     assert "(no results)" in result.stdout
 
@@ -1199,7 +1212,7 @@ def test_search_malformed_query_exits_one(isolated_jobs_repo: Path):
     _seed_search_data(isolated_jobs_repo)
     runner = CliRunner()
     # Unbalanced quotes are an FTS5 syntax error.
-    result = runner.invoke(cli.app, ["search", '"unterminated', "--json"])
+    result = runner.invoke(cli.app, ["search", '"unterminated', "--fts-only", "--json"])
     assert result.exit_code == 1
     combined = result.stdout + (result.stderr or "")
     assert "FTS5 query error" in combined

--- a/tests/test_storage_search.py
+++ b/tests/test_storage_search.py
@@ -1,14 +1,22 @@
-"""Tests for `research_agent.storage.search` (issue #22)."""
+"""Tests for `research_agent.storage.search` (issue #22 + #43)."""
 
 from __future__ import annotations
 
 import time
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from research_agent.storage import db
-from research_agent.storage.search import search_fts
+from research_agent.storage import search as search_mod
+from research_agent.storage.search import (
+    DEFAULT_RRF_K,
+    _rrf_fuse,
+    _try_load_sqlite_vec,
+    search_fts,
+    search_hybrid,
+)
 
 JOB_A = "2026-05-01-job-a"
 JOB_B = "2026-05-02-job-b"
@@ -196,3 +204,313 @@ def test_result_dict_has_expected_keys(seeded_db: Path) -> None:
     expected = {"kind", "score", "job_id", "snippet", "id", "md_path", "title_or_claim"}
     for row in results:
         assert expected <= row.keys()
+
+
+# ---------------------------------------------------------------------------
+# Hybrid search (#43): RRF + cosine + sqlite-vec fallback
+# ---------------------------------------------------------------------------
+
+
+EMBED_DIM = 1024
+
+
+def _pack(vec: np.ndarray) -> bytes:
+    return np.asarray(vec, dtype="<f4").tobytes()
+
+
+def _unit(seed: int, dim: int = EMBED_DIM) -> np.ndarray:
+    rng = np.random.default_rng(seed=seed)
+    v = rng.standard_normal(dim).astype(np.float32)
+    n = float(np.linalg.norm(v))
+    return v / n if n > 0 else v
+
+
+@pytest.fixture
+def embedded_db(tmp_path: Path) -> Path:
+    """DB seeded with findings + sources whose embeddings are deterministic.
+
+    Two findings and two sources, each with a unique unit vector, plus one
+    finding with no embedding (NULL) so we can exercise the IS NOT NULL gate.
+    """
+    db_path = tmp_path / "data" / "index.sqlite"
+    db.migrate(path=db_path).close()
+
+    now = int(time.time())
+    conn = db.connect(db_path)
+    try:
+        with conn:
+            for jid in (JOB_A, JOB_B):
+                conn.execute(
+                    "INSERT INTO jobs (id, goal, status, intake_json, created_at)"
+                    " VALUES (?, ?, ?, ?, ?)",
+                    (jid, "g", "pending", "{}", now),
+                )
+
+            # Finding 1 (JOB_A) — embedding aligned with seed 1.
+            conn.execute(
+                "INSERT INTO findings"
+                " (job_id, md_path, claim, confidence, source_ids, embedding, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    JOB_A,
+                    "findings/000001.md",
+                    "quantum entanglement breakthrough",
+                    0.9,
+                    "[]",
+                    _pack(_unit(1)),
+                    now,
+                ),
+            )
+            # Finding 2 (JOB_B) — embedding aligned with seed 2.
+            conn.execute(
+                "INSERT INTO findings"
+                " (job_id, md_path, claim, confidence, source_ids, embedding, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    JOB_B,
+                    "findings/000001.md",
+                    "quantum supremacy benchmark surpassed",
+                    0.8,
+                    "[]",
+                    _pack(_unit(2)),
+                    now,
+                ),
+            )
+            # Finding 3 (JOB_A) — no embedding; should be skipped by cosine path.
+            conn.execute(
+                "INSERT INTO findings"
+                " (job_id, md_path, claim, confidence, source_ids, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (JOB_A, "findings/000002.md", "unrelated coffee finding", 0.5, "[]", now),
+            )
+
+            cur1 = conn.execute(
+                "INSERT INTO sources"
+                " (sha256, url, title, fetched_at, md_path, kind, embedding)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "a" * 64,
+                    "https://example.com/q",
+                    "Quantum computing report",
+                    now,
+                    "sources/a.md",
+                    "web",
+                    _pack(_unit(3)),
+                ),
+            )
+            sid1 = cur1.lastrowid
+            cur2 = conn.execute(
+                "INSERT INTO sources"
+                " (sha256, url, title, fetched_at, md_path, kind, embedding)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "b" * 64,
+                    "https://example.com/c",
+                    "Coffee brewing techniques",
+                    now,
+                    "sources/b.md",
+                    "web",
+                    _pack(_unit(4)),
+                ),
+            )
+            sid2 = cur2.lastrowid
+
+            conn.execute(
+                "INSERT INTO job_sources (job_id, source_id) VALUES (?, ?)",
+                (JOB_A, sid1),
+            )
+            conn.execute(
+                "INSERT INTO job_sources (job_id, source_id) VALUES (?, ?)",
+                (JOB_B, sid1),
+            )
+            conn.execute(
+                "INSERT INTO job_sources (job_id, source_id) VALUES (?, ?)",
+                (JOB_A, sid2),
+            )
+
+            conn.execute("INSERT INTO findings_fts(findings_fts) VALUES('rebuild')")
+            conn.execute("INSERT INTO sources_fts(sources_fts) VALUES('rebuild')")
+    finally:
+        conn.close()
+
+    return db_path
+
+
+@pytest.fixture(autouse=True)
+def _reset_sqlite_vec_cache():
+    """Clear the per-process sqlite-vec availability cache between tests."""
+    search_mod._reset_sqlite_vec_cache()
+    yield
+    search_mod._reset_sqlite_vec_cache()
+
+
+# ---- _rrf_fuse ------------------------------------------------------------
+
+
+def test_rrf_dedup() -> None:
+    """An item present in both lists collapses to one entry with summed RRF."""
+    fts = [
+        {"kind": "finding", "id": 1, "score": 0.1, "snippet": "a [hit]"},
+        {"kind": "finding", "id": 2, "score": 0.5, "snippet": "b"},
+    ]
+    cosine = [
+        {"kind": "finding", "id": 1, "score": 0.9},
+        {"kind": "source", "id": 5, "score": 0.7},
+    ]
+    fused = _rrf_fuse(fts, cosine, k=60)
+
+    assert len(fused) == 3  # (finding,1) deduped, (finding,2), (source,5)
+    by_key = {(r["kind"], r["id"]): r for r in fused}
+
+    expected_dedup = (1.0 / (60 + 1)) + (1.0 / (60 + 1))
+    assert by_key[("finding", 1)]["score"] == pytest.approx(expected_dedup)
+    assert by_key[("finding", 1)]["snippet"] == "a [hit]"
+    assert by_key[("finding", 1)]["fts_score"] == 0.1
+    assert by_key[("finding", 1)]["cosine_score"] == 0.9
+
+
+def test_rrf_math() -> None:
+    """Hand-computed fused scores for a fixed 3-item / 3-item layout."""
+    fts = [
+        {"kind": "finding", "id": 10, "score": 0.0},  # rank 1 in FTS
+        {"kind": "finding", "id": 20, "score": 0.5},  # rank 2 in FTS
+        {"kind": "source", "id": 30, "score": 1.5},  # rank 3 in FTS
+    ]
+    cosine = [
+        {"kind": "source", "id": 30, "score": 0.95},  # rank 1 in cosine
+        {"kind": "finding", "id": 10, "score": 0.85},  # rank 2 in cosine
+        {"kind": "finding", "id": 40, "score": 0.80},  # rank 3 in cosine, new
+    ]
+    k = 60
+    fused = _rrf_fuse(fts, cosine, k=k)
+
+    expected = {
+        ("finding", 10): 1.0 / (k + 1) + 1.0 / (k + 2),
+        ("finding", 20): 1.0 / (k + 2),
+        ("source", 30): 1.0 / (k + 3) + 1.0 / (k + 1),
+        ("finding", 40): 1.0 / (k + 3),
+    }
+    by_key = {(r["kind"], r["id"]): r for r in fused}
+    assert set(by_key.keys()) == set(expected.keys())
+    for key, want in expected.items():
+        assert by_key[key]["score"] == pytest.approx(want)
+
+    # Output must be sorted by fused score descending.
+    scores = [r["score"] for r in fused]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_rrf_default_k_constant() -> None:
+    assert DEFAULT_RRF_K == 60
+
+
+def test_rrf_invalid_k() -> None:
+    with pytest.raises(ValueError):
+        _rrf_fuse([], [], k=0)
+
+
+# ---- search_hybrid --------------------------------------------------------
+
+
+def _patch_embed(monkeypatch: pytest.MonkeyPatch, vec: np.ndarray) -> None:
+    monkeypatch.setattr(search_mod, "_embed_query", lambda q, cfg=None: vec)
+
+
+def test_hybrid_falls_back_to_numpy(embedded_db: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When sqlite-vec can't load, results still rank correctly via numpy cosine."""
+    # Force the loader to report unavailable.
+    monkeypatch.setattr(search_mod, "_try_load_sqlite_vec", lambda conn: False)
+    # Below threshold the numpy path is selected anyway, but we also force
+    # the threshold to 0 to take the sqlite-vec branch and prove it falls back.
+    monkeypatch.setattr(search_mod, "SQLITE_VEC_THRESHOLD", 0)
+
+    # Query vector aligned with finding #1's embedding so cosine should
+    # rank that finding very high (cos ≈ 1.0).
+    _patch_embed(monkeypatch, _unit(1))
+
+    results = search_hybrid("quantum", job_id=None, kind="both", db_path=embedded_db, top_k=50)
+
+    assert results, "hybrid path should return at least one row"
+    # Finding #1 is the only one whose embedding is aligned with our query
+    # vector — it must appear and carry a cosine_score close to 1.
+    by_key = {(r["kind"], r["id"]): r for r in results}
+    assert ("finding", 1) in by_key
+    f1 = by_key[("finding", 1)]
+    assert f1["cosine_score"] is not None
+    assert f1["cosine_score"] == pytest.approx(1.0, abs=1e-5)
+    # Either it appeared in FTS too (then fts_score is set) or it didn't,
+    # but the fused score must include the cosine contribution at minimum.
+    assert f1["score"] >= 1.0 / (DEFAULT_RRF_K + 50)
+
+    # The unrelated finding #3 has no embedding, so it should never show up
+    # via the cosine path. It also doesn't match "quantum" via FTS.
+    assert ("finding", 3) not in by_key
+
+
+def test_hybrid_uses_sqlite_vec_above_threshold(
+    embedded_db: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Above the source-count threshold the sqlite-vec branch is selected.
+
+    Skips when the extension can't be loaded in this environment. We don't
+    rebuild a 5000+ row fixture; instead we monkeypatch ``_count_sources``
+    to report a high count, then assert that the sqlite-vec cosine helper
+    is invoked.
+    """
+    # Probe whether sqlite-vec is loadable in this process. Use a temp
+    # connection so the autouse fixture's reset still applies.
+    import sqlite3 as _sqlite3
+
+    probe_conn = _sqlite3.connect(":memory:")
+    try:
+        loadable = _try_load_sqlite_vec(probe_conn)
+    finally:
+        probe_conn.close()
+    if not loadable:
+        pytest.skip("sqlite-vec extension not available in this environment")
+    search_mod._reset_sqlite_vec_cache()
+
+    monkeypatch.setattr(search_mod, "_count_sources", lambda conn, jid: 10_000)
+
+    called: dict[str, int] = {"sqlite_vec": 0, "numpy": 0}
+    real_vec = search_mod._cosine_search_sqlite_vec
+    real_np = search_mod._cosine_search_numpy
+
+    def _spy_vec(*a, **kw):
+        called["sqlite_vec"] += 1
+        return real_vec(*a, **kw)
+
+    def _spy_np(*a, **kw):
+        called["numpy"] += 1
+        return real_np(*a, **kw)
+
+    monkeypatch.setattr(search_mod, "_cosine_search_sqlite_vec", _spy_vec)
+    monkeypatch.setattr(search_mod, "_cosine_search_numpy", _spy_np)
+
+    _patch_embed(monkeypatch, _unit(1))
+
+    search_hybrid("quantum", job_id=None, kind="both", db_path=embedded_db, top_k=50)
+
+    assert called["sqlite_vec"] == 1
+    assert called["numpy"] == 0
+
+
+def test_hybrid_returns_fused_score_keys(
+    embedded_db: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_embed(monkeypatch, _unit(1))
+    results = search_hybrid("quantum", job_id=None, kind="both", db_path=embedded_db)
+    assert results
+    expected = {"kind", "id", "job_id", "score", "fts_score", "cosine_score"}
+    for r in results:
+        assert expected <= r.keys()
+
+
+def test_hybrid_empty_query_raises(embedded_db: Path) -> None:
+    with pytest.raises(ValueError):
+        search_hybrid("   ", job_id=None, kind="both", db_path=embedded_db)
+
+
+def test_hybrid_invalid_kind_raises(embedded_db: Path) -> None:
+    with pytest.raises(ValueError):
+        search_hybrid("quantum", job_id=None, kind="bogus", db_path=embedded_db)

--- a/tests/test_storage_search.py
+++ b/tests/test_storage_search.py
@@ -404,6 +404,41 @@ def test_rrf_default_k_constant() -> None:
     assert DEFAULT_RRF_K == 60
 
 
+def test_try_load_sqlite_vec_loads_on_each_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cache short-circuit must not skip loading the extension on a new conn.
+
+    SQLite extensions are loaded per-connection, so even after a successful
+    first load we still have to call ``sqlite_vec.load(conn)`` on every new
+    connection. Regression guard for the cache that previously returned True
+    immediately and let the per-connection load silently get skipped.
+    """
+    import sqlite3 as _sqlite3
+
+    calls: list[object] = []
+
+    fake_module = type("FakeSqliteVec", (), {})()
+
+    def _fake_load(conn):  # type: ignore[no-untyped-def]
+        calls.append(conn)
+        # Register the function this load attempt is supposed to enable so
+        # the post-load probe (only run on first attempt) succeeds.
+        conn.create_function("vec_distance_cosine", 2, lambda a, b: 0.0)
+
+    fake_module.load = _fake_load
+    monkeypatch.setitem(__import__("sys").modules, "sqlite_vec", fake_module)
+
+    c1 = _sqlite3.connect(":memory:")
+    c2 = _sqlite3.connect(":memory:")
+    try:
+        assert search_mod._try_load_sqlite_vec(c1) is True
+        assert search_mod._try_load_sqlite_vec(c2) is True
+    finally:
+        c1.close()
+        c2.close()
+
+    assert len(calls) == 2, f"sqlite_vec.load must be called on each new conn; got {len(calls)}"
+
+
 def test_rrf_invalid_k() -> None:
     with pytest.raises(ValueError):
         _rrf_fuse([], [], k=0)


### PR DESCRIPTION
Closes #43

## Summary

Automated implementation of **Hybrid semantic + FTS search**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Hybrid FTS5 + cosine search with RRF is implemented end-to-end (CLI, storage, render); fixed a latent sqlite-vec per-connection load bug and documented hybrid search in the README.

- **WARNING** [FIXED] `src/research_agent/storage/search.py`: _try_load_sqlite_vec short-circuited on cached True without calling sqlite_vec.load(conn) on the new connection. SQLite extensions are connection-local, so the second hybrid search in the same process silently fell back to numpy via the OperationalError catch. Cache is now negative-only and the load runs on every new connection; added a regression test that verifies sqlite_vec.load is invoked for each connection.
- **WARNING** [FIXED] `README.md`: README still described 'research search' as FTS-only; no mention of hybrid mode (now default), --fts-only escape hatch, sqlite-vec auto-detection above 5000 sources, or the fts/cosine score columns surfaced in the Rich table. Updated the command examples and the 'research search' paragraph to document the new behavior.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*