### PR TITLE
feat: Federal Register API connector (federal rules + notices) (closes #102)

### DIFF
--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -146,6 +146,43 @@ def _smoke_courtlistener(query: str) -> str:
     return asyncio.run(_run())
 
 
+def _smoke_fedregister(query: str) -> str:
+    """Smoke wrapper: Federal Register search returning the top-5 hits.
+
+    Per AC #5: ``research _smoke-tool fedregister "AI executive order"`` should
+    surface federal rules / proposed rules / notices. Each line shows the
+    title, agencies, document type, publication date, significant flag,
+    permalink, and a short abstract snippet so an operator can eyeball
+    whether the Federal Register API is reachable.
+    """
+    from research_agent.tools import fedregister
+
+    async def _run() -> str:
+        results = await fedregister.search(query, max_results=5)
+        if not results:
+            return f"fedregister search returned no results for {query!r}"
+        lines: list[str] = []
+        for hit in results:
+            agencies = ", ".join(hit.extras.get("agencies") or []) or "?"
+            doc_type = hit.extras.get("document_type") or "?"
+            pub_date = (
+                hit.published_at.date().isoformat() if hit.published_at else "?"
+            )
+            significant = hit.extras.get("significant")
+            snippet = hit.snippet.replace("\n", " ")
+            if len(snippet) > 200:
+                snippet = snippet[:200] + "…"
+            lines.append(
+                f"- {hit.title} — {agencies} — {doc_type} — {pub_date} —"
+                f" significant={significant}\n"
+                f"  {hit.url}\n"
+                f"  {snippet}"
+            )
+        return "\n".join(lines)
+
+    return asyncio.run(_run())
+
+
 def _smoke_news(query: str) -> str:
     """Smoke wrapper: aggregate news hits and report per-source contributions.
 
@@ -352,6 +389,7 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "arxiv": _smoke_arxiv,
     "edgar": _smoke_edgar,
     "courtlistener": _smoke_courtlistener,
+    "fedregister": _smoke_fedregister,
     "news": _smoke_news,
     "reddit": _smoke_reddit,
     "pdf": _smoke_pdf,

--- a/src/research_agent/tools/fedregister.py
+++ b/src/research_agent/tools/fedregister.py
@@ -281,7 +281,11 @@ async def search(
 def _classify_url(url: str) -> str | None:
     """Return the document number when ``url`` is a Federal Register doc page."""
     parsed = urlparse(url)
-    if "federalregister.gov" not in (parsed.netloc or "").lower():
+    host = (parsed.netloc or "").lower().split(":", 1)[0]
+    # Strict host match so look-alikes like ``federalregister.gov.attacker.example``
+    # don't pass — the Source.url would otherwise leak the attacker domain
+    # downstream even though the body came from the official API.
+    if host != "federalregister.gov" and not host.endswith(".federalregister.gov"):
         return None
     m = _DOC_URL_RE.search(parsed.path or "")
     if not m:

--- a/src/research_agent/tools/fedregister.py
+++ b/src/research_agent/tools/fedregister.py
@@ -1,0 +1,425 @@
+"""Federal Register API connector (issue #102).
+
+Public surface:
+
+* ``async def search(query, *, since=None, agencies=None) -> list[SearchResult]``
+  hits ``federalregister.gov/api/v1/documents.json`` with optional date /
+  agency filters. Returns rules, proposed rules, and notices since 1994.
+* ``async def fetch(url, timeout=30.0) -> Source | None`` opens a document
+  page and returns markdown of the body text plus a significant-rule flag.
+
+No auth required. The API has no documented rate limit, but we throttle to
+≈2 RPS to stay polite. Pagination is capped at 2,000 results — the planner
+should narrow via date range or agency rather than loop pages here.
+
+Documents are immutable post-publication, so the API JSON for a given
+document is cached at ``corpus/.cache/fedregister/doc-<doc_number>.json``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import time
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+import httpx
+import trafilatura
+
+from research_agent import config
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://www.federalregister.gov/api/v1/"
+_SITE_BASE = "https://www.federalregister.gov"
+# No documented rate limit; ~2 RPS keeps us well within polite usage.
+_RATE_LIMIT_INTERVAL = 0.5
+_CACHE_DIR = Path("corpus/.cache/fedregister")
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+# Document URLs look like /documents/YYYY/MM/DD/<doc_number>/<slug>
+_DOC_URL_RE = re.compile(
+    r"/documents/\d{4}/\d{2}/\d{2}/(?P<doc>[A-Za-z0-9\-]+)(?:/|$)"
+)
+
+_SEARCH_FIELDS = (
+    "document_number",
+    "title",
+    "abstract",
+    "publication_date",
+    "html_url",
+    "document_type",
+    "agencies",
+    "significant",
+)
+
+_rate_lock = asyncio.Lock()
+_last_call_monotonic: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Accept": "application/json",
+        "User-Agent": config.get("RESEARCH_USER_AGENT")
+        or "research-agent/0.1 (+local; contact unset)",
+    }
+
+
+async def _rate_limit_gate() -> None:
+    """Block until at least ``_RATE_LIMIT_INTERVAL`` has passed since the last call."""
+    global _last_call_monotonic
+    async with _rate_lock:
+        if _last_call_monotonic is not None:
+            elapsed = time.monotonic() - _last_call_monotonic
+            wait = _RATE_LIMIT_INTERVAL - elapsed
+            if wait > 0:
+                await asyncio.sleep(wait)
+        _last_call_monotonic = time.monotonic()
+
+
+def _strip_html(html: str) -> str:
+    return _WS_RE.sub(" ", _TAG_RE.sub(" ", html)).strip()
+
+
+def _extract_html_text(html: str) -> str:
+    if not html:
+        return ""
+    try:
+        extracted = trafilatura.extract(
+            html,
+            include_comments=False,
+            include_tables=True,
+            favor_recall=True,
+        )
+    except Exception:  # noqa: BLE001 — never crash on extractor errors
+        extracted = None
+    if extracted and extracted.strip():
+        return extracted.strip()
+    return _strip_html(html)
+
+
+def _parse_iso_date(value: Any) -> datetime | None:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=UTC)
+    text = str(value).strip()
+    if not text:
+        return None
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%d"):
+        try:
+            parsed = datetime.strptime(text, fmt)
+            return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed
+        except ValueError:
+            continue
+    head = text.split("T", 1)[0]
+    try:
+        return datetime.strptime(head, "%Y-%m-%d").replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def _coerce_since_to_iso(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    text = str(value).strip()
+    if not text:
+        return None
+    # Accept anything _parse_iso_date can chew on; emit YYYY-MM-DD.
+    parsed = _parse_iso_date(text)
+    if parsed is not None:
+        return parsed.date().isoformat()
+    return text
+
+
+def _agency_names(raw: Any) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    out: list[str] = []
+    for entry in raw:
+        if isinstance(entry, dict):
+            name = entry.get("name") or entry.get("raw_name")
+            if isinstance(name, str) and name.strip():
+                out.append(name.strip())
+        elif isinstance(entry, str) and entry.strip():
+            out.append(entry.strip())
+    return out
+
+
+def _build_search_result(hit: dict[str, Any]) -> SearchResult | None:
+    url = hit.get("html_url") or ""
+    if not url:
+        return None
+    title = hit.get("title") or url
+    abstract = (hit.get("abstract") or "").strip()
+    snippet = abstract if abstract else str(title)
+    published_at = _parse_iso_date(hit.get("publication_date"))
+
+    extras: dict[str, Any] = {
+        "agencies": _agency_names(hit.get("agencies")),
+        "document_type": hit.get("document_type") or "",
+        "document_number": hit.get("document_number") or "",
+        "significant": bool(hit.get("significant")),
+    }
+
+    return SearchResult(
+        url=url,
+        title=str(title),
+        snippet=snippet,
+        published_at=published_at,
+        source_kind="fedregister",
+        extras=extras,
+    )
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def search(
+    query: str,
+    *,
+    since: date | datetime | str | None = None,
+    agencies: list[str] | None = None,
+    max_results: int = 20,
+    timeout: float = 15.0,
+) -> list[SearchResult]:
+    """Run a Federal Register search and return up to ``max_results`` hits.
+
+    ``since`` accepts a ``date``, ``datetime``, or ISO ``YYYY-MM-DD`` string and
+    maps to ``conditions[publication_date][gte]``. ``agencies`` is a list of
+    agency slugs (e.g. ``["environmental-protection-agency"]``) emitted as
+    repeated ``conditions[agencies][]`` params.
+
+    The endpoint paginates results at 2,000 max — narrow via date range when
+    needed; this connector never loops pages on the user's behalf.
+
+    Returns ``[]`` on transport / HTTP error / non-JSON body — connector
+    failures must never crash the planner.
+    """
+    params: list[tuple[str, Any]] = [("conditions[term]", query)]
+
+    iso_since = _coerce_since_to_iso(since)
+    if iso_since:
+        params.append(("conditions[publication_date][gte]", iso_since))
+
+    if agencies:
+        for slug in agencies:
+            if isinstance(slug, str) and slug.strip():
+                params.append(("conditions[agencies][]", slug.strip()))
+
+    per_page = max(1, min(max_results, 200))
+    params.append(("per_page", per_page))
+    for field in _SEARCH_FIELDS:
+        params.append(("fields[]", field))
+
+    await _rate_limit_gate()
+
+    url = urljoin(_BASE_URL, "documents.json")
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=_headers(),
+        ) as client:
+            response = await client.get(url, params=params)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("fedregister search failed for %r: %s", query, exc)
+        return []
+
+    if response.status_code != 200:
+        logger.warning(
+            "fedregister search returned HTTP %s for %r",
+            response.status_code,
+            query,
+        )
+        return []
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        logger.warning(
+            "fedregister search returned non-JSON for %r: %s", query, exc
+        )
+        return []
+
+    raw_hits = payload.get("results") or []
+    out: list[SearchResult] = []
+    for hit in raw_hits[:max_results]:
+        if not isinstance(hit, dict):
+            continue
+        result = _build_search_result(hit)
+        if result is not None:
+            out.append(result)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+def _classify_url(url: str) -> str | None:
+    """Return the document number when ``url`` is a Federal Register doc page."""
+    parsed = urlparse(url)
+    if "federalregister.gov" not in (parsed.netloc or "").lower():
+        return None
+    m = _DOC_URL_RE.search(parsed.path or "")
+    if not m:
+        return None
+    return m.group("doc")
+
+
+def _cache_path(doc_number: str) -> Path:
+    safe = doc_number.replace("/", "_")
+    return _CACHE_DIR / f"doc-{safe}.json"
+
+
+def _write_cache(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _load_cache(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+async def _http_get_json(
+    url: str, timeout: float
+) -> tuple[int | None, dict[str, Any] | None]:
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=_headers(),
+        ) as client:
+            response = await client.get(url)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("fedregister fetch failed for %s: %s", url, exc)
+        return None, None
+    if response.status_code != 200:
+        return response.status_code, None
+    try:
+        return response.status_code, response.json()
+    except ValueError:
+        return response.status_code, None
+
+
+def _document_body(payload: dict[str, Any]) -> str:
+    body_html = payload.get("body_html")
+    if isinstance(body_html, str) and body_html.strip():
+        extracted = _extract_html_text(body_html)
+        if extracted:
+            return extracted
+    abstract = payload.get("abstract")
+    if isinstance(abstract, str) and abstract.strip():
+        return abstract.strip()
+    return ""
+
+
+async def fetch(url: str, timeout: float = 30.0) -> Source | None:
+    """Open a Federal Register document page and return a :class:`Source`.
+
+    The URL is classified via the path ``/documents/YYYY/MM/DD/<doc>/<slug>``;
+    any URL not matching that shape (or pointing outside federalregister.gov)
+    returns ``None``. The doc detail JSON is cached at
+    ``corpus/.cache/fedregister/doc-<doc_number>.json`` so repeated fetches
+    skip the network entirely.
+
+    Markdown body prefers ``body_html`` (extracted via trafilatura w/
+    favor_recall=True) and falls back to ``abstract``. Returns ``None`` for
+    transport / HTTP / parse failures.
+    """
+    if not url:
+        return None
+    doc_number = _classify_url(url)
+    if not doc_number:
+        return None
+
+    cache = _cache_path(doc_number)
+    payload = _load_cache(cache)
+    if payload is None:
+        await _rate_limit_gate()
+        api_url = urljoin(_BASE_URL, f"documents/{doc_number}.json")
+        status, payload = await _http_get_json(api_url, timeout)
+        if status is None or status >= 400 or not isinstance(payload, dict):
+            if status is not None and status >= 400:
+                logger.warning(
+                    "fedregister doc HTTP %s for %s", status, api_url
+                )
+            return None
+        _write_cache(cache, payload)
+
+    title = payload.get("title") or url
+    body = _document_body(payload)
+    if not body:
+        return None
+
+    publication_date = payload.get("publication_date") or ""
+    document_type = payload.get("document_type") or ""
+    agency_names = _agency_names(payload.get("agencies"))
+    agencies_line = ", ".join(agency_names) if agency_names else "—"
+    metadata_line = (
+        f"_{document_type or 'Document'} · {publication_date or '?'} · "
+        f"{agencies_line}_"
+    )
+
+    cleaned_text = f"# {title}\n\n{metadata_line}\n\n{body}".strip()
+
+    metadata: dict[str, Any] = {
+        "document_number": doc_number,
+        "document_type": document_type,
+        "publication_date": publication_date,
+        "agencies": agency_names,
+        "significant": bool(payload.get("significant")),
+        "html_url": payload.get("html_url") or url,
+        "pdf_url": payload.get("pdf_url") or "",
+        "public_inspection_pdf_url": payload.get("public_inspection_pdf_url")
+        or "",
+    }
+
+    return Source(
+        url=url,
+        title=str(title),
+        cleaned_text=cleaned_text,
+        raw_html=None,
+        fetched_at=datetime.now(UTC),
+        source_kind="fedregister",
+        metadata=metadata,
+    )
+
+
+def reset_for_tests() -> None:
+    """Clear per-process rate-limit state. Test-only."""
+    global _last_call_monotonic, _rate_lock
+    _last_call_monotonic = None
+    _rate_lock = asyncio.Lock()
+
+
+__all__ = ["fetch", "reset_for_tests", "search"]

--- a/src/research_agent/tools/models.py
+++ b/src/research_agent/tools/models.py
@@ -34,6 +34,7 @@ SourceKind = Literal[
     "sec",
     "fec",
     "courtlistener",
+    "fedregister",
 ]
 
 

--- a/tests/test_tools_fedregister.py
+++ b/tests/test_tools_fedregister.py
@@ -368,6 +368,15 @@ async def test_fetch_returns_none_for_unknown_host(
     assert await fedregister.fetch("https://example.com/some-page") is None
 
 
+async def test_fetch_rejects_lookalike_host(monkeypatch, cache_dir: Path):
+    """A subdomain spoof like ``federalregister.gov.evil.example`` must not pass."""
+    spoof = (
+        "https://federalregister.gov.evil.example/"
+        "documents/2023/11/01/2023-28147/safe-secure"
+    )
+    assert await fedregister.fetch(spoof) is None
+
+
 async def test_fetch_returns_none_for_non_doc_path(
     monkeypatch, cache_dir: Path
 ):

--- a/tests/test_tools_fedregister.py
+++ b/tests/test_tools_fedregister.py
@@ -1,0 +1,433 @@
+"""Tests for `research_agent.tools.fedregister` (issue #102)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from datetime import date
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from research_agent.tools import fedregister
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    fedregister.reset_for_tests()
+    monkeypatch.setattr(fedregister.asyncio, "sleep", AsyncMock())
+    yield
+    fedregister.reset_for_tests()
+
+
+@pytest.fixture
+def cache_dir(tmp_path: Path, monkeypatch) -> Path:
+    target = tmp_path / "fedregister-cache"
+    monkeypatch.setattr(fedregister, "_CACHE_DIR", target)
+    return target
+
+
+_SEARCH_PAYLOAD = {
+    "count": 2,
+    "results": [
+        {
+            "document_number": "2023-28147",
+            "title": "Safe, Secure, and Trustworthy Development and Use of AI",
+            "abstract": (
+                "Executive Order on the Safe, Secure, and Trustworthy "
+                "Development and Use of Artificial Intelligence."
+            ),
+            "publication_date": "2023-11-01",
+            "html_url": (
+                "https://www.federalregister.gov/documents/2023/11/01/"
+                "2023-28147/safe-secure-and-trustworthy-development-and-use-of-ai"
+            ),
+            "document_type": "Presidential Document",
+            "agencies": [
+                {"name": "Executive Office of the President", "raw_name": "EOP"}
+            ],
+            "significant": True,
+        },
+        {
+            "document_number": "2024-99999",
+            "title": "AI Notice of Inquiry",
+            "abstract": "",
+            "publication_date": "2024-02-15",
+            "html_url": (
+                "https://www.federalregister.gov/documents/2024/02/15/"
+                "2024-99999/ai-notice-of-inquiry"
+            ),
+            "document_type": "Notice",
+            "agencies": [
+                {"name": "Department of Commerce", "raw_name": "DOC"}
+            ],
+            "significant": False,
+        },
+    ],
+}
+
+
+_DOC_NUMBER = "2023-28147"
+_DOC_URL = (
+    "https://www.federalregister.gov/documents/2023/11/01/"
+    "2023-28147/safe-secure-and-trustworthy-development-and-use-of-ai"
+)
+_DOC_API = (
+    "https://www.federalregister.gov/api/v1/documents/2023-28147.json"
+)
+
+_DOC_PAYLOAD = {
+    "document_number": "2023-28147",
+    "title": "Safe, Secure, and Trustworthy Development and Use of AI",
+    "abstract": "Short abstract about the executive order.",
+    "publication_date": "2023-11-01",
+    "html_url": _DOC_URL,
+    "pdf_url": "https://www.federalregister.gov/d/2023-28147.pdf",
+    "public_inspection_pdf_url": "",
+    "document_type": "Presidential Document",
+    "agencies": [{"name": "Executive Office of the President", "raw_name": "EOP"}],
+    "significant": True,
+    "body_html": (
+        "<html><body><p>Section 1 of the executive order directs agencies "
+        "to coordinate AI safety standards, model evaluations, and reporting "
+        "requirements across the federal government.</p></body></html>"
+    ),
+}
+
+
+def _patch_httpx(monkeypatch, *, responder):
+    """Replace ``httpx.AsyncClient`` with a fake driven by ``responder(url, params)``.
+
+    Returns ``(status_code, body_text)``.
+    """
+    captured: dict[str, list] = {"urls": [], "headers": [], "params": []}
+
+    class _FakeResp:
+        def __init__(self, status: int, text: str) -> None:
+            self.status_code = status
+            self.text = text
+
+        def json(self):
+            return json.loads(self.text)
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        captured["headers"].append(kwargs.get("headers"))
+
+        class _Client:
+            async def get(self, url, *, params=None, **_kwargs):
+                captured["urls"].append(url)
+                captured["params"].append(params)
+                status, text = responder(url, params)
+                return _FakeResp(status, text)
+
+        yield _Client()
+
+    monkeypatch.setattr(fedregister.httpx, "AsyncClient", _client_factory)
+    return captured
+
+
+def _params_to_pairs(params) -> list[tuple[str, object]]:
+    """Normalise the captured params (which are passed as a list of tuples) to a list."""
+    if params is None:
+        return []
+    if isinstance(params, dict):
+        return list(params.items())
+    return list(params)
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def test_search_builds_correct_query_and_headers(monkeypatch):
+    payload = json.dumps(_SEARCH_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await fedregister.search(
+        "AI executive order",
+        since=date(2023, 1, 1),
+        agencies=[
+            "executive-office-of-the-president",
+            "department-of-commerce",
+        ],
+    )
+
+    assert len(results) == 2
+    headers = captured["headers"][0]
+    assert headers["Accept"] == "application/json"
+    assert headers["User-Agent"]
+    assert captured["urls"][0].endswith("/api/v1/documents.json")
+
+    pairs = _params_to_pairs(captured["params"][0])
+    keys = [k for k, _ in pairs]
+
+    assert ("conditions[term]", "AI executive order") in pairs
+    assert ("conditions[publication_date][gte]", "2023-01-01") in pairs
+
+    agency_values = [v for k, v in pairs if k == "conditions[agencies][]"]
+    assert agency_values == [
+        "executive-office-of-the-president",
+        "department-of-commerce",
+    ]
+
+    assert "per_page" in keys
+    fields = [v for k, v in pairs if k == "fields[]"]
+    assert "document_number" in fields
+    assert "title" in fields
+    assert "html_url" in fields
+    assert "agencies" in fields
+    assert "significant" in fields
+
+
+async def test_search_parses_results(monkeypatch):
+    payload = json.dumps(_SEARCH_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await fedregister.search("AI executive order")
+
+    first = results[0]
+    assert first.source_kind == "fedregister"
+    assert first.url == _DOC_URL
+    assert first.title.startswith("Safe, Secure")
+    assert "Executive Order" in first.snippet
+    assert first.published_at is not None
+    assert first.published_at.year == 2023
+    assert first.extras["document_type"] == "Presidential Document"
+    assert first.extras["document_number"] == "2023-28147"
+    assert first.extras["significant"] is True
+    assert first.extras["agencies"] == [
+        "Executive Office of the President"
+    ]
+
+    second = results[1]
+    # Empty abstract -> snippet falls back to the title.
+    assert second.snippet == second.title
+    assert second.extras["significant"] is False
+
+
+async def test_search_without_since_or_agencies_omits_those_params(monkeypatch):
+    payload = json.dumps({"results": []})
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    await fedregister.search("anything")
+
+    pairs = _params_to_pairs(captured["params"][0])
+    keys = [k for k, _ in pairs]
+    assert "conditions[publication_date][gte]" not in keys
+    assert "conditions[agencies][]" not in keys
+
+
+async def test_search_since_accepts_iso_string(monkeypatch):
+    payload = json.dumps({"results": []})
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    await fedregister.search("anything", since="2024-05-01")
+
+    pairs = _params_to_pairs(captured["params"][0])
+    assert ("conditions[publication_date][gte]", "2024-05-01") in pairs
+
+
+async def test_search_returns_empty_on_500(monkeypatch):
+    def _respond(url, params):
+        return 500, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await fedregister.search("anything") == []
+
+
+async def test_search_returns_empty_on_transport_error(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(fedregister.httpx, "AsyncClient", _client_factory)
+
+    assert await fedregister.search("anything") == []
+
+
+async def test_search_returns_empty_on_non_json(monkeypatch):
+    def _respond(url, params):
+        return 200, "<html>not json</html>"
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await fedregister.search("anything") == []
+
+
+async def test_rate_limit_gate_sleeps_within_interval(monkeypatch):
+    """Two concurrent search calls must both pass through the rate gate."""
+    clock = [100.0]
+
+    def fake_monotonic() -> float:
+        return clock[0]
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        clock[0] += seconds
+
+    monkeypatch.setattr(fedregister.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(fedregister.asyncio, "sleep", fake_sleep)
+
+    payload = json.dumps({"results": []})
+
+    def _respond(url, params):
+        return 200, payload
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    await asyncio.gather(
+        fedregister.search("a"), fedregister.search("b")
+    )
+
+    assert any(s > 0 for s in sleep_calls), (
+        f"expected at least one >0 sleep through the rate gate; got {sleep_calls!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_happy_path_builds_markdown_and_caches(
+    monkeypatch, cache_dir: Path
+):
+    doc_payload = json.dumps(_DOC_PAYLOAD)
+
+    def _respond(url, params):
+        if url == _DOC_API:
+            return 200, doc_payload
+        return 404, ""
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await fedregister.fetch(_DOC_URL)
+
+    assert source is not None
+    assert source.source_kind == "fedregister"
+    assert source.url == _DOC_URL
+    assert source.title.startswith("Safe, Secure")
+    assert source.cleaned_text.startswith("# Safe, Secure")
+    assert "Section 1 of the executive order" in source.cleaned_text
+    assert "Presidential Document" in source.cleaned_text
+    assert "2023-11-01" in source.cleaned_text
+    assert "Executive Office of the President" in source.cleaned_text
+    assert source.metadata["document_number"] == "2023-28147"
+    assert source.metadata["significant"] is True
+    assert source.metadata["agencies"] == [
+        "Executive Office of the President"
+    ]
+    assert source.metadata["pdf_url"].endswith("2023-28147.pdf")
+
+    cached = list(cache_dir.glob("doc-*.json"))
+    assert len(cached) == 1
+
+    # Second call serves from cache — no second HTTP hit.
+    api_calls_before = [u for u in captured["urls"] if u == _DOC_API]
+    s2 = await fedregister.fetch(_DOC_URL)
+    assert s2 is not None
+    api_calls_after = [u for u in captured["urls"] if u == _DOC_API]
+    assert len(api_calls_after) == len(api_calls_before)
+
+
+async def test_fetch_returns_none_for_unknown_host(
+    monkeypatch, cache_dir: Path
+):
+    assert await fedregister.fetch("https://example.com/some-page") is None
+
+
+async def test_fetch_returns_none_for_non_doc_path(
+    monkeypatch, cache_dir: Path
+):
+    assert (
+        await fedregister.fetch("https://www.federalregister.gov/agencies")
+        is None
+    )
+
+
+async def test_fetch_returns_none_on_404(monkeypatch, cache_dir: Path):
+    def _respond(url, params):
+        return 404, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await fedregister.fetch(_DOC_URL) is None
+
+
+async def test_fetch_returns_none_on_transport_error(
+    monkeypatch, cache_dir: Path
+):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(fedregister.httpx, "AsyncClient", _client_factory)
+
+    assert await fedregister.fetch(_DOC_URL) is None
+
+
+async def test_fetch_falls_back_to_abstract_when_no_body_html(
+    monkeypatch, cache_dir: Path
+):
+    payload = dict(_DOC_PAYLOAD)
+    payload["body_html"] = ""
+    payload["abstract"] = "Bare abstract text used because body_html is empty."
+
+    def _respond(url, params):
+        if url == _DOC_API:
+            return 200, json.dumps(payload)
+        return 404, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await fedregister.fetch(_DOC_URL)
+
+    assert source is not None
+    assert "Bare abstract text" in source.cleaned_text
+
+
+# ---------------------------------------------------------------------------
+# Smoke registration
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_registry_includes_fedregister():
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "fedregister" in TOOL_REGISTRY

--- a/tests/test_tools_models.py
+++ b/tests/test_tools_models.py
@@ -28,6 +28,7 @@ EXPECTED_SOURCE_KINDS = (
     "sec",
     "fec",
     "courtlistener",
+    "fedregister",
 )
 
 


### PR DESCRIPTION
Closes #102
Part of #107

## Summary

Automated implementation of **Federal Register API connector (federal rules + notices)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Federal Register connector meets all AC; tightened a loose host check in _classify_url that could let lookalike domains spoof Source.url.

- **WARNING** [FIXED] `src/research_agent/tools/fedregister.py`: _classify_url used a substring match (`'federalregister.gov' in netloc`), so URLs like https://federalregister.gov.attacker.example/documents/.../<doc>/... passed through and would be returned as Source.url even though the body came from the trusted API. Tightened to require exact 'federalregister.gov' or a real subdomain; added test_fetch_rejects_lookalike_host.
- **INFO** [OPEN] `src/research_agent/orchestrator/loop.py`: Federal Register orchestrator wiring (TaskKind 'fedregister_search' / handler in default_handlers) is not present, so the planner cannot dispatch fedregister tasks yet. Out of scope for #102 (the AC only require search/fetch + smoke); same status as edgar/courtlistener which landed in earlier issues.
- **INFO** [OPEN] `README.md`: README's 'Tool registry probes' example block still lists only web_search/web_fetch/arxiv/news; new connectors (edgar, courtlistener, fedregister) are not mentioned. Pre-existing doc gap that pre-dates this issue, not a regression.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*