### PR TITLE
feat: Senate LDA (Lobbying Disclosure) connector (closes #103)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,9 @@ COURTLISTENER_API_TOKEN=
 # when unset the connector falls back to `DEMO_KEY` which is throttled to
 # ~40 req/hr per IP — fine for `_smoke-tool` runs but not for real workloads.
 DATA_GOV_API_KEY=
+
+# Optional: Senate Lobbying Disclosure API key used by `tools/lda.py`.
+# Anonymous access works for occasional smoke runs, but registering a key
+# (free at https://lda.senate.gov/api/register/) raises rate limits. The
+# key is sent via the `Authorization: Token <key>` header.
+LDA_API_KEY=

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ that list, so there is no drift.
 | `RESEARCH_DAEMON_PROGRESS` | no | Set to `0` to suppress the foreground Rich progress bar the daemon writes to stdout when run interactively. |
 | `COURTLISTENER_API_TOKEN` | no | CourtListener API token (free w/ signup) — required by `tools/courtlistener.py`. Authenticated tier is 5,000 req/hr; anonymous traffic is throttled to the point of unusability. |
 | `DATA_GOV_API_KEY` | no | api.data.gov key (free w/ signup at <https://api.data.gov/signup/>) — used by `tools/fec.py` (OpenFEC). Authenticated tier is 1,000 req/hr; falls back to `DEMO_KEY` (~40 req/hr per IP) when unset. |
+| `LDA_API_KEY` | no | Senate Lobbying Disclosure Act API key (free, optional, register at <https://lda.senate.gov/api/register/>) — used by `tools/lda.py`. Anonymous works for low-volume; authenticated raises rate limits. Sent via `Authorization: Token <key>`. |
 
 ## LM Studio
 

--- a/src/research_agent/config.py
+++ b/src/research_agent/config.py
@@ -108,6 +108,15 @@ EXPECTED_ENV_KEYS: tuple[EnvKey, ...] = (
             " when unset. Free signup at https://api.data.gov/signup/."
         ),
     ),
+    EnvKey(
+        name="LDA_API_KEY",
+        required=False,
+        description=(
+            "Senate Lobbying Disclosure Act API key (free, lda.senate.gov)."
+            " Anonymous access works for tools/lda.py; setting a registered"
+            " key raises rate limits. Sent as `Authorization: Token <key>`."
+        ),
+    ),
 )
 
 

--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -267,6 +267,58 @@ def _smoke_fec(query: str) -> str:
     return asyncio.run(_run())
 
 
+def _smoke_lda(query: str) -> str:
+    """Smoke wrapper: LDA registrant search + recent quarterly filings.
+
+    Per AC: ``research _smoke-tool lda "Heritage Foundation"`` should
+    surface the registrant record + recent quarterly filings. Lists the
+    top-5 registrant hits, then for the top hit lists the 5 most recent
+    LD-1/LD-2 filings so an operator can eyeball whether the REST API is
+    reachable and the optional API token (when set) is healthy.
+    """
+    from research_agent.tools import lda
+
+    async def _run() -> str:
+        registrants = await lda.search(query, kind="registrants", max_results=5)
+        if not registrants:
+            return f"lda search returned no registrants for {query!r}"
+        lines: list[str] = ["# Registrants"]
+        for hit in registrants:
+            address = hit.extras.get("address") or "?"
+            contact = hit.extras.get("contact") or "?"
+            snippet = hit.snippet.replace("\n", " ")
+            if len(snippet) > 200:
+                snippet = snippet[:200] + "…"
+            lines.append(
+                f"- {hit.title}\n"
+                f"  {address}\n"
+                f"  Contact: {contact}\n"
+                f"  {hit.url}\n"
+                f"  {snippet}"
+            )
+
+        top = registrants[0]
+        filings = await lda.search(top.title, kind="filings", max_results=5)
+        lines.append(f"\n# Recent filings for {top.title}")
+        if not filings:
+            lines.append("(no filings returned)")
+        else:
+            for hit in filings:
+                year = hit.extras.get("filing_year") or "?"
+                period = hit.extras.get("filing_period") or "?"
+                ftype = hit.extras.get("filing_type") or "?"
+                income = hit.extras.get("income")
+                expenses = hit.extras.get("expenses")
+                lines.append(
+                    f"- {hit.title}\n"
+                    f"  {ftype} — {year} {period} — income={income} expenses={expenses}\n"
+                    f"  {hit.url}"
+                )
+        return "\n".join(lines)
+
+    return asyncio.run(_run())
+
+
 def _smoke_congress(query: str) -> str:
     """Smoke wrapper: Congress.gov v3 bill search returning the top-5 hits.
 
@@ -516,6 +568,7 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "nonprofits": _smoke_nonprofits,
     "fec": _smoke_fec,
     "congress": _smoke_congress,
+    "lda": _smoke_lda,
     "news": _smoke_news,
     "reddit": _smoke_reddit,
     "pdf": _smoke_pdf,

--- a/src/research_agent/tools/lda.py
+++ b/src/research_agent/tools/lda.py
@@ -1,0 +1,610 @@
+"""Senate LDA (Lobbying Disclosure Act) connector (issue #103).
+
+Public surface:
+
+* ``async def search(query, *, kind="filings", max_results=20) -> list[SearchResult]``
+  hits the LDA REST API (``lda.senate.gov/api/v1/``). ``kind`` selects among
+  ``filings`` (LD-1 / LD-2 quarterly), ``registrants`` (lobbying firms /
+  in-house registrants) or ``contributions`` (LD-203 semi-annual political
+  contributions).
+* ``async def fetch(url) -> Source | None`` opens an LD-2 filing detail page
+  and returns markdown of the issues lobbied, the lobbyists named, and the
+  income/expenses amount.
+
+Auth: anonymous works for low-volume calls; setting ``LDA_API_KEY`` (free
+registration at https://lda.senate.gov/api/register/) raises rate limits.
+The token is sent via ``Authorization: Token <key>`` (REST framework
+convention).
+
+Per AC: 1 RPS per-host gate, mirroring ``tools/nonprofits.py``.
+
+TODO(2026-06-30): the LDA team is migrating from ``lda.senate.gov`` to
+``lda.gov``. Re-evaluate ``_BASE_URL`` and the accepted-host set near that
+date — the old domain is expected to keep redirecting for a grace period
+but new clients should target ``lda.gov`` once cutover finalises.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from datetime import UTC, date, datetime
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from research_agent import config
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://lda.senate.gov/api/v1/"
+_SITE_BASE = "https://lda.senate.gov"
+# Accept the new ``lda.gov`` cutover host once the migration lands; keeping
+# both in the set means we don't have to flip a flag the moment it happens.
+_ACCEPTED_HOSTS = frozenset({"lda.senate.gov", "lda.gov"})
+# AC: per-host rate of 1 RPS.
+_RATE_LIMIT_INTERVAL = 1.0
+
+_VALID_KINDS = {"filings", "registrants", "contributions"}
+
+# LDA filing UUIDs are upper-case hex w/ dashes (RFC 4122). Tolerate either
+# trailing slash and an optional ``/api/v1/filings/`` (REST endpoint) or
+# ``/filings/`` (human-facing) prefix.
+_FILING_URL_RE = re.compile(
+    r"^/(?:api/v1/)?filings/(?P<uuid>[A-Fa-f0-9-]{36})/?$"
+)
+
+_rate_lock = asyncio.Lock()
+_last_call_monotonic: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Config / rate-limit helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_api_key() -> str | None:
+    """Return the configured LDA API key, or ``None`` for anonymous access."""
+    raw = config.get("LDA_API_KEY") or ""
+    key = raw.strip()
+    return key or None
+
+
+def _headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": config.get("RESEARCH_USER_AGENT")
+        or "research-agent/0.1 (+local; contact unset)",
+    }
+    key = _resolve_api_key()
+    if key:
+        headers["Authorization"] = f"Token {key}"
+    return headers
+
+
+async def _rate_limit_gate() -> None:
+    """Block until at least ``_RATE_LIMIT_INTERVAL`` has passed since the last call."""
+    global _last_call_monotonic
+    async with _rate_lock:
+        if _last_call_monotonic is not None:
+            elapsed = time.monotonic() - _last_call_monotonic
+            wait = _RATE_LIMIT_INTERVAL - elapsed
+            if wait > 0:
+                await asyncio.sleep(wait)
+        _last_call_monotonic = time.monotonic()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso_date(value: Any) -> datetime | None:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=UTC)
+    text = str(value).strip()
+    if not text:
+        return None
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%d"):
+        try:
+            parsed = datetime.strptime(text, fmt)
+            return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed
+        except ValueError:
+            continue
+    head = text.split("T", 1)[0]
+    try:
+        return datetime.strptime(head, "%Y-%m-%d").replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def _fmt_money(value: Any) -> str:
+    if value in (None, "", "null"):
+        return "—"
+    try:
+        return f"${int(round(float(value))):,}"
+    except (TypeError, ValueError):
+        return "—"
+
+
+def _name_of(obj: Any) -> str:
+    """Pull a human name from either a dict-of-strings or a bare string."""
+    if isinstance(obj, dict):
+        return str(obj.get("name") or "").strip()
+    if obj is None:
+        return ""
+    return str(obj).strip()
+
+
+def _filing_permalink(filing_uuid: str) -> str:
+    return f"{_SITE_BASE}/filings/{filing_uuid}/"
+
+
+def _filing_total(hit: dict[str, Any]) -> Any:
+    """Return the dollar figure relevant to a filing (income xor expenses)."""
+    income = hit.get("income")
+    expenses = hit.get("expenses")
+    # LD-2 reports either income (lobbying firm) or expenses (in-house),
+    # never both. Prefer the populated one; fall back to whichever is present.
+    if income not in (None, "", "null"):
+        return income
+    return expenses
+
+
+# ---------------------------------------------------------------------------
+# search() builders
+# ---------------------------------------------------------------------------
+
+
+def _build_filing_result(hit: dict[str, Any]) -> SearchResult | None:
+    filing_uuid = (hit.get("filing_uuid") or "").strip()
+    if not filing_uuid:
+        return None
+
+    filing_type_raw = hit.get("filing_type_display") or hit.get("filing_type") or ""
+    filing_type = str(filing_type_raw).strip()
+    filing_year = hit.get("filing_year")
+    filing_period_raw = (
+        hit.get("filing_period_display") or hit.get("filing_period") or ""
+    )
+    filing_period = str(filing_period_raw).strip()
+
+    client_name = _name_of(hit.get("client"))
+    registrant_name = _name_of(hit.get("registrant"))
+    income = hit.get("income")
+    expenses = hit.get("expenses")
+    total = _filing_total(hit)
+    dt_posted = hit.get("dt_posted")
+
+    title_bits = [b for b in (client_name, filing_type, str(filing_year or ""), filing_period) if b]
+    title = " – ".join(title_bits) if title_bits else f"LDA filing {filing_uuid}"
+
+    snippet_bits: list[str] = []
+    if registrant_name:
+        snippet_bits.append(f"Registrant: {registrant_name}")
+    if total not in (None, "", "null"):
+        snippet_bits.append(f"Total: {_fmt_money(total)}")
+    if filing_period:
+        snippet_bits.append(filing_period)
+    snippet = " — ".join(snippet_bits)
+
+    document_url = (hit.get("filing_document_url") or "").strip()
+    url = document_url or _filing_permalink(filing_uuid)
+
+    extras: dict[str, Any] = {
+        "filing_uuid": filing_uuid,
+        "filing_type": filing_type,
+        "filing_year": filing_year,
+        "filing_period": filing_period,
+        "client_name": client_name,
+        "registrant_name": registrant_name,
+        "income": income,
+        "expenses": expenses,
+        "url": url,
+    }
+    return SearchResult(
+        url=url,
+        title=title,
+        snippet=snippet,
+        published_at=_parse_iso_date(dt_posted),
+        source_kind="lda",
+        extras=extras,
+    )
+
+
+def _build_registrant_result(hit: dict[str, Any]) -> SearchResult | None:
+    name = (hit.get("name") or "").strip()
+    if not name:
+        return None
+    registrant_id = hit.get("id")
+
+    addr_bits = [
+        (hit.get("address_1") or "").strip(),
+        (hit.get("address_2") or "").strip(),
+        (hit.get("city") or "").strip(),
+        (hit.get("state_display") or hit.get("state") or "").strip(),
+        (hit.get("zip") or "").strip(),
+    ]
+    address = ", ".join(b for b in addr_bits if b)
+    country = (hit.get("country_display") or hit.get("country") or "").strip()
+    contact = (hit.get("contact_name") or "").strip()
+
+    snippet_bits: list[str] = []
+    if address:
+        snippet_bits.append(address)
+    if country:
+        snippet_bits.append(country)
+    if contact:
+        snippet_bits.append(f"Contact: {contact}")
+    snippet = " — ".join(snippet_bits)
+
+    extras: dict[str, Any] = {
+        "registrant_id": registrant_id,
+        "name": name,
+        "address": address,
+        "country": country,
+        "contact": contact,
+    }
+    # Registrants don't have a stable public detail page on lda.senate.gov;
+    # link to the filings list filtered by registrant id so an operator can
+    # eyeball recent activity.
+    url = f"{_SITE_BASE}/system/public/filings/?registrant_id={registrant_id}" if registrant_id else _SITE_BASE
+    return SearchResult(
+        url=url,
+        title=name,
+        snippet=snippet,
+        published_at=None,
+        source_kind="lda",
+        extras=extras,
+    )
+
+
+def _build_contribution_result(hit: dict[str, Any]) -> SearchResult | None:
+    filing_uuid = (hit.get("filing_uuid") or "").strip()
+    filer_name = _name_of(hit.get("filer")) or (hit.get("filer_name") or "").strip()
+    if not filing_uuid and not filer_name:
+        return None
+    filer_type = (
+        hit.get("filer_type_display") or hit.get("filer_type") or ""
+    ).strip()
+    contribution_total = hit.get("contributions_total") or hit.get("contribution_total")
+    filing_year = hit.get("filing_year")
+    filing_period_raw = (
+        hit.get("filing_period_display") or hit.get("filing_period") or ""
+    )
+    filing_period = str(filing_period_raw).strip()
+    dt_posted = hit.get("dt_posted")
+
+    title_bits = [b for b in (filer_name, "LD-203", str(filing_year or ""), filing_period) if b]
+    title = " – ".join(title_bits) if title_bits else (filer_name or "LD-203 contribution report")
+
+    snippet_bits: list[str] = []
+    if filer_type:
+        snippet_bits.append(filer_type)
+    if contribution_total not in (None, "", "null"):
+        snippet_bits.append(f"Total contributions: {_fmt_money(contribution_total)}")
+    snippet = " — ".join(snippet_bits)
+
+    url = _filing_permalink(filing_uuid) if filing_uuid else _SITE_BASE
+
+    extras: dict[str, Any] = {
+        "filing_uuid": filing_uuid,
+        "filer_type": filer_type,
+        "filer_name": filer_name,
+        "contribution_total": contribution_total,
+        "filing_year": filing_year,
+        "filing_period": filing_period,
+    }
+    return SearchResult(
+        url=url,
+        title=title,
+        snippet=snippet,
+        published_at=_parse_iso_date(dt_posted),
+        source_kind="lda",
+        extras=extras,
+    )
+
+
+_KIND_TO_ENDPOINT_AND_QPARAM: dict[str, tuple[str, str]] = {
+    "filings": ("filings/", "registrant_name"),
+    "registrants": ("registrants/", "name"),
+    "contributions": ("contributions/", "filer_name"),
+}
+
+_KIND_TO_BUILDER = {
+    "filings": _build_filing_result,
+    "registrants": _build_registrant_result,
+    "contributions": _build_contribution_result,
+}
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def search(
+    query: str,
+    *,
+    kind: str = "filings",
+    max_results: int = 20,
+    timeout: float = 15.0,
+) -> list[SearchResult]:
+    """Run an LDA search and return up to ``max_results`` hits.
+
+    ``kind`` selects the index — ``filings`` (LD-1/LD-2 quarterly, query goes
+    to ``registrant_name``), ``registrants`` (firm / in-house, query goes to
+    ``name``) or ``contributions`` (LD-203, query goes to ``filer_name``).
+
+    Returns ``[]`` on transport / HTTP error / non-JSON body or unknown
+    ``kind`` — connector failures must never crash the planner.
+    """
+    if kind not in _VALID_KINDS:
+        logger.warning(
+            "lda.search: unknown kind %r; expected one of %s",
+            kind,
+            sorted(_VALID_KINDS),
+        )
+        return []
+
+    endpoint, qparam = _KIND_TO_ENDPOINT_AND_QPARAM[kind]
+    builder = _KIND_TO_BUILDER[kind]
+
+    params: dict[str, Any] = {
+        qparam: query,
+        "page_size": max_results,
+    }
+
+    await _rate_limit_gate()
+
+    url = urljoin(_BASE_URL, endpoint)
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=_headers(),
+        ) as client:
+            response = await client.get(url, params=params)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("lda search failed for %r (%s): %s", query, kind, exc)
+        return []
+
+    if response.status_code != 200:
+        logger.warning(
+            "lda search returned HTTP %s for %r (%s)",
+            response.status_code,
+            query,
+            kind,
+        )
+        return []
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        logger.warning("lda search returned non-JSON for %r: %s", query, exc)
+        return []
+
+    raw_hits = payload.get("results") or []
+    out: list[SearchResult] = []
+    for hit in raw_hits[:max_results]:
+        if not isinstance(hit, dict):
+            continue
+        result = builder(hit)
+        if result is not None:
+            out.append(result)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+def _classify_url(url: str) -> str | None:
+    """Return the filing UUID when ``url`` is an LDA filing detail page.
+
+    Strict host match against ``_ACCEPTED_HOSTS`` so look-alikes like
+    ``lda.senate.gov.attacker.example`` are rejected.
+    """
+    parsed = urlparse(url)
+    host = (parsed.netloc or "").lower().split(":", 1)[0]
+    if host not in _ACCEPTED_HOSTS:
+        return None
+    m = _FILING_URL_RE.match(parsed.path or "")
+    if not m:
+        return None
+    return m.group("uuid")
+
+
+async def _http_get_json(
+    url: str, timeout: float
+) -> tuple[int | None, dict[str, Any] | None]:
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=_headers(),
+        ) as client:
+            response = await client.get(url)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("lda fetch failed for %s: %s", url, exc)
+        return None, None
+    if response.status_code != 200:
+        return response.status_code, None
+    try:
+        return response.status_code, response.json()
+    except ValueError:
+        return response.status_code, None
+
+
+def _activities_block(activities: Any) -> tuple[str, list[dict[str, Any]]]:
+    if not isinstance(activities, list) or not activities:
+        return "", []
+    rows: list[dict[str, Any]] = []
+    for act in activities:
+        if not isinstance(act, dict):
+            continue
+        code = (
+            act.get("general_issue_code_display")
+            or act.get("general_issue_code")
+            or ""
+        ).strip()
+        description = (act.get("description") or "").strip()
+        rows.append({"code": code, "description": description})
+    if not rows:
+        return "", rows
+    lines = ["## Issues lobbied", ""]
+    for r in rows:
+        if r["code"] and r["description"]:
+            lines.append(f"- **{r['code']}** — {r['description']}")
+        elif r["code"]:
+            lines.append(f"- **{r['code']}**")
+        elif r["description"]:
+            lines.append(f"- {r['description']}")
+    return "\n".join(lines), rows
+
+
+def _lobbyists_block(activities: Any) -> tuple[str, list[str]]:
+    """Pull lobbyist names off the per-activity ``lobbyists[]`` lists.
+
+    The LDA schema nests lobbyists under each activity (since covered
+    positions and new-hire flags vary per issue), so we de-duplicate names
+    across activities to give the operator a single roster line.
+    """
+    if not isinstance(activities, list):
+        return "", []
+    names: list[str] = []
+    seen: set[str] = set()
+    for act in activities:
+        if not isinstance(act, dict):
+            continue
+        for entry in act.get("lobbyists") or []:
+            if not isinstance(entry, dict):
+                continue
+            person = entry.get("lobbyist") or {}
+            if not isinstance(person, dict):
+                continue
+            first = (person.get("first_name") or "").strip()
+            last = (person.get("last_name") or "").strip()
+            full = " ".join(p for p in (first, last) if p).strip()
+            if full and full not in seen:
+                seen.add(full)
+                names.append(full)
+    if not names:
+        return "", names
+    lines = ["## Lobbyists", ""]
+    for name in names:
+        lines.append(f"- {name}")
+    return "\n".join(lines), names
+
+
+def _amount_block(payload: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    income = payload.get("income")
+    expenses = payload.get("expenses")
+    has_amount = income not in (None, "", "null") or expenses not in (None, "", "null")
+    if not has_amount:
+        return "", {"income": income, "expenses": expenses}
+    lines = ["## Amount", ""]
+    if income not in (None, "", "null"):
+        lines.append(f"- **Income:** {_fmt_money(income)}")
+    if expenses not in (None, "", "null"):
+        lines.append(f"- **Expenses:** {_fmt_money(expenses)}")
+    return "\n".join(lines), {"income": income, "expenses": expenses}
+
+
+async def fetch(url: str, timeout: float = 30.0) -> Source | None:
+    """Open an LD-2 filing detail page and return a :class:`Source`.
+
+    Returns ``None`` for anything outside ``_ACCEPTED_HOSTS`` or paths other
+    than ``/filings/<uuid>/`` (with or without the ``/api/v1/`` prefix), and
+    for any transport / HTTP / parse failure.
+    """
+    if not url:
+        return None
+    filing_uuid = _classify_url(url)
+    if not filing_uuid:
+        return None
+
+    api_url = urljoin(_BASE_URL, f"filings/{filing_uuid}/")
+    await _rate_limit_gate()
+    status, payload = await _http_get_json(api_url, timeout)
+    if status is None or status >= 400 or not isinstance(payload, dict):
+        if status is not None and status >= 400:
+            logger.warning("lda filing HTTP %s for %s", status, api_url)
+        return None
+
+    client_name = _name_of(payload.get("client"))
+    registrant_name = _name_of(payload.get("registrant"))
+    filing_type = (
+        payload.get("filing_type_display") or payload.get("filing_type") or ""
+    ).strip()
+    filing_year = payload.get("filing_year")
+    filing_period = (
+        payload.get("filing_period_display") or payload.get("filing_period") or ""
+    ).strip()
+
+    title_bits = [b for b in (client_name, filing_type, str(filing_year or ""), filing_period) if b]
+    title = " – ".join(title_bits) if title_bits else f"LDA filing {filing_uuid}"
+
+    activities = payload.get("lobbying_activities") or []
+    issues_md, issues_rows = _activities_block(activities)
+    lobbyists_md, lobbyist_names = _lobbyists_block(activities)
+    amount_md, amount_extras = _amount_block(payload)
+
+    meta_bits = [b for b in (registrant_name, filing_type, str(filing_year or ""), filing_period) if b]
+    meta_line = "_" + " · ".join(meta_bits) + "_" if meta_bits else ""
+
+    sections = [f"# {title}"]
+    if meta_line:
+        sections.append(meta_line)
+    if issues_md:
+        sections.append(issues_md)
+    if lobbyists_md:
+        sections.append(lobbyists_md)
+    if amount_md:
+        sections.append(amount_md)
+
+    cleaned_text = "\n\n".join(sections).strip()
+    if not cleaned_text:
+        return None
+
+    metadata: dict[str, Any] = {
+        "filing_uuid": filing_uuid,
+        "filing_type": filing_type,
+        "filing_year": filing_year,
+        "filing_period": filing_period,
+        "client_name": client_name,
+        "registrant_name": registrant_name,
+        "income": amount_extras.get("income"),
+        "expenses": amount_extras.get("expenses"),
+        "issues": issues_rows,
+        "lobbyists": lobbyist_names,
+    }
+
+    return Source(
+        url=url,
+        title=title,
+        cleaned_text=cleaned_text,
+        raw_html=None,
+        fetched_at=datetime.now(UTC),
+        source_kind="lda",
+        metadata=metadata,
+    )
+
+
+def reset_for_tests() -> None:
+    """Clear per-process rate-limit state. Test-only."""
+    global _last_call_monotonic, _rate_lock
+    _last_call_monotonic = None
+    _rate_lock = asyncio.Lock()
+
+
+__all__ = ["fetch", "reset_for_tests", "search"]

--- a/src/research_agent/tools/models.py
+++ b/src/research_agent/tools/models.py
@@ -37,6 +37,7 @@ SourceKind = Literal[
     "fedregister",
     "nonprofits",
     "congress",
+    "lda",
 ]
 
 

--- a/tests/test_tools_lda.py
+++ b/tests/test_tools_lda.py
@@ -1,0 +1,505 @@
+"""Tests for `research_agent.tools.lda` (issue #103)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from research_agent.tools import lda
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    monkeypatch.delenv("LDA_API_KEY", raising=False)
+    lda.reset_for_tests()
+    monkeypatch.setattr(lda.asyncio, "sleep", AsyncMock())
+    yield
+    lda.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Test payloads
+# ---------------------------------------------------------------------------
+
+
+_FILINGS_PAYLOAD = {
+    "results": [
+        {
+            "filing_uuid": "11111111-2222-3333-4444-555555555555",
+            "filing_type": "Q1",
+            "filing_type_display": "QUARTERLY REPORT",
+            "filing_year": 2024,
+            "filing_period": "first_quarter",
+            "filing_period_display": "First Quarter",
+            "dt_posted": "2024-04-20T15:30:00Z",
+            "income": 250000.0,
+            "expenses": None,
+            "client": {"name": "HERITAGE FOUNDATION"},
+            "registrant": {"name": "ACME LOBBYING LLC"},
+            "filing_document_url": (
+                "https://lda.senate.gov/filings/public/filing/"
+                "11111111-2222-3333-4444-555555555555/print/"
+            ),
+        }
+    ]
+}
+
+
+_REGISTRANTS_PAYLOAD = {
+    "results": [
+        {
+            "id": 12345,
+            "name": "ACME LOBBYING LLC",
+            "address_1": "123 K Street NW",
+            "city": "Washington",
+            "state": "DC",
+            "state_display": "DC",
+            "zip": "20005",
+            "country_display": "UNITED STATES OF AMERICA",
+            "contact_name": "Jane Doe",
+        }
+    ]
+}
+
+
+_CONTRIBUTIONS_PAYLOAD = {
+    "results": [
+        {
+            "filing_uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "filer_type": "lobbyist",
+            "filer_type_display": "Lobbyist",
+            "filer_name": "JANE DOE",
+            "filing_year": 2024,
+            "filing_period": "mid_year",
+            "filing_period_display": "Mid-Year",
+            "contributions_total": 5000.0,
+            "dt_posted": "2024-08-01T12:00:00Z",
+        }
+    ]
+}
+
+
+_LD2_DETAIL_PAYLOAD = {
+    "filing_uuid": "11111111-2222-3333-4444-555555555555",
+    "filing_type": "Q1",
+    "filing_type_display": "QUARTERLY REPORT",
+    "filing_year": 2024,
+    "filing_period": "first_quarter",
+    "filing_period_display": "First Quarter",
+    "income": 250000.0,
+    "expenses": None,
+    "client": {"name": "HERITAGE FOUNDATION"},
+    "registrant": {"name": "ACME LOBBYING LLC"},
+    "lobbying_activities": [
+        {
+            "general_issue_code": "TAX",
+            "general_issue_code_display": "Taxation/Internal Revenue Code",
+            "description": "Tax reform legislation including HR 1234.",
+            "lobbyists": [
+                {
+                    "lobbyist": {
+                        "first_name": "Jane",
+                        "last_name": "Doe",
+                    }
+                },
+                {
+                    "lobbyist": {
+                        "first_name": "John",
+                        "last_name": "Smith",
+                    }
+                },
+            ],
+        },
+        {
+            "general_issue_code": "BUD",
+            "general_issue_code_display": "Budget/Appropriations",
+            "description": "FY2024 appropriations.",
+            "lobbyists": [
+                {
+                    "lobbyist": {
+                        "first_name": "Jane",
+                        "last_name": "Doe",
+                    }
+                },
+            ],
+        },
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# httpx mock plumbing
+# ---------------------------------------------------------------------------
+
+
+def _patch_httpx(monkeypatch, *, responder):
+    """Replace ``httpx.AsyncClient`` with a fake driven by ``responder(url, params)``.
+
+    Returns a dict capturing urls / headers / params per call.
+    """
+    captured: dict[str, list] = {"urls": [], "headers": [], "params": []}
+
+    class _FakeResp:
+        def __init__(self, status: int, text: str) -> None:
+            self.status_code = status
+            self.text = text
+
+        def json(self):
+            return json.loads(self.text)
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        captured["headers"].append(kwargs.get("headers"))
+
+        class _Client:
+            async def get(self, url, *, params=None, **_kwargs):
+                captured["urls"].append(url)
+                captured["params"].append(params)
+                status, text = responder(url, params)
+                return _FakeResp(status, text)
+
+        yield _Client()
+
+    monkeypatch.setattr(lda.httpx, "AsyncClient", _client_factory)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def test_search_filings_endpoint(monkeypatch):
+    payload = json.dumps(_FILINGS_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await lda.search("Heritage Foundation", kind="filings")
+
+    assert captured["urls"][0].endswith("/api/v1/filings/")
+    params = captured["params"][0]
+    assert params["registrant_name"] == "Heritage Foundation"
+    assert params["page_size"] == 20
+
+    assert len(results) == 1
+    hit = results[0]
+    assert hit.source_kind == "lda"
+    assert hit.extras["filing_uuid"] == "11111111-2222-3333-4444-555555555555"
+    assert hit.extras["client_name"] == "HERITAGE FOUNDATION"
+    assert hit.extras["registrant_name"] == "ACME LOBBYING LLC"
+    assert hit.extras["filing_year"] == 2024
+    assert hit.extras["income"] == 250000.0
+    assert "HERITAGE FOUNDATION" in hit.title
+    assert "QUARTERLY REPORT" in hit.title
+    assert "First Quarter" in hit.title
+    assert "ACME LOBBYING LLC" in hit.snippet
+    assert "$250,000" in hit.snippet
+    # Permalink falls through to filing_document_url when present.
+    assert hit.url.startswith("https://lda.senate.gov/")
+    assert hit.published_at is not None
+
+
+async def test_search_registrants_endpoint(monkeypatch):
+    payload = json.dumps(_REGISTRANTS_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await lda.search("Acme Lobbying", kind="registrants", max_results=5)
+
+    assert captured["urls"][0].endswith("/api/v1/registrants/")
+    params = captured["params"][0]
+    assert params["name"] == "Acme Lobbying"
+    assert params["page_size"] == 5
+
+    assert len(results) == 1
+    hit = results[0]
+    assert hit.title == "ACME LOBBYING LLC"
+    assert hit.extras["registrant_id"] == 12345
+    assert "123 K Street NW" in hit.extras["address"]
+    assert "Washington" in hit.extras["address"]
+    assert "DC" in hit.extras["address"]
+    assert hit.extras["contact"] == "Jane Doe"
+    assert hit.extras["country"] == "UNITED STATES OF AMERICA"
+
+
+async def test_search_contributions_endpoint(monkeypatch):
+    payload = json.dumps(_CONTRIBUTIONS_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await lda.search("Jane Doe", kind="contributions")
+
+    assert captured["urls"][0].endswith("/api/v1/contributions/")
+    params = captured["params"][0]
+    assert params["filer_name"] == "Jane Doe"
+
+    assert len(results) == 1
+    hit = results[0]
+    assert hit.extras["filing_uuid"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    assert hit.extras["filer_type"] == "Lobbyist"
+    assert hit.extras["filer_name"] == "JANE DOE"
+    assert hit.extras["contribution_total"] == 5000.0
+    assert hit.extras["filing_year"] == 2024
+    assert "$5,000" in hit.snippet
+    assert hit.url.endswith("/filings/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/")
+
+
+async def test_search_unknown_kind_returns_empty(monkeypatch):
+    """Unknown kinds short-circuit to ``[]`` without an HTTP call."""
+    called = {"count": 0}
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        called["count"] += 1
+
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise AssertionError("should not be called")
+
+        yield _Client()
+
+    monkeypatch.setattr(lda.httpx, "AsyncClient", _client_factory)
+
+    assert await lda.search("anything", kind="bogus") == []
+    assert called["count"] == 0
+
+
+async def test_search_anonymous_no_auth_header(monkeypatch):
+    """With LDA_API_KEY unset, requests must NOT include an Authorization header."""
+    payload = json.dumps({"results": []})
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    await lda.search("Anything", kind="filings")
+
+    headers = captured["headers"][0] or {}
+    assert "Authorization" not in headers
+
+
+async def test_search_with_api_key_sends_token(monkeypatch):
+    """With LDA_API_KEY set, requests carry ``Authorization: Token <key>``."""
+    monkeypatch.setenv("LDA_API_KEY", "abc-test-key")
+    payload = json.dumps({"results": []})
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    await lda.search("Anything", kind="filings")
+
+    headers = captured["headers"][0] or {}
+    assert headers.get("Authorization") == "Token abc-test-key"
+
+
+async def test_search_http_error_returns_empty(monkeypatch):
+    """A non-200 response is logged and returns ``[]``."""
+
+    def _respond(url, params):
+        return 500, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await lda.search("anything", kind="filings") == []
+
+
+async def test_search_transport_error_returns_empty(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(lda.httpx, "AsyncClient", _client_factory)
+
+    assert await lda.search("anything", kind="filings") == []
+
+
+async def test_search_non_json_returns_empty(monkeypatch):
+    def _respond(url, params):
+        return 200, "<html>not json</html>"
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await lda.search("anything", kind="filings") == []
+
+
+async def test_rate_limit_gate_enforces_one_rps(monkeypatch):
+    """Two concurrent search calls must space out by at least ~1s."""
+    clock = [100.0]
+
+    def fake_monotonic() -> float:
+        return clock[0]
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        clock[0] += seconds
+
+    monkeypatch.setattr(lda.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(lda.asyncio, "sleep", fake_sleep)
+
+    payload = json.dumps({"results": []})
+
+    def _respond(url, params):
+        return 200, payload
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    await asyncio.gather(
+        lda.search("a", kind="filings"), lda.search("b", kind="filings")
+    )
+
+    # At least one sleep should have been ~1.0s (the rate gate forcing the
+    # second call to wait out the 1 RPS interval).
+    assert any(abs(s - 1.0) < 1e-6 for s in sleep_calls), (
+        f"expected a ~1s sleep through the rate gate; got {sleep_calls!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_ld2_filing_returns_markdown_sections(monkeypatch):
+    """Happy path: detail JSON renders to markdown with all required sections."""
+
+    def _respond(url, params):
+        if "filings/11111111-2222-3333-4444-555555555555" in url:
+            return 200, json.dumps(_LD2_DETAIL_PAYLOAD)
+        return 404, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    url = "https://lda.senate.gov/filings/11111111-2222-3333-4444-555555555555/"
+    source = await lda.fetch(url)
+
+    assert source is not None
+    assert source.source_kind == "lda"
+    assert source.url == url
+    body = source.cleaned_text
+    assert "HERITAGE FOUNDATION" in body
+    assert "## Issues lobbied" in body
+    assert "Taxation/Internal Revenue Code" in body
+    assert "Budget/Appropriations" in body
+    assert "## Lobbyists" in body
+    assert "Jane Doe" in body
+    assert "John Smith" in body
+    # Jane Doe appears in two activities — assert de-duplication.
+    assert body.count("- Jane Doe") == 1
+    assert "## Amount" in body
+    assert "$250,000" in body
+
+    md = source.metadata
+    assert md["filing_uuid"] == "11111111-2222-3333-4444-555555555555"
+    assert md["client_name"] == "HERITAGE FOUNDATION"
+    assert md["registrant_name"] == "ACME LOBBYING LLC"
+    assert md["income"] == 250000.0
+    assert md["expenses"] is None
+    assert len(md["issues"]) == 2
+    assert md["lobbyists"] == ["Jane Doe", "John Smith"]
+
+
+async def test_fetch_rejects_non_lda_host(monkeypatch):
+    """A look-alike host like ``lda.senate.gov.attacker.example`` must not pass."""
+
+    def _respond(url, params):
+        raise AssertionError("should not be called")
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    spoof = (
+        "https://lda.senate.gov.attacker.example/filings/"
+        "11111111-2222-3333-4444-555555555555/"
+    )
+    assert await lda.fetch(spoof) is None
+
+
+async def test_fetch_unknown_path_returns_none(monkeypatch):
+    """Paths outside ``/filings/<uuid>/`` resolve to ``None``."""
+
+    def _respond(url, params):
+        raise AssertionError("should not be called")
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await lda.fetch("https://lda.senate.gov/api/v1/registrants/") is None
+
+
+async def test_fetch_returns_none_for_empty_url():
+    assert await lda.fetch("") is None
+
+
+async def test_fetch_returns_none_on_404(monkeypatch):
+    def _respond(url, params):
+        return 404, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    url = "https://lda.senate.gov/filings/11111111-2222-3333-4444-555555555555/"
+    assert await lda.fetch(url) is None
+
+
+async def test_fetch_returns_none_on_transport_error(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(lda.httpx, "AsyncClient", _client_factory)
+
+    url = "https://lda.senate.gov/filings/11111111-2222-3333-4444-555555555555/"
+    assert await lda.fetch(url) is None
+
+
+async def test_fetch_accepts_lda_gov_cutover_host(monkeypatch):
+    """The post-cutover ``lda.gov`` host is accepted alongside ``lda.senate.gov``."""
+
+    def _respond(url, params):
+        return 200, json.dumps(_LD2_DETAIL_PAYLOAD)
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    url = "https://lda.gov/filings/11111111-2222-3333-4444-555555555555/"
+    source = await lda.fetch(url)
+    assert source is not None
+    assert source.url == url
+
+
+# ---------------------------------------------------------------------------
+# Smoke registration
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_registry_includes_lda():
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "lda" in TOOL_REGISTRY

--- a/tests/test_tools_models.py
+++ b/tests/test_tools_models.py
@@ -31,6 +31,7 @@ EXPECTED_SOURCE_KINDS = (
     "fedregister",
     "nonprofits",
     "congress",
+    "lda",
 )
 
 


### PR DESCRIPTION
Closes #103
Part of #107

## Summary

Automated implementation of **Senate LDA (Lobbying Disclosure) connector**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

LDA connector fully implements all AC: 3-kind search, LD-2 fetch w/ markdown sections, anonymous + token auth, 1 RPS gate, smoke registered. 18/18 tests pass.

- **INFO** [OPEN] `src/research_agent/tools/lda.py`: search() returns SearchResult.url=filing_document_url when present (PDF/HTML print form), so calling lda.fetch() on that URL returns None — fetch() only accepts /filings/<uuid>/. Not a defect: filing_uuid is in extras and the canonical permalink can be reconstructed; document_url is fetchable via web_fetch directly. Worth noting if the planner ever pipes search.url straight into lda.fetch.
- **INFO** [OPEN] `src/research_agent/tools/lda.py`: _filing_permalink hardcodes lda.senate.gov even though _ACCEPTED_HOSTS includes lda.gov. After the 2026-06-30 cutover the old host is expected to redirect, but the TODO comment near _BASE_URL flags that the base URL should be revisited at that point.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*