### PR TITLE
feat: FEC OpenFEC connector (federal campaign finance) (closes #94)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,9 @@ RESEARCH_DAEMON_PROGRESS=
 # capped at 5,000 req/hr — the anonymous tier is throttled to the point of
 # unusability, so `tools/courtlistener.py` requires this token to be set.
 COURTLISTENER_API_TOKEN=
+
+# Optional: api.data.gov API key used by `tools/fec.py` (OpenFEC). Sign up
+# free at https://api.data.gov/signup/. Authenticated tier is 1,000 req/hr;
+# when unset the connector falls back to `DEMO_KEY` which is throttled to
+# ~40 req/hr per IP — fine for `_smoke-tool` runs but not for real workloads.
+DATA_GOV_API_KEY=

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ that list, so there is no drift.
 | `YOUTUBE_API_KEY` | no | YouTube Data API v3 key (free quota: 10,000 units/day). When set, `tools/youtube.py:search` uses the official API; absent, it falls back to scraping the public results page via Playwright. |
 | `RESEARCH_DAEMON_PROGRESS` | no | Set to `0` to suppress the foreground Rich progress bar the daemon writes to stdout when run interactively. |
 | `COURTLISTENER_API_TOKEN` | no | CourtListener API token (free w/ signup) — required by `tools/courtlistener.py`. Authenticated tier is 5,000 req/hr; anonymous traffic is throttled to the point of unusability. |
+| `DATA_GOV_API_KEY` | no | api.data.gov key (free w/ signup at <https://api.data.gov/signup/>) — used by `tools/fec.py` (OpenFEC). Authenticated tier is 1,000 req/hr; falls back to `DEMO_KEY` (~40 req/hr per IP) when unset. |
 
 ## LM Studio
 

--- a/src/research_agent/config.py
+++ b/src/research_agent/config.py
@@ -99,6 +99,15 @@ EXPECTED_ENV_KEYS: tuple[EnvKey, ...] = (
             " point of unusability."
         ),
     ),
+    EnvKey(
+        name="DATA_GOV_API_KEY",
+        required=False,
+        description=(
+            "api.data.gov key used by tools/fec.py (OpenFEC). Authenticated"
+            " tier: 1,000 req/hr; falls back to DEMO_KEY (~40 req/hr per IP)"
+            " when unset. Free signup at https://api.data.gov/signup/."
+        ),
+    ),
 )
 
 

--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -217,13 +217,12 @@ def _smoke_nonprofits(query: str) -> str:
 
 
 def _smoke_fec(query: str) -> str:
-    """Smoke wrapper: FEC OpenFEC candidate search returning the top-5 hits.
+    """Smoke wrapper: FEC OpenFEC candidate search + top-hit cycle totals.
 
     Per AC: ``research _smoke-tool fec "George Santos"`` should surface the
-    candidate record + cycle totals. Each line shows the candidate name,
-    candidate ID, party, state, office, election years, permalink, and
-    snippet so an operator can eyeball whether the OpenFEC API is reachable
-    and the api.data.gov key is healthy.
+    candidate record + cycle totals. Lists the top-5 search hits, then
+    follows up on the top hit with ``fetch()`` so an operator can eyeball
+    receipts / disbursements / cash-on-hand alongside the candidate record.
     """
     from research_agent.tools import fec
 
@@ -248,6 +247,21 @@ def _smoke_fec(query: str) -> str:
                 f"  {hit.url}\n"
                 f"  {snippet}"
             )
+
+        top = results[0]
+        source = await fec.fetch(top.url)
+        if source is None:
+            lines.append(f"\nfetch({top.url}) returned None — cycle totals unavailable")
+        else:
+            totals = source.metadata.get("cycle_totals") or {}
+            cycle = totals.get("cycle")
+            header = f"\nCycle totals for {top.title} ({cycle})" if cycle else (
+                f"\nCycle totals for {top.title}"
+            )
+            lines.append(header)
+            lines.append(f"  receipts: {totals.get('receipts')}")
+            lines.append(f"  disbursements: {totals.get('disbursements')}")
+            lines.append(f"  cash_on_hand_end_period: {totals.get('cash_on_hand_end_period')}")
         return "\n".join(lines)
 
     return asyncio.run(_run())

--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -216,6 +216,43 @@ def _smoke_nonprofits(query: str) -> str:
     return asyncio.run(_run())
 
 
+def _smoke_fec(query: str) -> str:
+    """Smoke wrapper: FEC OpenFEC candidate search returning the top-5 hits.
+
+    Per AC: ``research _smoke-tool fec "George Santos"`` should surface the
+    candidate record + cycle totals. Each line shows the candidate name,
+    candidate ID, party, state, office, election years, permalink, and
+    snippet so an operator can eyeball whether the OpenFEC API is reachable
+    and the api.data.gov key is healthy.
+    """
+    from research_agent.tools import fec
+
+    async def _run() -> str:
+        results = await fec.search(query, kind="candidates", max_results=5)
+        if not results:
+            return f"fec search returned no results for {query!r}"
+        lines: list[str] = []
+        for hit in results:
+            cand_id = hit.extras.get("candidate_id") or "?"
+            party = hit.extras.get("party") or "?"
+            state = hit.extras.get("state") or "?"
+            office = hit.extras.get("office") or "?"
+            cycles = hit.extras.get("election_years") or []
+            cycles_str = ", ".join(str(c) for c in cycles) if cycles else "?"
+            snippet = hit.snippet.replace("\n", " ")
+            if len(snippet) > 200:
+                snippet = snippet[:200] + "…"
+            lines.append(
+                f"- {hit.title} — {cand_id} — {party} — {state} — {office} —"
+                f" cycles {cycles_str}\n"
+                f"  {hit.url}\n"
+                f"  {snippet}"
+            )
+        return "\n".join(lines)
+
+    return asyncio.run(_run())
+
+
 def _smoke_news(query: str) -> str:
     """Smoke wrapper: aggregate news hits and report per-source contributions.
 
@@ -424,6 +461,7 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "courtlistener": _smoke_courtlistener,
     "fedregister": _smoke_fedregister,
     "nonprofits": _smoke_nonprofits,
+    "fec": _smoke_fec,
     "news": _smoke_news,
     "reddit": _smoke_reddit,
     "pdf": _smoke_pdf,

