### PR TITLE
feat: CourtListener / RECAP connector (federal court records) (closes #93)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,9 @@ YOUTUBE_API_KEY=
 # writes to stdout when run interactively. Has no effect on `research start`
 # (its daemon redirects stdout to a log file, so the bar stays dormant).
 RESEARCH_DAEMON_PROGRESS=
+
+# Optional: CourtListener API token (free w/ signup at
+# https://www.courtlistener.com/help/api/rest/). Authenticated traffic is
+# capped at 5,000 req/hr — the anonymous tier is throttled to the point of
+# unusability, so `tools/courtlistener.py` requires this token to be set.
+COURTLISTENER_API_TOKEN=

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ that list, so there is no drift.
 | `LMSTUDIO_BASE_URL` | no | Override the default `http://localhost:1234/v1`. |
 | `YOUTUBE_API_KEY` | no | YouTube Data API v3 key (free quota: 10,000 units/day). When set, `tools/youtube.py:search` uses the official API; absent, it falls back to scraping the public results page via Playwright. |
 | `RESEARCH_DAEMON_PROGRESS` | no | Set to `0` to suppress the foreground Rich progress bar the daemon writes to stdout when run interactively. |
+| `COURTLISTENER_API_TOKEN` | no | CourtListener API token (free w/ signup) — required by `tools/courtlistener.py`. Authenticated tier is 5,000 req/hr; anonymous traffic is throttled to the point of unusability. |
 
 ## LM Studio
 

--- a/src/research_agent/config.py
+++ b/src/research_agent/config.py
@@ -90,6 +90,15 @@ EXPECTED_ENV_KEYS: tuple[EnvKey, ...] = (
             " unaffected (its stdout is a log file, so the bar stays dormant)."
         ),
     ),
+    EnvKey(
+        name="COURTLISTENER_API_TOKEN",
+        required=False,
+        description=(
+            "CourtListener API token (free w/ signup). Required by"
+            " tools/courtlistener.py — anonymous tier is rate-limited to the"
+            " point of unusability."
+        ),
+    ),
 )
 
 

--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -110,6 +110,42 @@ def _smoke_edgar(query: str) -> str:
     return asyncio.run(_run())
 
 
