### PR TITLE
feat: YouTube transcript extraction (yt-dlp + Whisper fallback) (closes #111)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,11 @@ RESEARCH_PDF_VLM_ESCALATION=
 # Optional: override the default LM Studio base URL (http://localhost:1234/v1).
 LMSTUDIO_BASE_URL=
 
+# Optional: YouTube Data API v3 key. When set, `tools/youtube.py:search`
+# uses the official Data API; otherwise it falls back to scraping the
+# public results page via Playwright. Free quota is 10,000 units/day.
+YOUTUBE_API_KEY=
+
 # Optional: set to 0 to suppress the foreground Rich progress bar the daemon
 # writes to stdout when run interactively. Has no effect on `research start`
 # (its daemon redirects stdout to a log file, so the bar stays dormant).

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ that list, so there is no drift.
 | `RESEARCH_IGNORE_ROBOTS` | no | Set to `1` to bypass robots.txt checks in `web_fetch`. |
 | `RESEARCH_PDF_VLM_ESCALATION` | no | Set to `1` to enable Opus 4.7 vision escalation for PDFs that fail every cheaper layer. Off by default — costs real money; emits a `pdf_vlm_escalation` WARN event when fired. |
 | `LMSTUDIO_BASE_URL` | no | Override the default `http://localhost:1234/v1`. |
+| `YOUTUBE_API_KEY` | no | YouTube Data API v3 key (free quota: 10,000 units/day). When set, `tools/youtube.py:search` uses the official API; absent, it falls back to scraping the public results page via Playwright. |
 | `RESEARCH_DAEMON_PROGRESS` | no | Set to `0` to suppress the foreground Rich progress bar the daemon writes to stdout when run interactively. |
 
 ## LM Studio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "unstructured>=0.14",
     "pywhispercpp>=1.2",
     "mlx-whisper>=0.4; platform_machine=='arm64' and sys_platform=='darwin'",
+    "yt-dlp>=2024.4",
 ]
 
 [project.optional-dependencies]

