### PR TITLE
feat: GDELT 2.0 DOC API connector (global news anomaly detection) (closes #105)

### DIFF
--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -356,6 +356,49 @@ def _smoke_usaspending(query: str) -> str:
     return asyncio.run(_run())
 
 
+def _smoke_gdelt(query: str) -> str:
+    """Smoke wrapper: GDELT 2.0 DOC search + tone timeline.
+
+    Per AC: ``research _smoke-tool gdelt "Anysphere Cursor"`` should surface
+    recent global news / broadcast TV mentions plus a sentiment-over-time
+    series. Lists the top-5 article hits, then prints a one-line summary of
+    the ``tone_timeline`` series (point count + first/last datapoints) so
+    an operator can eyeball both surfaces in one shot.
+    """
+    from research_agent.tools import gdelt
+
+    async def _run() -> str:
+        results = await gdelt.search(query, max_results=5)
+        lines: list[str] = []
+        if not results:
+            lines.append(f"gdelt search returned no results for {query!r}")
+        else:
+            for hit in results:
+                domain = hit.extras.get("domain") or "?"
+                language = hit.extras.get("language") or "?"
+                seendate = hit.extras.get("seendate") or "?"
+                lines.append(
+                    f"- {hit.title}\n"
+                    f"  {hit.url}\n"
+                    f"  {domain} | {language} | {seendate}"
+                )
+
+        tone = await gdelt.tone_timeline(query)
+        lines.append(f"\ntone_points: {len(tone)}")
+        if tone:
+            first = tone[0]
+            last = tone[-1]
+            lines.append(
+                f"  first: {first['datetime'].isoformat()} value={first['value']}"
+            )
+            lines.append(
+                f"  last:  {last['datetime'].isoformat()} value={last['value']}"
+            )
+        return "\n".join(lines)
+
+    return asyncio.run(_run())
+
+
 def _smoke_congress(query: str) -> str:
     """Smoke wrapper: Congress.gov v3 bill search returning the top-5 hits.
 
@@ -607,6 +650,7 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "congress": _smoke_congress,
     "lda": _smoke_lda,
     "usaspending": _smoke_usaspending,
+    "gdelt": _smoke_gdelt,
     "news": _smoke_news,
     "reddit": _smoke_reddit,
     "pdf": _smoke_pdf,

--- a/src/research_agent/tools/gdelt.py
+++ b/src/research_agent/tools/gdelt.py
@@ -1,0 +1,352 @@
+"""GDELT 2.0 DOC API connector (issue #105).
+
+Public surface:
+
+* ``async def search(query, *, since=None, language="english", max_results=20) -> list[SearchResult]``
+  hits the DOC API ``ArtList`` mode for global news / broadcast TV transcripts.
+* ``async def fetch(url) -> Source | None`` — no-op delegate to ``web_fetch.fetch``.
+  GDELT is purely an index; article bodies live on the source's own domain.
+* ``async def tone_timeline(query, *, since=None, language="english") -> list[dict]``
+  returns a sentiment-over-time series via the ``TimelineTone`` mode. This is
+  GDELT's distinctive feature — mention velocity + tone deltas surface
+  coverage waves (and anomalies) before any single outlet's RSS does.
+
+Auth: none required. The DOC API is public and free.
+
+Refresh cadence: 15 minutes — GDELT 2.0 reindexes the global news web roughly
+every 15 minutes, which is the killer feature for ambient anomaly detection
+relative to outlet-specific RSS. Coverage spans the open web *and* broadcast
+TV transcripts (the GDELT Global Knowledge Graph ingests closed-caption
+streams from CNN, MSNBC, BBC News, etc.).
+
+Per AC, the per-host gate is 1.0s (1 RPS) to be polite to the public endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+
+from research_agent import config
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.gdeltproject.org/api/v2/doc/doc"
+# AC: per-host 1 RPS.
+_RATE_LIMIT_INTERVAL = 1.0
+_DEFAULT_TIMESPAN = "1d"
+
+# GDELT expects 3-letter ISO 639-2/B codes via the ``sourcelang:<code>``
+# query token. A small map covers the common cases callers reach for; any
+# value not in the map is passed through verbatim so callers can opt into
+# the full ISO-3 set without an API surface change.
+_LANGUAGE_MAP: dict[str, str] = {
+    "english": "eng",
+    "spanish": "spa",
+    "french": "fra",
+    "german": "deu",
+    "italian": "ita",
+    "portuguese": "por",
+    "russian": "rus",
+    "chinese": "zho",
+    "japanese": "jpn",
+    "arabic": "ara",
+}
+
+_rate_lock = asyncio.Lock()
+_last_call_monotonic: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Config / rate-limit helpers
+# ---------------------------------------------------------------------------
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Accept": "application/json",
+        "User-Agent": config.get("RESEARCH_USER_AGENT")
+        or "research-agent/0.1 (+local; contact unset)",
+    }
+
+
+async def _rate_limit_gate() -> None:
+    """Block until at least ``_RATE_LIMIT_INTERVAL`` has passed since the last call."""
+    global _last_call_monotonic
+    async with _rate_lock:
+        if _last_call_monotonic is not None:
+            elapsed = time.monotonic() - _last_call_monotonic
+            wait = _RATE_LIMIT_INTERVAL - elapsed
+            if wait > 0:
+                await asyncio.sleep(wait)
+        _last_call_monotonic = time.monotonic()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_timespan(since: datetime | None) -> str | None:
+    """Convert a tz-aware datetime to GDELT's ``timespan`` token.
+
+    GDELT accepts forms like ``15min``, ``1h``, ``1d``, ``2w``, ``1m``. We map
+    ``now - since`` to the smallest unit that still fits cleanly: minutes
+    under an hour, hours under a day, days otherwise. ``None`` returns
+    ``None`` so callers can omit the param and let GDELT apply its default.
+    """
+    if since is None:
+        return None
+    now = datetime.now(UTC)
+    if since.tzinfo is None:
+        since = since.replace(tzinfo=UTC)
+    delta = now - since
+    if delta <= timedelta(0):
+        return "15min"
+    seconds = int(delta.total_seconds())
+    if seconds < 3600:
+        minutes = max(15, seconds // 60)
+        return f"{minutes}min"
+    if seconds < 86400:
+        return f"{max(1, seconds // 3600)}h"
+    return f"{max(1, seconds // 86400)}d"
+
+
+def _parse_gdelt_dt(seendate: Any) -> datetime | None:
+    """Parse GDELT's ``YYYYMMDDTHHMMSSZ`` timestamp format."""
+    if not seendate:
+        return None
+    text = str(seendate).strip()
+    if not text:
+        return None
+    try:
+        return datetime.strptime(text, "%Y%m%dT%H%M%SZ").replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def _language_token(language: str | None) -> str | None:
+    if not language:
+        return None
+    key = language.strip().lower()
+    if not key:
+        return None
+    return _LANGUAGE_MAP.get(key, key)
+
+
+def _build_query(query: str, language: str | None) -> str:
+    token = _language_token(language)
+    if token:
+        return f"{query} sourcelang:{token}"
+    return query
+
+
+# ---------------------------------------------------------------------------
+# GET helper
+# ---------------------------------------------------------------------------
+
+
+async def _get(
+    params: dict[str, Any], timeout: float
+) -> tuple[int | None, dict[str, Any] | None]:
+    """GET ``_BASE_URL`` with ``params`` after the rate gate.
+
+    Returns ``(status_code, payload)``. GDELT occasionally responds with an
+    HTML error page (rate-limited bot detection, malformed query) — those
+    surface as ``(200, None)`` after the JSON parse fails, not as a raise.
+    """
+    await _rate_limit_gate()
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=_headers(),
+        ) as client:
+            response = await client.get(_BASE_URL, params=params)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("gdelt GET failed: %s", exc)
+        return None, None
+    if response.status_code != 200:
+        return response.status_code, None
+    try:
+        return response.status_code, response.json()
+    except ValueError as exc:
+        logger.warning("gdelt GET returned non-JSON body: %s", exc)
+        return response.status_code, None
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def search(
+    query: str,
+    *,
+    since: datetime | None = None,
+    language: str = "english",
+    max_results: int = 20,
+    timeout: float = 15.0,
+) -> list[SearchResult]:
+    """Run a GDELT DOC ``ArtList`` query and return up to ``max_results`` hits.
+
+    ``since`` narrows the search window. When ``None``, GDELT applies its
+    default (typically the last few days). ``language`` is mapped to a
+    ``sourcelang:<iso3>`` token in the query — pass an unknown value to opt
+    into the raw ISO-3 code without changing the connector.
+
+    Returns ``[]`` on transport / HTTP error / non-JSON body — connector
+    failures must never crash the planner.
+    """
+    params: dict[str, Any] = {
+        "query": _build_query(query, language),
+        "mode": "ArtList",
+        "format": "json",
+        "maxrecords": max_results,
+        "sort": "datedesc",
+    }
+    timespan = _to_timespan(since)
+    if timespan is not None:
+        params["timespan"] = timespan
+
+    status, payload = await _get(params, timeout)
+    if status is None or status != 200 or not isinstance(payload, dict):
+        if status is not None and status != 200:
+            logger.warning("gdelt search returned HTTP %s for %r", status, query)
+        return []
+
+    raw = payload.get("articles") or []
+    out: list[SearchResult] = []
+    for art in raw[:max_results]:
+        if not isinstance(art, dict):
+            continue
+        url = (art.get("url") or "").strip()
+        title = (art.get("title") or "").strip()
+        if not url or not title:
+            continue
+        seendate = art.get("seendate") or ""
+        domain = (art.get("domain") or "").strip()
+        snippet_bits = [str(b) for b in (seendate, domain) if b]
+        snippet = " — ".join(snippet_bits)
+        out.append(
+            SearchResult(
+                url=url,
+                title=title,
+                snippet=snippet,
+                published_at=_parse_gdelt_dt(seendate),
+                source_kind="gdelt",
+                extras={
+                    "domain": domain,
+                    "language": (art.get("language") or "").strip() or None,
+                    "sourcecountry": (art.get("sourcecountry") or "").strip() or None,
+                    "socialimage": (art.get("socialimage") or "").strip() or None,
+                    "seendate": seendate,
+                },
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+async def fetch(url: str) -> Source | None:
+    """Delegate to :func:`web_fetch.fetch`.
+
+    GDELT only indexes article URLs — bodies live on the source's own
+    domain — so the connector's ``fetch`` is a thin pass-through. The
+    central ``web_fetch`` pipeline handles robots/UA/Playwright fallback
+    and Wayback archiving uniformly with the rest of the agent's web layer.
+    """
+    if not url:
+        return None
+    from research_agent.tools import web_fetch
+
+    return await web_fetch.fetch(url)
+
+
+# ---------------------------------------------------------------------------
+# tone_timeline()
+# ---------------------------------------------------------------------------
+
+
+async def tone_timeline(
+    query: str,
+    *,
+    since: datetime | None = None,
+    language: str = "english",
+    timeout: float = 15.0,
+) -> list[dict[str, Any]]:
+    """Return a GDELT ``TimelineTone`` series as ``[{datetime, value}, ...]``.
+
+    Tone is GDELT's average sentiment score across the matching mention
+    population, sampled at GDELT's native cadence. Mention-velocity spikes
+    and tone deltas together are what make this useful for anomaly
+    detection — outlet RSS only catches a wave once a single source picks
+    it up; the tone timeline reflects the *aggregate* shift.
+
+    Returns ``[]`` on transport / HTTP error / non-JSON body / unexpected
+    payload shape.
+    """
+    params: dict[str, Any] = {
+        "query": _build_query(query, language),
+        "mode": "TimelineTone",
+        "format": "json",
+    }
+    timespan = _to_timespan(since)
+    if timespan is not None:
+        params["timespan"] = timespan
+
+    status, payload = await _get(params, timeout)
+    if status is None or status != 200 or not isinstance(payload, dict):
+        if status is not None and status != 200:
+            logger.warning("gdelt tone_timeline HTTP %s for %r", status, query)
+        return []
+
+    timeline = payload.get("timeline")
+    if not isinstance(timeline, list) or not timeline:
+        return []
+    first = timeline[0]
+    if not isinstance(first, dict):
+        return []
+    data = first.get("data")
+    if not isinstance(data, list):
+        return []
+
+    out: list[dict[str, Any]] = []
+    for point in data:
+        if not isinstance(point, dict):
+            continue
+        dt = _parse_gdelt_dt(point.get("date"))
+        raw_val = point.get("value")
+        if dt is None or raw_val is None:
+            continue
+        try:
+            value = float(raw_val)
+        except (TypeError, ValueError):
+            continue
+        out.append({"datetime": dt, "value": value})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Test hooks
+# ---------------------------------------------------------------------------
+
+
+def reset_for_tests() -> None:
+    """Clear per-process rate-limit state. Test-only."""
+    global _last_call_monotonic, _rate_lock
+    _last_call_monotonic = None
+    _rate_lock = asyncio.Lock()
+
+
+__all__ = ["fetch", "reset_for_tests", "search", "tone_timeline"]

--- a/tests/test_tools_gdelt.py
+++ b/tests/test_tools_gdelt.py
@@ -1,0 +1,336 @@
+"""Tests for `research_agent.tools.gdelt` (issue #105)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from research_agent.tools import gdelt
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    gdelt.reset_for_tests()
+    monkeypatch.setattr(gdelt.asyncio, "sleep", AsyncMock())
+    yield
+    gdelt.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Test payloads
+# ---------------------------------------------------------------------------
+
+
+_ARTLIST_PAYLOAD = {
+    "articles": [
+        {
+            "url": "https://example.com/anysphere-cursor-launch",
+            "url_mobile": "",
+            "title": "Anysphere ships Cursor 1.0",
+            "seendate": "20260301T120000Z",
+            "socialimage": "https://example.com/img.png",
+            "domain": "example.com",
+            "language": "English",
+            "sourcecountry": "United States",
+        },
+        {
+            "url": "https://news.example.org/cursor-coverage",
+            "title": "Cursor adoption climbs",
+            "seendate": "20260228T090000Z",
+            "domain": "news.example.org",
+            "language": "English",
+            "sourcecountry": "United Kingdom",
+        },
+    ]
+}
+
+
+_TIMELINE_PAYLOAD = {
+    "timeline": [
+        {
+            "data": [
+                {"date": "20260301T000000Z", "value": -1.5},
+                {"date": "20260301T010000Z", "value": -0.7},
+                {"date": "20260301T020000Z", "value": 2.1},
+            ]
+        }
+    ]
+}
+
+
+# ---------------------------------------------------------------------------
+# httpx mock plumbing
+# ---------------------------------------------------------------------------
+
+
+def _patch_httpx(monkeypatch, *, get_responder):
+    captured: dict[str, list] = {
+        "urls": [],
+        "params": [],
+        "headers": [],
+    }
+
+    class _FakeResp:
+        def __init__(self, status: int, text: str) -> None:
+            self.status_code = status
+            self.text = text
+
+        def json(self):
+            return json.loads(self.text)
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        captured["headers"].append(kwargs.get("headers"))
+
+        class _Client:
+            async def get(self, url, *, params=None, **_kwargs):
+                captured["urls"].append(url)
+                captured["params"].append(params)
+                status, text = get_responder(url, params)
+                return _FakeResp(status, text)
+
+        yield _Client()
+
+    monkeypatch.setattr(gdelt.httpx, "AsyncClient", _client_factory)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def test_search_parses_artlist(monkeypatch):
+    payload = json.dumps(_ARTLIST_PAYLOAD)
+
+    def _get(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, get_responder=_get)
+
+    results = await gdelt.search("Anysphere Cursor", max_results=10)
+
+    assert len(captured["urls"]) == 1
+    assert captured["urls"][0] == gdelt._BASE_URL
+    params = captured["params"][0]
+    assert params["mode"] == "ArtList"
+    assert params["format"] == "json"
+    assert params["maxrecords"] == 10
+    assert params["sort"] == "datedesc"
+    assert "sourcelang:eng" in params["query"]
+    assert "Anysphere Cursor" in params["query"]
+    # No since => no timespan param.
+    assert "timespan" not in params
+
+    assert len(results) == 2
+    hit = results[0]
+    assert hit.source_kind == "gdelt"
+    assert hit.url == "https://example.com/anysphere-cursor-launch"
+    assert hit.title == "Anysphere ships Cursor 1.0"
+    assert hit.extras["domain"] == "example.com"
+    assert hit.extras["language"] == "English"
+    assert hit.extras["sourcecountry"] == "United States"
+    assert hit.extras["socialimage"] == "https://example.com/img.png"
+    # Published_at parsed from YYYYMMDDTHHMMSSZ.
+    assert hit.published_at == datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC)
+
+
+async def test_search_handles_non_json(monkeypatch):
+    """HTML error pages must not crash — they surface as []."""
+
+    def _get(url, params):
+        return 200, "<html>not json</html>"
+
+    _patch_httpx(monkeypatch, get_responder=_get)
+
+    assert await gdelt.search("anything") == []
+
+
+async def test_search_passes_timespan(monkeypatch):
+    payload = json.dumps({"articles": []})
+
+    def _get(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, get_responder=_get)
+
+    since = datetime.now(UTC) - timedelta(days=2)
+    await gdelt.search("anything", since=since)
+
+    params = captured["params"][0]
+    assert params["timespan"] == "2d"
+
+
+async def test_search_http_error_returns_empty(monkeypatch):
+    def _get(url, params):
+        return 500, ""
+
+    _patch_httpx(monkeypatch, get_responder=_get)
+
+    assert await gdelt.search("anything") == []
+
+
+async def test_search_transport_error_returns_empty(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(gdelt.httpx, "AsyncClient", _client_factory)
+
+    assert await gdelt.search("anything") == []
+
+
+async def test_search_unknown_language_passes_through(monkeypatch):
+    """An unmapped language value should pass through verbatim as the iso3 token."""
+    payload = json.dumps({"articles": []})
+
+    def _get(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, get_responder=_get)
+
+    await gdelt.search("anything", language="kor")
+    assert "sourcelang:kor" in captured["params"][0]["query"]
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_delegates_to_web_fetch(monkeypatch):
+    """``gdelt.fetch`` must be a no-op pass-through to ``web_fetch.fetch``."""
+    from research_agent.tools import web_fetch
+
+    sentinel_source = object()
+    mock_fetch = AsyncMock(return_value=sentinel_source)
+    monkeypatch.setattr(web_fetch, "fetch", mock_fetch)
+
+    url = "https://example.com/article"
+    result = await gdelt.fetch(url)
+
+    assert result is sentinel_source
+    mock_fetch.assert_awaited_once_with(url)
+
+
+async def test_fetch_empty_url_returns_none():
+    assert await gdelt.fetch("") is None
+
+
+# ---------------------------------------------------------------------------
+# tone_timeline()
+# ---------------------------------------------------------------------------
+
+
+async def test_tone_timeline_parses_payload(monkeypatch):
+    payload = json.dumps(_TIMELINE_PAYLOAD)
+
+    def _get(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, get_responder=_get)
+
+    series = await gdelt.tone_timeline("Anysphere Cursor")
+
+    params = captured["params"][0]
+    assert params["mode"] == "TimelineTone"
+    assert params["format"] == "json"
+
+    assert len(series) == 3
+    assert series[0]["datetime"] == datetime(2026, 3, 1, 0, 0, 0, tzinfo=UTC)
+    assert series[0]["value"] == -1.5
+    assert series[2]["value"] == pytest.approx(2.1)
+
+
+async def test_tone_timeline_handles_empty_shape(monkeypatch):
+    """Missing ``timeline`` key (or unexpected shape) returns []."""
+    payload = json.dumps({"unexpected": "shape"})
+
+    def _get(url, params):
+        return 200, payload
+
+    _patch_httpx(monkeypatch, get_responder=_get)
+
+    assert await gdelt.tone_timeline("anything") == []
+
+
+async def test_tone_timeline_handles_non_json(monkeypatch):
+    def _get(url, params):
+        return 200, "<html>blocked</html>"
+
+    _patch_httpx(monkeypatch, get_responder=_get)
+
+    assert await gdelt.tone_timeline("anything") == []
+
+
+async def test_tone_timeline_http_error_returns_empty(monkeypatch):
+    def _get(url, params):
+        return 503, ""
+
+    _patch_httpx(monkeypatch, get_responder=_get)
+
+    assert await gdelt.tone_timeline("anything") == []
+
+
+# ---------------------------------------------------------------------------
+# Rate limit gate
+# ---------------------------------------------------------------------------
+
+
+async def test_rate_limit_gate_serializes_calls(monkeypatch):
+    """Two concurrent _get calls must space out by ~_RATE_LIMIT_INTERVAL."""
+    clock = [100.0]
+
+    def fake_monotonic() -> float:
+        return clock[0]
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        clock[0] += seconds
+
+    monkeypatch.setattr(gdelt.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(gdelt.asyncio, "sleep", fake_sleep)
+
+    payload = json.dumps({"articles": []})
+
+    def _get(url, params):
+        return 200, payload
+
+    _patch_httpx(monkeypatch, get_responder=_get)
+
+    await asyncio.gather(
+        gdelt.search("a"),
+        gdelt.search("b"),
+    )
+
+    assert any(abs(s - gdelt._RATE_LIMIT_INTERVAL) < 1e-6 for s in sleep_calls), (
+        f"expected a ~{gdelt._RATE_LIMIT_INTERVAL}s sleep through the rate gate; "
+        f"got {sleep_calls!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Smoke registration
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_registry_includes_gdelt():
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "gdelt" in TOOL_REGISTRY


### PR DESCRIPTION
Closes #105
Part of #107

## Summary

Automated implementation of **GDELT 2.0 DOC API connector (global news anomaly detection)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

GDELT 2.0 DOC connector fully meets all ACs: search/fetch/tone_timeline with correct signatures, 1 RPS rate gate, fetch delegates to web_fetch, smoke registry entry wired, SourceKind extended, robust error handling, 14/14 tests pass.

- **INFO** [OPEN] `src/research_agent/tools/gdelt.py`: Issue endpoint example mentions `TimelineVolRaw` but the AC text specifies a 'sentiment-over-time series' — implementation correctly uses `TimelineTone` (the sentiment mode). Honoring AC text over the example endpoint is the right call.
- **INFO** [OPEN] `src/research_agent/orchestrator/loop.py`: Connector is registered in TOOL_REGISTRY (smoke wrapper) but not wired into orchestrator/loop.py task handlers (no `gdelt_search` kind). This matches the pattern of the other recent epic-107 connectors (edgar, fec, courtlistener, fedregister, nonprofits, congress, lda, usaspending) — orchestrator dispatch integration is a separate epic concern, not in this issue's AC.
- **INFO** [OPEN] `README.md`: README.md `Tool registry probes` section lists only 4 example smoke commands and does not enumerate gdelt — same omission applies to all other recently-added connectors. Not a GDELT-specific drift; the section is intentionally illustrative. docs/API_KEYS.md already documents GDELT as no-key (issue #105).

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*