+def _smoke_courtlistener(query: str) -> str:
+    """Smoke wrapper: CourtListener opinions search returning the top-5 hits.
+
+    Per AC #6: ``research _smoke-tool courtlistener "first amendment retaliation"``
+    should surface federal court opinions. Each line shows the case name, court,
+    file date, citation, permalink, and a short snippet so an operator can
+    eyeball whether the REST API is reachable and the token is healthy.
+    """
+    from research_agent.tools import courtlistener
+
+    async def _run() -> str:
+        results = await courtlistener.search(
+            query, kind="opinions", max_results=5
+        )
+        if not results:
+            return f"courtlistener search returned no results for {query!r}"
+        lines: list[str] = []
+        for hit in results:
+            court = hit.extras.get("court") or "?"
+            file_date = (
+                hit.published_at.date().isoformat() if hit.published_at else "?"
+            )
+            citation = hit.extras.get("citation") or "?"
+            snippet = hit.snippet.replace("\n", " ")
+            if len(snippet) > 200:
+                snippet = snippet[:200] + "…"
+            lines.append(
+                f"- {hit.title} — {court} — {file_date} — {citation}\n"
+                f"  {hit.url}\n"
+                f"  {snippet}"
+            )
+        return "\n".join(lines)
+
+    return asyncio.run(_run())
+
+
 def _smoke_news(query: str) -> str:
     """Smoke wrapper: aggregate news hits and report per-source contributions.
 
@@ -315,6 +351,7 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "local_corpus": _smoke_local_corpus,
     "arxiv": _smoke_arxiv,
     "edgar": _smoke_edgar,
+    "courtlistener": _smoke_courtlistener,
     "news": _smoke_news,
     "reddit": _smoke_reddit,
     "pdf": _smoke_pdf,

--- a/src/research_agent/tools/courtlistener.py
+++ b/src/research_agent/tools/courtlistener.py
@@ -1,0 +1,571 @@
+"""CourtListener / RECAP connector (issue #93).
+
+Public surface:
+
+* ``async def search(query, *, kind="opinions", max_results=20) -> list[SearchResult]``
+  hits the REST v3 ``search/`` endpoint for opinions, dockets (RECAP), or oral
+  arguments. ``kind`` maps to the API's ``type`` code (``o``/``r``/``oa``).
+* ``async def fetch(url, timeout=30.0) -> Source | None`` opens an opinion or
+  docket page and returns markdown of the opinion text or docket entries.
+
+CourtListener offers ~5,000 req/hr with an API token (free w/ signup) and
+heavily rate-limits anonymous traffic — we treat the token as required and
+fail loudly when absent. Per-host bucket gates calls to ≈1 RPS to stay polite.
+
+Filings and opinions are immutable, so the API JSON for a given resource is
+cached at ``corpus/.cache/courtlistener/<id>.json``.
+
+For dockets where RECAP doesn't have the document, the entry is still rendered
+with a ``(no RECAP document available — surface to synthesizer)`` line; we
+never auto-trigger a paid PACER fetch on the user's behalf.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import time
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+import httpx
+import trafilatura
+
+from research_agent import config
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://www.courtlistener.com/api/rest/v3/"
+_SITE_BASE = "https://www.courtlistener.com"
+# 5000 req/hr ≈ 1.4 RPS; we throttle to 1 RPS to leave headroom.
+_RATE_LIMIT_INTERVAL = 1.0
+_CACHE_DIR = Path("corpus/.cache/courtlistener")
+
+_KIND_TO_TYPE = {
+    "opinions": "o",
+    "dockets": "r",
+    "oral_arguments": "oa",
+}
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+_OPINION_ID_RE = re.compile(r"/opinion/(\d+)(?:/|$)")
+_DOCKET_ID_RE = re.compile(r"/docket/(\d+)(?:/|$)")
+
+_rate_lock = asyncio.Lock()
+_last_call_monotonic: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Config / rate-limit helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_token() -> str:
+    """Return the configured API token. Raise RuntimeError if missing.
+
+    Anonymous CourtListener traffic is throttled to the point of unusability
+    per the issue notes, so a missing token is a configuration error — fail
+    loudly here rather than silently degrade to broken-by-default behavior.
+    """
+    token = config.get("COURTLISTENER_API_TOKEN") or ""
+    if not token.strip():
+        raise RuntimeError(
+            "CourtListener requires an API token. Sign up at "
+            "https://www.courtlistener.com/help/api/rest/ and set "
+            "COURTLISTENER_API_TOKEN in your .env."
+        )
+    return token.strip()
+
+
+def _auth_headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Token {_resolve_token()}",
+        "Accept": "application/json",
+        "User-Agent": config.get("RESEARCH_USER_AGENT")
+        or "research-agent/0.1 (+local; contact unset)",
+    }
+
+
+async def _rate_limit_gate() -> None:
+    """Block until at least ``_RATE_LIMIT_INTERVAL`` has passed since the last call."""
+    global _last_call_monotonic
+    async with _rate_lock:
+        if _last_call_monotonic is not None:
+            elapsed = time.monotonic() - _last_call_monotonic
+            wait = _RATE_LIMIT_INTERVAL - elapsed
+            if wait > 0:
+                await asyncio.sleep(wait)
+        _last_call_monotonic = time.monotonic()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _strip_html(html: str) -> str:
+    return _WS_RE.sub(" ", _TAG_RE.sub(" ", html)).strip()
+
+
+def _extract_html_text(html: str) -> str:
+    if not html:
+        return ""
+    try:
+        extracted = trafilatura.extract(
+            html,
+            include_comments=False,
+            include_tables=True,
+            favor_recall=True,
+        )
+    except Exception:  # noqa: BLE001 — never crash on extractor errors
+        extracted = None
+    if extracted and extracted.strip():
+        return extracted.strip()
+    return _strip_html(html)
+
+
+def _parse_iso_date(value: Any) -> datetime | None:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=UTC)
+    text = str(value).strip()
+    if not text:
+        return None
+    # CourtListener returns dates in ISO-8601 (``YYYY-MM-DD`` or full ts).
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%d"):
+        try:
+            parsed = datetime.strptime(text, fmt)
+            return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed
+        except ValueError:
+            continue
+    # Last-ditch: split on T and try just the date part.
+    head = text.split("T", 1)[0]
+    try:
+        return datetime.strptime(head, "%Y-%m-%d").replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def _best_citation(hit: dict[str, Any]) -> str:
+    citations = hit.get("citation")
+    if isinstance(citations, list):
+        for c in citations:
+            if isinstance(c, str) and c.strip():
+                return c.strip()
+    elif isinstance(citations, str) and citations.strip():
+        return citations.strip()
+    for key in ("lexisCite", "neutralCite", "lexis_cite", "neutral_cite"):
+        value = hit.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _absolute_url(rel: str) -> str:
+    if not rel:
+        return ""
+    if rel.startswith("http://") or rel.startswith("https://"):
+        return rel
+    return urljoin(_SITE_BASE, rel)
+
+
+def _build_search_result(
+    hit: dict[str, Any], *, kind: str
+) -> SearchResult | None:
+    rel = hit.get("absolute_url") or ""
+    if not rel:
+        return None
+    url = _absolute_url(rel)
+
+    title = (
+        hit.get("caseName")
+        or hit.get("case_name")
+        or hit.get("caseNameShort")
+        or hit.get("case_name_short")
+        or url
+    )
+
+    snippet_raw = hit.get("snippet") or ""
+    if not snippet_raw:
+        text = hit.get("text") or ""
+        if isinstance(text, str):
+            snippet_raw = text[:300]
+    if not snippet_raw:
+        snippet_raw = title
+
+    snippet = _strip_html(str(snippet_raw))
+
+    published_at = _parse_iso_date(
+        hit.get("dateFiled") or hit.get("date_filed")
+    )
+
+    extras: dict[str, Any] = {
+        "court": hit.get("court") or hit.get("court_id") or "",
+        "citation": _best_citation(hit),
+        "docket_number": hit.get("docketNumber") or hit.get("docket_number") or "",
+        "kind": kind,
+    }
+
+    return SearchResult(
+        url=url,
+        title=str(title),
+        snippet=snippet,
+        published_at=published_at,
+        source_kind="courtlistener",
+        extras=extras,
+    )
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def search(
+    query: str,
+    *,
+    kind: str = "opinions",
+    max_results: int = 20,
+    timeout: float = 15.0,
+) -> list[SearchResult]:
+    """Run a CourtListener REST search and return up to ``max_results`` hits.
+
+    ``kind`` selects the index — ``opinions`` (case law), ``dockets`` (RECAP
+    PACER mirror), or ``oral_arguments``. Returns ``[]`` on transport / HTTP
+    error / non-JSON body — connector failures must never crash the planner.
+    """
+    if kind not in _KIND_TO_TYPE:
+        raise ValueError(
+            f"unknown kind {kind!r}; expected one of {sorted(_KIND_TO_TYPE)}"
+        )
+
+    params = {"q": query, "type": _KIND_TO_TYPE[kind]}
+    headers = _auth_headers()
+
+    await _rate_limit_gate()
+
+    url = urljoin(_BASE_URL, "search/")
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=headers,
+        ) as client:
+            response = await client.get(url, params=params)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("courtlistener search failed for %r: %s", query, exc)
+        return []
+
+    if response.status_code != 200:
+        logger.warning(
+            "courtlistener search returned HTTP %s for %r",
+            response.status_code,
+            query,
+        )
+        return []
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        logger.warning(
+            "courtlistener search returned non-JSON for %r: %s", query, exc
+        )
+        return []
+
+    raw_hits = payload.get("results") or []
+    out: list[SearchResult] = []
+    for hit in raw_hits[:max_results]:
+        if not isinstance(hit, dict):
+            continue
+        result = _build_search_result(hit, kind=kind)
+        if result is not None:
+            out.append(result)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+def _classify_url(url: str) -> tuple[str | None, str | None]:
+    """Return ``(resource, id)`` where resource ∈ {"opinion","docket"}.
+
+    Returns ``(None, None)`` when the URL doesn't point at a recognised
+    CourtListener resource page.
+    """
+    parsed = urlparse(url)
+    if "courtlistener.com" not in (parsed.netloc or "").lower():
+        return None, None
+    path = parsed.path or ""
+    m = _OPINION_ID_RE.search(path)
+    if m:
+        return "opinion", m.group(1)
+    m = _DOCKET_ID_RE.search(path)
+    if m:
+        return "docket", m.group(1)
+    return None, None
+
+
+def _cache_path(prefix: str, resource_id: str) -> Path:
+    safe = resource_id.replace("/", "_")
+    return _CACHE_DIR / f"{prefix}-{safe}.json"
+
+
+def _write_cache(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _load_cache(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+async def _http_get_json(
+    url: str, timeout: float, *, params: dict[str, Any] | None = None
+) -> tuple[int | None, dict[str, Any] | None]:
+    headers = _auth_headers()
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=headers,
+        ) as client:
+            response = await client.get(url, params=params)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("courtlistener fetch failed for %s: %s", url, exc)
+        return None, None
+    if response.status_code != 200:
+        return response.status_code, None
+    try:
+        return response.status_code, response.json()
+    except ValueError:
+        return response.status_code, None
+
+
+def _opinion_text(payload: dict[str, Any]) -> str:
+    plain = payload.get("plain_text")
+    if isinstance(plain, str) and plain.strip():
+        return plain.strip()
+    for key in ("html_with_citations", "html", "html_lawbox"):
+        html = payload.get(key)
+        if isinstance(html, str) and html.strip():
+            extracted = _extract_html_text(html)
+            if extracted:
+                return extracted
+    return ""
+
+
+def _has_recap_doc(entry: dict[str, Any]) -> bool:
+    docs = entry.get("recap_documents")
+    if not isinstance(docs, list):
+        return False
+    for doc in docs:
+        if isinstance(doc, dict):
+            # Either a populated filepath_local or a is_available flag indicates
+            # RECAP has the actual document on file.
+            if doc.get("filepath_local") or doc.get("is_available"):
+                return True
+    return False
+
+
+def _render_docket_entries(entries: list[dict[str, Any]]) -> str:
+    lines: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        number = entry.get("entry_number")
+        date_filed = entry.get("date_filed") or ""
+        description = (entry.get("description") or "").strip()
+        header = f"## Entry {number if number is not None else '?'} — {date_filed}"
+        lines.append(header)
+        if description:
+            lines.append(description)
+        if not _has_recap_doc(entry):
+            lines.append(
+                "(no RECAP document available — surface to synthesizer)"
+            )
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
+async def _fetch_opinion(
+    opinion_id: str, source_url: str, timeout: float
+) -> Source | None:
+    cache = _cache_path("opinion", opinion_id)
+    payload = _load_cache(cache)
+    if payload is None:
+        await _rate_limit_gate()
+        api_url = urljoin(_BASE_URL, f"opinions/{opinion_id}/")
+        status, payload = await _http_get_json(api_url, timeout)
+        if status is None or status >= 400 or not isinstance(payload, dict):
+            if status is not None and status >= 400:
+                logger.warning(
+                    "courtlistener opinion HTTP %s for %s", status, api_url
+                )
+            return None
+        _write_cache(cache, payload)
+
+    cleaned_text = _opinion_text(payload)
+    if not cleaned_text:
+        return None
+
+    title = (
+        payload.get("case_name")
+        or payload.get("caseName")
+        or payload.get("cluster_id")
+        or source_url
+    )
+
+    metadata: dict[str, Any] = {
+        "court": payload.get("court") or payload.get("court_id") or "",
+        "docket_number": payload.get("docket_number") or "",
+        "citation": payload.get("citation") or "",
+        "date_filed": payload.get("date_filed") or "",
+        "recap_available": False,
+        "opinion_id": opinion_id,
+    }
+
+    return Source(
+        url=source_url,
+        title=str(title),
+        cleaned_text=cleaned_text,
+        raw_html=None,
+        fetched_at=datetime.now(UTC),
+        source_kind="courtlistener",
+        metadata=metadata,
+    )
+
+
+async def _fetch_docket(
+    docket_id: str, source_url: str, timeout: float
+) -> Source | None:
+    docket_cache = _cache_path("docket", docket_id)
+    docket_payload = _load_cache(docket_cache)
+    if docket_payload is None:
+        await _rate_limit_gate()
+        api_url = urljoin(_BASE_URL, f"dockets/{docket_id}/")
+        status, docket_payload = await _http_get_json(api_url, timeout)
+        if (
+            status is None
+            or status >= 400
+            or not isinstance(docket_payload, dict)
+        ):
+            if status is not None and status >= 400:
+                logger.warning(
+                    "courtlistener docket HTTP %s for %s", status, api_url
+                )
+            return None
+        _write_cache(docket_cache, docket_payload)
+
+    entries_cache = _cache_path("docket-entries", docket_id)
+    entries_payload = _load_cache(entries_cache)
+    if entries_payload is None:
+        await _rate_limit_gate()
+        entries_url = urljoin(_BASE_URL, "docket-entries/")
+        status, entries_payload = await _http_get_json(
+            entries_url,
+            timeout,
+            params={"docket": docket_id, "order_by": "entry_number"},
+        )
+        if (
+            status is None
+            or status >= 400
+            or not isinstance(entries_payload, dict)
+        ):
+            entries_payload = {"results": []}
+        else:
+            _write_cache(entries_cache, entries_payload)
+
+    raw_entries = entries_payload.get("results") or []
+    # Keep payload bounded — first page / ~100 entries is plenty for synth.
+    entries = [e for e in raw_entries[:100] if isinstance(e, dict)]
+    body = _render_docket_entries(entries)
+
+    case_name = (
+        docket_payload.get("case_name")
+        or docket_payload.get("caseName")
+        or source_url
+    )
+    docket_number = docket_payload.get("docket_number") or ""
+
+    header_parts = [str(case_name)]
+    if docket_number:
+        header_parts.append(f"Docket No. {docket_number}")
+    header = " — ".join(header_parts)
+    cleaned_text = f"# {header}\n\n{body}".strip() if body else f"# {header}".strip()
+
+    if not cleaned_text:
+        return None
+
+    recap_available = any(_has_recap_doc(e) for e in entries)
+
+    metadata: dict[str, Any] = {
+        "court": docket_payload.get("court") or docket_payload.get("court_id") or "",
+        "docket_number": docket_number,
+        "citation": "",
+        "date_filed": docket_payload.get("date_filed") or "",
+        "recap_available": recap_available,
+        "docket_id": docket_id,
+        "entry_count": len(entries),
+    }
+
+    return Source(
+        url=source_url,
+        title=str(case_name),
+        cleaned_text=cleaned_text,
+        raw_html=None,
+        fetched_at=datetime.now(UTC),
+        source_kind="courtlistener",
+        metadata=metadata,
+    )
+
+
+async def fetch(url: str, timeout: float = 30.0) -> Source | None:
+    """Open a CourtListener opinion or docket page and return a :class:`Source`.
+
+    The URL is classified by path: ``/opinion/<id>/...`` routes through the
+    ``opinions/<id>/`` endpoint and prefers ``plain_text`` over the various
+    HTML fields. ``/docket/<id>/...`` fetches the docket plus its first page
+    of entries via ``docket-entries/?docket=<id>&order_by=entry_number``.
+
+    Returns ``None`` for unrecognised URLs and for any transport / HTTP /
+    parse failure.
+    """
+    if not url:
+        return None
+    resource, resource_id = _classify_url(url)
+    if not resource or not resource_id:
+        return None
+
+    if resource == "opinion":
+        return await _fetch_opinion(resource_id, url, timeout)
+    if resource == "docket":
+        return await _fetch_docket(resource_id, url, timeout)
+    return None
+
+
+def reset_for_tests() -> None:
+    """Clear per-process rate-limit state. Test-only."""
+    global _last_call_monotonic, _rate_lock
+    _last_call_monotonic = None
+    _rate_lock = asyncio.Lock()
+
+
+__all__ = ["fetch", "reset_for_tests", "search"]

--- a/tests/test_tools_courtlistener.py
+++ b/tests/test_tools_courtlistener.py
@@ -1,0 +1,520 @@
+"""Tests for `research_agent.tools.courtlistener` (issue #93)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from research_agent.tools import courtlistener
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _set_token(monkeypatch):
+    monkeypatch.setenv("COURTLISTENER_API_TOKEN", "tok-test-1234567890abcdef")
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    courtlistener.reset_for_tests()
+    monkeypatch.setattr(courtlistener.asyncio, "sleep", AsyncMock())
+    yield
+    courtlistener.reset_for_tests()
+
+
+@pytest.fixture
+def cache_dir(tmp_path: Path, monkeypatch) -> Path:
+    target = tmp_path / "courtlistener-cache"
+    monkeypatch.setattr(courtlistener, "_CACHE_DIR", target)
+    return target
+
+
+_SEARCH_PAYLOAD = {
+    "count": 2,
+    "results": [
+        {
+            "absolute_url": "/opinion/4341372/lozman-v-city-of-riviera-beach/",
+            "caseName": "Lozman v. City of Riviera Beach",
+            "case_name_short": "Lozman",
+            "court": "Supreme Court of the United States",
+            "court_id": "scotus",
+            "dateFiled": "2018-06-18",
+            "docketNumber": "17-21",
+            "snippet": "First Amendment <em>retaliation</em> arrest claim",
+            "citation": ["585 U.S. 87"],
+            "lexisCite": "138 S. Ct. 1945",
+            "neutralCite": "",
+        },
+        {
+            "absolute_url": "/opinion/12345/doe-v-roe/",
+            "caseName": "Doe v. Roe",
+            "court": "9th Cir.",
+            "court_id": "ca9",
+            "dateFiled": "2021-03-04",
+            "docketNumber": "20-1234",
+            "snippet": "",
+            "text": (
+                "This is a long opinion text used to derive a snippet "
+                "when no highlight snippet is provided by the API."
+            ),
+            "citation": [],
+            "lexisCite": "999 F.3d 1",
+            "neutralCite": "",
+        },
+    ],
+}
+
+
+_OPINION_PAYLOAD = {
+    "id": 4341372,
+    "case_name": "Lozman v. City of Riviera Beach",
+    "court": "scotus",
+    "court_id": "scotus",
+    "docket_number": "17-21",
+    "citation": "585 U.S. 87",
+    "date_filed": "2018-06-18",
+    "plain_text": (
+        "Held: The existence of probable cause does not bar Lozman's"
+        " First Amendment retaliation claim."
+    ),
+    "html_with_citations": "<p>fallback html</p>",
+    "html": "",
+    "html_lawbox": "",
+}
+
+
+_DOCKET_PAYLOAD = {
+    "id": 555,
+    "case_name": "United States v. Acme",
+    "court": "nysd",
+    "court_id": "nysd",
+    "docket_number": "1:23-cv-12345",
+    "date_filed": "2023-01-15",
+}
+
+
+_DOCKET_ENTRIES_PAYLOAD = {
+    "count": 2,
+    "results": [
+        {
+            "entry_number": 1,
+            "date_filed": "2023-01-15",
+            "description": "COMPLAINT against Acme Corp.",
+            "recap_documents": [
+                {"id": 1, "is_available": True, "filepath_local": "x.pdf"}
+            ],
+        },
+        {
+            "entry_number": 2,
+            "date_filed": "2023-02-01",
+            "description": "ORDER setting initial conference.",
+            "recap_documents": [],
+        },
+    ],
+}
+
+
+def _patch_httpx(monkeypatch, *, responder):
+    """Replace ``httpx.AsyncClient`` with a fake driven by ``responder(url, params)``.
+
+    Returns ``(status_code, body_text)``.
+    """
+    captured: dict[str, list] = {"urls": [], "headers": [], "params": []}
+
+    class _FakeResp:
+        def __init__(self, status: int, text: str) -> None:
+            self.status_code = status
+            self.text = text
+
+        def json(self):
+            return json.loads(self.text)
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        captured["headers"].append(kwargs.get("headers"))
+
+        class _Client:
+            async def get(self, url, *, params=None, **_kwargs):
+                captured["urls"].append(url)
+                captured["params"].append(params)
+                status, text = responder(url, params)
+                return _FakeResp(status, text)
+
+        yield _Client()
+
+    monkeypatch.setattr(courtlistener.httpx, "AsyncClient", _client_factory)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def test_search_builds_correct_query_and_auth_header(monkeypatch):
+    payload = json.dumps(_SEARCH_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await courtlistener.search(
+        "first amendment retaliation", kind="opinions"
+    )
+
+    assert len(results) == 2
+    # Auth header carries the token.
+    headers = captured["headers"][0]
+    assert headers["Authorization"] == "Token tok-test-1234567890abcdef"
+    assert headers["Accept"] == "application/json"
+    # type=o for opinions.
+    assert captured["params"][0] == {
+        "q": "first amendment retaliation",
+        "type": "o",
+    }
+    # URL is the search endpoint.
+    assert captured["urls"][0].endswith("/api/rest/v3/search/")
+
+
+async def test_search_parses_results(monkeypatch):
+    payload = json.dumps(_SEARCH_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await courtlistener.search("first amendment retaliation")
+
+    first = results[0]
+    assert first.source_kind == "courtlistener"
+    assert first.url == (
+        "https://www.courtlistener.com/opinion/4341372/lozman-v-city-of-riviera-beach/"
+    )
+    assert first.title == "Lozman v. City of Riviera Beach"
+    assert "retaliation" in first.snippet
+    assert "<em>" not in first.snippet
+    assert first.published_at is not None
+    assert first.published_at.year == 2018
+    assert first.extras["court"] == "Supreme Court of the United States"
+    assert first.extras["citation"] == "585 U.S. 87"
+    assert first.extras["docket_number"] == "17-21"
+    assert first.extras["kind"] == "opinions"
+
+    # Second result has no snippet field — falls back to text[:300].
+    second = results[1]
+    assert second.snippet.startswith("This is a long opinion text")
+    # Falls back to lexisCite when citation list is empty.
+    assert second.extras["citation"] == "999 F.3d 1"
+
+
+async def test_search_kind_dockets_uses_type_r(monkeypatch):
+    payload = json.dumps({"results": []})
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    await courtlistener.search("anything", kind="dockets")
+
+    assert captured["params"][0]["type"] == "r"
+
+
+async def test_search_kind_oral_arguments_uses_type_oa(monkeypatch):
+    payload = json.dumps({"results": []})
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    await courtlistener.search("anything", kind="oral_arguments")
+
+    assert captured["params"][0]["type"] == "oa"
+
+
+async def test_search_unknown_kind_raises(monkeypatch):
+    with pytest.raises(ValueError, match="unknown kind"):
+        await courtlistener.search("anything", kind="bogus")
+
+
+async def test_search_returns_empty_on_401(monkeypatch):
+    def _respond(url, params):
+        return 401, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await courtlistener.search("anything") == []
+
+
+async def test_search_returns_empty_on_500(monkeypatch):
+    def _respond(url, params):
+        return 500, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await courtlistener.search("anything") == []
+
+
+async def test_search_returns_empty_on_non_json(monkeypatch):
+    def _respond(url, params):
+        return 200, "<html>not json</html>"
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await courtlistener.search("anything") == []
+
+
+async def test_search_returns_empty_on_transport_error(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(courtlistener.httpx, "AsyncClient", _client_factory)
+
+    assert await courtlistener.search("anything") == []
+
+
+async def test_search_raises_when_token_missing(monkeypatch):
+    monkeypatch.delenv("COURTLISTENER_API_TOKEN", raising=False)
+
+    with pytest.raises(RuntimeError, match="COURTLISTENER_API_TOKEN"):
+        await courtlistener.search("anything")
+
+
+async def test_search_max_results_caps_output(monkeypatch):
+    payload = json.dumps(_SEARCH_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await courtlistener.search("anything", max_results=1)
+
+    assert len(results) == 1
+
+
+async def test_rate_limit_gate_sleeps_within_interval(monkeypatch):
+    """Two concurrent search calls must both pass through the rate gate."""
+    clock = [100.0]
+
+    def fake_monotonic() -> float:
+        return clock[0]
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        clock[0] += seconds
+
+    monkeypatch.setattr(courtlistener.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(courtlistener.asyncio, "sleep", fake_sleep)
+
+    payload = json.dumps({"results": []})
+
+    def _respond(url, params):
+        return 200, payload
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    await asyncio.gather(
+        courtlistener.search("a"), courtlistener.search("b")
+    )
+
+    assert any(s > 0 for s in sleep_calls), (
+        f"expected at least one >0 sleep through the rate gate; got {sleep_calls!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+_OPINION_URL = (
+    "https://www.courtlistener.com/opinion/4341372/lozman-v-city-of-riviera-beach/"
+)
+_OPINION_API = "https://www.courtlistener.com/api/rest/v3/opinions/4341372/"
+
+_DOCKET_URL = "https://www.courtlistener.com/docket/555/united-states-v-acme/"
+_DOCKET_API = "https://www.courtlistener.com/api/rest/v3/dockets/555/"
+_DOCKET_ENTRIES_API = "https://www.courtlistener.com/api/rest/v3/docket-entries/"
+
+
+async def test_fetch_opinion_uses_plain_text(monkeypatch, cache_dir: Path):
+    opinion_payload = json.dumps(_OPINION_PAYLOAD)
+
+    def _respond(url, params):
+        if url == _OPINION_API:
+            return 200, opinion_payload
+        return 404, ""
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await courtlistener.fetch(_OPINION_URL)
+
+    assert source is not None
+    assert source.source_kind == "courtlistener"
+    assert source.url == _OPINION_URL
+    assert "probable cause" in source.cleaned_text
+    assert "First Amendment retaliation" in source.cleaned_text
+    assert source.metadata["court"] == "scotus"
+    assert source.metadata["docket_number"] == "17-21"
+    assert source.metadata["citation"] == "585 U.S. 87"
+    assert source.metadata["recap_available"] is False
+    assert _OPINION_API in captured["urls"]
+    # Cache file was written.
+    cached = list(cache_dir.glob("opinion-*.json"))
+    assert len(cached) == 1
+
+
+async def test_fetch_opinion_falls_back_to_html_when_no_plain_text(
+    monkeypatch, cache_dir: Path
+):
+    payload = dict(_OPINION_PAYLOAD)
+    payload["plain_text"] = ""
+    payload["html_with_citations"] = (
+        "<html><body><p>Falling back to extracted HTML body content with "
+        "enough text to be picked up by trafilatura's recall mode.</p></body></html>"
+    )
+
+    def _respond(url, params):
+        if url == _OPINION_API:
+            return 200, json.dumps(payload)
+        return 404, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await courtlistener.fetch(_OPINION_URL)
+
+    assert source is not None
+    assert "Falling back" in source.cleaned_text
+
+
+async def test_fetch_docket_paginates_entries_and_flags_missing_recap(
+    monkeypatch, cache_dir: Path
+):
+    docket_payload = json.dumps(_DOCKET_PAYLOAD)
+    entries_payload = json.dumps(_DOCKET_ENTRIES_PAYLOAD)
+
+    def _respond(url, params):
+        if url == _DOCKET_API:
+            return 200, docket_payload
+        if url == _DOCKET_ENTRIES_API:
+            assert params == {"docket": "555", "order_by": "entry_number"}
+            return 200, entries_payload
+        return 404, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await courtlistener.fetch(_DOCKET_URL)
+
+    assert source is not None
+    assert source.source_kind == "courtlistener"
+    assert "United States v. Acme" in source.cleaned_text
+    assert "## Entry 1" in source.cleaned_text
+    assert "## Entry 2" in source.cleaned_text
+    assert "COMPLAINT" in source.cleaned_text
+    # Entry 2 had an empty `recap_documents`, so the placeholder is rendered.
+    assert "no RECAP document available" in source.cleaned_text
+    assert source.metadata["court"] == "nysd"
+    assert source.metadata["docket_number"] == "1:23-cv-12345"
+    assert source.metadata["recap_available"] is True
+    assert source.metadata["entry_count"] == 2
+
+
+async def test_fetch_caches_api_response_on_second_call(
+    monkeypatch, cache_dir: Path
+):
+    opinion_payload = json.dumps(_OPINION_PAYLOAD)
+
+    def _respond(url, params):
+        if url == _OPINION_API:
+            return 200, opinion_payload
+        return 404, ""
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    s1 = await courtlistener.fetch(_OPINION_URL)
+    s2 = await courtlistener.fetch(_OPINION_URL)
+
+    assert s1 is not None
+    assert s2 is not None
+    # Only one network hit thanks to the JSON cache.
+    api_calls = [u for u in captured["urls"] if u == _OPINION_API]
+    assert len(api_calls) == 1
+
+
+async def test_fetch_returns_none_on_404(monkeypatch, cache_dir: Path):
+    def _respond(url, params):
+        return 404, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await courtlistener.fetch(_OPINION_URL) is None
+
+
+async def test_fetch_returns_none_on_transport_error(
+    monkeypatch, cache_dir: Path
+):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(courtlistener.httpx, "AsyncClient", _client_factory)
+
+    assert await courtlistener.fetch(_OPINION_URL) is None
+
+
+async def test_fetch_returns_none_on_unrecognised_url(
+    monkeypatch, cache_dir: Path
+):
+    assert (
+        await courtlistener.fetch("https://example.com/some-page")
+        is None
+    )
+    assert (
+        await courtlistener.fetch(
+            "https://www.courtlistener.com/random/path/"
+        )
+        is None
+    )
+
+
+async def test_fetch_token_missing_raises(monkeypatch, cache_dir: Path):
+    monkeypatch.delenv("COURTLISTENER_API_TOKEN", raising=False)
+
+    with pytest.raises(RuntimeError, match="COURTLISTENER_API_TOKEN"):
+        await courtlistener.fetch(_OPINION_URL)
+
+
+# ---------------------------------------------------------------------------
+# Smoke registration
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_registry_includes_courtlistener():
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "courtlistener" in TOOL_REGISTRY


### PR DESCRIPTION
Closes #93
Part of #107

## Summary

Automated implementation of **CourtListener / RECAP connector (federal court records)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

CourtListener connector fully implements issue #93 acceptance criteria; tests, lint, and mypy all pass.

- **INFO** [OPEN] `src/research_agent/orchestrator/loop.py`: Orchestrator loop has no courtlistener_search / courtlistener_fetch task handlers — connector is reachable via the smoke verb but not yet wired into the planner's dispatch table. This matches the established pattern (the EDGAR connector merged in the previous commit is in the same state) and is not part of this issue's AC, so noted as an INFO follow-up rather than a blocker.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*