### PR TITLE
feat: Replan when the task queue drains (currently the loop just exits) (closes #117)

### DIFF
--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -44,6 +44,7 @@ EventKind = Literal[
     "synthesis_failed",
     "critique_done",
     "critique_written",
+    "drain_replan",
     "replan_triggered",
     "llm_call",
     "lmstudio_degraded",

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -63,6 +63,7 @@ MAX_TASKS_PER_JOB = 10000
 HEURISTIC_CHECK_EVERY_N = 25
 RETRY_WAITS: tuple[int, ...] = (1, 2, 4, 8, 16, 30, 60)
 RETRY_MAX_ATTEMPTS = 5
+MAX_DRAIN_REPLANS = 10
 
 Handler = Callable[[Job, dict[str, Any]], Awaitable[dict[str, Any] | None]]
 
@@ -316,6 +317,141 @@ def _load_critique_md(job: Job, md_rel: str) -> str:
     """Read the rendered markdown for a critique that was just written."""
     md_path = job.root / md_rel
     return md_path.read_text(encoding="utf-8")
+
+
+def _load_all_findings(job: Job) -> list[dict[str, Any]]:
+    """Return every persisted finding for ``job`` as a list of dicts.
+
+    Drives the drain-replan context: the planner sees what's been learned
+    so far and can pivot rather than re-emit the same template. ``tags`` and
+    ``source_ids`` are stored as JSON in the column; we leave them as the
+    raw string the planner can read alongside the structured ``claim`` and
+    ``confidence`` fields.
+    """
+    import json as _json
+
+    conn = db.connect(job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT id, claim, confidence, source_ids, tags FROM findings"
+            " WHERE job_id = ? ORDER BY id ASC",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            source_ids = _json.loads(row["source_ids"]) if row["source_ids"] else []
+        except (TypeError, ValueError):
+            source_ids = []
+        try:
+            tags = _json.loads(row["tags"]) if row["tags"] else None
+        except (TypeError, ValueError):
+            tags = None
+        out.append(
+            {
+                "id": int(row["id"]),
+                "claim": row["claim"],
+                "confidence": float(row["confidence"]),
+                "source_ids": source_ids,
+                "tags": tags,
+            }
+        )
+    return out
+
+
+def _load_recent_task_results(job: Job, limit: int = 20) -> list[dict[str, Any]]:
+    """Return the most recently completed tasks for ``job`` (newest first).
+
+    Feeds the drain-replan with concrete evidence of what the prior plan
+    actually produced, so the planner can decide whether to broaden,
+    deepen, or pivot.
+    """
+    import json as _json
+
+    conn = db.connect(job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT id, kind, payload_json, result_json FROM tasks"
+            " WHERE job_id = ? AND status = 'done'"
+            " ORDER BY id DESC LIMIT ?",
+            (job.id, int(limit)),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            payload = _json.loads(row["payload_json"]) if row["payload_json"] else {}
+        except (TypeError, ValueError):
+            payload = {}
+        try:
+            result = _json.loads(row["result_json"]) if row["result_json"] else None
+        except (TypeError, ValueError):
+            result = None
+        out.append(
+            {
+                "task_id": int(row["id"]),
+                "kind": row["kind"],
+                "payload": payload,
+                "result": result,
+            }
+        )
+    return out
+
+
+async def _drain_replan(
+    job: Job,
+    plan: Plan,
+    *,
+    router: Any,
+    drain_count: int,
+) -> Plan | None:
+    """Fire a tactical replan when the queue drains mid-run.
+
+    Emits ``loop/drain_replan`` before calling the planner so operators can
+    see when this fires. Loads all findings + the latest synthesis as
+    context so the local-tier planner can pivot intelligently. Returns the
+    new plan, or ``None`` if the planner emitted no fresh tasks (treat as
+    "goal exhausted") or raised — the caller breaks the loop in either case.
+    """
+    from research_agent.orchestrator.plan import tactical_replan
+
+    emit(
+        job,
+        "INFO",
+        "loop",
+        "drain_replan",
+        {"drain_count": drain_count, "from_plan_version": plan.version},
+    )
+    try:
+        recent_results = _load_recent_task_results(job)
+        findings = _load_all_findings(job)
+        synth_md = _load_latest_synthesis_md(job)
+        new_plan = await tactical_replan(
+            job,
+            plan,
+            recent_results,
+            router=router,
+            findings=findings,
+            synthesis_md=synth_md,
+        )
+    except Exception as exc:  # noqa: BLE001 — drain replan failure must not kill the loop
+        emit(
+            job,
+            "WARN",
+            "loop",
+            "warning",
+            {"drain_replan_failed": True, "error": str(exc)},
+        )
+        return None
+
+    if not new_plan.task_template:
+        return None
+    return new_plan
 
 
 def _make_wait_fn(wait_seq: tuple[int, ...]) -> Callable[[Any], int]:
@@ -724,6 +860,7 @@ async def run_loop(
     tasks_done = 0
     stopped = False
     cap_hit = False
+    drain_replans = 0
 
     checkpoint(
         job,
@@ -734,7 +871,23 @@ async def run_loop(
     while not _should_stop(job) and not plan.is_complete() and tasks_done < max_tasks:
         task = next_pending(job)
         if task is None:
-            break
+            if drain_replans >= MAX_DRAIN_REPLANS:
+                emit(
+                    job,
+                    "WARN",
+                    "loop",
+                    "warning",
+                    {"drain_replan_cap_hit": True, "cap": MAX_DRAIN_REPLANS},
+                )
+                break
+            new_plan = await _drain_replan(
+                job, plan, router=router, drain_count=drain_replans + 1
+            )
+            drain_replans += 1
+            if new_plan is None:
+                break
+            plan = new_plan
+            continue
 
         mark_running(task["id"], db_path=job.db_path)
         emit(
@@ -889,6 +1042,7 @@ async def run_loop(
         "stopped": stopped,
         "completed": plan.is_complete(),
         "cap_hit": cap_hit,
+        "drain_replans": drain_replans,
     }
 
 
@@ -966,6 +1120,7 @@ async def _final_synthesis_best_effort(
 __all__ = [
     "HEURISTIC_CHECK_EVERY_N",
     "Handler",
+    "MAX_DRAIN_REPLANS",
     "MAX_TASKS_PER_JOB",
     "RETRY_MAX_ATTEMPTS",
     "RETRY_WAITS",

--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -285,23 +285,29 @@ async def tactical_replan(
     recent_results: list[dict[str, Any]],
     *,
     router: Router,
+    findings: list[dict[str, Any]] | None = None,
+    synthesis_md: str | None = None,
 ) -> Plan:
     """Run a small in-loop replan on the local ``general`` tier.
 
     The prior plan + recent task results are serialized into the run-prompt
-    payload so the planner can adjust without a full cloud rewrite. The
-    returned plan's version is set to ``plan.version + 1`` and persisted.
+    payload so the planner can adjust without a full cloud rewrite. Optional
+    ``findings`` and ``synthesis_md`` carry the wider research state so a
+    drain-driven replan (issue #117) can pivot on what's been learned, not
+    just on what just ran. The returned plan's version is set to
+    ``plan.version + 1`` and persisted.
     """
     _assert_under_cap(job)
     next_version = plan.version + 1
-    context = json.dumps(
-        {
-            "prior_plan": plan.model_dump(),
-            "recent_results": recent_results,
-        },
-        sort_keys=True,
-        default=str,
-    )
+    payload: dict[str, Any] = {
+        "prior_plan": plan.model_dump(),
+        "recent_results": recent_results,
+    }
+    if findings is not None:
+        payload["findings"] = findings
+    if synthesis_md is not None:
+        payload["synthesis_md"] = synthesis_md
+    context = json.dumps(payload, sort_keys=True, default=str)
     raw = await _run_planner_for_yaml(
         job, tier="general", router=router, user_message=context
     )

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -7,9 +7,11 @@ from typing import Any
 
 import pytest
 
+from research_agent.orchestrator import plan as plan_module
 from research_agent.orchestrator.errors import FatalError, RetriableError
 from research_agent.orchestrator.loop import (
     HEURISTIC_CHECK_EVERY_N,
+    MAX_DRAIN_REPLANS,
     MAX_TASKS_PER_JOB,
     RETRY_MAX_ATTEMPTS,
     Handler,
@@ -437,8 +439,6 @@ async def test_loop_exits_when_subgoals_all_done(job: Job, db_path: Path) -> Non
     guard sees ``plan.is_complete()`` and exits cleanly. The daemon then
     maps that to ``completion_reason='goal_complete'`` (see daemon.py:796).
     """
-    from research_agent.orchestrator import plan as plan_module
-
     seeded = Plan(
         version=1,
         objective="Investigate the target",
@@ -486,3 +486,177 @@ async def test_loop_exits_when_subgoals_all_done(job: Job, db_path: Path) -> Non
     pending_count = sum(1 for r in rows if r["status"] == STATUS_PENDING)
     assert done_count == HEURISTIC_CHECK_EVERY_N
     assert pending_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Drain-replan (issue #117) — keep the loop running when the queue empties
+# but the plan is not yet complete and the cap hasn't fired.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_drain_replan_chains_when_queue_empties(
+    job: Job,
+    db_path: Path,
+    plan: Plan,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the queue drains, fire ``tactical_replan`` and keep going."""
+    _seed_tasks(job, ["web_search"] * 4)
+
+    drain_calls = {"n": 0}
+
+    async def fake_tactical_replan(
+        job_arg: Job,
+        prior_plan: Plan,
+        recent_results: list[dict[str, Any]],
+        *,
+        router: Any,
+        findings: list[dict[str, Any]] | None = None,
+        synthesis_md: str | None = None,
+    ) -> Plan:
+        drain_calls["n"] += 1
+        next_version = prior_plan.version + 1
+        if drain_calls["n"] == 1:
+            template = [TaskSpec(kind="web_search", payload={"q": f"r{i}"}) for i in range(4)]
+        else:
+            template = []
+        new = Plan(
+            version=next_version,
+            objective=prior_plan.objective,
+            subgoals=prior_plan.subgoals,
+            task_template=template,
+            expected_iterations=prior_plan.expected_iterations,
+        )
+        write_plan(job_arg, new.model_dump())
+        if template:
+            enqueue(job_arg, list(template), next_version)
+        return new
+
+    monkeypatch.setattr(plan_module, "tactical_replan", fake_tactical_replan)
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": _ok_handler()},
+        retry_waits=(0,),
+    )
+
+    assert drain_calls["n"] == 2
+    assert result["drain_replans"] == 2
+    assert result["tasks_done"] >= 8
+
+    events = _read_event_kinds(db_path, job.id)
+    assert events.count("drain_replan") == 2
+
+
+@pytest.mark.asyncio
+async def test_drain_replan_respects_cap(
+    job: Job,
+    db_path: Path,
+    plan: Plan,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Past ``MAX_DRAIN_REPLANS`` the loop must bail with a cap-hit warning."""
+    _seed_tasks(job, ["web_search"])
+
+    monkeypatch.setattr("research_agent.orchestrator.loop.MAX_DRAIN_REPLANS", 3)
+
+    async def fake_tactical_replan(
+        job_arg: Job,
+        prior_plan: Plan,
+        recent_results: list[dict[str, Any]],
+        *,
+        router: Any,
+        findings: list[dict[str, Any]] | None = None,
+        synthesis_md: str | None = None,
+    ) -> Plan:
+        next_version = prior_plan.version + 1
+        template = [TaskSpec(kind="web_search", payload={"q": "more"})]
+        new = Plan(
+            version=next_version,
+            objective=prior_plan.objective,
+            subgoals=prior_plan.subgoals,
+            task_template=template,
+            expected_iterations=prior_plan.expected_iterations,
+        )
+        write_plan(job_arg, new.model_dump())
+        enqueue(job_arg, list(template), next_version)
+        return new
+
+    monkeypatch.setattr(plan_module, "tactical_replan", fake_tactical_replan)
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": _ok_handler()},
+        retry_waits=(0,),
+    )
+
+    assert result["drain_replans"] == 3
+
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT payload_json FROM events WHERE job_id = ? AND kind = 'warning'",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    import json as _json
+
+    assert any(
+        _json.loads(r["payload_json"]).get("drain_replan_cap_hit") is True for r in rows
+    )
+
+
+@pytest.mark.asyncio
+async def test_drain_replan_break_on_empty_template(
+    job: Job,
+    db_path: Path,
+    plan: Plan,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty task_template means the planner thinks the goal is exhausted."""
+    _seed_tasks(job, ["web_search"])
+
+    async def fake_tactical_replan(
+        job_arg: Job,
+        prior_plan: Plan,
+        recent_results: list[dict[str, Any]],
+        *,
+        router: Any,
+        findings: list[dict[str, Any]] | None = None,
+        synthesis_md: str | None = None,
+    ) -> Plan:
+        next_version = prior_plan.version + 1
+        new = Plan(
+            version=next_version,
+            objective=prior_plan.objective,
+            subgoals=prior_plan.subgoals,
+            task_template=[],
+            expected_iterations=prior_plan.expected_iterations,
+        )
+        write_plan(job_arg, new.model_dump())
+        return new
+
+    monkeypatch.setattr(plan_module, "tactical_replan", fake_tactical_replan)
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": _ok_handler()},
+        retry_waits=(0,),
+    )
+
+    assert result["drain_replans"] == 1
+    assert result["tasks_done"] == 1
+    events = _read_event_kinds(db_path, job.id)
+    assert events.count("drain_replan") == 1
+
+
+def test_max_drain_replans_default_is_ten() -> None:
+    assert MAX_DRAIN_REPLANS == 10


### PR DESCRIPTION
Closes #117
Part of #107

## Summary

Automated implementation of **Replan when the task queue drains (currently the loop just exits)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | FAIL |
| Code review | PASS |
| Verification | PASS |

## Code Review

Drain-replan loop wired correctly: AC met, all 17 loop tests pass, no regressions vs origin/main.

- **INFO** [FIXED] `src/research_agent/orchestrator/loop.py`: All five acceptance criteria satisfied: (1) when next_pending returns None and plan is incomplete and tasks_done < max_tasks, run_loop calls _drain_replan instead of breaking (loop.py:871-890); (2) tactical_replan now accepts findings + synthesis_md kwargs and serializes them into the planner payload (plan.py:278-315), with _drain_replan loading every finding via _load_all_findings and the latest synthesis via _load_latest_synthesis_md (loop.py:430-441); (3) MAX_DRAIN_REPLANS=10 cap enforced with a drain_replan_cap_hit warning event when exceeded (loop.py:874-882); (4) new drain_replan event kind added to the EventKind literal and emitted on every drain-replan attempt with drain_count + from_plan_version (events.py:44, loop.py:423-429); (5) test_drain_replan_chains_when_queue_empties demonstrates iterative chaining without the planner pre-emitting all tasks.
- **INFO** [FIXED] `src/research_agent/orchestrator/loop.py`: Failure isolation looks right: an exception inside tactical_replan emits a 'warning' event with drain_replan_failed=True and returns None so the outer loop breaks cleanly rather than crashing the daemon. STOP flag continues to win (re-checked at while head after the continue).
- **INFO** [FIXED] `src/research_agent/daemon.py`: Daemon consumes loop_result['cap_hit'] / 'stopped' but does not surface drain_replans. That is intentional — drain_replans is operator-facing telemetry visible via the drain_replan events; final job status semantics don't change.
- **INFO** [OPEN]: Pre-existing failures in tests/test_cli.py::test_start_skip_intake_creates_job and test_start_runs_intake_when_not_skipped also fail on origin/main; unrelated to this change.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*