### PR TITLE
feat: Synth output: Recommended Human Follow-Ups section (whistleblower lines, fact-check targets, subpoena candidates, FOIA leads) (closes #112)

### DIFF
--- a/src/research_agent/orchestrator/synth.py
+++ b/src/research_agent/orchestrator/synth.py
@@ -31,6 +31,7 @@ import json
 import logging
 import re
 import sqlite3
+from importlib.resources import files
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict
@@ -55,6 +56,32 @@ logger = logging.getLogger(__name__)
 
 TOP_N_FINDINGS = 50
 FINAL_TOP_N = 200
+
+_FOLLOWUP_RECIPES: str | None = None
+_FOLLOWUP_RECIPES_WARN_LOGGED = False
+
+
+def _load_followup_recipes() -> str:
+    """Read ``prompts/followup_recipes.md`` raw and cache the body.
+
+    The file is reference data (no YAML frontmatter), so the prompt loader
+    is bypassed. A missing file is tolerated — synth must keep running
+    even if an operator deletes the catalog. The WARN log fires once.
+    """
+    global _FOLLOWUP_RECIPES, _FOLLOWUP_RECIPES_WARN_LOGGED
+    if _FOLLOWUP_RECIPES is not None:
+        return _FOLLOWUP_RECIPES
+    try:
+        body = (files("research_agent.prompts") / "followup_recipes.md").read_text(
+            encoding="utf-8"
+        )
+    except (FileNotFoundError, OSError) as exc:
+        if not _FOLLOWUP_RECIPES_WARN_LOGGED:
+            logger.warning("synth: followup_recipes.md unavailable: %s", exc)
+            _FOLLOWUP_RECIPES_WARN_LOGGED = True
+        body = ""
+    _FOLLOWUP_RECIPES = body
+    return body
 
 _BUDGET_STUB_REPORT = (
     "# Report (truncated)\n\n"
@@ -195,6 +222,7 @@ def _build_context(
     sources: dict[int, dict[str, Any]],
     prior: str | None,
     critique: str | None,
+    followup_recipes: str,
     final: bool = False,
 ) -> str:
     payload: dict[str, Any] = {
@@ -207,6 +235,7 @@ def _build_context(
         "sources": {str(k): v for k, v in sources.items()},
         "prior_synthesis": prior,
         "critique": critique,
+        "followup_recipes": followup_recipes,
     }
     if final:
         payload["final"] = True
@@ -324,6 +353,7 @@ async def _do_synthesis(
     sources = _load_sources_for(job, findings)
     prior = _load_prior_synthesis(job)
     critique = _load_latest_critique(job)
+    followup_recipes = _load_followup_recipes()
 
     context = _build_context(
         goal=job.goal,
@@ -332,6 +362,7 @@ async def _do_synthesis(
         sources=sources,
         prior=prior,
         critique=critique,
+        followup_recipes=followup_recipes,
         final=final,
     )
 
@@ -651,6 +682,7 @@ async def final_synthesis_after_cap(
     sources = _load_sources_for(job, findings)
     prior = _load_prior_synthesis(job)
     critique = _load_latest_critique(job)
+    followup_recipes = _load_followup_recipes()
 
     context = _build_context(
         goal=job.goal,
@@ -659,6 +691,7 @@ async def final_synthesis_after_cap(
         sources=sources,
         prior=prior,
         critique=critique,
+        followup_recipes=followup_recipes,
         final=True,
     )
 

--- a/src/research_agent/prompts/critic.md
+++ b/src/research_agent/prompts/critic.md
@@ -1,5 +1,5 @@
 ---
-version: "2"
+version: "3"
 model_tier: frontier_alt
 description: System prompt for the critic agent that audits a synthesis report against its findings.
 ---
@@ -33,6 +33,20 @@ critique the synthesizer (or a follow-up plan) can act on.
    `confirmed` or `refuted`, check whether the findings actually support
    that closure. If not, list the subgoal id in `premature_subgoals` so
    the loop reopens it.
+7. **Missing follow-up categories** — the report must contain a
+   `## Recommended Human Follow-Ups` section. Audit it for completeness:
+   - When the report names a subject organization or person, expect at
+     least one entry under **Adversarial fact-check targets** (their
+     spokesperson, press contact, or counsel of record). Absence is a
+     `warn`-severity gap with `area=follow-ups`.
+   - When the report relies on government records or alleges agency
+     misconduct, expect at least one **FOIA candidate** or
+     **Whistleblower / tip-line** entry naming a concrete agency, form,
+     or statute. Absence is a `warn`-severity gap with
+     `area=follow-ups`.
+   - Generic recommendations that don't end with `because <reason>`
+     tied to a specific finding or named subject are also `warn`-level
+     gaps in `follow-ups` — flag them so the synthesizer can rewrite.
 
 ## What to produce
 

--- a/src/research_agent/prompts/followup_recipes.md
+++ b/src/research_agent/prompts/followup_recipes.md
@@ -1,0 +1,131 @@
+# Recommended Human Follow-Ups — Recipe Catalog
+
+This file is reference data, not a templated prompt. The synth orchestrator
+loads it raw and injects it into the synthesizer's context payload under the
+`followup_recipes` key. The synthesizer uses it to populate the
+"Recommended Human Follow-Ups" section of every report — bridging the
+categorical gaps where software cannot help and only humans can.
+
+## How to use this catalog
+
+When drafting the "Recommended Human Follow-Ups" section, match the
+investigation's **domain** (securities fraud, public corruption, healthcare,
+etc.) to the relevant block(s) below and pull the specific hotline, agency,
+form, or statute by name. Every recommendation must end with a one-line
+`because <reason>` tying it to a concrete finding or named subject from the
+report — never recommend a hotline generically. If a domain doesn't apply,
+omit it; do not pad the section.
+
+## Generic fact-check / FOIA prompts (apply to almost every report)
+
+- **Any named subject (person or org)** → identify their spokesperson,
+  press contact, or opposing counsel of record and recommend calling for
+  on-the-record response to the strongest specific claim against them.
+- **Any licensed entity** (contractor, broker, attorney, physician, etc.)
+  → check the relevant state licensing board's public discipline record,
+  and recommend a FOIA / public-records request for the full disciplinary
+  file (board complaints, investigator notes, settlement agreements).
+- **Any government action cited** (permit, contract award, enforcement
+  letter) → recommend a FOIA / state public-records request for the
+  underlying file (correspondence, internal memos, scoring sheets).
+- **Any sealed or redacted court filing referenced** → flag as a
+  motion-to-unseal candidate; identify the case number and court.
+- **Any claim that names a specific person's conduct** → flag for
+  pre-publication libel review; defamation risk scales with specificity.
+
+## Domain-specific recipes
+
+### Securities fraud / market manipulation / investor harm
+- **SEC Tip, Complaint, and Referral (TCR) form** — `sec.gov/tcr` —
+  whistleblower awards possible under Dodd-Frank §922.
+- **FINRA Whistleblower / Office of the Whistleblower** —
+  `finra.org/rules-guidance/key-topics/whistleblower` — for
+  broker-dealer misconduct.
+- **State securities regulator (NASAA member)** — for state-registered
+  advisers and intrastate offerings.
+
+### Federal corruption / abuse of office / contractor fraud (federal)
+- **DOJ Office of Inspector General Hotline** — `oig.justice.gov/hotline`
+  — for misconduct by DOJ employees and federal officials.
+- **FBI Public Corruption Unit** — local FBI field-office tip line or
+  `tips.fbi.gov` — for bribery, kickbacks, abuse of office.
+- **GAO FraudNET** — `gao.gov/about/what-gao-does/fraudnet` — for waste,
+  fraud, abuse in federal programs.
+- **Agency-specific OIG** (e.g., Pentagon IG, USPS IG, EPA OIG) — when the
+  alleged misconduct is inside a specific federal agency.
+
+### State / local corruption
+- **State Attorney General public-corruption / consumer-protection
+  hotline** — most states publish a tip line; cite by state.
+- **State ethics commission** — for officeholder financial-disclosure
+  violations and conflicts of interest.
+- **Local district attorney's public-integrity unit** — for county- and
+  city-level officials.
+
+### Healthcare fraud / Medicare-Medicaid abuse / patient safety
+- **HHS-OIG Hotline** — `oig.hhs.gov/fraud/report-fraud` —
+  Medicare/Medicaid fraud, kickbacks, patient harm.
+- **CMS Medicare fraud line** — `1-800-MEDICARE` — beneficiary-reported
+  billing fraud.
+- **State Medicaid Fraud Control Unit (MFCU)** — for state-program
+  Medicaid fraud and nursing-home abuse.
+- **State medical / nursing licensing board** — for clinician-specific
+  misconduct; FOIA the full complaint file.
+
+### Tax fraud / abuse of nonprofit status
+- **IRS Whistleblower Office (Form 211)** — `irs.gov/whistleblower` —
+  awards tied to recovered tax owed.
+- **State charity registry / AG charities bureau** — for 501(c)(3)
+  governance, self-dealing, or solicitation fraud.
+- **IRS Form 13909** — public complaint about a tax-exempt org.
+
+### Financial elder abuse / vulnerable-adult exploitation
+- **State Adult Protective Services (APS)** — every state has one;
+  mandatory-reporter pathways apply.
+- **FINRA Securities Helpline for Seniors** — `1-844-57-HELPS` — for
+  investment exploitation of seniors.
+- **Local law-enforcement elder-abuse unit** — many DAs have one.
+
+### OSHA / workplace safety / labor whistleblower
+- **OSHA Whistleblower Protection Program** — `whistleblowers.gov` —
+  retaliation complaints under 20+ statutes.
+- **NLRB** — for unfair labor practices and protected concerted activity.
+- **State labor commissioner** — for state-law wage-theft and retaliation.
+
+### Environmental / EPA
+- **EPA Tipline / "Report Environmental Violations"** —
+  `epa.gov/enforcement/report-environmental-violations`.
+- **State environmental agency hotline** (e.g., CalEPA, NYSDEC) — for
+  state-permitted facilities.
+- **National Response Center** — `1-800-424-8802` — for chemical /
+  oil-spill emergencies.
+
+### Defense / federal contractor / classified misconduct
+- **DoD Hotline** — `dodig.mil/Hotline` — fraud, waste, abuse by DoD
+  personnel and contractors.
+- **Intelligence Community IG** — for IC-specific concerns; use proper
+  channels for classified material.
+- **DCAA / DCMA** — contract-audit avenues for cost-mischarging.
+
+### Immigration / ICE / CBP misconduct
+- **DHS OIG Hotline** — `oig.dhs.gov/hotline`.
+- **CBP Office of Professional Responsibility** — `1-877-2INTAKE`.
+- **Civil Rights and Civil Liberties (CRCL) complaints** — DHS-wide.
+
+### Banking / consumer financial / housing
+- **CFPB consumer complaint** — `consumerfinance.gov/complaint`.
+- **OCC Customer Assistance** — for nationally chartered banks.
+- **FTC Consumer Sentinel** — for deceptive-practices intake.
+- **HUD Office of Fair Housing** — for housing-discrimination complaints.
+
+## Notes for the synthesizer
+
+- Prefer the most specific channel available. "Federal corruption" → name
+  the agency's IG, not just "DOJ".
+- When two hotlines compete (e.g., HHS-OIG vs. state MFCU), recommend
+  both with a one-line distinction (federal vs. state program).
+- For FOIA candidates, name the **specific record** ("disciplinary file
+  for license #12345"), the **agency**, and the **statute** (FOIA, or the
+  state's equivalent — e.g., California Public Records Act).
+- Operators can extend this catalog by editing this file directly; no
+  code changes required.

--- a/src/research_agent/prompts/synthesizer.md
+++ b/src/research_agent/prompts/synthesizer.md
@@ -1,5 +1,5 @@
 ---
-version: "3"
+version: "4"
 model_tier: frontier
 description: System prompt for the synthesizer. Emits a raw markdown report followed by a single fenced JSON block with subgoal status.
 ---
@@ -18,6 +18,11 @@ source.
   `confirmed`, `refuted`, or `inconclusive` in the JSON trailer below.
 - **Findings:** the canonical record of what was fetched and what was claimed.
   Each finding carries its source URL, retrieval timestamp, and confidence.
+- **Followup recipes:** a reference catalog of hotlines, agencies, forms,
+  and FOIA channels keyed by investigation domain (securities fraud, public
+  corruption, healthcare, etc.). Use it to populate the "Recommended Human
+  Follow-Ups" section described below — never invent agency names or
+  hotline numbers; pull them from the catalog by name.
 
 ## Output format — RAW markdown + a trailing JSON block
 
@@ -29,6 +34,8 @@ fenced ```json block carrying subgoal status. Nothing else.
 - Do **not** add a preamble like "Here is the report:".
 - Your first character should be `#` (the report heading).
 - Newlines are real newlines. Do not escape them as `\n`.
+- The **Recommended Human Follow-Ups** section comes between
+  **Open questions** and **Sources**.
 - After the **Sources** section emit exactly one fenced ```json block whose
   body is `{"subgoal_status": {"<id>": "confirmed"|"refuted"|"inconclusive"}}`
   covering every subgoal id you were given. No other JSON fences anywhere
@@ -63,7 +70,36 @@ A markdown report with:
    events that the findings reveal but no single source spells out.
 4. **Open questions** — what the investigation could not resolve, and why
    (e.g., source unavailable, contradictory evidence, ambiguous goal).
-5. **Sources** — numbered list mapping `[N]` → URL + retrieved-at.
+5. **Recommended Human Follow-Ups** — actionable next steps for the
+   operator that software cannot do alone (calls, FOIA requests, legal
+   review). Use the sub-headings below; **omit a sub-heading entirely
+   when no items apply** (do not print "(none)"):
+
+   - `### Whistleblower / tip-line contacts (when applicable)`
+   - `### Adversarial fact-check targets`
+   - `### Legal review flags`
+   - `### Subpoena / motion-to-unseal candidates`
+   - `### FOIA candidates`
+
+   Rules for this section:
+   - Every item must end with `because <one-line reason>` tying it back
+     to a specific finding, named subject, or claim in the report — no
+     generic recommendations.
+   - Pull hotlines, forms, agencies, and statutes by name from the
+     `followup_recipes` block in the input context. Match the recipe
+     domain to the investigation (securities fraud → SEC TCR; healthcare
+     → HHS-OIG; etc.).
+   - For FOIA candidates, name the **specific record**, the **agency**,
+     and the **statute** (federal FOIA or the state's equivalent).
+   - For libel/legal-review flags, name the **specific claim** that
+     creates the risk; defamation risk scales with specificity.
+   - If the report names any subject organization or person, expect at
+     least one Adversarial fact-check target (their spokesperson, press
+     contact, or counsel of record).
+   - If the report relies on government records or alleges agency
+     misconduct, expect at least one FOIA candidate or whistleblower
+     hotline.
+6. **Sources** — numbered list mapping `[N]` → URL + retrieved-at.
 
 ## Rules
 
@@ -100,6 +136,18 @@ A markdown report with:
 ## Open Questions
 
 - ...
+
+## Recommended Human Follow-Ups
+
+### Adversarial fact-check targets
+- Acme Co media relations (press@acme.example) — call for on-the-record
+  response to the kickback allegation [2], because the strongest claim
+  in the report names Acme directly.
+
+### FOIA candidates
+- Disciplinary file for license #12345 at the State Contractors Board —
+  request under the state Public Records Act, because the report cites
+  prior board complaints summarised second-hand [3].
 
 ## Sources
 

--- a/tests/test_orchestrator_synth.py
+++ b/tests/test_orchestrator_synth.py
@@ -700,6 +700,100 @@ def test_synthesize_repeat_status_skips_plan_version_bump(
     assert len(updated) == 1
 
 
+# ---------------------------------------------------------------------------
+# Recommended Human Follow-Ups (issue #112)
+# ---------------------------------------------------------------------------
+
+
+def test_followup_recipes_in_context(job: Job, db_path: Path, plan: Plan) -> None:
+    """The context payload sent to the synthesizer carries the recipe catalog."""
+    _seed_findings(job, [0.7])
+    router = _StubRouter()
+
+    asyncio.run(synthesize(job, plan, router=router))
+
+    assert router.calls
+    _tier, args, _kwargs = router.calls[0]
+    payload = json.loads(args[0])
+    recipes = payload.get("followup_recipes")
+    assert isinstance(recipes, str) and recipes, "recipes must be a non-empty string"
+    # Spot-check a few specific channels the catalog must surface.
+    assert "SEC TCR" in recipes or "Tip, Complaint, and Referral" in recipes
+    assert "HHS-OIG Hotline" in recipes
+    assert "licensing board" in recipes
+
+
+def test_synthesizer_prompt_requires_followups_section() -> None:
+    """The synthesizer prompt must instruct the model to emit the new section."""
+    body = prompts_loader.load_prompt("synthesizer", goal="x")
+    assert "Recommended Human Follow-Ups" in body
+    assert "Adversarial fact-check targets" in body
+    assert "FOIA candidates" in body
+    assert "Whistleblower" in body
+
+
+def test_critic_prompt_flags_missing_followups() -> None:
+    """The critic prompt must audit the follow-ups section for completeness."""
+    body = prompts_loader.load_prompt("critic")
+    assert "follow-ups" in body
+    assert "fact-check" in body
+
+
+def test_build_context_exposes_goal_and_licensing_board_guidance(
+    job: Job, db_path: Path
+) -> None:
+    """SBI Builders fixture-style structural check.
+
+    Feeds a goal naming a subject + agency through ``_build_context`` and
+    asserts the rendered JSON exposes both the goal and the recipe text
+    that should drive an Adversarial fact-check target (the spokesperson)
+    and a FOIA candidate (the licensing board's disciplinary file).
+    """
+    sbi_plan = Plan(
+        version=1,
+        objective="Investigate SBI Builders",
+        subgoals=[Subgoal(id=1, description="background", done=False)],
+        task_template=[TaskSpec(kind="web_search")],
+        expected_iterations=1,
+    )
+    findings = [
+        {
+            "id": 1,
+            "claim": "SBI Builders is licensed by the State Contractors Board",
+            "confidence": 0.9,
+            "source_ids": [1],
+            "tags": [],
+        }
+    ]
+    sources = {
+        1: {
+            "id": 1,
+            "url": "https://example.com/sbi",
+            "title": "SBI Builders licensing record",
+            "fetched_at": 0,
+            "archive_url": None,
+        }
+    }
+
+    context_json = synth_module._build_context(
+        goal="investigate SBI Builders",
+        plan=sbi_plan,
+        findings=findings,
+        sources=sources,
+        prior=None,
+        critique=None,
+        followup_recipes=synth_module._load_followup_recipes(),
+        final=False,
+    )
+    payload = json.loads(context_json)
+
+    assert payload["goal"] == "investigate SBI Builders"
+    recipes = payload["followup_recipes"]
+    assert "licensing board" in recipes
+    assert "spokesperson" in recipes or "press contact" in recipes
+    assert "FOIA" in recipes
+
+
 def test_synthesize_accepts_fence_with_space_before_json_lang(
     job: Job, db_path: Path, multi_subgoal_plan: Plan
 ) -> None:


### PR DESCRIPTION
Closes #112
Part of #107

## Summary

Automated implementation of **Synth output: Recommended Human Follow-Ups section (whistleblower lines, fact-check targets, subpoena candidates, FOIA leads)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

All acceptance criteria met: synthesizer requires new section, recipes catalog created and threaded through context, critic flags missing categories, tests cover wiring. 811/811 tests pass.

- **INFO** [OPEN] `tests/test_orchestrator_synth.py`: The 'SBI Builders fixture' acceptance test is implemented as a structural test (verifies the recipe text and goal land in the context payload) rather than asserting actual model output. This is the only practical option since the synth path stubs the LLM router; deterministic testing of model-emitted entries would require a real LLM call. Acceptable interpretation.
- **INFO** [OPEN] `src/research_agent/orchestrator/synth.py`: The non-LLM emergency fallback _write_template_stub_output (used when the budget cap is hit and no LLM call is possible) does not produce the Recommended Human Follow-Ups section. This is an acceptable degradation: the path is already labeled truncated/budget_capped and intelligent recommendations require model reasoning. Worth noting if a future change wants stub reports to include catalog-based default recommendations.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*