### PR TITLE
feat: Synth/critique: flag paid-API opportunities when public sources gap (closes #113)

### DIFF
--- a/src/research_agent/orchestrator/critique.py
+++ b/src/research_agent/orchestrator/critique.py
@@ -60,6 +60,25 @@ class Gap(BaseModel):
     area: str | None = None
 
 
+class PaidOpportunity(BaseModel):
+    """A paid resource that would close a specific evidenced gap.
+
+    ``service`` and ``cost_range`` come verbatim from the
+    ``paid_unblock_recipes`` catalog (e.g., "LinkedIn Premium",
+    "$60–$150/mo"); ``gap`` ties the recommendation back to a concrete
+    finding/subject; ``tier`` distinguishes "the paid resource is the
+    only realistic path" (``high``) from "a public alternative may
+    suffice" (``low``).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    service: str = Field(min_length=1)
+    cost_range: str = Field(min_length=1)
+    gap: str = Field(min_length=1)
+    tier: Literal["high", "low"]
+
+
 class CritiqueOutput(BaseModel):
     """Structured critique consumed by the loop + the planner.
 
@@ -75,6 +94,7 @@ class CritiqueOutput(BaseModel):
     suggested_subgoals: list[str] = Field(default_factory=list)
     confidence_concerns: list[str] = Field(default_factory=list)
     premature_subgoals: list[int] = Field(default_factory=list)
+    paid_opportunities: list[PaidOpportunity] = Field(default_factory=list)
     should_replan: bool = False
 
     version: int = 0
@@ -175,6 +195,7 @@ def _build_context(
     sources: dict[int, dict[str, Any]],
     synthesis: str | None,
     prior_critique: str | None,
+    paid_unblock_recipes: str,
 ) -> str:
     payload: dict[str, Any] = {
         "goal": goal,
@@ -182,6 +203,7 @@ def _build_context(
         "sources": {str(k): v for k, v in sources.items()},
         "synthesis": synthesis,
         "prior_critique": prior_critique,
+        "paid_unblock_recipes": paid_unblock_recipes,
     }
     return json.dumps(payload, sort_keys=True, default=str)
 
@@ -235,6 +257,15 @@ def _render_critique_md(payload: CritiqueOutput) -> str:
     else:
         lines.append("- (none)\n")
 
+    lines.append("\n## Paid resource opportunities\n")
+    if payload.paid_opportunities:
+        for opp in payload.paid_opportunities:
+            lines.append(
+                f"- **{opp.tier}**: {opp.service} ({opp.cost_range}) — {opp.gap}\n"
+            )
+    else:
+        lines.append("- (none)\n")
+
     return "".join(lines)
 
 
@@ -245,6 +276,7 @@ def _stub_output() -> CritiqueOutput:
         unsupported_claims=[],
         suggested_subgoals=[],
         confidence_concerns=[],
+        paid_opportunities=[],
         should_replan=False,
         version=0,
         model="budget_capped",
@@ -277,6 +309,11 @@ async def critique(
     findings = _load_top_findings(job, TOP_N_FINDINGS)
     sources = _load_sources_for(job, findings)
     prior = _load_prior_critique(job)
+    # Reuse synth's loader so the catalog cache + missing-file behavior
+    # stays in one place.
+    from research_agent.orchestrator.synth import _load_paid_unblock_recipes
+
+    paid_unblock_recipes = _load_paid_unblock_recipes()
 
     context = _build_context(
         goal=job.goal,
@@ -284,6 +321,7 @@ async def critique(
         sources=sources,
         synthesis=latest_synthesis,
         prior_critique=prior,
+        paid_unblock_recipes=paid_unblock_recipes,
     )
 
     rendered = load_prompt("critic", job=job, goal=job.goal)
@@ -373,5 +411,6 @@ __all__ = [
     "TOP_N_FINDINGS",
     "CritiqueOutput",
     "Gap",
+    "PaidOpportunity",
     "critique",
 ]

--- a/src/research_agent/orchestrator/synth.py
+++ b/src/research_agent/orchestrator/synth.py
@@ -60,6 +60,9 @@ FINAL_TOP_N = 200
 _FOLLOWUP_RECIPES: str | None = None
 _FOLLOWUP_RECIPES_WARN_LOGGED = False
 
+_PAID_UNBLOCK_RECIPES: str | None = None
+_PAID_UNBLOCK_RECIPES_WARN_LOGGED = False
+
 
 def _load_followup_recipes() -> str:
     """Read ``prompts/followup_recipes.md`` raw and cache the body.
@@ -81,6 +84,28 @@ def _load_followup_recipes() -> str:
             _FOLLOWUP_RECIPES_WARN_LOGGED = True
         body = ""
     _FOLLOWUP_RECIPES = body
+    return body
+
+
+def _load_paid_unblock_recipes() -> str:
+    """Read ``prompts/paid_unblock_recipes.md`` raw and cache the body.
+
+    Same contract as :func:`_load_followup_recipes` — reference data,
+    tolerates a missing file with a one-time WARN log.
+    """
+    global _PAID_UNBLOCK_RECIPES, _PAID_UNBLOCK_RECIPES_WARN_LOGGED
+    if _PAID_UNBLOCK_RECIPES is not None:
+        return _PAID_UNBLOCK_RECIPES
+    try:
+        body = (files("research_agent.prompts") / "paid_unblock_recipes.md").read_text(
+            encoding="utf-8"
+        )
+    except (FileNotFoundError, OSError) as exc:
+        if not _PAID_UNBLOCK_RECIPES_WARN_LOGGED:
+            logger.warning("synth: paid_unblock_recipes.md unavailable: %s", exc)
+            _PAID_UNBLOCK_RECIPES_WARN_LOGGED = True
+        body = ""
+    _PAID_UNBLOCK_RECIPES = body
     return body
 
 _BUDGET_STUB_REPORT = (
@@ -223,6 +248,7 @@ def _build_context(
     prior: str | None,
     critique: str | None,
     followup_recipes: str,
+    paid_unblock_recipes: str,
     final: bool = False,
 ) -> str:
     payload: dict[str, Any] = {
@@ -236,6 +262,7 @@ def _build_context(
         "prior_synthesis": prior,
         "critique": critique,
         "followup_recipes": followup_recipes,
+        "paid_unblock_recipes": paid_unblock_recipes,
     }
     if final:
         payload["final"] = True
@@ -354,6 +381,7 @@ async def _do_synthesis(
     prior = _load_prior_synthesis(job)
     critique = _load_latest_critique(job)
     followup_recipes = _load_followup_recipes()
+    paid_unblock_recipes = _load_paid_unblock_recipes()
 
     context = _build_context(
         goal=job.goal,
@@ -363,6 +391,7 @@ async def _do_synthesis(
         prior=prior,
         critique=critique,
         followup_recipes=followup_recipes,
+        paid_unblock_recipes=paid_unblock_recipes,
         final=final,
     )
 
@@ -683,6 +712,7 @@ async def final_synthesis_after_cap(
     prior = _load_prior_synthesis(job)
     critique = _load_latest_critique(job)
     followup_recipes = _load_followup_recipes()
+    paid_unblock_recipes = _load_paid_unblock_recipes()
 
     context = _build_context(
         goal=job.goal,
@@ -692,6 +722,7 @@ async def final_synthesis_after_cap(
         prior=prior,
         critique=critique,
         followup_recipes=followup_recipes,
+        paid_unblock_recipes=paid_unblock_recipes,
         final=True,
     )
 

--- a/src/research_agent/prompts/critic.md
+++ b/src/research_agent/prompts/critic.md
@@ -1,5 +1,5 @@
 ---
-version: "3"
+version: "4"
 model_tier: frontier_alt
 description: System prompt for the critic agent that audits a synthesis report against its findings.
 ---
@@ -47,6 +47,35 @@ critique the synthesizer (or a follow-up plan) can act on.
    - Generic recommendations that don't end with `because <reason>`
      tied to a specific finding or named subject are also `warn`-level
      gaps in `follow-ups` — flag them so the synthesizer can rewrite.
+8. **Paid-resource opportunities** — investigations should never silently
+   leave gaps the operator could pay $50–$500 to close. Walk the
+   findings + report and ask: is there a **specific evidenced gap** that
+   a known paid service from the `paid_unblock_recipes` catalog (in your
+   input context) would close?
+   - Examples: the report names an individual's professional history
+     but lacks any LinkedIn / career signal → LinkedIn Premium /
+     Sales Navigator. The report relies on summarised state-court
+     activity but never cites the underlying docket → per-jurisdiction
+     state/county pay-per-search portals or PACER for federal docs.
+     The report quotes paywalled previews of WSJ / Bloomberg / FT or
+     trade press (ENR / Crain's / regional business journals) but
+     cannot show the article body → individual subscriptions.
+   - For each gap, emit one `paid_opportunity` entry tied to the
+     concrete finding/subject:
+       - `service` — the catalog name (e.g., "LinkedIn Premium").
+       - `cost_range` — verbatim from the catalog (e.g., "$60–$150/mo").
+       - `gap` — one sentence naming the specific finding/subject and
+         what the paid service would surface, ending in `because
+         <reason>` tying back to a finding or claim.
+       - `tier` — `high` when the paid resource is the only realistic
+         path to fill the gap (or by far the cheapest reliable one);
+         `low` when public alternatives might suffice but the gap is
+         real enough to flag.
+   - **Hard rule:** never recommend a paid resource just to be
+     thorough. Only flag when the gap is evidenced in the findings or
+     report. If nothing qualifies, return `paid_opportunities: []`.
+   - Do **not** invent service names or prices — pull them from the
+     `paid_unblock_recipes` catalog block in your input context.
 
 ## What to produce
 
@@ -64,8 +93,12 @@ Plus the following structured fields:
 - `premature_subgoals`: list of integer subgoal ids whose synthesis status
   (`confirmed` / `refuted`) is not actually supported by the findings.
   Empty list when all closures look defensible.
+- `paid_opportunities`: list of `{service, cost_range, gap, tier}` entries
+  per check #8 above. Empty list when no evidenced gap maps to a paid
+  resource.
 
 If the report is shippable as-is, return an empty critique with a one-line
-rationale and `premature_subgoals: []`. Do not invent issues.
+rationale, `premature_subgoals: []`, and `paid_opportunities: []`. Do not
+invent issues.
 
 Return the critique as the structured output the caller requested.

--- a/src/research_agent/prompts/paid_unblock_recipes.md
+++ b/src/research_agent/prompts/paid_unblock_recipes.md
@@ -1,0 +1,112 @@
+# Paid Resources That Would Unblock an Investigation — Recipe Catalog
+
+This file is reference data, not a templated prompt. The orchestrator loads
+it raw and injects it into the critic and synthesizer context payloads
+under the `paid_unblock_recipes` key. The critic uses it to detect when a
+specific *evidenced* gap maps to a known paid resource; the synthesizer
+uses it to render the "Paid Resources That Would Unblock This
+Investigation" section of the report.
+
+## How to use this catalog
+
+When the critic identifies a gap in coverage that a specific paid resource
+would close, emit a `paid_opportunity` entry tied to the concrete
+finding/subject. The synthesizer then groups those entries into **High
+value** (the paid resource is the only realistic path to fill the gap or
+the cheapest reliable one) and **Lower value** (cheaper public alternatives
+may suffice; flag only because the gap is real and the operator should
+make the call).
+
+**Hard rules:**
+
+- Only flag a paid resource when there is an **actual evidenced gap** in
+  the report or findings — never recommend paid services to be thorough.
+- Every entry must reference a specific finding, named subject, agency,
+  or claim. Generic "you could subscribe to LinkedIn" is not allowed.
+- Pull the service name and approximate cost range verbatim from this
+  catalog. Do not invent prices or services.
+- If no gap maps to a paid resource, omit the section entirely.
+
+## Catalog
+
+### Employment / professional networks of an individual
+- **LinkedIn Premium / Sales Navigator** — $60–$150/mo — would clarify
+  employment history, role transitions, mutual connections, and
+  professional network of a named person beyond what public search
+  surfaces.
+
+### Aggregated people search (phone, address history, aliases)
+- **Pipl** / **BeenVerified** / **Spokeo** — $30–$200/mo — would surface
+  phone numbers, prior addresses, known aliases, and likely relatives for
+  a named individual when public records and free search return little.
+
+### Case law / state-court precedents beyond Casetext / CourtListener
+- **Westlaw** / **Lexis Nexis** — $1k–$10k/yr (or pay-per-search) —
+  would surface state-court precedents, secondary materials (treatises,
+  ALR), and litigation history not indexed by free legal databases.
+
+### Federal court docket pages not in RECAP
+- **PACER pay-per-page** — $0.10/page (capped $3/document) — would pull
+  the specific federal docket entry, motion, or exhibit when RECAP /
+  CourtListener does not have it cached.
+
+### State / county court records (TX, NY, FL, county clerks, etc.)
+- **Per-jurisdiction pay-per-search portals** — varies — would surface
+  state-court filings, civil judgments, liens, or criminal history at
+  the county or state level when no aggregator covers that jurisdiction.
+
+### Premium business news (paywalled)
+- **WSJ** / **Bloomberg** / **Financial Times** subscriptions —
+  $20–$50/mo each — would unlock paywalled investigative pieces,
+  earnings coverage, or executive profiles that public previews tease.
+
+### Trade press (regional construction / legal / industry journals)
+- **ENR (Engineering News-Record)**, **Crain's** (Chicago / NY /
+  Detroit), regional business journals — $200–$500/yr each — would
+  surface industry-specific reporting on contracts, executives, project
+  awards, and disputes that mainstream press does not cover.
+
+### Property records aggregators (multi-county)
+- **PropertyShark** / **ATTOM** — $50–$300/mo — would aggregate deed,
+  mortgage, lien, and ownership-chain data across counties for a named
+  property, owner, or LLC when single-county portals are insufficient.
+
+### Glassdoor employee reviews at scale
+- **Glassdoor for Employers** — $100+/mo — would surface salary bands,
+  internal sentiment, and review counts on a named employer beyond the
+  free five-review preview.
+
+### Sanctions / OFAC commercial-grade with deduplication
+- **Refinitiv World-Check** / **Dow Jones Risk & Compliance** — $$$$
+  (enterprise pricing) — would deduplicate sanctions, PEP, and adverse-
+  media hits across global lists when free OFAC search returns ambiguous
+  matches for a common name.
+
+### Real-time stock / financial data
+- **Bloomberg Terminal** / **Refinitiv Eikon** — $$$$ ($24k+/yr) —
+  would provide intraday pricing, holdings disclosures, and earnings
+  transcripts when free EDGAR / public quotes are insufficient for the
+  specific finding.
+
+### OCCRP Aleph private-leak datasets
+- **OCCRP Aleph** — free with verified-journalist credentials —
+  would surface offshore leaks (Pandora / Paradise / Panama Papers),
+  leaked corporate registries, and investigative datasets for a named
+  individual or entity. Gated access; not paid in dollars but paid in
+  verification.
+
+## Notes for the critic and synthesizer
+
+- The critic emits `paid_opportunity` entries with `service`,
+  `cost_range`, `gap`, and `tier` (`high` or `low`). The synthesizer
+  reads the rendered critique markdown (and structured fields exposed
+  via `latest_critique`) and turns those entries into the report's
+  "Paid Resources That Would Unblock This Investigation" section.
+- Match by *evidenced* gap, not by domain. If the report does not
+  actually rely on case-law precedent, do not flag Westlaw just because
+  the topic is "legal".
+- When two services compete (e.g., Pipl vs. BeenVerified), pick the one
+  most commonly used in journalist workflows and note the alternative
+  parenthetically.
+- Operators can extend this catalog by editing this file directly; no
+  code changes required.

--- a/src/research_agent/prompts/synthesizer.md
+++ b/src/research_agent/prompts/synthesizer.md
@@ -1,5 +1,5 @@
 ---
-version: "4"
+version: "5"
 model_tier: frontier
 description: System prompt for the synthesizer. Emits a raw markdown report followed by a single fenced JSON block with subgoal status.
 ---
@@ -23,6 +23,15 @@ source.
   corruption, healthcare, etc.). Use it to populate the "Recommended Human
   Follow-Ups" section described below — never invent agency names or
   hotline numbers; pull them from the catalog by name.
+- **Paid unblock recipes:** a reference catalog of paid services
+  (LinkedIn Premium, PACER, Westlaw, regional trade press, etc.) keyed
+  by gap pattern, with approximate cost ranges. Use it to populate the
+  "Paid Resources That Would Unblock This Investigation" section
+  described below — pull service names and cost ranges verbatim; never
+  invent prices or services.
+- **Critique:** the latest critic pass over the prior draft. The
+  critique's `paid_opportunities` field is the only signal you should
+  use to decide whether the paid-resources section appears at all.
 
 ## Output format — RAW markdown + a trailing JSON block
 
@@ -34,8 +43,13 @@ fenced ```json block carrying subgoal status. Nothing else.
 - Do **not** add a preamble like "Here is the report:".
 - Your first character should be `#` (the report heading).
 - Newlines are real newlines. Do not escape them as `\n`.
-- The **Recommended Human Follow-Ups** section comes between
-  **Open questions** and **Sources**.
+- The **Recommended Human Follow-Ups** section comes after
+  **Open questions**. The **Paid Resources That Would Unblock This
+  Investigation** section comes immediately after **Recommended Human
+  Follow-Ups** and immediately before **Sources** — but **only when**
+  the critique flagged at least one paid opportunity. Omit the section
+  heading entirely when the critique's `paid_opportunities` list is
+  empty.
 - After the **Sources** section emit exactly one fenced ```json block whose
   body is `{"subgoal_status": {"<id>": "confirmed"|"refuted"|"inconclusive"}}`
   covering every subgoal id you were given. No other JSON fences anywhere
@@ -99,7 +113,35 @@ A markdown report with:
    - If the report relies on government records or alleges agency
      misconduct, expect at least one FOIA candidate or whistleblower
      hotline.
-6. **Sources** — numbered list mapping `[N]` → URL + retrieved-at.
+6. **Paid Resources That Would Unblock This Investigation** —
+   *include this section only when the critique's `paid_opportunities`
+   list has at least one entry; otherwise omit the heading entirely.*
+   Render it with the two sub-headings below, in this order:
+
+   - `### High value`
+   - `### Lower value`
+
+   Place each `paid_opportunity` entry under the sub-heading that
+   matches its `tier` (`high` → High value; `low` → Lower value). Skip
+   a sub-heading entirely if no entries match it.
+
+   Format each entry as:
+
+   - **<Service name> (<approximate cost>)** — would surface
+     <specific gap>, because <reason tying to a finding or named
+     subject>.
+
+   Rules for this section:
+   - Pull `service` names and `cost_range` strings verbatim from the
+     `paid_unblock_recipes` block in the input context. Do not invent
+     prices or services.
+   - Every entry must reference a specific finding, named subject,
+     agency, or claim and end with `because <reason>` — no boilerplate
+     "you could subscribe to LinkedIn".
+   - Only flag a paid resource when the critique surfaced an actual
+     evidenced gap. If the critique returned no `paid_opportunities`,
+     omit the entire section (do not write "(none)").
+7. **Sources** — numbered list mapping `[N]` → URL + retrieved-at.
 
 ## Rules
 
@@ -148,6 +190,18 @@ A markdown report with:
 - Disciplinary file for license #12345 at the State Contractors Board —
   request under the state Public Records Act, because the report cites
   prior board complaints summarised second-hand [3].
+
+## Paid Resources That Would Unblock This Investigation
+
+### High value
+- **LinkedIn Premium ($60–$150/mo)** — would surface employment history
+  and professional network of CEO Jane Doe, because the report can only
+  cite a single press release naming her prior role [1].
+
+### Lower value
+- **ENR (Engineering News-Record) subscription ($200–$500/yr)** —
+  would surface trade-press coverage of Acme Co's regional contract
+  awards, because the report cites only paywalled previews [2].
 
 ## Sources
 

--- a/tests/test_orchestrator_critique.py
+++ b/tests/test_orchestrator_critique.py
@@ -17,6 +17,7 @@ from research_agent.orchestrator.critique import (
     DEFAULT_TIER,
     CritiqueOutput,
     Gap,
+    PaidOpportunity,
     critique,
 )
 from research_agent.orchestrator.plan import Plan, Subgoal, TaskSpec
@@ -544,3 +545,118 @@ def test_critique_empty_premature_subgoals_is_noop(
 
     events = _read_event_rows(db_path, job.id)
     assert not [e for e in events if e["kind"] == "subgoals_reopened"]
+
+
+# ---------------------------------------------------------------------------
+# Paid resource opportunities (issue #113)
+# ---------------------------------------------------------------------------
+
+
+def test_critic_prompt_flags_paid_opportunities() -> None:
+    """The critic prompt must instruct the model to emit paid_opportunities."""
+    body = prompts_loader.load_prompt("critic")
+    assert "Paid-resource opportunities" in body
+    assert "paid_opportunities" in body
+    assert "paid_unblock_recipes" in body
+    # The catalog hard rule: only flag when the gap is evidenced.
+    assert "actual evidenced gap" in body or "evidenced gap" in body
+    # Spot-check a few catalog services the prompt should reference.
+    assert "LinkedIn" in body
+    assert "PACER" in body or "Westlaw" in body
+
+
+def test_critique_paid_opportunities_rendered(job: Job, db_path: Path, plan: Plan) -> None:
+    """A non-empty paid_opportunities list lands in critique md + JSON sidecar."""
+    _seed_findings(job, [0.6])
+    output = CritiqueOutput(
+        gaps=[],
+        unsupported_claims=[],
+        suggested_subgoals=[],
+        confidence_concerns=[],
+        paid_opportunities=[
+            PaidOpportunity(
+                service="LinkedIn Premium",
+                cost_range="$60–$150/mo",
+                gap=(
+                    "would clarify employment history of CEO Jane Doe, because "
+                    "the report can only cite a single press release [1]"
+                ),
+                tier="high",
+            ),
+            PaidOpportunity(
+                service="ENR (Engineering News-Record)",
+                cost_range="$200–$500/yr",
+                gap=(
+                    "would surface trade-press coverage of Acme Co's regional "
+                    "contract awards, because the report cites paywalled "
+                    "previews only [2]"
+                ),
+                tier="low",
+            ),
+        ],
+        should_replan=False,
+    )
+    router = _StubRouter(output=output)
+
+    out = asyncio.run(critique(job, plan, "# Synth\n", router=router))
+
+    assert out.paid_opportunities
+    assert {p.service for p in out.paid_opportunities} == {
+        "LinkedIn Premium",
+        "ENR (Engineering News-Record)",
+    }
+
+    md = (job.root / "critique/0001.md").read_text(encoding="utf-8")
+    assert "Paid resource opportunities" in md
+    assert "LinkedIn Premium" in md
+    assert "$60–$150/mo" in md
+    assert "**high**" in md
+    assert "**low**" in md
+    assert "ENR (Engineering News-Record)" in md
+
+    sidecar = json.loads((job.root / "critique/0001.json").read_text(encoding="utf-8"))
+    paid = sidecar["payload"]["paid_opportunities"]
+    assert len(paid) == 2
+    assert {p["service"] for p in paid} == {
+        "LinkedIn Premium",
+        "ENR (Engineering News-Record)",
+    }
+    assert {p["tier"] for p in paid} == {"high", "low"}
+
+    rows = _read_critique_rows(db_path, job.id)
+    db_payload = json.loads(rows[0]["payload_json"])
+    assert len(db_payload["paid_opportunities"]) == 2
+
+
+def test_critique_empty_paid_opportunities_renders_none(
+    job: Job, db_path: Path, plan: Plan
+) -> None:
+    """When the model returns no paid opportunities the md says ``(none)``."""
+    _seed_findings(job, [0.6])
+    router = _StubRouter()  # default output has no paid_opportunities
+
+    asyncio.run(critique(job, plan, "# Synth\n", router=router))
+
+    md = (job.root / "critique/0001.md").read_text(encoding="utf-8")
+    assert "Paid resource opportunities" in md
+    # Anchor on the list bullet so we don't false-match the heading.
+    paid_section = md.split("Paid resource opportunities", 1)[1]
+    assert "- (none)" in paid_section
+
+
+def test_critique_passes_paid_unblock_recipes_in_context(
+    job: Job, db_path: Path, plan: Plan
+) -> None:
+    """The critic's context payload carries the paid-unblock catalog."""
+    _seed_findings(job, [0.6])
+    router = _StubRouter()
+
+    asyncio.run(critique(job, plan, "# Synth\n", router=router))
+
+    tier, args, _kwargs = router.calls[0]
+    assert tier == "frontier_alt"
+    payload = json.loads(args[0])
+    paid = payload.get("paid_unblock_recipes")
+    assert isinstance(paid, str) and paid
+    assert "LinkedIn" in paid
+    assert "PACER" in paid

--- a/tests/test_orchestrator_synth.py
+++ b/tests/test_orchestrator_synth.py
@@ -783,6 +783,7 @@ def test_build_context_exposes_goal_and_licensing_board_guidance(
         prior=None,
         critique=None,
         followup_recipes=synth_module._load_followup_recipes(),
+        paid_unblock_recipes=synth_module._load_paid_unblock_recipes(),
         final=False,
     )
     payload = json.loads(context_json)
@@ -792,6 +793,50 @@ def test_build_context_exposes_goal_and_licensing_board_guidance(
     assert "licensing board" in recipes
     assert "spokesperson" in recipes or "press contact" in recipes
     assert "FOIA" in recipes
+
+    # SBI Builders acceptance criterion: paid catalog must surface
+    # LinkedIn (for company employees) and a regional / trade-press
+    # subscription that an investigation of a regional builder would
+    # plausibly need.
+    paid = payload["paid_unblock_recipes"]
+    assert isinstance(paid, str) and paid
+    assert "LinkedIn" in paid
+    assert "ENR" in paid or "Crain" in paid or "trade press" in paid.lower()
+
+
+# ---------------------------------------------------------------------------
+# Paid Resources That Would Unblock This Investigation (issue #113)
+# ---------------------------------------------------------------------------
+
+
+def test_paid_unblock_recipes_in_context(job: Job, db_path: Path, plan: Plan) -> None:
+    """The synthesizer's context payload carries the paid-unblock catalog."""
+    _seed_findings(job, [0.7])
+    router = _StubRouter()
+
+    asyncio.run(synthesize(job, plan, router=router))
+
+    assert router.calls
+    _tier, args, _kwargs = router.calls[0]
+    payload = json.loads(args[0])
+    paid = payload.get("paid_unblock_recipes")
+    assert isinstance(paid, str) and paid
+    # Spot-check several specific services from the seeded catalog so a
+    # regression that drops one is caught.
+    assert "LinkedIn" in paid
+    assert "PACER" in paid
+    assert "Westlaw" in paid
+
+
+def test_synthesizer_prompt_requires_paid_resources_section() -> None:
+    """The synthesizer prompt must instruct the model to emit the new section."""
+    body = prompts_loader.load_prompt("synthesizer", goal="x")
+    assert "Paid Resources That Would Unblock This Investigation" in body
+    assert "High value" in body
+    assert "Lower value" in body
+    assert "because" in body
+    # The section must be conditional on the critique's flagged opportunities.
+    assert "paid_opportunities" in body
 
 
 def test_synthesize_accepts_fence_with_space_before_json_lang(


### PR DESCRIPTION
Closes #113
Part of #107

## Summary

Automated implementation of **Synth/critique: flag paid-API opportunities when public sources gap**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Issue #113 implementation is complete and well-wired: critic emits structured paid_opportunities, synthesizer prompt renders the new section conditionally, catalog file ships with all required services, and tests cover the catalog payload + rendering paths.

- **INFO** [OPEN] `src/research_agent/prompts/synthesizer.md`: Synthesizer prompt phrases the paid_opportunities source as a 'field', but the synth context only ships the critique markdown body (not a structured critique JSON). The model has to read the '## Paid resource opportunities' bullets to find them. Works in practice since the markdown rendering is unambiguous, but the wording is slightly indirect. Not a blocker.
- **INFO** [OPEN] `tests/test_orchestrator_synth.py`: The 'SBI Builders re-run' acceptance criterion is covered indirectly: tests assert the paid_unblock_recipes payload contains LinkedIn and a regional trade-press entry (ENR/Crain's), and the rendering pipeline is unit-tested end-to-end. A live SBI Builders integration test was not added (would require a full investigation run), which is consistent with the project's 'no paid live runs in CI' stance.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*