### PR TITLE
feat: README + operator docs (closes #44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,23 @@
 # research-agent
 
-Autonomous CLI research agent. See `research-agent-implementation-guide.md` for the
-full architecture and `CLAUDE.md` for the issue-driven workflow.
+Autonomous CLI research agent. Run `research start` against a goal and walk
+away — the daemon plans, fetches, synthesizes, and cites until the goal is
+met (or the budget / time cap fires).
+
+This README is the entry point. It walks an operator from "fresh laptop" to
+"24-hour soak running unattended". Deeper detail (architecture, tier
+routing, connector design) lives in the three foundational research docs in
+this repo:
+
+- [`ai-agent-research-setup.md`](ai-agent-research-setup.md) — model
+  routing, hardware sizing, LM Studio ergonomics.
+- [`ai-agent-investigation-playbook.md`](ai-agent-investigation-playbook.md)
+  — investigation patterns and source taxonomy.
+- [`research-agent-implementation-guide.md`](research-agent-implementation-guide.md)
+  — the locked-in v1 architecture (Pydantic AI, SQLite, per-job folder,
+  Typer CLI, model tiers).
+
+`CLAUDE.md` describes the issue-driven build loop.
 
 ## Install
 
@@ -13,26 +29,21 @@ pip install -e ".[dev]"
 
 # one-time browser bootstrap (binaries are not pip-installable)
 playwright install chromium
-```
 
-## Configuration
-
-`.env` is the only place runtime secrets and operator overrides live — no
-`export` required. Copy the template and fill in what you need:
-
-```bash
+# create your local .env from the template
 cp .env.example .env
 ```
 
-Lookup order, highest precedence first:
+`.env` is the only place runtime secrets and operator overrides live — no
+`export` required. Lookup order, highest precedence first:
 
 1. Existing process env vars (CI, one-shot `OPENROUTER_API_KEY=... research ...`).
 2. `./.env.local` (gitignored, dev-only overrides).
 3. `./.env` (or the nearest ancestor walking up to repo root).
 
 The full list of recognized keys lives in `src/research_agent/config.py`
-(`EXPECTED_ENV_KEYS`). `.env.example` and `research doctor` both read from that
-list, so there is no drift.
+(`EXPECTED_ENV_KEYS`). `.env.example` and `research doctor` both read from
+that list, so there is no drift.
 
 | Key | Required | Purpose |
 |---|---|---|
@@ -43,7 +54,56 @@ list, so there is no drift.
 | `LMSTUDIO_BASE_URL` | no | Override the default `http://localhost:1234/v1`. |
 | `RESEARCH_DAEMON_PROGRESS` | no | Set to `0` to suppress the foreground Rich progress bar the daemon writes to stdout when run interactively. |
 
-## CLI
+## LM Studio
+
+Local tiers run through [LM Studio](https://lmstudio.ai/) at
+`http://localhost:1234/v1`. The exact model identifiers the router maps to
+each tier live in [`config/models.yaml`](config/models.yaml); never
+hardcode model names elsewhere — pick a tier.
+
+**Models to download** (LM Studio UI → Discover → search by exact ID):
+
+| Tier | Model ID | Purpose |
+|---|---|---|
+| `fast` | `qwen3-4b-instruct-q4_k_m` | Classification, dedup, language detection. |
+| `general` | `qwen3-32b-instruct-q6_k` | Worker default — query rewriting, extraction, summarization. |
+| `reasoner` | `deepseek-r1-distill-32b-q6_k` | Hypothesis ranking, contradiction detection. |
+| `vision` | `qwen3-vl-8b-instruct` | PDF page screenshots, chart reading. |
+| `embeddings` | `qwen3-embedding-4b` | Semantic search across findings + sources. |
+
+After downloading, start the LM Studio local server (Developer tab →
+Server → Start). The default port is `1234` and the OpenAI-compatible
+endpoint mounts at `/v1`. Override with `LMSTUDIO_BASE_URL` if you've
+moved it (e.g. `http://192.168.1.10:1234/v1` for a workstation across the
+LAN).
+
+`embeddings` intentionally has no cloud fallback — a stall surfaces as a
+hard error rather than silently rerouting to a chat model. Keep
+`qwen3-embedding-4b` loaded any time you plan to use `research search` or
+the daemon's hybrid retrieval.
+
+## OpenRouter
+
+Cloud tiers go through [OpenRouter](https://openrouter.ai/). Create a key
+(Dashboard → Keys → Create Key) and paste it into `.env`:
+
+```bash
+OPENROUTER_API_KEY=sk-or-v1-...
+```
+
+The key drives three tiers:
+
+| Tier | Model | When it fires |
+|---|---|---|
+| `frontier` | `anthropic/claude-opus-4-7` | Major synthesis, critique, final report, planner rewrites. |
+| `frontier_alt` | `moonshotai/kimi-k2-1t` | Critique pass — diverse second opinion. |
+| `frontier_speed` | `anthropic/claude-haiku-4-5` | Fast cloud calls when local isn't enough but Opus is overkill; intake follow-ups; tier fallback. |
+
+`research doctor` sanity-checks the key shape (`sk-or-` prefix) without
+hitting the network. List prices live in `config/models.yaml` under
+`pricing:` and feed the budget tracker (`src/research_agent/llm/budgets.py`).
+
+## `research doctor`
 
 ```bash
 research --help
@@ -52,206 +112,254 @@ research doctor             # environment readiness checks (Rich table)
 research doctor --json      # same report as machine-readable JSON
 ```
 
-`research doctor` exits non-zero if any required check fails — safe to wire
-into CI as a pre-flight gate. Optional checks (LM Studio reachability, optional
-env keys) never affect the exit code.
+`research doctor` is the canonical wiring check. It verifies:
+
+- Python ≥ 3.12 and the `.env` files that were loaded.
+- Every key in `EXPECTED_ENV_KEYS` (presence + masked tail).
+- `OPENROUTER_API_KEY` shape (`sk-or-` prefix).
+- LM Studio reachability at `LMSTUDIO_BASE_URL` (optional check, never required).
+- `data/` and `jobs/` exist and are writable.
+- SQLite WAL mode is selectable.
+- `config/models.yaml` parses.
+
+Required failures exit non-zero (safe to wire into CI as a pre-flight
+gate). Optional skips (LM Studio unreachable, optional env keys missing)
+never affect the exit code.
+
+## Walk-through
+
+End-to-end: from clean repo to a finished report.
+
+```bash
+# 1. Verify the stack.
+research doctor
+# All required checks should be green. LM Studio "skip" is fine if you're
+# only running cloud tiers; "fail" on OPENROUTER_API_KEY is not.
+
+# 2. Start a job. The daemon runs detached; control returns immediately.
+research start --skip-intake \
+    --goal "Compare Pydantic AI, LangGraph, and CrewAI" \
+    --budget-usd 5.00 \
+    --time-cap 24 \
+    --disk-cap-gb 10
+# → Started job 2026-05-02-compare-pydantic-ai- (daemon pid 12345).
+#   Tail logs with: research logs 2026-05-02-compare-pydantic-ai- -f
+
+# 3. See what's running.
+research list                          # newest first
+
+# 4. Watch progress live.
+JOB=$(research list --json | jq -r '.[0].id')
+research status "$JOB" --watch         # Rich panel, refreshes every 2s
+
+# 5. Tail events as they fire.
+research logs "$JOB" -f
+
+# 6. Read the report when synthesis lands (auto-rewrites as it iterates).
+research view "$JOB" --report          # opens $EDITOR on a TTY
+
+# 7. Stop early if you want — graceful by default.
+research stop "$JOB"                   # daemon finishes current task, then synthesizes
+research stop "$JOB" --kill            # hard SIGTERM/SIGKILL escalation
+
+# 8. Resume from the last checkpoint after a crash or a clean stop.
+research resume "$JOB"
+```
+
+For long unattended runs, see [macOS hygiene](#macos-hygiene) below.
+
+## CLI surface
 
 ### Job verbs
 
 ```bash
-# Register a new job and spawn the background daemon.
-research start --skip-intake --goal "Investigate Widget Co" \
+research start --skip-intake --goal "<goal>" \
     [--budget-usd 5.0] [--time-cap 24] [--corpus path/to/notes] [--disk-cap-gb 10]
 
-research list                      # newest first; Rich table on a TTY, JSON otherwise
-research list --json               # force JSON output
-research list --status running     # filter by job status
+research list                      # newest first; Rich on a TTY, JSON otherwise
+research list --json
+research list --status running
 
 research status <job-id>           # detailed Rich panel
-research status <job-id> --watch   # refresh every 2 seconds
+research status <job-id> --watch   # refresh every 2s
 
-research view <job-id>             # open report.md in $EDITOR (or print on non-TTY)
-research view <job-id> --report    # same as default
+research view <job-id>             # report.md in $EDITOR (or stdout off-TTY)
+research view <job-id> --report
 research view <job-id> --findings  # latest findings/NNNNNN.md
-research view <job-id> --sources   # generated list of recorded sources
+research view <job-id> --sources
 
 research logs <job-id>             # print existing events.jsonl entries
 research logs <job-id> -f          # follow appended events
 research logs <job-id> --level ERROR
 
-research stop <job-id>             # graceful: drop STOP flag, daemon finishes current task
-research stop <job-id> --kill      # hard: SIGTERM then SIGKILL after 10s, unlinks daemon.pid
+research stop <job-id>             # graceful: drop STOP flag
+research stop <job-id> --kill      # SIGTERM, then SIGKILL after 10s
 
-research resume <job-id>           # respawn the daemon; restores from last checkpoint
-research resume <job-id> --force   # resume even when job is completed/failed
+research resume <job-id>           # respawn daemon, restore from checkpoint
+research resume <job-id> --force   # resume even when completed/failed
 
-research search "<query>"          # hybrid FTS5 + semantic (cross-job, default)
-research search "<query>" --fts-only         # legacy FTS5-only escape hatch
-research search "<query>" --job <job-id>     # scope to one job
-research search "<query>" --kind findings    # findings only (default: both)
-research search "<query>" --kind sources     # sources only
-research search "<query>" --json             # machine-readable list
+research search "<query>"          # hybrid FTS5 + semantic (cross-job)
+research search "<query>" --fts-only
+research search "<query>" --job <job-id>
+research search "<query>" --kind findings
+research search "<query>" --kind sources
+research search "<query>" --json
 
-research export <job-id> --zip               # bundle jobs/<id>/ into <job-id>.zip in cwd
-research export <job-id> --md-bundle         # one markdown file: report + findings + sources
-research export <job-id> --zip --out PATH    # write to PATH (file) or PATH/<job-id>.zip (dir)
-research export <job-id> --md-bundle --include-history   # also inline report.history/
+research export <job-id> --zip
+research export <job-id> --md-bundle
+research export <job-id> --zip --out PATH
+research export <job-id> --md-bundle --include-history
 ```
 
-`research search` defaults to a hybrid pass: it runs the query through
-SQLite FTS5 against `findings_fts` (claim text) and `sources_fts` (source
-titles), embeds the same query through the `embeddings` tier, and scores
-every embedded `findings.embedding` / `sources.embedding` blob by cosine
-similarity. The two top-50 lists are deduped on `(kind, id)` and combined
-via reciprocal-rank fusion (k=60). The Rich table surfaces both the fused
-`score` and the underlying `fts` / `cosine` components so it is obvious
-why a row ranked where it did. When the visible source count exceeds 5000,
-the cosine pass tries the optional `sqlite-vec` extension to run KNN in
-SQL; any load or execution error falls back to numpy cosine, so the hybrid
-path is always available. Pass `--fts-only` to skip the semantic pass
-(useful for FTS-syntax debugging or when LM Studio is offline). Snippet
-highlights come from the FTS5 `snippet()` function — the table renders
-matched terms in bold yellow; the `--json` payload preserves them as
-literal `[`/`]` markers. Source rows join through `job_sources`, so the
-`--job` filter correctly excludes sources fetched only by other jobs even
-when the underlying content is shared. FTS5 syntax errors (e.g. unbalanced
-quotes) exit `1` with a clear `FTS5 query error: ...` line on stderr.
+`research start` runs interactive intake (or accepts `--skip-intake --goal
+"..."` as a non-interactive testing back door), creates the job folder +
+DB row, and spawns a detached daemon via
+`subprocess.Popen(start_new_session=True)`. The PID is written atomically
+to `jobs/<id>/daemon.pid`; the daemon's stdout/stderr land in
+`jobs/<id>/daemon.{out,err}.log`.
+
+`research search` defaults to a hybrid pass: FTS5 on `findings_fts` /
+`sources_fts` plus semantic cosine over `embeddings` blobs, deduped and
+fused via reciprocal-rank fusion (k=60). Pass `--fts-only` for a
+keyword-only escape hatch (useful when LM Studio is offline or for
+debugging FTS5 syntax).
 
 `research export` bundles a job for sharing. `--zip` walks
-`jobs/<job-id>/` and emits a single `ZIP_DEFLATED` archive whose entries
-are rooted at `<job-id>/...` so unzipping reproduces the full folder.
-`--md-bundle` concatenates the intake front matter, `report.md`, every
-finding (ordered by id), and the source list (with `archive_url` links)
-into one navigable markdown file. Exactly one mode flag is required —
-omitting both, or passing both, exits `2`. `--out` accepts either a file
-path or an existing directory (in which case `<job-id>.{zip,md}` is
-appended); when omitted the file lands in the current working directory.
-`--include-history` adds `report.history/` to either format. Both writes
-use the project's atomic `*.tmp` + `os.replace` convention, so a crash
-mid-export never leaves a half-written archive on disk.
+`jobs/<job-id>/` into a `ZIP_DEFLATED` archive; `--md-bundle` concatenates
+intake, `report.md`, every finding, and the source list into one navigable
+markdown file. Exactly one mode flag is required.
 
 ### Config verbs
 
 ```bash
-research config cache-clear        # wipe data/llm_cache.sqlite (LLM response cache)
+research config cache-clear        # wipe data/llm_cache.sqlite
 ```
 
-The LLM response cache lives in its own SQLite file (`data/llm_cache.sqlite`),
-keyed on `(provider, model, prompt, sampling-params, tool-defs)` with a 30-day
+The LLM response cache lives in its own SQLite file, keyed on
+`(provider, model, prompt, sampling-params, tool-defs)` with a 30-day
 default TTL. The router opts in per call (`cache=True`) — deterministic
-extractions opt in, exploratory synthesis opts out. `cache-clear` removes the
-file (and its `-wal`/`-shm` sidecars) without touching the main index DB.
+extractions opt in, exploratory synthesis opts out.
 
-`research start` runs the interactive intake (or accepts `--skip-intake
---goal "..."` as a non-interactive testing back door), creates the job
-folder + DB row, and then spawns a detached daemon via
-`subprocess.Popen(start_new_session=True)`. Control returns immediately
-with `Started job <id> (daemon pid <pid>). Tail logs with: research logs
-<id> -f`. The PID is written atomically to `jobs/<id>/daemon.pid`; the
-daemon's stdout/stderr are appended to `jobs/<id>/daemon.{out,err}.log`.
-On clean shutdown (including SIGTERM/SIGINT) the daemon's atexit hook
-removes `daemon.pid`. `daemon.is_daemon_alive(<id>)` checks liveness via
-`kill -0` plus a `/proc/<pid>/cmdline` peek on Linux, so a recycled PID
-won't false-positive.
+### Hidden smoke verbs
 
-`research stop --graceful` (the default) atomically writes a `STOP` flag
-under `jobs/<id>/`; the daemon's between-task watcher picks it up, lets
-the in-flight task finish, runs a final synthesis pass, then exits. The
-command returns immediately with `Stop requested; daemon will finish
-current task and synthesize.` `research stop --kill` SIGTERMs the PID,
-escalates to SIGKILL after 10 s, and unlinks `daemon.pid` so a follow-up
-`research resume` won't trip the alive-check. `research resume <id>`
-refuses if a live daemon is already running (PID file present and the
-process responds to `kill -0`), or if the job is in a terminal
-`completed`/`failed` state — pass `--force` to override the latter.
-Otherwise it spawns a fresh daemon, which restores from the last
-checkpoint at startup.
+`_smoke-llm` and `_smoke-tool` are operator/CI helpers, hidden from
+`--help` but stable enough to script against. See
+[Troubleshooting](#troubleshooting) for usage.
 
-## Troubleshooting
+## Costs
 
-### Disk cap
+Local LM Studio inference is free at the wallet (the cost is the GPU/CPU
+time on your laptop). All dollar spend goes through OpenRouter via the
+`frontier`, `frontier_alt`, and `frontier_speed` tiers.
 
-Each job has a per-job disk cap (default `10` GB, override with
-`--disk-cap-gb`). The daemon polls `jobs/<id>/` every 5 minutes; when
-total on-disk usage exceeds the cap, it scores every linked source by
-`5 * findings_usage + 1 * fts_title_hits − 0.1 * age_days` and prunes
-the lowest-scored 10 % until usage drops below 90 % of the cap. A
-single `WARN`/`warning` event marks the cap crossing; one
-`INFO`/`source_pruned` event fires per file removed. Pruned ≠ banned:
-the `sources` row stays in the cross-job index with `md_path = NULL`,
-and a future fetch with the same sha256 transparently re-creates the
-file under the current job (see `storage/sources.py`).
+### Realistic per-run dollar ranges
 
-Two hidden verbs (`_smoke-llm` and `_smoke-tool`) exist for operators and CI
-to verify the LLM stack and the tool registry without spinning up a job.
-They are intentionally hidden from `--help` (the leading underscore plus
-`hidden=True` keeps them out of the standard surface) but are stable enough
-to script against.
+The default cap on `research start` is `--budget-usd 5.00`. Typical
+spend for a single run, depending on goal scope and aggressiveness:
 
-### `research _smoke-llm <tier> "<prompt>"`
+| Run shape | Typical spend | Notes |
+|---|---|---|
+| Quick recon (≤ 1 hr, ~50 tasks) | $0.10 – $1.00 | Mostly local; one or two cloud syntheses. |
+| Half-day investigation (~4 hr) | $1 – $5 | Several synth + critique passes; cap defaults handle this. |
+| 24-hour soak (Phase 6 fixture) | $5 – $25 | Set `--budget-usd 25.00` for the full soak per `tests/integration/test_phase6_soak_24h.md`. |
 
-Runs a single structured-output call against one tier in `config/models.yaml`
-and prints the response, token counts, and (for cloud tiers) computed cost.
-Exits non-zero on any failure with the underlying error written to stderr.
+The exact ratio depends on how often the planner triggers cloud calls,
+which models actually serve them (Opus is ~25× the price of Haiku per
+output token), and whether the LLM cache returns hits.
 
-```bash
-# Local tiers — require LM Studio at $LMSTUDIO_BASE_URL (default :1234).
-research _smoke-llm fast "Say hello"
-research _smoke-llm general "Say hello"
-research _smoke-llm reasoner "Say hello"
+### What triggers cloud calls
 
-# Cloud tiers — require OPENROUTER_API_KEY.
-research _smoke-llm frontier "Say hello"
-research _smoke-llm frontier_alt "Say hello"
-research _smoke-llm frontier_speed "Say hello"
+In rough order of frequency:
+
+- **Synthesis passes** — `frontier` for major checkpoints, `frontier_speed`
+  as a budget-aware fallback if `frontier` would tip over the cap.
+- **Critique** — `frontier_alt` is preferred so the synthesizer and critic
+  disagree productively.
+- **Adaptive intake follow-ups** — `frontier_speed` for short clarifying
+  turns during interactive intake.
+- **Local-tier fallbacks** — when an LM Studio tier times out or returns a
+  `RateLimitError`, the router routes to the tier's `fallback_tier`. This
+  is the only path where a "local-looking" task quietly costs money;
+  watch for `tier_fallback` events in `events.jsonl` if your spend looks
+  high.
+
+### How the budget cap behaves
+
+The cap is enforced in `src/research_agent/llm/budgets.py` at the
+OpenRouter wrapper — every cloud call passes through it; no direct
+OpenRouter clients exist elsewhere.
+
+- **Soft warning at 90 %.** A single `WARNING` log fires the first time
+  spend crosses 90 % of the cap. Use it as your "wrap up" signal if
+  watching live.
+- **Hard stop at 100 %.** `BudgetTracker.precheck()` raises
+  `BudgetExceeded` before the next cloud call ships. The loop catches it,
+  emits `cap_hit`, and triggers a **final-pass synthesis** on the cheaper
+  `frontier_speed` tier so the user gets a report. If even
+  `frontier_speed` would blow the cap, a template stub is rendered from
+  on-disk findings without any LLM call (per issue #39).
+- **State survives restarts.** `BudgetTracker` re-hydrates `spent` from
+  `jobs.cost_so_far_usd` at construction, so a daemon restart picks up
+  the same running total.
+- **Local tiers are free.** `cost_usd = 0.0` for local rows in
+  `llm_calls`; only OpenRouter tiers are priced. Pricing is read from
+  the `pricing:` block in `config/models.yaml` (manually maintained).
+
+## Directory layout
+
+### Per-job folder (`jobs/<job-id>/`)
+
+Every job is a self-contained folder. The cross-job DB only mirrors
+metadata for fast queries — the folder is the source of truth.
+
+```
+jobs/<job-id>/
+├── job.json              # canonical metadata (id, goal, status, timestamps)
+├── intake.json           # frozen intake answers
+├── goal.md               # human-readable goal + scope
+├── plan/                 # planner state (versioned)
+├── findings/             # findings/NNNNNN.md (zero-padded, monotonic)
+├── sources/              # symlinks/copies of canonical source markdown
+├── synthesis/            # synthesis/NNNN.md (versioned)
+├── critique/             # critique/NNNN.md (versioned)
+├── report.md             # current report (rotated to report.history/ on rewrite)
+├── report.history/       # archived prior reports
+├── events.jsonl          # append-only event log
+├── daemon.pid            # written on spawn, removed on clean exit
+├── daemon.out.log        # daemon stdout
+├── daemon.err.log        # daemon stderr
+└── STOP                  # presence signals graceful stop request
 ```
 
-Two tiers behave specially:
+Job IDs are deterministic: `YYYY-MM-DD-<slug>` derived from the intake
+goal. All on-disk writes go through atomic `*.tmp` + `os.replace` so a
+crashed process never leaves half-written sidecars.
 
-- **`vision`**: skipped (exit 0) unless you pass `--image PATH`. The skip is
-  reported as `output: skipped: vision: no image provided` so CI can tell
-  apart a green skip from a green call.
-- **`embeddings`**: bypasses Pydantic AI and hits the configured provider's
-  `/embeddings` endpoint directly, reporting the vector dimension as
-  `output: dim=<N>` instead of a chat completion.
+### Cross-job state (`data/`)
 
-### `research _smoke-tool <tool_name> <query>`
-
-Looks up `<tool_name>` in the in-process `TOOL_REGISTRY` (Phase 3 connectors
-register here) and invokes it with `<query>`. Exits with code 2 and a
-`tool not registered` message on stderr when the name is unknown.
-
-```bash
-research _smoke-tool web_search "alpha research project"
-research _smoke-tool web_fetch "https://example.com/article"
-research _smoke-tool arxiv "transformer interpretability"
-research _smoke-tool news "federal reserve"
+```
+data/
+├── index.sqlite          # WAL-mode; jobs, findings, sources, llm_calls, FTS5, embeddings
+├── index.sqlite-wal
+├── index.sqlite-shm
+└── llm_cache.sqlite      # LLM response cache (separate file for safe wipe)
 ```
 
-`web_fetch` prints the resolved title, the path that served the fetch
-(`httpx` vs `playwright`), HTTP status code, word count, the Wayback
-archive URL (when Save Page Now completed in time), and the first 200
-characters of cleaned text. Background Wayback archival is fire-and-forget,
-so a missing `archive_url` is not a fetch failure.
+`research config cache-clear` wipes `llm_cache.sqlite` (and its `-wal`/
+`-shm` sidecars) without touching `index.sqlite`.
 
-`arxiv` prints the top 5 hits as `- <title>\n  <abs URL>\n  <abstract
-preview>`. The connector honours arXiv's 3 s request-spacing recommendation
-and runs the synchronous `arxiv` lib through `asyncio.to_thread`.
+### Gitignored regenerable dirs
 
-`news` aggregates every RSS feed and Playwright scrape recipe declared in
-`config/sources.yaml` under the `news:` key, prints the total hit count,
-a per-source breakdown grouped by `fetched_via` (`rss` vs `scrape`), and
-the top 5 hits. RSS is preferred; sites without a public feed get a
-per-source CSS selector recipe under `scrape:`. No paid news APIs.
+`jobs/`, `runs/`, `data/`, `logs/`, `sessions/`, `.alpha-loop/`, `.venv/`.
+Lockfiles (`uv.lock`) are committed.
 
-### Long-running soaks (macOS)
+## macOS hygiene
 
-Multi-hour `research start` runs (Phase 5's 4-hour close-terminal soak,
-Phase 6's 24-hour soak) need the laptop to stay awake. macOS will idle
-sleep on default Energy Saver settings after ~10–30 minutes of no user
-input, which freezes the daemon's loop and times out any in-flight
-OpenRouter HTTP keepalives — long activity gaps in `events.jsonl` are
-usually idle-sleep, not a bug in the daemon.
+A 24-hour soak on a laptop has three failure modes that aren't bugs in
+the daemon: idle sleep, OS auto-reboot, and you closing the lid in the
+wrong way. Address them once, up front.
+
+### Prevent idle sleep — `caffeinate -i -w <pid>`
 
 After `research start` returns, capture the daemon PID and tie a
 `caffeinate` to it from a second terminal:
@@ -264,28 +372,149 @@ caffeinate -i -w "$DAEMON_PID" &
 - `-i` blocks **idle sleep** specifically (the display can still dim,
   which is fine — the soak doesn't need pixels).
 - `-w <pid>` ties caffeinate's lifetime to the daemon. When the daemon
-  exits — graceful stop, kill, or crash — caffeinate auto-exits with
-  it, so there's no orphan process holding the system awake. No manual
-  cleanup required.
+  exits — graceful stop, kill, or crash — caffeinate auto-exits with it,
+  so there's no orphan process holding the system awake.
 
-On non-macOS hosts, use the equivalent for your OS (e.g. Linux:
-`systemd-inhibit --what=idle`) and document the choice in the
-postmortem so the next operator knows what worked.
+Long activity gaps in `events.jsonl` are usually idle-sleep, not a bug
+in the daemon. On non-macOS hosts, use the equivalent for your OS (e.g.
+Linux `systemd-inhibit --what=idle`).
 
-The Phase 6 soak playbook walks through this end-to-end —
-prerequisites, launch, sleep prevention, walk-away health checks,
-graceful stop, and per-AC verification. See
-`tests/integration/test_phase6_soak_24h.md`.
+### Disable auto-reboot for system updates
+
+macOS will silently install and reboot for security updates by default.
+A reboot mid-soak loses the daemon and leaves a stale PID file behind.
+Either:
+
+- **GUI:** System Settings → General → Software Update → Automatic
+  Updates → toggle off "Install macOS updates" and "Install Security
+  Responses and system files".
+- **CLI:**
+  ```bash
+  sudo softwareupdate --schedule off
+  ```
+
+Re-enable after the soak finishes if you want the OS to keep itself
+patched.
+
+### Optional `launchd` plist for auto-resume on boot
+
+If a reboot does happen (power loss, manual restart), you can have the
+most recent running job auto-resume. Drop a launch agent at
+`~/Library/LaunchAgents/com.alpha.research.resume.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.alpha.research.resume</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>cd /path/to/alpha-research &amp;&amp; \
+            JOB=$(./.venv/bin/research list --json --status running 2>/dev/null \
+                  | /usr/bin/python3 -c 'import json,sys; jobs=json.load(sys.stdin); print(jobs[0]["id"]) if jobs else None') &amp;&amp; \
+            [ -n "$JOB" ] &amp;&amp; ./.venv/bin/research resume "$JOB"</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/tmp/research-resume.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/research-resume.err.log</string>
+</dict>
+</plist>
+```
+
+Load it once: `launchctl load ~/Library/LaunchAgents/com.alpha.research.resume.plist`.
+Edit `/path/to/alpha-research` to your checkout. Inspect
+`/tmp/research-resume.{out,err}.log` if a boot doesn't pick up the job
+you expected.
+
+## Troubleshooting
+
+### `research doctor` failures
+
+| Failure | What to do |
+|---|---|
+| `python: fail` | Install Python 3.12+ (`brew install python@3.12`) and rebuild the venv. |
+| `env:OPENROUTER_API_KEY: missing (required)` | Add the key to `.env`. Restart any open shell so the new value is picked up. |
+| `openrouter_key_shape: fail` | Key doesn't start with `sk-or-` — copy it again from the OpenRouter dashboard. |
+| `lm_studio: skip ... not reachable` | Optional, but local tiers won't work. Start LM Studio, click Server → Start, confirm port `1234`. |
+| `writable_dirs: fail` | `data/` or `jobs/` permissions issue. `mkdir -p data jobs && chmod u+rwx data jobs`. |
+| `sqlite_wal: fail` | Stdlib SQLite is too old or the temp dir is read-only. Re-run on a writable partition. |
+| `models_yaml: fail` | `config/models.yaml` was edited and no longer parses. `git diff config/models.yaml` to inspect. |
+
+When in doubt: `research doctor --json | jq .` for a structured view that
+omits the Rich formatting.
+
+### Smoke commands
+
+Two hidden verbs verify the LLM stack and tool registry without spinning
+up a job:
+
+```bash
+# Single structured-output call against one tier in config/models.yaml.
+research _smoke-llm fast "Say hello"
+research _smoke-llm general "Say hello"
+research _smoke-llm reasoner "Say hello"
+research _smoke-llm frontier "Say hello"
+research _smoke-llm frontier_alt "Say hello"
+research _smoke-llm frontier_speed "Say hello"
+
+# Skipped (exit 0) without --image; reports `output: skipped: vision: no image provided`.
+research _smoke-llm vision "Describe this" --image path/to/page.png
+
+# Bypasses Pydantic AI; hits /embeddings directly. Reports `output: dim=<N>`.
+research _smoke-llm embeddings "vector me"
+
+# Tool registry probes (Phase 3 connectors).
+research _smoke-tool web_search "alpha research project"
+research _smoke-tool web_fetch "https://example.com/article"
+research _smoke-tool arxiv "transformer interpretability"
+research _smoke-tool news "federal reserve"
+```
+
+`web_fetch` prints the resolved title, the path that served the fetch
+(`httpx` vs `playwright`), HTTP status, word count, the Wayback archive
+URL (when Save Page Now completed in time), and the first 200 characters
+of cleaned text. A missing `archive_url` is not a fetch failure —
+Wayback archival is fire-and-forget.
+
+### Where to read events
+
+- `research logs <job-id> -f` — formatted tail of `events.jsonl` (level
+  filter via `--level ERROR`).
+- `jobs/<job-id>/events.jsonl` — raw append-only JSON, one event per
+  line. `jq` is your friend (`jq 'select(.level=="ERROR")' events.jsonl`).
+- `jobs/<job-id>/daemon.err.log` — daemon stderr (uncaught exceptions,
+  process-level errors that didn't make it to `events.jsonl`).
+- `data/index.sqlite` — cross-job mirror of events / findings / sources /
+  llm_calls. Open with `sqlite3 data/index.sqlite` for ad-hoc queries.
+
+### Disk cap
+
+Each job has a per-job disk cap (default `10` GB, override with
+`--disk-cap-gb`). The daemon polls `jobs/<id>/` every 5 minutes; when
+total usage exceeds the cap, it scores every linked source by
+`5 * findings_usage + 1 * fts_title_hits − 0.1 * age_days` and prunes
+the lowest-scored 10 % until usage drops below 90 % of the cap. A single
+`WARN`/`warning` event marks the cap crossing; one `INFO`/`source_pruned`
+event fires per file removed. Pruned ≠ banned: the `sources` row stays
+in the cross-job index with `md_path = NULL`, and a future fetch with
+the same sha256 transparently re-creates the file under the current job.
 
 ## End-to-end testing
 
 The Phase 4 "done when" gate is exercised manually — too heavy and too
 cost-bearing for CI. See `tests/integration/test_phase4_e2e.md` for the
-playbook (canonical fixture goal, driver script, AC verification commands,
-and a triage table for common failures).
+playbook (canonical fixture goal, driver script, AC verification
+commands, and a triage table for common failures).
 
-The Phase 5 (4-hour daemon-lifecycle soak) and Phase 6 (24-hour real-goal
-soak) gates have their own playbooks alongside it:
+The Phase 5 (4-hour daemon-lifecycle soak) and Phase 6 (24-hour
+real-goal soak) gates have their own playbooks alongside it:
 `tests/integration/test_phase5_lifecycle.md` and
 `tests/integration/test_phase6_soak_24h.md`. Phase 6 also captures its
 results in `tests/integration/soak_24h_postmortem.md`.

--- a/tests/test_readme_doc.py
+++ b/tests/test_readme_doc.py
@@ -1,0 +1,199 @@
+"""README contract tests.
+
+Issue #44 promises operators a single document that walks them from a
+fresh laptop to an unattended soak. These tests pin the contract:
+
+- The required sections exist (install, LM Studio, OpenRouter, doctor,
+  walk-through, CLI, costs, directory layout, macOS hygiene,
+  troubleshooting).
+- The three foundational research docs are linked (and the linked files
+  exist on disk).
+- Each tier in ``config/models.yaml`` is named in the README so a fresh
+  operator knows which models to download / which key drives which tier.
+- Every CLI verb registered with the Typer app is mentioned (so adding
+  a verb without README coverage trips the suite).
+
+The goal is to fail loudly when docs drift, not to pin exact prose.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml  # type: ignore[import-untyped]
+
+from research_agent import cli
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+README = REPO_ROOT / "README.md"
+
+
+@pytest.fixture(scope="module")
+def readme_text() -> str:
+    return README.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def readme_lower(readme_text: str) -> str:
+    return readme_text.lower()
+
+
+def test_readme_exists() -> None:
+    assert README.is_file(), "README.md is the operator entry point"
+
+
+@pytest.mark.parametrize(
+    "heading",
+    [
+        "## Install",
+        "## LM Studio",
+        "## OpenRouter",
+        "## `research doctor`",
+        "## Walk-through",
+        "## CLI surface",
+        "## Costs",
+        "## Directory layout",
+        "## macOS hygiene",
+        "## Troubleshooting",
+    ],
+)
+def test_required_section_present(readme_text: str, heading: str) -> None:
+    assert heading in readme_text, f"missing required README section: {heading!r}"
+
+
+@pytest.mark.parametrize(
+    "doc",
+    [
+        "ai-agent-research-setup.md",
+        "ai-agent-investigation-playbook.md",
+        "research-agent-implementation-guide.md",
+    ],
+)
+def test_foundational_doc_linked_and_exists(readme_text: str, doc: str) -> None:
+    assert f"({doc})" in readme_text, f"README does not link the foundational doc {doc!r}"
+    assert (REPO_ROOT / doc).is_file(), f"linked doc {doc!r} is not on disk"
+
+
+def test_all_model_tiers_named_in_readme(readme_text: str) -> None:
+    """Every tier in config/models.yaml must appear by name in the README."""
+    models = yaml.safe_load((REPO_ROOT / "config" / "models.yaml").read_text())
+    tiers = list(models["tiers"].keys())
+    assert tiers, "config/models.yaml has no tiers; sanity check failed"
+    for tier in tiers:
+        assert tier in readme_text, f"tier {tier!r} not mentioned in README"
+
+
+def test_lmstudio_model_ids_listed(readme_text: str) -> None:
+    """The LM Studio model IDs an operator must download must appear verbatim."""
+    models = yaml.safe_load((REPO_ROOT / "config" / "models.yaml").read_text())
+    for tier_name, tier in models["tiers"].items():
+        if tier.get("provider") != "lmstudio":
+            continue
+        model_id = tier["model"]
+        assert model_id in readme_text, (
+            f"LM Studio tier {tier_name!r} model id {model_id!r} not listed in README"
+        )
+
+
+def test_openrouter_env_var_documented(readme_text: str) -> None:
+    assert "OPENROUTER_API_KEY" in readme_text
+    assert "sk-or-" in readme_text, "key shape ('sk-or-' prefix) should be documented"
+
+
+def test_caffeinate_block_present(readme_text: str) -> None:
+    assert "caffeinate -i -w" in readme_text, "macOS hygiene must show `caffeinate -i -w <pid>`"
+
+
+def test_auto_reboot_guidance_present(readme_lower: str) -> None:
+    assert "softwareupdate --schedule off" in readme_lower or (
+        "automatic updates" in readme_lower and "reboot" in readme_lower
+    ), "macOS hygiene must cover disabling auto-reboot for system updates"
+
+
+def test_launchd_plist_example_present(readme_text: str) -> None:
+    assert "LaunchAgents" in readme_text
+    assert "com.alpha.research.resume" in readme_text
+    assert "research resume" in readme_text
+
+
+def test_costs_section_covers_cap_behavior(readme_lower: str) -> None:
+    for needle in ("90", "final-pass", "budgetexceeded", "frontier_speed"):
+        assert needle in readme_lower, (
+            f"Costs section should explain budget cap behavior; missing {needle!r}"
+        )
+
+
+def test_directory_layout_describes_per_job_folder(readme_text: str) -> None:
+    for path in (
+        "jobs/<job-id>/",
+        "job.json",
+        "intake.json",
+        "events.jsonl",
+        "daemon.pid",
+        "report.history/",
+        "STOP",
+    ):
+        assert path in readme_text, f"per-job folder contract missing {path!r}"
+
+
+def test_directory_layout_describes_data(readme_text: str) -> None:
+    for path in ("data/index.sqlite", "data/llm_cache.sqlite"):
+        assert path in readme_text, f"data/ contract missing {path!r}"
+
+
+def test_troubleshooting_lists_smoke_commands(readme_text: str) -> None:
+    for cmd in ("research _smoke-llm", "research _smoke-tool"):
+        assert cmd in readme_text, f"troubleshooting must show {cmd!r}"
+
+
+def test_troubleshooting_points_to_event_locations(readme_text: str) -> None:
+    for path in ("research logs", "events.jsonl", "daemon.err.log"):
+        assert path in readme_text
+
+
+def _cli_verb_paths() -> set[tuple[str, ...]]:
+    """Walk the Typer app and return the full command path for every verb.
+
+    A top-level verb like `research start` returns `("start",)`; a
+    sub-typer command like `research config cache-clear` returns
+    `("config", "cache-clear")`.
+    """
+    paths: set[tuple[str, ...]] = set()
+
+    def _walk(app, prefix: tuple[str, ...]) -> None:
+        for info in getattr(app, "registered_commands", []) or []:
+            if info.name:
+                paths.add(prefix + (info.name,))
+        for group in getattr(app, "registered_groups", []) or []:
+            sub = group.typer_instance
+            if sub is None:
+                continue
+            sub_name = getattr(sub.info, "name", None) or group.name
+            _walk(sub, prefix + (sub_name,))
+
+    _walk(cli.app, ())
+    return paths
+
+
+def test_every_cli_verb_documented(readme_text: str) -> None:
+    """Every public verb registered on the Typer app must appear in the README."""
+    paths = _cli_verb_paths()
+    # Hidden smoke verbs (leading underscore) live in Troubleshooting; they
+    # are explicitly excluded from the verb tables.
+    public = {p for p in paths if not any(seg.startswith("_") for seg in p)}
+    assert public, "no CLI verbs discovered; sanity check failed"
+    missing = []
+    for path in public:
+        needle = "research " + " ".join(path)
+        if needle not in readme_text:
+            missing.append(needle)
+    assert not missing, f"CLI verbs not mentioned in README: {sorted(missing)}"
+
+
+def test_env_keys_table_covers_expected_keys(readme_text: str) -> None:
+    """Every key in EXPECTED_ENV_KEYS must show up in the env-keys table."""
+    from research_agent import config as cfg
+
+    for key in cfg.EXPECTED_ENV_KEYS:
+        assert key.name in readme_text, f"env key {key.name!r} not documented in README"


### PR DESCRIPTION
Closes #44

## Summary

Automated implementation of **README + operator docs**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

README + operator docs cover every acceptance criterion; contract tests pin claims against config/CLI/doctor and full suite (672 tests) is green.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*