--- a/src/research_agent/tools/fec.py
+++ b/src/research_agent/tools/fec.py
@@ -1,0 +1,895 @@
+"""FEC OpenFEC connector (issue #94).
+
+Public surface:
+
+* ``async def search(query, *, kind="candidates", max_results=20) -> list[SearchResult]``
+  hits ``api.open.fec.gov/v1/`` for candidates, committees, individual contributions
+  (``schedules/schedule_a``) or independent expenditures (``schedules/schedule_e``).
+* ``async def fetch(url) -> Source | None`` opens a candidate or committee detail
+  page on ``www.fec.gov/data/`` and returns rolled-up cycle totals, top donors,
+  and top expenditures.
+
+Auth: api.data.gov key in ``DATA_GOV_API_KEY`` (free signup at
+https://api.data.gov/signup/). Authenticated tier is 1,000 req/hr; falling back
+to ``DEMO_KEY`` works for smoke but is throttled to ~40 req/hr per IP and emits
+a warning. Key is passed via the ``api_key`` query parameter.
+
+Per AC, response JSON is cached at ``corpus/.cache/fec/<kind>-<id>.json`` with a
+1-hour TTL (mtime check) — bulk files refresh daily upstream and the ProPublica
+real-time mirror is 15-min stale, so an hour is a safe ceiling.
+
+For bulk historical analysis (donors-by-state, FECfile-grade dumps) point
+operators at https://www.fec.gov/data/browse-data/ — the connector itself
+stays REST-only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import time
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from research_agent import config
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.open.fec.gov/v1/"
+_SITE_BASE = "https://www.fec.gov/data/"
+# 1000 req/hr authenticated => ~3.6s; round to 4s for headroom. Anonymous
+# DEMO_KEY only practical for smoke (~40 req/hr per IP).
+_RATE_LIMIT_INTERVAL = 4.0
+_CACHE_DIR = Path("corpus/.cache/fec")
+# Per AC: 1-hour TTL — bulk files refresh daily; ProPublica real-time mirror
+# is 15-min stale; an hour is a safe ceiling.
+_CACHE_TTL = 3600.0
+
+_VALID_KINDS = {
+    "candidates",
+    "committees",
+    "schedules/schedule_a",
+    "schedules/schedule_e",
+}
+
+# Candidate IDs: letter prefix (H/S/P) + 8 digits typically; allow alphanumeric.
+# Committee IDs: C + 8 digits typically; allow alphanumeric to be tolerant.
+_CANDIDATE_URL_RE = re.compile(
+    r"^/data/candidate/(?P<id>[A-Za-z0-9]+)/?$"
+)
+_COMMITTEE_URL_RE = re.compile(
+    r"^/data/committee/(?P<id>[A-Za-z0-9]+)/?$"
+)
+
+_rate_lock = asyncio.Lock()
+_last_call_monotonic: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Config / rate-limit helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_api_key() -> str:
+    """Return the configured api.data.gov key, falling back to DEMO_KEY.
+
+    DEMO_KEY is throttled to ~40 req/hr per IP — fine for `_smoke-tool` runs
+    but it will fall over under any real workload, so emit a warning so
+    operators see why the connector mysteriously starts returning [].
+    """
+    raw = config.get("DATA_GOV_API_KEY") or ""
+    key = raw.strip()
+    if not key:
+        logger.warning(
+            "DATA_GOV_API_KEY not set — falling back to DEMO_KEY (40 req/hr "
+            "per IP). Sign up at https://api.data.gov/signup/ for the 1000 "
+            "req/hr authenticated tier."
+        )
+        return "DEMO_KEY"
+    return key
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Accept": "application/json",
+        "User-Agent": config.get("RESEARCH_USER_AGENT")
+        or "research-agent/0.1 (+local; contact unset)",
+    }
+
+
+async def _rate_limit_gate() -> None:
+    """Block until at least ``_RATE_LIMIT_INTERVAL`` has passed since the last call."""
+    global _last_call_monotonic
+    async with _rate_lock:
+        if _last_call_monotonic is not None:
+            elapsed = time.monotonic() - _last_call_monotonic
+            wait = _RATE_LIMIT_INTERVAL - elapsed
+            if wait > 0:
+                await asyncio.sleep(wait)
+        _last_call_monotonic = time.monotonic()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso_date(value: Any) -> datetime | None:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=UTC)
+    text = str(value).strip()
+    if not text:
+        return None
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%d"):
+        try:
+            parsed = datetime.strptime(text, fmt)
+            return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed
+        except ValueError:
+            continue
+    head = text.split("T", 1)[0]
+    try:
+        return datetime.strptime(head, "%Y-%m-%d").replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def _fmt_money(value: Any) -> str:
+    try:
+        # Allow floats in totals (api returns floats); render as integer dollars.
+        return f"${int(round(float(value))):,}"
+    except (TypeError, ValueError):
+        return "—"
+
+
+def _candidate_url(candidate_id: str) -> str:
+    return f"{_SITE_BASE}candidate/{candidate_id}/"
+
+
+def _committee_url(committee_id: str) -> str:
+    return f"{_SITE_BASE}committee/{committee_id}/"
+
+
+# ---------------------------------------------------------------------------
+# search() result builders
+# ---------------------------------------------------------------------------
+
+
+def _build_candidate_result(hit: dict[str, Any]) -> SearchResult | None:
+    cand_id = (hit.get("candidate_id") or "").strip()
+    name = (hit.get("name") or "").strip()
+    if not cand_id or not name:
+        return None
+    party = (hit.get("party") or "").strip()
+    state = (hit.get("state") or "").strip()
+    office = (hit.get("office_full") or hit.get("office") or "").strip()
+    incumbent = (hit.get("incumbent_challenge_full") or "").strip()
+    election_years = hit.get("election_years") or []
+    if not isinstance(election_years, list):
+        election_years = []
+
+    bits = [name]
+    if party:
+        bits.append(party)
+    if state:
+        bits.append(state)
+    if office:
+        bits.append(office)
+    if incumbent:
+        bits.append(incumbent)
+    snippet = " — ".join(bits)
+
+    extras: dict[str, Any] = {
+        "candidate_id": cand_id,
+        "party": party,
+        "state": state,
+        "office": office,
+        "office_full": office,
+        "incumbent_challenge_full": incumbent,
+        "election_years": election_years,
+    }
+    return SearchResult(
+        url=_candidate_url(cand_id),
+        title=name,
+        snippet=snippet,
+        published_at=None,
+        source_kind="fec",
+        extras=extras,
+    )
+
+
+def _build_committee_result(hit: dict[str, Any]) -> SearchResult | None:
+    com_id = (hit.get("committee_id") or "").strip()
+    name = (hit.get("name") or "").strip()
+    if not com_id or not name:
+        return None
+    committee_type = (hit.get("committee_type_full") or "").strip()
+    designation = (hit.get("designation_full") or "").strip()
+    org_type = (hit.get("organization_type_full") or hit.get("organization_type") or "").strip()
+    party = (hit.get("party_full") or hit.get("party") or "").strip()
+    state = (hit.get("state") or "").strip()
+
+    bits = [name]
+    if committee_type:
+        bits.append(committee_type)
+    if designation:
+        bits.append(designation)
+    if state:
+        bits.append(state)
+    snippet = " — ".join(bits)
+
+    extras: dict[str, Any] = {
+        "committee_id": com_id,
+        "committee_type_full": committee_type,
+        "designation_full": designation,
+        "organization_type": org_type,
+        "party": party,
+        "state": state,
+    }
+    return SearchResult(
+        url=_committee_url(com_id),
+        title=name,
+        snippet=snippet,
+        published_at=None,
+        source_kind="fec",
+        extras=extras,
+    )
+
+
+def _build_schedule_a_result(hit: dict[str, Any]) -> SearchResult | None:
+    contributor = (hit.get("contributor_name") or "").strip()
+    amount = hit.get("contribution_receipt_amount")
+    committee_field = hit.get("committee")
+    if isinstance(committee_field, dict):
+        recipient = (committee_field.get("name") or "").strip()
+    else:
+        recipient = ""
+    if not recipient:
+        recipient = (hit.get("recipient_name") or "").strip()
+    receipt_date = hit.get("contribution_receipt_date")
+    employer = (hit.get("contributor_employer") or "").strip()
+    occupation = (hit.get("contributor_occupation") or "").strip()
+    com_id = (hit.get("committee_id") or "").strip()
+
+    if not contributor and not amount:
+        return None
+
+    title = contributor or recipient or "FEC contribution"
+    snippet_bits = []
+    if contributor:
+        snippet_bits.append(contributor)
+    if amount is not None:
+        snippet_bits.append(_fmt_money(amount))
+    if recipient:
+        snippet_bits.append(f"→ {recipient}")
+    if receipt_date:
+        snippet_bits.append(str(receipt_date))
+    snippet = " — ".join(snippet_bits)
+
+    # Schedule A query echoes the contributor name so an operator clicking the
+    # url lands on a filtered FEC site search rather than a raw committee page.
+    base = f"{_SITE_BASE}receipts/"
+    qs = f"?contributor_name={contributor.replace(' ', '+')}" if contributor else ""
+    url = base + qs
+
+    extras: dict[str, Any] = {
+        "amount": amount,
+        "contributor_name": contributor,
+        "contributor_employer": employer,
+        "contributor_occupation": occupation,
+        "recipient_name": recipient,
+        "committee_id": com_id,
+        "contribution_receipt_date": receipt_date,
+    }
+    return SearchResult(
+        url=url,
+        title=str(title),
+        snippet=snippet,
+        published_at=_parse_iso_date(receipt_date),
+        source_kind="fec",
+        extras=extras,
+    )
+
+
+def _build_schedule_e_result(hit: dict[str, Any]) -> SearchResult | None:
+    payee = (hit.get("payee_name") or "").strip()
+    amount = hit.get("expenditure_amount")
+    candidate = (hit.get("candidate_name") or "").strip()
+    expenditure_date = hit.get("expenditure_date")
+    indicator = (hit.get("support_oppose_indicator") or "").strip()
+    com_id = (hit.get("committee_id") or "").strip()
+
+    if not payee and not amount:
+        return None
+
+    title = payee or "FEC independent expenditure"
+    indicator_label = (
+        "Support"
+        if indicator.upper() == "S"
+        else "Oppose"
+        if indicator.upper() == "O"
+        else (indicator or "?")
+    )
+    snippet_bits: list[str] = []
+    if payee:
+        snippet_bits.append(payee)
+    if amount is not None:
+        snippet_bits.append(_fmt_money(amount))
+    if candidate:
+        snippet_bits.append(f"{indicator_label} {candidate}")
+    if expenditure_date:
+        snippet_bits.append(str(expenditure_date))
+    snippet = " — ".join(snippet_bits)
+
+    url = _committee_url(com_id) if com_id else f"{_SITE_BASE}independent-expenditures/"
+
+    extras: dict[str, Any] = {
+        "expenditure_amount": amount,
+        "payee_name": payee,
+        "candidate_name": candidate,
+        "support_oppose_indicator": indicator,
+        "expenditure_date": expenditure_date,
+        "committee_id": com_id,
+    }
+    return SearchResult(
+        url=url,
+        title=str(title),
+        snippet=snippet,
+        published_at=_parse_iso_date(expenditure_date),
+        source_kind="fec",
+        extras=extras,
+    )
+
+
+_KIND_TO_ENDPOINT_AND_QPARAM: dict[str, tuple[str, str]] = {
+    "candidates": ("candidates/search/", "q"),
+    "committees": ("committees/", "q"),
+    "schedules/schedule_a": ("schedules/schedule_a/", "contributor_name"),
+    "schedules/schedule_e": ("schedules/schedule_e/", "payee_name"),
+}
+
+_KIND_TO_BUILDER = {
+    "candidates": _build_candidate_result,
+    "committees": _build_committee_result,
+    "schedules/schedule_a": _build_schedule_a_result,
+    "schedules/schedule_e": _build_schedule_e_result,
+}
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def search(
+    query: str,
+    *,
+    kind: str = "candidates",
+    max_results: int = 20,
+    timeout: float = 15.0,
+) -> list[SearchResult]:
+    """Run an OpenFEC search and return up to ``max_results`` hits.
+
+    ``kind`` selects the index — ``candidates``, ``committees``,
+    ``schedules/schedule_a`` (individual contributions, query goes to
+    ``contributor_name``) or ``schedules/schedule_e`` (independent
+    expenditures, query goes to ``payee_name``).
+
+    Returns ``[]`` on transport / HTTP error / non-JSON body or unknown
+    ``kind`` — connector failures must never crash the planner.
+    """
+    if kind not in _VALID_KINDS:
+        logger.warning(
+            "fec.search: unknown kind %r; expected one of %s",
+            kind,
+            sorted(_VALID_KINDS),
+        )
+        return []
+
+    endpoint, qparam = _KIND_TO_ENDPOINT_AND_QPARAM[kind]
+    builder = _KIND_TO_BUILDER[kind]
+
+    params: dict[str, Any] = {
+        "api_key": _resolve_api_key(),
+        "per_page": max_results,
+        qparam: query,
+    }
+
+    await _rate_limit_gate()
+
+    url = urljoin(_BASE_URL, endpoint)
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=_headers(),
+        ) as client:
+            response = await client.get(url, params=params)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("fec search failed for %r (%s): %s", query, kind, exc)
+        return []
+
+    if response.status_code != 200:
+        logger.warning(
+            "fec search returned HTTP %s for %r (%s)",
+            response.status_code,
+            query,
+            kind,
+        )
+        return []
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        logger.warning("fec search returned non-JSON for %r: %s", query, exc)
+        return []
+
+    raw_hits = payload.get("results") or []
+    out: list[SearchResult] = []
+    for hit in raw_hits[:max_results]:
+        if not isinstance(hit, dict):
+            continue
+        result = builder(hit)
+        if result is not None:
+            out.append(result)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+def _classify_url(url: str) -> tuple[str | None, str | None]:
+    """Return ``(resource, id)`` where resource ∈ {"candidate","committee"}.
+
+    Anything outside ``www.fec.gov`` (strict host match — look-alikes like
+    ``www.fec.gov.attacker.example`` must not pass) returns ``(None, None)``.
+    """
+    parsed = urlparse(url)
+    host = (parsed.netloc or "").lower().split(":", 1)[0]
+    if host != "www.fec.gov":
+        return None, None
+    path = parsed.path or ""
+    m = _CANDIDATE_URL_RE.match(path)
+    if m:
+        return "candidate", m.group("id")
+    m = _COMMITTEE_URL_RE.match(path)
+    if m:
+        return "committee", m.group("id")
+    return None, None
+
+
+def _cache_path(prefix: str, resource_id: str) -> Path:
+    safe = re.sub(r"[^A-Za-z0-9]", "_", resource_id)
+    return _CACHE_DIR / f"{prefix}-{safe}.json"
+
+
+def _write_cache(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _load_cache(path: Path) -> dict[str, Any] | None:
+    """Return cached payload if present and within TTL; else delete + None."""
+    if not path.exists():
+        return None
+    try:
+        age = time.time() - path.stat().st_mtime
+    except OSError:
+        return None
+    if age > _CACHE_TTL:
+        # Stale — drop it so the next call re-fetches.
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+async def _http_get_json(
+    url: str, timeout: float, *, params: dict[str, Any] | None = None
+) -> tuple[int | None, dict[str, Any] | None]:
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=_headers(),
+        ) as client:
+            response = await client.get(url, params=params)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("fec fetch failed for %s: %s", url, exc)
+        return None, None
+    if response.status_code != 200:
+        return response.status_code, None
+    try:
+        return response.status_code, response.json()
+    except ValueError:
+        return response.status_code, None
+
+
+def _latest_cycle(values: Any) -> int | None:
+    if not isinstance(values, list):
+        return None
+    cycles: list[int] = []
+    for v in values:
+        try:
+            cycles.append(int(v))
+        except (TypeError, ValueError):
+            continue
+    return max(cycles) if cycles else None
+
+
+def _cycle_totals_block(
+    totals: dict[str, Any] | None, *, cycle: int | None
+) -> tuple[str, dict[str, Any]]:
+    if not totals:
+        return "", {}
+    receipts = totals.get("receipts")
+    disb = totals.get("disbursements")
+    coh = (
+        totals.get("cash_on_hand_end_period")
+        or totals.get("last_cash_on_hand_end_period")
+    )
+    rows = [
+        ("Receipts", _fmt_money(receipts)),
+        ("Disbursements", _fmt_money(disb)),
+        ("Cash on hand (end)", _fmt_money(coh)),
+    ]
+    header = f"## Cycle totals ({cycle})" if cycle else "## Cycle totals"
+    lines = [header, ""]
+    for label, value in rows:
+        lines.append(f"- **{label}:** {value}")
+    md = "\n".join(lines)
+    extras = {
+        "cycle": cycle,
+        "receipts": receipts,
+        "disbursements": disb,
+        "cash_on_hand_end_period": coh,
+    }
+    return md, extras
+
+
+def _top_donors_block(
+    payload: dict[str, Any] | None,
+) -> tuple[str, list[dict[str, Any]]]:
+    if not payload:
+        return "", []
+    raw = payload.get("results") or []
+    rows: list[dict[str, Any]] = []
+    for r in raw[:10]:
+        if not isinstance(r, dict):
+            continue
+        label = (
+            r.get("employer")
+            or r.get("contributor_employer")
+            or r.get("size")
+            or "?"
+        )
+        total = r.get("total")
+        rows.append({"label": str(label), "total": total})
+    if not rows:
+        return "", rows
+    lines = ["## Top donors", ""]
+    for r in rows:
+        lines.append(f"- {r['label']} — {_fmt_money(r['total'])}")
+    return "\n".join(lines), rows
+
+
+def _top_expenditures_block(
+    payload: dict[str, Any] | None,
+) -> tuple[str, list[dict[str, Any]]]:
+    if not payload:
+        return "", []
+    raw = payload.get("results") or []
+    rows: list[dict[str, Any]] = []
+    for r in raw[:10]:
+        if not isinstance(r, dict):
+            continue
+        label = (
+            r.get("purpose")
+            or r.get("category_full")
+            or r.get("recipient_name")
+            or r.get("disbursement_purpose_category")
+            or "?"
+        )
+        total = r.get("total")
+        rows.append({"label": str(label), "total": total})
+    if not rows:
+        return "", rows
+    lines = ["## Top expenditures", ""]
+    for r in rows:
+        lines.append(f"- {r['label']} — {_fmt_money(r['total'])}")
+    return "\n".join(lines), rows
+
+
+async def _fetch_json_cached(
+    cache_key_prefix: str,
+    cache_id: str,
+    api_url: str,
+    timeout: float,
+    *,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Fetch JSON, caching at ``corpus/.cache/fec/<prefix>-<id>.json`` for 1h."""
+    cache = _cache_path(cache_key_prefix, cache_id)
+    payload = _load_cache(cache)
+    if payload is not None:
+        return payload
+    await _rate_limit_gate()
+    status, payload = await _http_get_json(api_url, timeout, params=params)
+    if status is None or status >= 400 or not isinstance(payload, dict):
+        if status is not None and status >= 400:
+            logger.warning("fec %s HTTP %s for %s", cache_key_prefix, status, api_url)
+        return None
+    _write_cache(cache, payload)
+    return payload
+
+
+def _first_result(payload: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not payload:
+        return None
+    results = payload.get("results")
+    if not isinstance(results, list) or not results:
+        return None
+    first = results[0]
+    return first if isinstance(first, dict) else None
+
+
+async def _fetch_candidate(
+    candidate_id: str, source_url: str, timeout: float
+) -> Source | None:
+    common_params = {"api_key": _resolve_api_key()}
+
+    header_payload = await _fetch_json_cached(
+        "candidate",
+        candidate_id,
+        urljoin(_BASE_URL, f"candidate/{candidate_id}/"),
+        timeout,
+        params=common_params,
+    )
+    header = _first_result(header_payload)
+    if not header:
+        return None
+
+    name = (header.get("name") or "").strip()
+    if not name:
+        return None
+    cycle = _latest_cycle(header.get("election_years"))
+
+    totals_params = dict(common_params)
+    if cycle is not None:
+        totals_params["cycle"] = cycle
+    totals_payload = await _fetch_json_cached(
+        "candidate-totals",
+        f"{candidate_id}-{cycle}" if cycle else candidate_id,
+        urljoin(_BASE_URL, f"candidate/{candidate_id}/totals/"),
+        timeout,
+        params=totals_params,
+    )
+    totals = _first_result(totals_payload)
+
+    donors_params = dict(common_params)
+    donors_params.update(
+        {"candidate_id": candidate_id, "per_page": 10, "sort": "-total"}
+    )
+    donors_payload = await _fetch_json_cached(
+        "candidate-donors",
+        f"{candidate_id}-{cycle}" if cycle else candidate_id,
+        urljoin(_BASE_URL, "schedules/schedule_a/by_employer/"),
+        timeout,
+        params=donors_params,
+    )
+
+    purposes_params = dict(common_params)
+    purposes_params.update(
+        {"candidate_id": candidate_id, "per_page": 10, "sort": "-total"}
+    )
+    purposes_payload = await _fetch_json_cached(
+        "candidate-purposes",
+        f"{candidate_id}-{cycle}" if cycle else candidate_id,
+        urljoin(_BASE_URL, "schedules/schedule_b/by_purpose/"),
+        timeout,
+        params=purposes_params,
+    )
+
+    totals_md, totals_extras = _cycle_totals_block(totals, cycle=cycle)
+    donors_md, donors_rows = _top_donors_block(donors_payload)
+    spend_md, spend_rows = _top_expenditures_block(purposes_payload)
+
+    party = (header.get("party_full") or header.get("party") or "").strip()
+    state = (header.get("state") or "").strip()
+    office = (header.get("office_full") or header.get("office") or "").strip()
+    incumbent = (header.get("incumbent_challenge_full") or "").strip()
+    meta_bits = [b for b in (party, state, office, incumbent) if b]
+    meta_line = "_" + " · ".join(meta_bits) + "_" if meta_bits else ""
+
+    sections = [f"# {name}"]
+    if meta_line:
+        sections.append(meta_line)
+    if totals_md:
+        sections.append(totals_md)
+    if donors_md:
+        sections.append(donors_md)
+    if spend_md:
+        sections.append(spend_md)
+
+    cleaned_text = "\n\n".join(sections).strip()
+    if not cleaned_text:
+        return None
+
+    metadata: dict[str, Any] = {
+        "candidate_id": candidate_id,
+        "party": party,
+        "state": state,
+        "office": office,
+        "incumbent_challenge_full": incumbent,
+        "cycle_totals": totals_extras,
+        "top_donors": donors_rows,
+        "top_expenditures": spend_rows,
+    }
+
+    return Source(
+        url=source_url,
+        title=name,
+        cleaned_text=cleaned_text,
+        raw_html=None,
+        fetched_at=datetime.now(UTC),
+        source_kind="fec",
+        metadata=metadata,
+    )
+
+
+async def _fetch_committee(
+    committee_id: str, source_url: str, timeout: float
+) -> Source | None:
+    common_params = {"api_key": _resolve_api_key()}
+
+    header_payload = await _fetch_json_cached(
+        "committee",
+        committee_id,
+        urljoin(_BASE_URL, f"committee/{committee_id}/"),
+        timeout,
+        params=common_params,
+    )
+    header = _first_result(header_payload)
+    if not header:
+        return None
+
+    name = (header.get("name") or "").strip()
+    if not name:
+        return None
+    cycles = header.get("cycles") or []
+    cycle = _latest_cycle(cycles)
+
+    totals_params = dict(common_params)
+    if cycle is not None:
+        totals_params["cycle"] = cycle
+    totals_payload = await _fetch_json_cached(
+        "committee-totals",
+        f"{committee_id}-{cycle}" if cycle else committee_id,
+        urljoin(_BASE_URL, f"committee/{committee_id}/totals/"),
+        timeout,
+        params=totals_params,
+    )
+    totals = _first_result(totals_payload)
+
+    donors_params = dict(common_params)
+    donors_params.update(
+        {"committee_id": committee_id, "per_page": 10, "sort": "-total"}
+    )
+    donors_payload = await _fetch_json_cached(
+        "committee-donors",
+        f"{committee_id}-{cycle}" if cycle else committee_id,
+        urljoin(_BASE_URL, "schedules/schedule_a/by_employer/"),
+        timeout,
+        params=donors_params,
+    )
+
+    purposes_params = dict(common_params)
+    purposes_params.update(
+        {"committee_id": committee_id, "per_page": 10, "sort": "-total"}
+    )
+    purposes_payload = await _fetch_json_cached(
+        "committee-purposes",
+        f"{committee_id}-{cycle}" if cycle else committee_id,
+        urljoin(_BASE_URL, "schedules/schedule_b/by_purpose/"),
+        timeout,
+        params=purposes_params,
+    )
+
+    totals_md, totals_extras = _cycle_totals_block(totals, cycle=cycle)
+    donors_md, donors_rows = _top_donors_block(donors_payload)
+    spend_md, spend_rows = _top_expenditures_block(purposes_payload)
+
+    committee_type = (header.get("committee_type_full") or "").strip()
+    designation = (header.get("designation_full") or "").strip()
+    party = (header.get("party_full") or header.get("party") or "").strip()
+    state = (header.get("state") or "").strip()
+    org_type = (header.get("organization_type_full") or "").strip()
+    meta_bits = [
+        b for b in (committee_type, designation, party, state, org_type) if b
+    ]
+    meta_line = "_" + " · ".join(meta_bits) + "_" if meta_bits else ""
+
+    sections = [f"# {name}"]
+    if meta_line:
+        sections.append(meta_line)
+    if totals_md:
+        sections.append(totals_md)
+    if donors_md:
+        sections.append(donors_md)
+    if spend_md:
+        sections.append(spend_md)
+
+    cleaned_text = "\n\n".join(sections).strip()
+    if not cleaned_text:
+        return None
+
+    metadata: dict[str, Any] = {
+        "committee_id": committee_id,
+        "committee_type_full": committee_type,
+        "designation_full": designation,
+        "party": party,
+        "state": state,
+        "organization_type": org_type,
+        "cycle_totals": totals_extras,
+        "top_donors": donors_rows,
+        "top_expenditures": spend_rows,
+    }
+
+    return Source(
+        url=source_url,
+        title=name,
+        cleaned_text=cleaned_text,
+        raw_html=None,
+        fetched_at=datetime.now(UTC),
+        source_kind="fec",
+        metadata=metadata,
+    )
+
+
+async def fetch(url: str, timeout: float = 30.0) -> Source | None:
+    """Open a candidate or committee page on www.fec.gov/data/ and return a Source.
+
+    Returns ``None`` for unrecognised URLs (anything outside ``www.fec.gov``,
+    or paths other than ``/data/candidate/<id>/`` and ``/data/committee/<id>/``)
+    and for any transport / HTTP / parse failure.
+    """
+    if not url:
+        return None
+    resource, resource_id = _classify_url(url)
+    if not resource or not resource_id:
+        return None
+
+    if resource == "candidate":
+        return await _fetch_candidate(resource_id, url, timeout)
+    if resource == "committee":
+        return await _fetch_committee(resource_id, url, timeout)
+    return None
+
+
+def reset_for_tests() -> None:
+    """Clear per-process rate-limit state. Test-only."""
+    global _last_call_monotonic, _rate_lock
+    _last_call_monotonic = None
+    _rate_lock = asyncio.Lock()
+
+
+__all__ = ["fetch", "reset_for_tests", "search"]

--- a/tests/test_tools_fec.py
+++ b/tests/test_tools_fec.py
@@ -1,0 +1,614 @@
+"""Tests for `research_agent.tools.fec` (issue #94)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from research_agent.tools import fec
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _set_key(monkeypatch):
+    monkeypatch.setenv("DATA_GOV_API_KEY", "test-key-1234567890abcdef")
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    fec.reset_for_tests()
+    monkeypatch.setattr(fec.asyncio, "sleep", AsyncMock())
+    yield
+    fec.reset_for_tests()
+
+
+@pytest.fixture
+def cache_dir(tmp_path: Path, monkeypatch) -> Path:
+    target = tmp_path / "fec-cache"
+    monkeypatch.setattr(fec, "_CACHE_DIR", target)
+    return target
+
+
+# ---------------------------------------------------------------------------
+# Test payloads
+# ---------------------------------------------------------------------------
+
+
+_CANDIDATE_SEARCH_PAYLOAD = {
+    "results": [
+        {
+            "candidate_id": "H0NY03169",
+            "name": "SANTOS, GEORGE",
+            "party": "REP",
+            "state": "NY",
+            "office": "H",
+            "office_full": "House",
+            "incumbent_challenge_full": "Incumbent",
+            "election_years": [2020, 2022, 2024],
+        },
+        {
+            "candidate_id": "H8NY03000",
+            "name": "DOE, JANE",
+            "party": "DEM",
+            "state": "NY",
+            "office": "H",
+            "office_full": "House",
+            "incumbent_challenge_full": "Challenger",
+            "election_years": [2024],
+        },
+    ]
+}
+
+
+_COMMITTEE_SEARCH_PAYLOAD = {
+    "results": [
+        {
+            "committee_id": "C00500587",
+            "name": "MAKE AMERICA GREAT AGAIN PAC",
+            "committee_type_full": "Political Action Committee",
+            "designation_full": "Lobbyist/Registrant PAC",
+            "organization_type_full": "",
+            "party_full": "",
+            "state": "FL",
+        }
+    ]
+}
+
+
+_SCHEDULE_A_PAYLOAD = {
+    "results": [
+        {
+            "contributor_name": "SMITH, JOHN A.",
+            "contribution_receipt_amount": 2900.0,
+            "contribution_receipt_date": "2024-04-15",
+            "contributor_employer": "ACME CORP",
+            "contributor_occupation": "EXECUTIVE",
+            "committee": {"name": "SANTOS FOR CONGRESS"},
+            "committee_id": "C00712641",
+        }
+    ]
+}
+
+
+_SCHEDULE_E_PAYLOAD = {
+    "results": [
+        {
+            "payee_name": "PATRIOT MEDIA LLC",
+            "expenditure_amount": 50000.0,
+            "expenditure_date": "2024-09-15",
+            "candidate_name": "SMITH, JANE",
+            "support_oppose_indicator": "S",
+            "committee_id": "C00712641",
+        }
+    ]
+}
+
+
+_CANDIDATE_HEADER_PAYLOAD = {
+    "results": [
+        {
+            "candidate_id": "H0NY03169",
+            "name": "SANTOS, GEORGE",
+            "party_full": "REPUBLICAN PARTY",
+            "party": "REP",
+            "state": "NY",
+            "office_full": "House",
+            "office": "H",
+            "incumbent_challenge_full": "Incumbent",
+            "election_years": [2020, 2022, 2024],
+        }
+    ]
+}
+
+
+_CANDIDATE_TOTALS_PAYLOAD = {
+    "results": [
+        {
+            "candidate_id": "H0NY03169",
+            "cycle": 2024,
+            "receipts": 1234567.0,
+            "disbursements": 1100000.0,
+            "cash_on_hand_end_period": 134567.0,
+        }
+    ]
+}
+
+
+_CANDIDATE_DONORS_PAYLOAD = {
+    "results": [
+        {"employer": "ACME CORP", "total": 25000.0},
+        {"employer": "WIDGET INC", "total": 18500.0},
+    ]
+}
+
+
+_CANDIDATE_PURPOSES_PAYLOAD = {
+    "results": [
+        {"purpose": "Media", "total": 600000.0},
+        {"purpose": "Travel", "total": 75000.0},
+    ]
+}
+
+
+_COMMITTEE_HEADER_PAYLOAD = {
+    "results": [
+        {
+            "committee_id": "C00500587",
+            "name": "MAKE AMERICA GREAT AGAIN PAC",
+            "committee_type_full": "Political Action Committee",
+            "designation_full": "Lobbyist/Registrant PAC",
+            "party_full": "",
+            "party": "",
+            "state": "FL",
+            "organization_type_full": "",
+            "cycles": [2018, 2020, 2022, 2024],
+        }
+    ]
+}
+
+
+_COMMITTEE_TOTALS_PAYLOAD = {
+    "results": [
+        {
+            "committee_id": "C00500587",
+            "cycle": 2024,
+            "receipts": 9_999_999.0,
+            "disbursements": 8_888_888.0,
+            "cash_on_hand_end_period": 1_111_111.0,
+        }
+    ]
+}
+
+
+# ---------------------------------------------------------------------------
+# httpx mock plumbing
+# ---------------------------------------------------------------------------
+
+
+def _patch_httpx(monkeypatch, *, responder):
+    """Replace ``httpx.AsyncClient`` with a fake driven by ``responder(url, params)``.
+
+    Returns ``(status_code, body_text)``.
+    """
+    captured: dict[str, list] = {"urls": [], "headers": [], "params": []}
+
+    class _FakeResp:
+        def __init__(self, status: int, text: str) -> None:
+            self.status_code = status
+            self.text = text
+
+        def json(self):
+            return json.loads(self.text)
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        captured["headers"].append(kwargs.get("headers"))
+
+        class _Client:
+            async def get(self, url, *, params=None, **_kwargs):
+                captured["urls"].append(url)
+                captured["params"].append(params)
+                status, text = responder(url, params)
+                return _FakeResp(status, text)
+
+        yield _Client()
+
+    monkeypatch.setattr(fec.httpx, "AsyncClient", _client_factory)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def test_search_candidates_builds_correct_query(monkeypatch):
+    payload = json.dumps(_CANDIDATE_SEARCH_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await fec.search("George Santos", kind="candidates")
+
+    assert len(results) == 2
+    assert captured["urls"][0].endswith("/v1/candidates/search/")
+    params = captured["params"][0]
+    assert params["q"] == "George Santos"
+    assert params["api_key"] == "test-key-1234567890abcdef"
+    assert params["per_page"] == 20
+
+    first = results[0]
+    assert first.source_kind == "fec"
+    assert first.url == "https://www.fec.gov/data/candidate/H0NY03169/"
+    assert first.title == "SANTOS, GEORGE"
+    assert first.extras["candidate_id"] == "H0NY03169"
+    assert first.extras["party"] == "REP"
+    assert first.extras["state"] == "NY"
+    assert first.extras["office"] == "House"
+    assert first.extras["election_years"] == [2020, 2022, 2024]
+    assert "REP" in first.snippet
+    assert "NY" in first.snippet
+
+
+async def test_search_committees_endpoint(monkeypatch):
+    payload = json.dumps(_COMMITTEE_SEARCH_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await fec.search("MAGA PAC", kind="committees", max_results=5)
+
+    assert captured["urls"][0].endswith("/v1/committees/")
+    params = captured["params"][0]
+    assert params["q"] == "MAGA PAC"
+    assert params["per_page"] == 5
+
+    assert len(results) == 1
+    hit = results[0]
+    assert hit.url == "https://www.fec.gov/data/committee/C00500587/"
+    assert hit.extras["committee_id"] == "C00500587"
+    assert hit.extras["committee_type_full"] == "Political Action Committee"
+    assert hit.extras["state"] == "FL"
+
+
+async def test_search_schedule_a_endpoint(monkeypatch):
+    payload = json.dumps(_SCHEDULE_A_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await fec.search("John Smith", kind="schedules/schedule_a")
+
+    assert captured["urls"][0].endswith("/v1/schedules/schedule_a/")
+    params = captured["params"][0]
+    assert params["contributor_name"] == "John Smith"
+
+    assert len(results) == 1
+    hit = results[0]
+    assert hit.source_kind == "fec"
+    assert hit.extras["amount"] == 2900.0
+    assert hit.extras["contributor_name"] == "SMITH, JOHN A."
+    assert hit.extras["contributor_employer"] == "ACME CORP"
+    assert hit.extras["recipient_name"] == "SANTOS FOR CONGRESS"
+    assert hit.extras["contribution_receipt_date"] == "2024-04-15"
+    assert "$2,900" in hit.snippet
+
+
+async def test_search_schedule_e_endpoint(monkeypatch):
+    payload = json.dumps(_SCHEDULE_E_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await fec.search("Patriot Media", kind="schedules/schedule_e")
+
+    assert captured["urls"][0].endswith("/v1/schedules/schedule_e/")
+    params = captured["params"][0]
+    assert params["payee_name"] == "Patriot Media"
+
+    assert len(results) == 1
+    hit = results[0]
+    assert hit.extras["expenditure_amount"] == 50000.0
+    assert hit.extras["payee_name"] == "PATRIOT MEDIA LLC"
+    assert hit.extras["candidate_name"] == "SMITH, JANE"
+    assert hit.extras["support_oppose_indicator"] == "S"
+    assert "Support" in hit.snippet
+    assert hit.url == "https://www.fec.gov/data/committee/C00712641/"
+
+
+async def test_search_unknown_kind_returns_empty(monkeypatch):
+    # Should not even call httpx — emit warning + return [].
+    called = {"count": 0}
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        called["count"] += 1
+
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise AssertionError("should not be called")
+
+        yield _Client()
+
+    monkeypatch.setattr(fec.httpx, "AsyncClient", _client_factory)
+
+    assert await fec.search("anything", kind="bogus") == []
+    assert called["count"] == 0
+
+
+async def test_search_returns_empty_on_500(monkeypatch):
+    def _respond(url, params):
+        return 500, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await fec.search("anything") == []
+
+
+async def test_search_returns_empty_on_transport_error(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(fec.httpx, "AsyncClient", _client_factory)
+
+    assert await fec.search("anything") == []
+
+
+async def test_search_returns_empty_on_non_json(monkeypatch):
+    def _respond(url, params):
+        return 200, "<html>not json</html>"
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await fec.search("anything") == []
+
+
+async def test_demo_key_fallback_when_unset(monkeypatch):
+    monkeypatch.delenv("DATA_GOV_API_KEY", raising=False)
+    payload = json.dumps({"results": []})
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    await fec.search("anything")
+
+    assert captured["params"][0]["api_key"] == "DEMO_KEY"
+
+
+async def test_rate_limit_gate_sleeps_within_interval(monkeypatch):
+    """Two concurrent search calls must both pass through the rate gate."""
+    clock = [100.0]
+
+    def fake_monotonic() -> float:
+        return clock[0]
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        clock[0] += seconds
+
+    monkeypatch.setattr(fec.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(fec.asyncio, "sleep", fake_sleep)
+
+    payload = json.dumps({"results": []})
+
+    def _respond(url, params):
+        return 200, payload
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    await asyncio.gather(fec.search("a"), fec.search("b"))
+
+    assert any(s > 0 for s in sleep_calls), (
+        f"expected at least one >0 sleep through the rate gate; got {sleep_calls!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# fetch() — URL classifier
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_returns_none_for_unknown_host(cache_dir: Path):
+    assert await fec.fetch("https://example.com/data/candidate/H0NY03169/") is None
+
+
+async def test_fetch_rejects_lookalike_host(cache_dir: Path):
+    spoof = "https://www.fec.gov.evil.example/data/candidate/H0NY03169/"
+    assert await fec.fetch(spoof) is None
+
+
+async def test_fetch_returns_none_for_non_resource_path(cache_dir: Path):
+    assert await fec.fetch("https://www.fec.gov/data/browse-data/") is None
+
+
+async def test_fetch_returns_none_for_empty_url(cache_dir: Path):
+    assert await fec.fetch("") is None
+
+
+# ---------------------------------------------------------------------------
+# fetch() — candidate happy path + caching
+# ---------------------------------------------------------------------------
+
+
+def _candidate_responder(_url, _params):
+    """Route candidate-fetch URLs to canned payloads."""
+    if "candidate/H0NY03169/totals" in _url:
+        return 200, json.dumps(_CANDIDATE_TOTALS_PAYLOAD)
+    if "candidate/H0NY03169/" in _url:
+        return 200, json.dumps(_CANDIDATE_HEADER_PAYLOAD)
+    if "schedule_a/by_employer" in _url:
+        return 200, json.dumps(_CANDIDATE_DONORS_PAYLOAD)
+    if "schedule_b/by_purpose" in _url:
+        return 200, json.dumps(_CANDIDATE_PURPOSES_PAYLOAD)
+    return 404, ""
+
+
+async def test_fetch_candidate_builds_markdown_and_caches(
+    monkeypatch, cache_dir: Path
+):
+    captured = _patch_httpx(monkeypatch, responder=_candidate_responder)
+
+    url = "https://www.fec.gov/data/candidate/H0NY03169/"
+    source = await fec.fetch(url)
+
+    assert source is not None
+    assert source.source_kind == "fec"
+    assert source.url == url
+    assert source.title == "SANTOS, GEORGE"
+    body = source.cleaned_text
+    assert body.startswith("# SANTOS, GEORGE")
+    # Header metadata
+    assert "REPUBLICAN PARTY" in body
+    assert "NY" in body
+    assert "House" in body
+    # Cycle totals roll-up — uses latest cycle from election_years (2024)
+    assert "Cycle totals (2024)" in body
+    assert "$1,234,567" in body  # receipts
+    assert "$1,100,000" in body  # disbursements
+    assert "$134,567" in body  # cash on hand
+    # Top donors
+    assert "Top donors" in body
+    assert "ACME CORP" in body
+    assert "$25,000" in body
+    # Top expenditures
+    assert "Top expenditures" in body
+    assert "Media" in body
+    assert "$600,000" in body
+
+    # Metadata structured roll-up
+    md = source.metadata
+    assert md["candidate_id"] == "H0NY03169"
+    assert md["cycle_totals"]["cycle"] == 2024
+    assert md["cycle_totals"]["receipts"] == 1234567.0
+    assert len(md["top_donors"]) == 2
+    assert md["top_donors"][0]["label"] == "ACME CORP"
+    assert md["top_donors"][0]["total"] == 25000.0
+    assert md["top_expenditures"][0]["label"] == "Media"
+
+    # Cache files written
+    cached = sorted(p.name for p in cache_dir.glob("*.json"))
+    assert any(c.startswith("candidate-") for c in cached)
+    assert any(c.startswith("candidate-totals-") for c in cached)
+    assert any(c.startswith("candidate-donors-") for c in cached)
+    assert any(c.startswith("candidate-purposes-") for c in cached)
+
+    # Second call serves from cache — no additional HTTP hits.
+    api_calls_before = len(captured["urls"])
+    s2 = await fec.fetch(url)
+    assert s2 is not None
+    assert len(captured["urls"]) == api_calls_before
+
+
+async def test_fetch_committee_happy_path(monkeypatch, cache_dir: Path):
+    def _respond(_url, _params):
+        if "committee/C00500587/totals" in _url:
+            return 200, json.dumps(_COMMITTEE_TOTALS_PAYLOAD)
+        if "committee/C00500587/" in _url:
+            return 200, json.dumps(_COMMITTEE_HEADER_PAYLOAD)
+        if "schedule_a/by_employer" in _url:
+            return 200, json.dumps(_CANDIDATE_DONORS_PAYLOAD)
+        if "schedule_b/by_purpose" in _url:
+            return 200, json.dumps(_CANDIDATE_PURPOSES_PAYLOAD)
+        return 404, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    url = "https://www.fec.gov/data/committee/C00500587/"
+    source = await fec.fetch(url)
+
+    assert source is not None
+    assert source.title == "MAKE AMERICA GREAT AGAIN PAC"
+    body = source.cleaned_text
+    assert "Cycle totals (2024)" in body
+    assert "$9,999,999" in body
+    md = source.metadata
+    assert md["committee_id"] == "C00500587"
+    assert md["committee_type_full"] == "Political Action Committee"
+    assert md["cycle_totals"]["cycle"] == 2024
+
+
+async def test_fetch_returns_none_on_404(monkeypatch, cache_dir: Path):
+    def _respond(url, params):
+        return 404, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    url = "https://www.fec.gov/data/candidate/H0NY03169/"
+    assert await fec.fetch(url) is None
+
+
+async def test_fetch_returns_none_on_transport_error(monkeypatch, cache_dir: Path):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(fec.httpx, "AsyncClient", _client_factory)
+
+    url = "https://www.fec.gov/data/candidate/H0NY03169/"
+    assert await fec.fetch(url) is None
+
+
+async def test_cache_ttl_expires_after_one_hour(monkeypatch, cache_dir: Path):
+    """A cache file older than ``_CACHE_TTL`` (1h) is dropped + re-fetched."""
+    captured = _patch_httpx(monkeypatch, responder=_candidate_responder)
+
+    url = "https://www.fec.gov/data/candidate/H0NY03169/"
+    source = await fec.fetch(url)
+    assert source is not None
+    calls_after_first = len(captured["urls"])
+    assert calls_after_first > 0
+
+    # Age every cache file to 2 hours old (TTL is 1h).
+    two_hours_ago = time.time() - 7200
+    for path in cache_dir.glob("*.json"):
+        import os as _os
+
+        _os.utime(path, (two_hours_ago, two_hours_ago))
+
+    source2 = await fec.fetch(url)
+    assert source2 is not None
+    # A second round of HTTP calls should have fired (stale cache dropped).
+    assert len(captured["urls"]) > calls_after_first
+
+
+# ---------------------------------------------------------------------------
+# Smoke registration
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_registry_includes_fec():
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "fec" in TOOL_REGISTRY


### PR DESCRIPTION
Closes #94
Part of #107

## Summary

Automated implementation of **FEC OpenFEC connector (federal campaign finance)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

FEC connector implementation meets all ACs after fixing the smoke wrapper to include cycle totals from the top hit.

- **WARNING** [FIXED] `src/research_agent/tools/__init__.py`: Smoke wrapper `_smoke_fec` only ran search() and printed candidate records with election years (cycles), but never surfaced cycle totals (receipts/disbursements/cash-on-hand). AC requires `_smoke-tool fec "George Santos"` to return the candidate record + cycle totals. Extended the wrapper to fetch() the top search hit and print the totals from its metadata.
- **INFO** [OPEN] `src/research_agent/tools/fec.py`: Schedule A search result URL builds query string with `contributor.replace(' ', '+')` rather than `urllib.parse.quote_plus` — names containing apostrophes, ampersands, etc. would be URL-malformed. Cosmetic only; the URL is for human navigation, not API calls.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*