--- a/src/research_agent/config.py
+++ b/src/research_agent/config.py
@@ -65,6 +65,14 @@ EXPECTED_ENV_KEYS: tuple[EnvKey, ...] = (
         ),
     ),
     EnvKey(
+        name="YOUTUBE_API_KEY",
+        required=False,
+        description=(
+            "YouTube Data API v3 key — enables youtube.search; planner falls back"
+            " to SERP scraping (and ultimately web_search) when absent."
+        ),
+    ),
+    EnvKey(
         name="RESEARCH_DAEMON_PROGRESS",
         required=False,
         description=(

--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -188,6 +188,35 @@ def _smoke_audio(path_or_url: str) -> str:
     )
 
 
+def _smoke_youtube(query: str) -> str:
+    """Smoke wrapper: run youtube.search and print up to 10 hits formatted.
+
+    Lets a human eyeball whether the Data API key (when set) or the SERP
+    fallback parser still picks up videos for ``query``.
+    """
+    from research_agent.tools import youtube
+
+    async def _run() -> str:
+        results = await youtube.search(query, max_results=10)
+        if not results:
+            return f"youtube search returned no results for {query!r}"
+        lines: list[str] = [f"total: {len(results)}"]
+        for hit in results[:10]:
+            channel = hit.extras.get("channel") or "?"
+            published = (
+                hit.published_at.isoformat()
+                if hit.published_at
+                else (hit.extras.get("published_text") or "?")
+            )
+            views = hit.extras.get("view_count_text") or "?"
+            lines.append(
+                f"- {hit.title}\n  {hit.url}\n  {channel} | views={views} | published={published}"
+            )
+        return "\n".join(lines)
+
+    return asyncio.run(_run())
+
+
 def _smoke_web_fetch(url: str) -> str:
     """Smoke wrapper for web_fetch: print word count, path, preview, archive URL.
 
@@ -236,6 +265,7 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "reddit": _smoke_reddit,
     "pdf": _smoke_pdf,
     "audio": _smoke_audio,
+    "youtube": _smoke_youtube,
 }
 
 __all__ = ["TOOL_REGISTRY", "SearchResult", "Source", "SourceKind"]

--- a/src/research_agent/tools/web_fetch.py
+++ b/src/research_agent/tools/web_fetch.py
@@ -275,6 +275,10 @@ _REDDIT_HOSTS = frozenset(
     {"reddit.com", "www.reddit.com", "old.reddit.com", "new.reddit.com"}
 )
 
+_YOUTUBE_HOSTS = frozenset(
+    {"youtube.com", "www.youtube.com", "m.youtube.com", "youtu.be", "www.youtu.be"}
+)
+
 _PDF_CONTENT_TYPE = "application/pdf"
 
 
@@ -410,10 +414,16 @@ async def fetch(
     if not url or not urlparse(url).netloc:
         return None
 
-    if urlparse(url).netloc in _REDDIT_HOSTS:
+    netloc = urlparse(url).netloc.lower()
+    if netloc in _REDDIT_HOSTS:
         from research_agent.tools import reddit
 
         return await reddit.fetch(url)
+
+    if netloc in _YOUTUBE_HOSTS:
+        from research_agent.tools import youtube
+
+        return await youtube.fetch(url)
 
     user_agent = _resolve_user_agent()
 

--- a/src/research_agent/tools/youtube.py
+++ b/src/research_agent/tools/youtube.py
@@ -1,0 +1,679 @@
+"""YouTube connector (issue #111): yt-dlp captions first, Whisper fallback.
+
+Many investigative leads surface as YouTube content (interviews, conference
+talks, podcast episodes, leaked recordings, news clips). The generic
+trafilatura + Playwright path strips a YouTube watch page to its SPA shell
+and yields nothing useful, so a dedicated connector is required.
+
+Strategy:
+
+1. **yt-dlp auto-captions first** — most YouTube videos have auto-generated
+   English captions. ``yt-dlp --skip-download --write-auto-sub --write-sub
+   --sub-format vtt --sub-langs 'en.*'`` is fast and free.
+2. **Local Whisper fallback** — when no captions exist (older videos,
+   intentional absence) we download the audio track with ``yt-dlp -x`` and
+   route it through :func:`research_agent.tools.audio.transcribe`.
+
+Public surface mirrors :mod:`research_agent.tools.reddit`:
+
+* ``async def fetch(url) -> Source | None`` — accepts any YouTube URL shape
+  (``youtube.com/watch?v=…``, ``youtu.be/…``, ``youtube.com/shorts/…``) and
+  returns a :class:`Source` whose ``cleaned_text`` is the transcript with
+  ``[mm:ss]`` timestamp markers preserved.
+* ``async def search(query, max_results=25) -> list[SearchResult]`` — uses
+  YouTube Data API v3 when ``YOUTUBE_API_KEY`` is set, otherwise scrapes the
+  public results page via :func:`tools.browser.browser_session`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import shutil
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, quote_plus, urlparse
+
+import httpx
+
+from research_agent import config
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+_YOUTUBE_HOSTS: frozenset[str] = frozenset(
+    {
+        "youtube.com",
+        "www.youtube.com",
+        "m.youtube.com",
+        "youtu.be",
+        "www.youtu.be",
+    }
+)
+
+_DATA_API_BASE = "https://www.googleapis.com/youtube/v3/search"
+_HTTP_TIMEOUT_S = 15.0
+_YT_DLP_TIMEOUT_S = 120.0
+_VIDEO_ID_RE = re.compile(r"^[A-Za-z0-9_-]{6,20}$")
+
+# yt-dlp surfaces age/region restrictions in stderr. Match conservatively —
+# any of these substrings means we should bail rather than retry.
+_RESTRICTED_KEYWORDS: tuple[str, ...] = (
+    "Sign in to confirm your age",
+    "age-restricted",
+    "is not available in your country",
+    "unavailable in your country",
+    "video is private",
+    "Private video",
+    "Video unavailable",
+)
+
+
+# ---------------------------------------------------------------------------
+# URL normalisation
+# ---------------------------------------------------------------------------
+
+
+def _normalize_video_id(url: str) -> str | None:
+    """Return the canonical ``https://www.youtube.com/watch?v=<id>`` URL.
+
+    Handles ``watch?v=<id>``, ``youtu.be/<id>``, ``youtube.com/shorts/<id>``,
+    and ``youtube.com/embed/<id>``. Returns None when the URL isn't a YouTube
+    video reference (subscription pages, channel pages, malformed input).
+    """
+    if not url:
+        return None
+    parsed = urlparse(url)
+    host = parsed.netloc.lower()
+    if host not in _YOUTUBE_HOSTS:
+        return None
+
+    video_id: str | None = None
+
+    # youtu.be/<id>
+    if host in {"youtu.be", "www.youtu.be"}:
+        candidate = parsed.path.lstrip("/").split("/")[0]
+        if _VIDEO_ID_RE.match(candidate):
+            video_id = candidate
+
+    # youtube.com/watch?v=<id>
+    if video_id is None and parsed.path.rstrip("/") == "/watch":
+        params = parse_qs(parsed.query)
+        candidate = (params.get("v") or [""])[0]
+        if _VIDEO_ID_RE.match(candidate):
+            video_id = candidate
+
+    # youtube.com/shorts/<id>, youtube.com/embed/<id>, youtube.com/v/<id>
+    if video_id is None:
+        parts = [p for p in parsed.path.split("/") if p]
+        if len(parts) >= 2 and parts[0] in {"shorts", "embed", "v"}:
+            candidate = parts[1]
+            if _VIDEO_ID_RE.match(candidate):
+                video_id = candidate
+
+    if video_id is None:
+        return None
+    return f"https://www.youtube.com/watch?v={video_id}"
+
+
+def _video_id_from_canonical(url: str) -> str | None:
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    values = params.get("v")
+    return values[0] if values else None
+
+
+# ---------------------------------------------------------------------------
+# yt-dlp subprocess
+# ---------------------------------------------------------------------------
+
+
+def _is_restricted(stderr: str) -> bool:
+    if not stderr:
+        return False
+    for marker in _RESTRICTED_KEYWORDS:
+        if marker.lower() in stderr.lower():
+            return True
+    return False
+
+
+def _parse_metadata_line(line: str) -> dict[str, Any]:
+    """Parse the ``--print`` line ``title\\tchannel\\tduration\\tupload_date``.
+
+    Returns an empty dict when the line is malformed — callers fall back to
+    the URL itself for the Source title.
+    """
+    if not line:
+        return {}
+    parts = line.split("\t")
+    if len(parts) < 4:
+        # Some videos elide channel or duration; pad with empties so the
+        # zip below doesn't drop fields silently.
+        parts = parts + [""] * (4 - len(parts))
+    title, channel, duration_s, upload_date = parts[:4]
+    meta: dict[str, Any] = {}
+    if title and title != "NA":
+        meta["title"] = title.strip()
+    if channel and channel != "NA":
+        meta["channel"] = channel.strip()
+    try:
+        if duration_s and duration_s != "NA":
+            meta["duration_s"] = int(float(duration_s))
+    except (TypeError, ValueError):
+        pass
+    if upload_date and upload_date != "NA" and len(upload_date) == 8:
+        try:
+            meta["upload_date"] = datetime.strptime(upload_date, "%Y%m%d").date().isoformat()
+        except ValueError:
+            pass
+    return meta
+
+
+async def _run_ytdlp_captions(
+    url: str, tmpdir: Path
+) -> tuple[dict[str, Any], Path | None, str]:
+    """Run yt-dlp to write VTT captions + print metadata.
+
+    Returns ``(metadata, vtt_path_or_None, stderr)``. ``vtt_path`` is None
+    when no captions were emitted (yt-dlp prints the metadata regardless).
+    """
+    cmd = [
+        "yt-dlp",
+        "--skip-download",
+        "--write-auto-sub",
+        "--write-sub",
+        "--sub-format",
+        "vtt",
+        "--sub-langs",
+        "en.*",
+        "--print",
+        "%(title)s\t%(channel)s\t%(duration)s\t%(upload_date)s",
+        "-o",
+        str(tmpdir / "%(id)s.%(ext)s"),
+        url,
+    ]
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_b, stderr_b = await asyncio.wait_for(
+            proc.communicate(), timeout=_YT_DLP_TIMEOUT_S
+        )
+    except FileNotFoundError as exc:
+        logger.warning("yt-dlp not installed: %s", exc)
+        return {}, None, "yt-dlp not installed"
+    except TimeoutError as exc:
+        logger.warning("yt-dlp captions timed out for %s: %s", url, exc)
+        return {}, None, "timeout"
+
+    stdout = stdout_b.decode("utf-8", errors="replace")
+    stderr = stderr_b.decode("utf-8", errors="replace")
+
+    metadata: dict[str, Any] = {}
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        # The metadata --print line is tab-separated; subtitle progress lines
+        # printed to stdout look like ``[info] Writing video subtitles…``.
+        if "\t" in line:
+            metadata = _parse_metadata_line(line)
+            break
+
+    # Pick the first VTT file yt-dlp dropped in tmpdir.
+    vtt_path: Path | None = None
+    for candidate in sorted(tmpdir.glob("*.vtt")):
+        vtt_path = candidate
+        break
+
+    return metadata, vtt_path, stderr
+
+
+async def _run_ytdlp_audio(url: str, tmpdir: Path) -> Path | None:
+    """Download bestaudio as an mp3 via yt-dlp; return the file path or None."""
+    cmd = [
+        "yt-dlp",
+        "-x",
+        "--audio-format",
+        "mp3",
+        "-o",
+        str(tmpdir / "%(id)s.%(ext)s"),
+        url,
+    ]
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr_b = await asyncio.wait_for(
+            proc.communicate(), timeout=_YT_DLP_TIMEOUT_S
+        )
+    except FileNotFoundError:
+        return None
+    except TimeoutError:
+        logger.warning("yt-dlp audio download timed out for %s", url)
+        return None
+
+    if proc.returncode != 0:
+        logger.warning(
+            "yt-dlp audio download failed for %s: %s",
+            url,
+            stderr_b.decode("utf-8", errors="replace")[:200],
+        )
+        return None
+
+    for candidate in sorted(tmpdir.glob("*.mp3")):
+        return candidate
+    return None
+
+
+# ---------------------------------------------------------------------------
+# VTT parsing
+# ---------------------------------------------------------------------------
+
+
+_VTT_TIMESTAMP_RE = re.compile(
+    r"^(\d{2}):(\d{2}):(\d{2})\.\d{3}\s+-->\s+\d{2}:\d{2}:\d{2}\.\d{3}"
+)
+_VTT_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _format_mmss(hours: int, minutes: int, seconds: int) -> str:
+    total_minutes = hours * 60 + minutes
+    return f"[{total_minutes:02d}:{seconds:02d}]"
+
+
+def _parse_vtt(text: str) -> str:
+    """Convert VTT to a single transcript blob with ``[mm:ss]`` markers.
+
+    YouTube auto-captions repeat the previous cue lines verbatim on the next
+    cue ("rolling" captions). We dedupe consecutive identical caption lines
+    so the transcript reads cleanly.
+    """
+    if not text:
+        return ""
+
+    lines: list[str] = []
+    last_emitted: str | None = None
+    current_marker: str | None = None
+    pending_buffer: list[str] = []
+
+    def _flush() -> None:
+        nonlocal last_emitted, pending_buffer, current_marker
+        if not pending_buffer:
+            return
+        joined = " ".join(s.strip() for s in pending_buffer if s.strip())
+        joined = joined.strip()
+        pending_buffer = []
+        if not joined or joined == last_emitted:
+            return
+        if current_marker:
+            lines.append(f"{current_marker} {joined}")
+        else:
+            lines.append(joined)
+        last_emitted = joined
+
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        # Skip the WEBVTT header, NOTE blocks, STYLE blocks, and any
+        # ``Kind:``/``Language:`` metadata that YouTube emits at the top.
+        if not line:
+            _flush()
+            continue
+        if line.startswith("WEBVTT"):
+            continue
+        if line.startswith(("NOTE", "STYLE", "Kind:", "Language:")):
+            continue
+        m = _VTT_TIMESTAMP_RE.match(line)
+        if m:
+            _flush()
+            hours = int(m.group(1))
+            minutes = int(m.group(2))
+            seconds = int(m.group(3))
+            current_marker = _format_mmss(hours, minutes, seconds)
+            continue
+        # Cue identifier (just digits or a hash) — skip.
+        if line.isdigit():
+            continue
+        # Strip inline timing tags like <c> and <00:00:00.000>.
+        cleaned = _VTT_TAG_RE.sub("", line).strip()
+        if not cleaned:
+            continue
+        pending_buffer.append(cleaned)
+
+    _flush()
+    return "\n".join(lines).strip()
+
+
+# ---------------------------------------------------------------------------
+# Public: fetch
+# ---------------------------------------------------------------------------
+
+
+async def fetch(url: str) -> Source | None:
+    """Fetch the transcript for a YouTube URL.
+
+    Pipeline: yt-dlp → VTT (captions). When captions are absent yt-dlp
+    re-runs to pull the audio track and we route it through
+    :func:`audio.transcribe`. Age-restricted / region-locked / removed
+    videos return None with a WARN log so the planner can move on rather
+    than retry forever.
+    """
+    canonical = _normalize_video_id(url)
+    if canonical is None:
+        return None
+
+    tmp_root = Path(tempfile.mkdtemp(prefix="yt_dlp_"))
+    try:
+        metadata, vtt_path, stderr = await _run_ytdlp_captions(canonical, tmp_root)
+
+        if _is_restricted(stderr):
+            logger.warning(
+                "youtube fetch skipped (age-restricted / region-locked): %s", canonical
+            )
+            return None
+
+        title = metadata.get("title") or canonical
+        channel = metadata.get("channel")
+        duration_s = metadata.get("duration_s")
+        upload_date = metadata.get("upload_date")
+
+        base_metadata: dict[str, Any] = {
+            "platform": "youtube",
+            "channel": channel,
+            "duration_s": duration_s,
+            "upload_date": upload_date,
+            "video_id": _video_id_from_canonical(canonical),
+            "transcript_unavailable": False,
+        }
+
+        # Captions path.
+        if vtt_path is not None and vtt_path.exists():
+            try:
+                vtt_text = vtt_path.read_text(encoding="utf-8", errors="replace")
+            except OSError as exc:
+                logger.warning("youtube vtt read failed for %s: %s", canonical, exc)
+                vtt_text = ""
+            transcript = _parse_vtt(vtt_text)
+            if transcript:
+                meta = dict(base_metadata)
+                meta["fetched_via"] = "yt-dlp-captions"
+                return Source(
+                    url=canonical,
+                    title=title,
+                    cleaned_text=transcript,
+                    fetched_at=datetime.now(UTC),
+                    source_kind="web",
+                    metadata=meta,
+                )
+
+        # Whisper fallback path.
+        audio_path = await _run_ytdlp_audio(canonical, tmp_root)
+        if audio_path is not None and audio_path.exists():
+            from research_agent.tools import audio as audio_tool
+
+            try:
+                transcript = await audio_tool.transcribe(audio_path)
+            except Exception as exc:  # noqa: BLE001 — never crash the loop
+                logger.warning(
+                    "youtube whisper fallback failed for %s: %s", canonical, exc
+                )
+                transcript = ""
+            if transcript.strip():
+                meta = dict(base_metadata)
+                meta["fetched_via"] = "yt-dlp-whisper"
+                return Source(
+                    url=canonical,
+                    title=title,
+                    cleaned_text=transcript,
+                    fetched_at=datetime.now(UTC),
+                    source_kind="web",
+                    metadata=meta,
+                )
+
+        # Both paths empty — only return a stub Source if we actually got
+        # metadata back (means yt-dlp reached the video). Otherwise the call
+        # failed before it touched YouTube and we should signal None so the
+        # planner doesn't waste a citation slot on an empty body.
+        if metadata:
+            meta = dict(base_metadata)
+            meta["fetched_via"] = "yt-dlp"
+            meta["transcript_unavailable"] = True
+            return Source(
+                url=canonical,
+                title=title,
+                cleaned_text="",
+                fetched_at=datetime.now(UTC),
+                source_kind="web",
+                metadata=meta,
+            )
+        return None
+    finally:
+        shutil.rmtree(tmp_root, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Public: search
+# ---------------------------------------------------------------------------
+
+
+def _parse_data_api_results(payload: dict[str, Any]) -> list[SearchResult]:
+    items = payload.get("items") or []
+    out: list[SearchResult] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        snippet = (item.get("snippet") or {}) if isinstance(item.get("snippet"), dict) else {}
+        ident = (item.get("id") or {}) if isinstance(item.get("id"), dict) else {}
+        video_id = ident.get("videoId")
+        title = (snippet.get("title") or "").strip()
+        if not video_id or not title:
+            continue
+        channel = (snippet.get("channelTitle") or "").strip()
+        description = (snippet.get("description") or "").strip()
+        published_raw = snippet.get("publishedAt")
+        published_at: datetime | None = None
+        if isinstance(published_raw, str) and published_raw:
+            try:
+                published_at = datetime.fromisoformat(published_raw.replace("Z", "+00:00"))
+            except ValueError:
+                published_at = None
+        out.append(
+            SearchResult(
+                url=f"https://www.youtube.com/watch?v={video_id}",
+                title=title,
+                snippet=description[:400],
+                published_at=published_at,
+                source_kind="web",
+                extras={
+                    "channel": channel,
+                    "video_id": video_id,
+                    "fetched_via": "youtube-data-api",
+                },
+            )
+        )
+    return out
+
+
+async def _search_via_data_api(query: str, max_results: int, api_key: str) -> list[SearchResult]:
+    params: dict[str, str | int] = {
+        "part": "snippet",
+        "q": query,
+        "type": "video",
+        "maxResults": max(1, min(int(max_results), 50)),
+        "key": api_key,
+    }
+    try:
+        async with httpx.AsyncClient(
+            timeout=_HTTP_TIMEOUT_S, follow_redirects=True
+        ) as client:
+            resp = await client.get(_DATA_API_BASE, params=params)
+    except httpx.HTTPError as exc:
+        logger.warning("youtube data api HTTP error for %r: %s", query, exc)
+        return []
+    if resp.status_code != 200:
+        logger.warning(
+            "youtube data api returned %s for %r: %s",
+            resp.status_code,
+            query,
+            resp.text[:200],
+        )
+        return []
+    try:
+        payload = resp.json()
+    except ValueError as exc:
+        logger.warning("youtube data api JSON decode failed: %s", exc)
+        return []
+    return _parse_data_api_results(payload)[:max_results]
+
+
+_YT_INITIAL_DATA_RE = re.compile(
+    r"var\s+ytInitialData\s*=\s*(\{.*?\})\s*;\s*</script>", re.DOTALL
+)
+
+
+def _walk_video_renderers(node: Any) -> list[dict[str, Any]]:
+    """Recursively pull every ``videoRenderer`` dict out of ``ytInitialData``.
+
+    YouTube's SERP shape changes; rather than encode the exact path through
+    ``contents.twoColumnSearchResultsRenderer.…`` we walk the whole tree so
+    the parser survives minor reshufflings.
+    """
+    out: list[dict[str, Any]] = []
+    if isinstance(node, dict):
+        if "videoRenderer" in node and isinstance(node["videoRenderer"], dict):
+            out.append(node["videoRenderer"])
+        for value in node.values():
+            out.extend(_walk_video_renderers(value))
+    elif isinstance(node, list):
+        for item in node:
+            out.extend(_walk_video_renderers(item))
+    return out
+
+
+def _runs_to_text(runs: Any) -> str:
+    if not isinstance(runs, list):
+        return ""
+    return "".join(
+        r.get("text", "") for r in runs if isinstance(r, dict) and isinstance(r.get("text"), str)
+    ).strip()
+
+
+def _renderer_to_search_result(renderer: dict[str, Any]) -> SearchResult | None:
+    video_id = renderer.get("videoId")
+    if not isinstance(video_id, str) or not video_id:
+        return None
+    title_obj = renderer.get("title") or {}
+    title = ""
+    if isinstance(title_obj, dict):
+        title = _runs_to_text(title_obj.get("runs"))
+        if not title:
+            simple = title_obj.get("simpleText")
+            if isinstance(simple, str):
+                title = simple.strip()
+    if not title:
+        return None
+
+    channel = ""
+    owner = renderer.get("ownerText") or renderer.get("longBylineText") or {}
+    if isinstance(owner, dict):
+        channel = _runs_to_text(owner.get("runs"))
+
+    snippet = ""
+    desc = renderer.get("detailedMetadataSnippets")
+    if isinstance(desc, list) and desc:
+        first = desc[0]
+        if isinstance(first, dict):
+            snippet_obj = first.get("snippetText") or {}
+            if isinstance(snippet_obj, dict):
+                snippet = _runs_to_text(snippet_obj.get("runs"))
+
+    published = ""
+    published_obj = renderer.get("publishedTimeText") or {}
+    if isinstance(published_obj, dict):
+        published = published_obj.get("simpleText") or ""
+
+    view_count = ""
+    view_obj = renderer.get("viewCountText") or {}
+    if isinstance(view_obj, dict):
+        view_count = view_obj.get("simpleText") or _runs_to_text(view_obj.get("runs"))
+
+    return SearchResult(
+        url=f"https://www.youtube.com/watch?v={video_id}",
+        title=title,
+        snippet=snippet[:400],
+        published_at=None,
+        source_kind="web",
+        extras={
+            "channel": channel,
+            "video_id": video_id,
+            "view_count_text": view_count or None,
+            "published_text": published or None,
+            "fetched_via": "youtube-serp",
+        },
+    )
+
+
+async def _search_via_serp(query: str, max_results: int) -> list[SearchResult]:
+    """Scrape the public YouTube results page when no API key is configured."""
+    from research_agent.tools import browser
+
+    target = f"https://www.youtube.com/results?search_query={quote_plus(query)}"
+    try:
+        async with browser.browser_session() as ctx:
+            page = await ctx.new_page()
+            try:
+                await browser.navigate(page, target)
+                html = await page.content()
+            finally:
+                await page.close()
+    except Exception as exc:  # noqa: BLE001 — never crash the loop
+        logger.warning("youtube serp scrape failed for %r: %s", query, exc)
+        return []
+
+    match = _YT_INITIAL_DATA_RE.search(html)
+    if match is None:
+        logger.warning("youtube serp scrape: ytInitialData not found for %r", query)
+        return []
+    try:
+        data = json.loads(match.group(1))
+    except ValueError as exc:
+        logger.warning("youtube serp scrape JSON decode failed: %s", exc)
+        return []
+
+    renderers = _walk_video_renderers(data)
+    out: list[SearchResult] = []
+    for renderer in renderers:
+        sr = _renderer_to_search_result(renderer)
+        if sr is not None:
+            out.append(sr)
+        if len(out) >= max_results:
+            break
+    return out
+
+
+async def search(query: str, max_results: int = 25) -> list[SearchResult]:
+    """Search YouTube; return up to ``max_results`` :class:`SearchResult`.
+
+    Uses the YouTube Data API v3 when ``YOUTUBE_API_KEY`` is configured,
+    otherwise scrapes ``youtube.com/results`` via the shared Playwright
+    session. Returns ``[]`` on any error rather than raising — search
+    failures should not abort the orchestration loop.
+    """
+    if not query or not query.strip():
+        return []
+
+    api_key = config.get("YOUTUBE_API_KEY")
+    if api_key:
+        return await _search_via_data_api(query, max_results, api_key)
+    return await _search_via_serp(query, max_results)
+
+
+__all__ = ["fetch", "search"]

--- a/tests/test_tools_youtube.py
+++ b/tests/test_tools_youtube.py
@@ -1,0 +1,688 @@
+"""Tests for `research_agent.tools.youtube` (issue #111)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from research_agent import config as config_module
+from research_agent.tools import web_fetch, youtube
+
+
+@pytest.fixture(autouse=True)
+def _scrub_env(monkeypatch):
+    monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+    monkeypatch.delenv("RESEARCH_IGNORE_ROBOTS", raising=False)
+    web_fetch.reset_for_tests()
+    config_module.reset_for_tests()
+    yield
+    web_fetch.reset_for_tests()
+    config_module.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# URL normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_video_id_watch_url():
+    out = youtube._normalize_video_id("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    assert out == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+
+def test_normalize_video_id_youtu_be_short():
+    out = youtube._normalize_video_id("https://youtu.be/dQw4w9WgXcQ?t=42")
+    assert out == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+
+def test_normalize_video_id_shorts():
+    out = youtube._normalize_video_id("https://www.youtube.com/shorts/abc123XYZ_-")
+    assert out == "https://www.youtube.com/watch?v=abc123XYZ_-"
+
+
+def test_normalize_video_id_embed():
+    out = youtube._normalize_video_id("https://www.youtube.com/embed/dQw4w9WgXcQ")
+    assert out == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+
+def test_normalize_video_id_m_subdomain():
+    out = youtube._normalize_video_id("https://m.youtube.com/watch?v=dQw4w9WgXcQ&list=foo")
+    assert out == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+
+def test_normalize_video_id_rejects_non_youtube():
+    assert youtube._normalize_video_id("https://example.com/watch?v=abc") is None
+
+
+def test_normalize_video_id_rejects_channel_pages():
+    assert youtube._normalize_video_id("https://www.youtube.com/@SomeChannel") is None
+
+
+def test_normalize_video_id_rejects_results_page():
+    assert youtube._normalize_video_id("https://www.youtube.com/results?search_query=foo") is None
+
+
+# ---------------------------------------------------------------------------
+# VTT parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_vtt_strips_header_and_emits_timestamps():
+    vtt = (
+        "WEBVTT\n"
+        "Kind: captions\n"
+        "Language: en\n"
+        "\n"
+        "00:00:00.000 --> 00:00:04.000\n"
+        "hello world\n"
+        "\n"
+        "00:00:04.000 --> 00:00:08.000\n"
+        "second cue\n"
+    )
+    out = youtube._parse_vtt(vtt)
+    assert "WEBVTT" not in out
+    assert "Kind:" not in out
+    assert "[00:00] hello world" in out
+    assert "[00:04] second cue" in out
+
+
+def test_parse_vtt_dedupes_consecutive_repeats():
+    """YouTube auto-captions emit rolling cues — the same line on each cue.
+
+    The parser must dedupe consecutive duplicates so the transcript reads
+    cleanly rather than printing every phrase three times.
+    """
+    vtt = (
+        "WEBVTT\n"
+        "\n"
+        "00:00:00.000 --> 00:00:02.000\n"
+        "hello world\n"
+        "\n"
+        "00:00:02.000 --> 00:00:04.000\n"
+        "hello world\n"
+        "\n"
+        "00:00:04.000 --> 00:00:06.000\n"
+        "hello world\n"
+    )
+    out = youtube._parse_vtt(vtt)
+    assert out.count("hello world") == 1
+
+
+def test_parse_vtt_strips_inline_tags():
+    vtt = (
+        "WEBVTT\n"
+        "\n"
+        "00:00:00.000 --> 00:00:04.000\n"
+        "<c>tagged</c> text <00:00:01.000><c>here</c>\n"
+    )
+    out = youtube._parse_vtt(vtt)
+    assert "<c>" not in out
+    assert "tagged text here" in out
+
+
+def test_parse_vtt_handles_hours():
+    vtt = (
+        "WEBVTT\n"
+        "\n"
+        "01:02:03.000 --> 01:02:07.000\n"
+        "deep in a long video\n"
+    )
+    out = youtube._parse_vtt(vtt)
+    # 1h 2m → 62 minutes total in the [mm:ss] marker.
+    assert "[62:03] deep in a long video" in out
+
+
+# ---------------------------------------------------------------------------
+# Metadata + restriction parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_metadata_line_full():
+    meta = youtube._parse_metadata_line("My Video\tACME News\t1234\t20240115")
+    assert meta == {
+        "title": "My Video",
+        "channel": "ACME News",
+        "duration_s": 1234,
+        "upload_date": "2024-01-15",
+    }
+
+
+def test_parse_metadata_line_handles_na_fields():
+    meta = youtube._parse_metadata_line("Title\tNA\tNA\tNA")
+    assert meta == {"title": "Title"}
+
+
+def test_is_restricted_detects_age_gate():
+    assert youtube._is_restricted("ERROR: Sign in to confirm your age") is True
+    assert youtube._is_restricted("ERROR: Video unavailable") is True
+    assert youtube._is_restricted("[info] Writing video subtitles…") is False
+    assert youtube._is_restricted("") is False
+
+
+# ---------------------------------------------------------------------------
+# fetch() — captions path
+# ---------------------------------------------------------------------------
+
+
+_FAKE_VTT = (
+    "WEBVTT\n"
+    "Kind: captions\n"
+    "\n"
+    "00:00:00.000 --> 00:00:04.000\n"
+    "george santos addressed the house\n"
+    "\n"
+    "00:00:04.000 --> 00:00:08.000\n"
+    "in a remarkable speech\n"
+)
+
+
+async def test_fetch_returns_source_with_transcript(monkeypatch, tmp_path):
+    captured: dict[str, Any] = {}
+
+    async def _fake_captions(url, tmpdir):
+        captured["url"] = url
+        captured["tmpdir"] = tmpdir
+        # Plant a VTT file the way yt-dlp would.
+        vtt = tmpdir / "abc123.en.vtt"
+        vtt.write_text(_FAKE_VTT, encoding="utf-8")
+        meta = {
+            "title": "Santos floor speech",
+            "channel": "C-SPAN",
+            "duration_s": 600,
+            "upload_date": "2024-01-15",
+        }
+        return meta, vtt, ""
+
+    async def _no_audio(*args, **kwargs):
+        raise AssertionError("audio fallback should not run when captions exist")
+
+    monkeypatch.setattr(youtube, "_run_ytdlp_captions", _fake_captions)
+    monkeypatch.setattr(youtube, "_run_ytdlp_audio", _no_audio)
+
+    src = await youtube.fetch("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    assert src is not None
+    assert src.url == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    assert src.title == "Santos floor speech"
+    assert src.source_kind == "web"
+    assert src.metadata["fetched_via"] == "yt-dlp-captions"
+    assert src.metadata["channel"] == "C-SPAN"
+    assert src.metadata["duration_s"] == 600
+    assert src.metadata["transcript_unavailable"] is False
+    assert src.metadata["video_id"] == "dQw4w9WgXcQ"
+    assert "[00:00] george santos" in src.cleaned_text
+    assert "[00:04] in a remarkable speech" in src.cleaned_text
+    # tmpdir is cleaned up after fetch returns.
+    assert not captured["tmpdir"].exists()
+
+
+async def test_fetch_falls_back_to_whisper(monkeypatch, tmp_path):
+    """When yt-dlp produces no VTT, audio.transcribe is used instead."""
+
+    async def _fake_captions(url, tmpdir):
+        # No VTT planted — captions absent.
+        return {"title": "Older interview", "channel": "OldUploader"}, None, ""
+
+    async def _fake_audio(url, tmpdir):
+        mp3 = tmpdir / "abc123.mp3"
+        mp3.write_bytes(b"\x00\x01\x02")
+        return mp3
+
+    transcribed_paths: list[Path] = []
+
+    async def _fake_transcribe(path, **kwargs):
+        transcribed_paths.append(Path(path))
+        return "## Chunk 1 (00:00-30:00)\n\n[Speaker] this is the transcribed audio body."
+
+    monkeypatch.setattr(youtube, "_run_ytdlp_captions", _fake_captions)
+    monkeypatch.setattr(youtube, "_run_ytdlp_audio", _fake_audio)
+
+    from research_agent.tools import audio
+
+    monkeypatch.setattr(audio, "transcribe", _fake_transcribe)
+
+    src = await youtube.fetch("https://youtu.be/dQw4w9WgXcQ")
+    assert src is not None
+    assert src.metadata["fetched_via"] == "yt-dlp-whisper"
+    assert src.metadata["transcript_unavailable"] is False
+    assert "[Speaker] this is the transcribed audio body" in src.cleaned_text
+    assert len(transcribed_paths) == 1
+
+
+async def test_fetch_returns_none_for_age_restricted(monkeypatch):
+    async def _fake_captions(url, tmpdir):
+        stderr = "ERROR: Sign in to confirm your age. This video may be inappropriate."
+        return {}, None, stderr
+
+    async def _no_audio(*args, **kwargs):
+        raise AssertionError("audio fallback should not run for restricted videos")
+
+    monkeypatch.setattr(youtube, "_run_ytdlp_captions", _fake_captions)
+    monkeypatch.setattr(youtube, "_run_ytdlp_audio", _no_audio)
+
+    src = await youtube.fetch("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    assert src is None
+
+
+async def test_fetch_returns_stub_when_metadata_only(monkeypatch):
+    """Metadata succeeds, captions and audio both fail → stub Source."""
+
+    async def _fake_captions(url, tmpdir):
+        return {"title": "ghost video", "channel": "Ghost"}, None, ""
+
+    async def _fake_audio(url, tmpdir):
+        return None
+
+    monkeypatch.setattr(youtube, "_run_ytdlp_captions", _fake_captions)
+    monkeypatch.setattr(youtube, "_run_ytdlp_audio", _fake_audio)
+
+    src = await youtube.fetch("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    assert src is not None
+    assert src.cleaned_text == ""
+    assert src.metadata["transcript_unavailable"] is True
+    assert src.metadata["fetched_via"] == "yt-dlp"
+
+
+async def test_fetch_returns_none_when_no_metadata(monkeypatch):
+    """If yt-dlp can't even surface metadata we return None — not a stub.
+
+    Burning a citation slot on a Source with no body and no metadata is
+    worse than letting the planner re-route.
+    """
+
+    async def _fake_captions(url, tmpdir):
+        return {}, None, "ERROR: yt-dlp not installed"
+
+    async def _fake_audio(url, tmpdir):
+        return None
+
+    monkeypatch.setattr(youtube, "_run_ytdlp_captions", _fake_captions)
+    monkeypatch.setattr(youtube, "_run_ytdlp_audio", _fake_audio)
+
+    src = await youtube.fetch("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    assert src is None
+
+
+async def test_fetch_returns_none_for_non_youtube_url(monkeypatch):
+    sentinel: dict[str, bool] = {"called": False}
+
+    async def _fake_captions(url, tmpdir):
+        sentinel["called"] = True
+        return {}, None, ""
+
+    monkeypatch.setattr(youtube, "_run_ytdlp_captions", _fake_captions)
+    src = await youtube.fetch("https://example.com/")
+    assert src is None
+    assert sentinel["called"] is False
+
+
+# ---------------------------------------------------------------------------
+# search() — Data API path
+# ---------------------------------------------------------------------------
+
+
+class _StubResponse:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = json.dumps(payload) if isinstance(payload, (dict, list)) else str(payload)
+
+    def json(self) -> Any:
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class _StubAsyncClient:
+    last_url: str | None = None
+    last_params: dict[str, Any] | None = None
+
+    def __init__(
+        self,
+        *,
+        response: _StubResponse | None = None,
+        raise_with: Exception | None = None,
+    ) -> None:
+        self._response = response
+        self._raise = raise_with
+
+    async def __aenter__(self) -> _StubAsyncClient:
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        return None
+
+    async def get(self, url: str, params: dict[str, Any] | None = None, **_: Any) -> _StubResponse:
+        type(self).last_url = url
+        type(self).last_params = dict(params or {})
+        if self._raise is not None:
+            raise self._raise
+        assert self._response is not None
+        return self._response
+
+
+def _patch_httpx(monkeypatch: pytest.MonkeyPatch, **kwargs: Any) -> type[_StubAsyncClient]:
+    stub_cls = type("_Stub", (_StubAsyncClient,), {})
+    stub_cls.last_url = None
+    stub_cls.last_params = None
+    instance = stub_cls(**kwargs)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: instance)
+    return stub_cls
+
+
+async def test_search_uses_data_api_when_key_set(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_API_KEY", "AIzaTest")
+    config_module.reset_for_tests()
+
+    payload = {
+        "items": [
+            {
+                "id": {"videoId": "vid001"},
+                "snippet": {
+                    "title": "Santos hearing live",
+                    "channelTitle": "ABC News",
+                    "description": "Coverage of the floor speech.",
+                    "publishedAt": "2024-01-15T12:00:00Z",
+                },
+            },
+            {
+                "id": {"videoId": "vid002"},
+                "snippet": {
+                    "title": "Santos commentary",
+                    "channelTitle": "Pundit Channel",
+                    "description": "Reaction.",
+                    "publishedAt": "2024-01-16T08:30:00Z",
+                },
+            },
+        ]
+    }
+    stub = _patch_httpx(monkeypatch, response=_StubResponse(200, payload))
+
+    results = await youtube.search("george santos", max_results=5)
+    assert stub.last_url == youtube._DATA_API_BASE
+    assert stub.last_params["q"] == "george santos"
+    assert stub.last_params["key"] == "AIzaTest"
+    assert stub.last_params["part"] == "snippet"
+    assert stub.last_params["type"] == "video"
+    assert stub.last_params["maxResults"] == 5
+    assert len(results) == 2
+    assert results[0].url == "https://www.youtube.com/watch?v=vid001"
+    assert results[0].title == "Santos hearing live"
+    assert results[0].extras["channel"] == "ABC News"
+    assert results[0].extras["fetched_via"] == "youtube-data-api"
+    assert results[0].published_at is not None
+    assert results[0].published_at.year == 2024
+
+
+async def test_search_data_api_clamps_max_results(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_API_KEY", "AIzaTest")
+    config_module.reset_for_tests()
+    stub = _patch_httpx(monkeypatch, response=_StubResponse(200, {"items": []}))
+    await youtube.search("anything", max_results=999)
+    # Data API caps at 50 per page.
+    assert stub.last_params["maxResults"] == 50
+
+
+async def test_search_data_api_http_error_returns_empty(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_API_KEY", "AIzaTest")
+    config_module.reset_for_tests()
+    _patch_httpx(monkeypatch, raise_with=httpx.ConnectError("boom"))
+    assert await youtube.search("anything") == []
+
+
+async def test_search_data_api_non_200_returns_empty(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_API_KEY", "AIzaTest")
+    config_module.reset_for_tests()
+    _patch_httpx(monkeypatch, response=_StubResponse(403, {"error": "quota"}))
+    assert await youtube.search("anything") == []
+
+
+async def test_search_empty_query_returns_immediately():
+    # Even with no API key set, an empty query short-circuits before any I/O.
+    assert await youtube.search("   ") == []
+
+
+# ---------------------------------------------------------------------------
+# search() — SERP fallback
+# ---------------------------------------------------------------------------
+
+
+def _build_serp_html(*videos: dict[str, str]) -> str:
+    """Construct a minimal results page that embeds ``ytInitialData``."""
+    contents = []
+    for v in videos:
+        contents.append(
+            {
+                "videoRenderer": {
+                    "videoId": v["video_id"],
+                    "title": {"runs": [{"text": v["title"]}]},
+                    "ownerText": {"runs": [{"text": v["channel"]}]},
+                    "viewCountText": {"simpleText": v.get("views", "1,234 views")},
+                    "publishedTimeText": {"simpleText": v.get("published", "1 day ago")},
+                    "detailedMetadataSnippets": [
+                        {"snippetText": {"runs": [{"text": v.get("snippet", "")}]}}
+                    ],
+                }
+            }
+        )
+    data = {"contents": {"twoColumnSearchResultsRenderer": {"primaryContents": contents}}}
+    return f"<html><body><script>var ytInitialData = {json.dumps(data)};</script></body></html>"
+
+
+class _FakePage:
+    def __init__(self, html: str) -> None:
+        self._html = html
+
+    async def goto(self, url: str, **kwargs):
+        return None
+
+    async def content(self) -> str:
+        return self._html
+
+    async def close(self) -> None:
+        return None
+
+
+class _FakeContext:
+    def __init__(self, html: str) -> None:
+        self._html = html
+
+    async def new_page(self) -> _FakePage:
+        return _FakePage(self._html)
+
+
+class _FakeBrowserSession:
+    def __init__(self, html: str) -> None:
+        self._html = html
+
+    async def __aenter__(self) -> _FakeContext:
+        return _FakeContext(self._html)
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        return None
+
+
+async def test_search_falls_back_to_serp_without_api_key(monkeypatch):
+    html = _build_serp_html(
+        {
+            "video_id": "vid001",
+            "title": "Santos congressional speech",
+            "channel": "C-SPAN",
+            "views": "100K views",
+            "published": "2 weeks ago",
+            "snippet": "Floor speech delivered by Rep. Santos.",
+        },
+        {
+            "video_id": "vid002",
+            "title": "Santos commentary",
+            "channel": "Pundit",
+            "views": "5.2K views",
+            "published": "1 week ago",
+            "snippet": "Reaction to the speech.",
+        },
+    )
+
+    from research_agent.tools import browser as browser_mod
+
+    async def _no_throttle(url):
+        return None
+
+    monkeypatch.setattr(browser_mod, "browser_session", lambda **kw: _FakeBrowserSession(html))
+    monkeypatch.setattr(
+        browser_mod,
+        "navigate",
+        lambda page, url, timeout_ms=30000: _no_throttle(url),
+    )
+
+    results = await youtube.search("george santos", max_results=5)
+    assert len(results) == 2
+    assert results[0].url == "https://www.youtube.com/watch?v=vid001"
+    assert results[0].title == "Santos congressional speech"
+    assert results[0].extras["channel"] == "C-SPAN"
+    assert results[0].extras["fetched_via"] == "youtube-serp"
+    assert results[0].extras["view_count_text"] == "100K views"
+    assert results[0].snippet.startswith("Floor speech")
+
+
+async def test_search_serp_returns_empty_when_no_initial_data(monkeypatch):
+    from research_agent.tools import browser as browser_mod
+
+    monkeypatch.setattr(
+        browser_mod,
+        "browser_session",
+        lambda **kw: _FakeBrowserSession("<html><body>nothing here</body></html>"),
+    )
+
+    async def _navigate(page, url, timeout_ms=30000):
+        return None
+
+    monkeypatch.setattr(browser_mod, "navigate", _navigate)
+    assert await youtube.search("anything") == []
+
+
+async def test_search_serp_returns_empty_on_browser_error(monkeypatch):
+    from research_agent.tools import browser as browser_mod
+
+    class _Boom:
+        async def __aenter__(self):
+            raise RuntimeError("playwright not installed")
+
+        async def __aexit__(self, *exc_info):
+            return None
+
+    monkeypatch.setattr(browser_mod, "browser_session", lambda **kw: _Boom())
+    assert await youtube.search("anything") == []
+
+
+# ---------------------------------------------------------------------------
+# web_fetch dispatch
+# ---------------------------------------------------------------------------
+
+
+async def test_web_fetch_routes_youtube_to_youtube_fetch(monkeypatch):
+    captured_urls: list[str] = []
+
+    async def _fake_youtube_fetch(url):
+        captured_urls.append(url)
+        from datetime import UTC, datetime
+
+        from research_agent.tools.models import Source
+
+        return Source(
+            url=url,
+            title="t",
+            cleaned_text="dispatched body",
+            fetched_at=datetime.now(UTC),
+            source_kind="web",
+            metadata={"fetched_via": "yt-dlp-captions"},
+        )
+
+    monkeypatch.setattr(youtube, "fetch", _fake_youtube_fetch)
+
+    async def _explode_httpx(*args, **kwargs):
+        raise AssertionError("httpx should be skipped for youtube URLs")
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _explode_httpx)
+
+    src = await web_fetch.fetch("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    assert src is not None
+    assert src.cleaned_text == "dispatched body"
+    assert captured_urls == ["https://www.youtube.com/watch?v=dQw4w9WgXcQ"]
+
+
+async def test_web_fetch_routes_youtu_be_short_url(monkeypatch):
+    captured: list[str] = []
+
+    async def _fake_youtube_fetch(url):
+        captured.append(url)
+        return None
+
+    monkeypatch.setattr(youtube, "fetch", _fake_youtube_fetch)
+
+    async def _explode_httpx(*args, **kwargs):
+        raise AssertionError("httpx should be skipped for youtu.be URLs")
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _explode_httpx)
+
+    await web_fetch.fetch("https://youtu.be/dQw4w9WgXcQ")
+    assert captured == ["https://youtu.be/dQw4w9WgXcQ"]
+
+
+# ---------------------------------------------------------------------------
+# Smoke registry wiring
+# ---------------------------------------------------------------------------
+
+
+def test_tool_registry_has_youtube():
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "youtube" in TOOL_REGISTRY
+    assert callable(TOOL_REGISTRY["youtube"])
+
+
+def test_smoke_youtube_summary_matches_contract(monkeypatch):
+    """The smoke verb summary lists total + channel/url/views per hit."""
+    from research_agent.tools.models import SearchResult
+
+    fake_results = [
+        SearchResult(
+            url="https://www.youtube.com/watch?v=vid001",
+            title="Santos hearing live",
+            snippet="Coverage of the floor speech.",
+            source_kind="web",
+            extras={
+                "channel": "C-SPAN",
+                "video_id": "vid001",
+                "view_count_text": "100K views",
+                "published_text": "2 weeks ago",
+                "fetched_via": "youtube-serp",
+            },
+        )
+    ]
+
+    async def _fake_search(query, max_results=10):
+        return fake_results
+
+    monkeypatch.setattr(youtube, "search", _fake_search)
+
+    from research_agent.tools import _smoke_youtube
+
+    out = _smoke_youtube("george santos")
+    assert "total: 1" in out
+    assert "Santos hearing live" in out
+    assert "https://www.youtube.com/watch?v=vid001" in out
+    assert "C-SPAN" in out
+    assert "views=100K views" in out
+
+
+# ---------------------------------------------------------------------------
+# Config wiring
+# ---------------------------------------------------------------------------
+
+
+def test_youtube_api_key_in_expected_env_keys():
+    keys = {k.name for k in config_module.EXPECTED_ENV_KEYS}
+    assert "YOUTUBE_API_KEY" in keys

--- a/uv.lock
+++ b/uv.lock
@@ -3743,6 +3743,7 @@ dependencies = [
     { name = "unstructured" },
     { name = "watchfiles" },
     { name = "waybackpy" },
+    { name = "yt-dlp" },
 ]
 
 [package.optional-dependencies]
@@ -3797,6 +3798,7 @@ requires-dist = [
     { name = "unstructured", specifier = ">=0.14" },
     { name = "watchfiles", specifier = ">=0.21" },
     { name = "waybackpy", specifier = ">=3.0" },
+    { name = "yt-dlp", specifier = ">=2024.4" },
 ]
 provides-extras = ["dev", "ui", "web"]
 
@@ -4955,6 +4957,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/19/3774d162f6732d1cfb0b47b4140a942a35ca82bb19b6db1f80e9e7bdc8f8/yarl-1.23.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4503053d296bc6e4cbd1fad61cf3b6e33b939886c4f249ba7c78b602214fabe2", size = 97610, upload-time = "2026-03-01T22:07:45.773Z" },
     { url = "https://files.pythonhosted.org/packages/51/47/3fa2286c3cb162c71cdb34c4224d5745a1ceceb391b2bd9b19b668a8d724/yarl-1.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:44bb7bef4ea409384e3f8bc36c063d77ea1b8d4a5b2706956c0d6695f07dcc25", size = 86041, upload-time = "2026-03-01T22:07:49.026Z" },
     { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]
+
+[[package]]
+name = "yt-dlp"
+version = "2026.3.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/34/7c6b4e3f89cb6416d2cd7ab6dab141a1df97ab0fb22d15816db2c92148c9/yt_dlp-2026.3.17.tar.gz", hash = "sha256:ba7aa31d533f1ffccfe70e421596d7ca8ff0bf1398dc6bb658b7d9dec057d2c9", size = 3119221, upload-time = "2026-03-17T23:43:00.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/13/5093bcb954878e50f7217fd2ab94282b53934022e4e4a03265582da83bf5/yt_dlp-2026.3.17-py3-none-any.whl", hash = "sha256:32992db94303a8a5d211a183f2174834fe7f8c29d83ed2e7a324eae97a8f26d8", size = 3315134, upload-time = "2026-03-17T23:42:57.863Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #111
Part of #107

## Summary

Automated implementation of **YouTube transcript extraction (yt-dlp + Whisper fallback)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

YouTube connector mirrors the reddit shape cleanly: yt-dlp captions → Whisper fallback → metadata-only stub; web_fetch host-dispatch wired; Data API + Playwright SERP search both covered; 34 unit tests pass and the full 780-test suite is green.

- **INFO** [OPEN] `src/research_agent/tools/youtube.py`: YouTube Data API path does not populate view_count_text — search.list does not return statistics; a separate videos.list?part=statistics call would be required and would double the daily quota cost. SERP fallback path does include view counts, so the AC is met for the no-API-key configuration. Acceptable v1 trade-off.
- **INFO** [OPEN] `README.md`: README 'Smoke commands' section (lines 482-487) does not list the new `youtube` smoke verb (and also omits the previously-added pdf/audio/reddit verbs — pre-existing drift). The verbs are wired into TOOL_REGISTRY and discoverable via `_smoke-tool`, just not enumerated in the troubleshooting section.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*