### PR TITLE
feat: Scope-aware planning: scale initial task count to goal breadth (closes #118)

### DIFF
--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -60,6 +60,8 @@ TaskKind = Literal[
     "critique",
 ]
 
+ScopeClass = Literal["narrow", "medium", "broad", "comprehensive"]
+
 
 class Subgoal(BaseModel):
     """A single subgoal within a Plan. ``done=True`` retires it from the loop."""
@@ -104,6 +106,7 @@ class Plan(BaseModel):
     subgoals: list[Subgoal]
     task_template: list[TaskSpec]
     expected_iterations: int = Field(ge=1)
+    scope_class: ScopeClass | None = None
 
     def is_complete(self) -> bool:
         if not self.subgoals:
@@ -155,6 +158,7 @@ def _emit_plan_created(job: Job, plan: Plan, *, tier: str, kind: str) -> None:
             "kind": kind,
             "subgoals": len(plan.subgoals),
             "tasks": len(plan.task_template),
+            "scope_class": plan.scope_class,
         },
     )
 
@@ -347,6 +351,7 @@ __all__ = [
     "Plan",
     "PlanParseError",
     "PlanVersionCapExceeded",
+    "ScopeClass",
     "Subgoal",
     "TaskKind",
     "TaskSpec",

--- a/src/research_agent/prompts/planner.md
+++ b/src/research_agent/prompts/planner.md
@@ -23,6 +23,10 @@ the schema below.
 
 - `version`: integer, always `1` for the initial plan.
 - `objective`: one-sentence restatement of the goal.
+- `scope_class`: one of `narrow`, `medium`, `broad`, `comprehensive`. See
+  the **Scope-aware planning** section below — pick the class that
+  matches the goal's breadth before you write `task_template`. This
+  field is required.
 - `subgoals`: list of 3–6 subgoals. Each subgoal:
   - `id`: integer (1, 2, 3, …).
   - `description`: one sentence describing what answering this would prove.
@@ -120,6 +124,7 @@ For the goal "What does the public record show about Acme Corp's 2024 layoffs?":
 ```yaml
 version: 1
 objective: "Establish what is publicly documented about Acme Corp's 2024 layoffs."
+scope_class: narrow
 subgoals:
   - id: 1
     description: "Identify scope and dates of the layoffs from primary news sources."
@@ -162,6 +167,60 @@ Each search above will be automatically expanded into 3 fetches and 3
 extracts by the loop (configurable via `expand_top_k`). You do not need
 to write those fetch/extract tasks yourself.
 
+## Scope-aware planning
+
+**Before you write `task_template`, classify the goal's breadth.** A
+goal asking "what did Cursor change about pricing in June 2025?" needs
+a handful of focused searches; a goal asking "track Project 2025
+implementation across every federal department" needs dozens. A
+3-task plan for a department-spanning investigation will exhaust its
+queue in 30 minutes and stop. Pick the right tier up front.
+
+| `scope_class` | When to pick it | Initial `task_template` size |
+|---|---|---|
+| `narrow` | Single entity, single event, single time window | 3–8 search tasks |
+| `medium` | One entity with many facets, OR several closely related entities | 8–20 search tasks |
+| `broad` | Many entities (orgs, departments, people) under one umbrella | 20–50 search tasks |
+| `comprehensive` | Full corpus / multi-year / every-entity coverage | 50+ search tasks |
+
+Signals from your own subgoals: a 3-subgoal plan covering one company
+is `narrow`; a 6-subgoal plan that breaks down by department, by year,
+or by sub-policy is `broad` or `comprehensive`.
+
+### Worked one-line examples per tier
+
+- **narrow** — Goal: *"Cursor's June 2025 pricing changes — main
+  complaints"*. Queries: `Cursor pricing June 2025`, `Cursor pricing
+  complaints`, `Cursor pricing reddit`, `Cursor pricing changes
+  backlash` (~4 searches).
+- **medium** — Goal: *"George Santos pre-2022 election
+  misrepresentations"*. Queries: `George Santos resume`, `George
+  Santos Baruch College`, `George Santos Citigroup`, `George Santos
+  Goldman Sachs`, `George Santos Devolder`, `George Santos charity`,
+  `George Santos volleyball`, `George Santos Jewish heritage`,
+  `George Santos Brazil check fraud`, `George Santos campaign
+  finance`, `George Santos animal rescue`, `George Santos LinkedIn`
+  (~12 searches).
+- **broad** — Goal: *"Project 2025 implementation tracker across every
+  federal department"*. Queries: one or two per major
+  agency/department — `Project 2025 DOJ`, `Project 2025 State
+  Department`, `Project 2025 EPA`, `Project 2025 HHS`, `Project 2025
+  DHS`, `Project 2025 Education`, `Project 2025 Treasury`, `Project
+  2025 DOD`, `Project 2025 DOE`, `Project 2025 Interior`, `Project
+  2025 Commerce`, `Project 2025 Agriculture`, `Project 2025 Labor`,
+  `Project 2025 HUD`, `Project 2025 VA`, `Project 2025 Transportation`,
+  plus cross-cutting queries `Project 2025 executive orders`, `Project
+  2025 schedule F`, `Project 2025 Heritage Foundation`, `Project 2025
+  staffing tracker` (~20–30 searches).
+- **comprehensive** — Goal: *"Complete public record of Anthropic's
+  safety governance 2023–present"*. Queries span: each public policy
+  document, each leadership statement, each external commitment,
+  each board/committee, each year's RSP version, each model release's
+  safety brief, each external evaluation partnership, each
+  government-facing testimony or filing, each major journalistic
+  treatment — easily 50+ initial searches before iterative deepening
+  takes over.
+
 ## Hard rules
 
 - Output ONLY the fenced YAML block. No prose, no preamble, no postscript.
@@ -169,5 +228,9 @@ to write those fetch/extract tasks yourself.
   `arxiv_search`, `local_corpus_query`. NO others.
 - Every payload MUST include a `sub_question` describing what the
   downstream extract should look for.
-- Keep `task_template` to 3–8 search tasks (each one expands into ~6
-  follow-up tasks at runtime; more than 8 searches blows the queue cap).
+- Always include a top-level `scope_class` field. Size `task_template`
+  to match it (narrow 3–8, medium 8–20, broad 20–50, comprehensive
+  50+). The orchestrator's `MAX_TASKS_PER_JOB` cap is 10000, and each
+  search expands to roughly 6 follow-up tasks — even 50 searches
+  (~300 tasks) fits comfortably; do not undersize a broad goal out of
+  caution.

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -19,6 +19,7 @@ from research_agent.orchestrator.plan import (
     MAX_PLAN_VERSIONS,
     Plan,
     PlanVersionCapExceeded,
+    ScopeClass,
     Subgoal,
     TaskKind,
     TaskSpec,
@@ -31,6 +32,7 @@ from research_agent.storage import db
 from research_agent.storage.jobs import Job
 
 ALL_TASK_KINDS: tuple[str, ...] = get_args(TaskKind)
+ALL_SCOPE_CLASSES: tuple[str, ...] = get_args(ScopeClass)
 
 
 # ---------------------------------------------------------------------------
@@ -184,6 +186,43 @@ def test_plan_forbids_extra_keys() -> None:
     payload["surprise"] = "boom"
     with pytest.raises(ValidationError):
         Plan.model_validate(payload)
+
+
+# ---------------------------------------------------------------------------
+# Plan.scope_class — issue #118 (scope-aware planning)
+# ---------------------------------------------------------------------------
+
+
+def test_scope_class_enumeration_matches_spec() -> None:
+    assert set(ALL_SCOPE_CLASSES) == {
+        "narrow",
+        "medium",
+        "broad",
+        "comprehensive",
+    }
+
+
+def test_plan_scope_class_defaults_to_none() -> None:
+    plan = _sample_plan()
+    assert plan.scope_class is None
+
+
+@pytest.mark.parametrize("scope", ALL_SCOPE_CLASSES)
+def test_plan_accepts_each_scope_class(scope: str) -> None:
+    plan = _sample_plan(scope_class=scope)
+    assert plan.scope_class == scope
+
+
+def test_plan_rejects_unknown_scope_class() -> None:
+    with pytest.raises(ValidationError):
+        _sample_plan(scope_class="huge")
+
+
+def test_plan_scope_class_round_trips() -> None:
+    plan = _sample_plan(scope_class="broad")
+    rebuilt = Plan.model_validate(plan.model_dump())
+    assert rebuilt.scope_class == "broad"
+    assert rebuilt == plan
 
 
 # ---------------------------------------------------------------------------
@@ -475,6 +514,62 @@ def test_max_plan_versions_cap_raises_when_full(
         asyncio.run(tactical_replan(job, prior, [], router=router))
     with pytest.raises(PlanVersionCapExceeded):
         asyncio.run(cloud_replan(job, prior, "x", router=router))
+
+
+def test_plan_created_event_payload_includes_scope_class(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """Issue #118: ``plan_created`` payloads must surface ``scope_class``."""
+    router, _calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan(scope_class="broad")
+
+    asyncio.run(initial_plan(job, router=router))
+
+    conn = db.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT payload_json FROM events"
+            " WHERE job_id = ? AND kind = 'plan_created'"
+            " ORDER BY id ASC LIMIT 1",
+            (job.id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    payload = json.loads(row["payload_json"])
+    assert payload["scope_class"] == "broad"
+    assert payload["version"] == 1
+    assert payload["tier"] == "frontier"
+    assert payload["kind"] == "initial"
+
+
+def test_plan_created_event_payload_includes_scope_class_when_unset(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """When the planner omits ``scope_class``, the event still carries the key (None)."""
+    router, _calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()  # default: scope_class=None
+
+    asyncio.run(initial_plan(job, router=router))
+
+    conn = db.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT payload_json FROM events"
+            " WHERE job_id = ? AND kind = 'plan_created'"
+            " ORDER BY id ASC LIMIT 1",
+            (job.id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    payload = json.loads(row["payload_json"])
+    assert "scope_class" in payload
+    assert payload["scope_class"] is None
 
 
 def test_persisted_plan_round_trips_via_db(


### PR DESCRIPTION
Closes #118
Part of #107

## Summary

Automated implementation of **Scope-aware planning: scale initial task count to goal breadth**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Scope-aware planning fully implemented and wired end-to-end; 681 tests pass, ruff clean, prompt + model + event payload all updated.

- **INFO** [OPEN] `src/research_agent/orchestrator/plan.py`: Prompt declares scope_class 'required' but the Plan model treats it as Optional (defaults to None). Intentional defensive design — if the LLM forgets the field, the plan still parses and operators can audit `scope_class IS NULL` events to detect non-compliance. Reasonable tradeoff; no change needed.
- **INFO** [OPEN] `src/research_agent/prompts/planner.md`: Acceptance criteria 3 & 4 ask for live re-runs of the Project 2025 and Cursor goals to verify task counts. These require a real LLM and cannot be automated in unit tests; the implementer added structural tests (enum, round-trip, event payload) and worked examples in the prompt to anchor model behavior. Manual verification is still recommended before declaring the behavior change effective in production runs.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*