### PR TITLE
feat: LittleSis connector (relational power-mapping database) (closes #97)

### DIFF
--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -319,6 +319,56 @@ def _smoke_lda(query: str) -> str:
     return asyncio.run(_run())
 
 
+def _smoke_littlesis(query: str) -> str:
+    """Smoke wrapper: LittleSis entity search + top-hit relationships.
+
+    Per AC: ``research _smoke-tool littlesis "Peter Thiel"`` should surface
+    the entity row plus a snapshot of who they're connected to. Lists the
+    top-5 entity hits (name, primary_ext, permalink), then for the top hit
+    fetches relationships and prints a count + first 5 categorised edges.
+
+    LittleSis is user-contributed — output is a research lead, not evidence.
+    """
+    from research_agent.tools import littlesis
+
+    async def _run() -> str:
+        results = await littlesis.search(query, kind="entities", max_results=5)
+        if not results:
+            return f"littlesis search returned no results for {query!r}"
+        lines: list[str] = ["# Entities"]
+        for hit in results:
+            primary_ext = hit.extras.get("primary_ext") or "?"
+            snippet = hit.snippet.replace("\n", " ")
+            if len(snippet) > 200:
+                snippet = snippet[:200] + "…"
+            lines.append(
+                f"- {hit.title} — {primary_ext}\n"
+                f"  {hit.url}\n"
+                f"  {snippet}"
+            )
+
+        top = results[0]
+        rels = await littlesis.search(top.title, kind="relationships", max_results=5)
+        lines.append(f"\n# Relationships for {top.title}")
+        if not rels:
+            lines.append("(no relationships returned)")
+        else:
+            lines.append(f"total: {len(rels)}")
+            for rel in rels[:5]:
+                category = rel.extras.get("category_label") or "?"
+                snippet = rel.snippet.replace("\n", " ")
+                if len(snippet) > 200:
+                    snippet = snippet[:200] + "…"
+                lines.append(
+                    f"- {rel.title}\n"
+                    f"  [{category}] {snippet}\n"
+                    f"  {rel.url}"
+                )
+        return "\n".join(lines)
+
+    return asyncio.run(_run())
+
+
 def _smoke_usaspending(query: str) -> str:
     """Smoke wrapper: USAspending awards search returning the top-5 hits.
 
@@ -649,6 +699,7 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "fec": _smoke_fec,
     "congress": _smoke_congress,
     "lda": _smoke_lda,
+    "littlesis": _smoke_littlesis,
     "usaspending": _smoke_usaspending,
     "gdelt": _smoke_gdelt,
     "news": _smoke_news,

--- a/src/research_agent/tools/littlesis.py
+++ b/src/research_agent/tools/littlesis.py
@@ -1,0 +1,608 @@
+"""LittleSis connector — relational power-mapping database (issue #97).
+
+Public surface:
+
+* ``async def search(query, *, kind="entities", max_results=20) -> list[SearchResult]``
+  hits the LittleSis REST API (``littlesis.org/api/``). ``kind`` is either
+  ``entities`` (people / orgs) or ``relationships`` (positions, donations,
+  family ties, ownership stakes, …).
+* ``async def fetch(url) -> Source | None`` opens an entity page and returns
+  markdown of the entity's roles, categorised relationships, and connected
+  organisations.
+
+LittleSis is **user-contributed** ("Wikipedia for power"). Treat results as a
+**lead**, not as evidence — verify against primary sources (FEC, IRS Form
+990, court records, EDGAR, …) before any factual claim ends up in a report.
+
+No auth required. Per AC: per-host 1 RPS gate, mirroring ``tools/lda.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from research_agent import config
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://littlesis.org/api/"
+_SITE_BASE = "https://littlesis.org"
+_ACCEPTED_HOSTS = frozenset({"littlesis.org", "www.littlesis.org"})
+# AC: per-host rate of 1 RPS.
+_RATE_LIMIT_INTERVAL = 1.0
+
+_VALID_KINDS = {"entities", "relationships"}
+
+# Entity URLs look like /entity/<id>(-Slug)? or /api/entities/<id>. Numeric id
+# is the only stable handle; the trailing slug is cosmetic.
+_ENTITY_URL_RE = re.compile(
+    r"^/(?:api/entities|entity)/(?P<id>\d+)(?:-[^/]*)?/?$"
+)
+
+# LittleSis category_id → human label. Stable IDs published in the API docs;
+# unknown ids are tolerated and grouped under ``Other`` so a future schema
+# addition doesn't crash the renderer.
+_CATEGORY_LABELS: dict[int, str] = {
+    1: "Position",
+    2: "Education",
+    3: "Membership",
+    4: "Family",
+    5: "Donation",
+    6: "Transaction",
+    7: "Lobbying",
+    8: "Social",
+    9: "Professional",
+    10: "Ownership",
+    11: "Hierarchy",
+    12: "Generic",
+}
+
+_rate_lock = asyncio.Lock()
+_last_call_monotonic: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Config / rate-limit helpers
+# ---------------------------------------------------------------------------
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Accept": "application/json",
+        "User-Agent": config.get("RESEARCH_USER_AGENT")
+        or "research-agent/0.1 (+local; contact unset)",
+    }
+
+
+async def _rate_limit_gate() -> None:
+    """Block until at least ``_RATE_LIMIT_INTERVAL`` has passed since the last call."""
+    global _last_call_monotonic
+    async with _rate_lock:
+        if _last_call_monotonic is not None:
+            elapsed = time.monotonic() - _last_call_monotonic
+            wait = _RATE_LIMIT_INTERVAL - elapsed
+            if wait > 0:
+                await asyncio.sleep(wait)
+        _last_call_monotonic = time.monotonic()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _entity_attrs(item: Any) -> dict[str, Any]:
+    """Return the entity attribute dict regardless of envelope shape.
+
+    LittleSis returns JSON:API-flavoured records — top-level fields live
+    under ``attributes``. Some endpoints flatten this on older responses,
+    so we tolerate both shapes.
+    """
+    if not isinstance(item, dict):
+        return {}
+    attrs = item.get("attributes")
+    if isinstance(attrs, dict):
+        merged = dict(attrs)
+        if "id" not in merged and "id" in item:
+            merged["id"] = item["id"]
+        return merged
+    return item
+
+
+def _entity_permalink(entity_id: int | str) -> str:
+    return f"{_SITE_BASE}/entity/{entity_id}"
+
+
+def _entity_self_link(item: Any) -> str | None:
+    if not isinstance(item, dict):
+        return None
+    links = item.get("links")
+    if not isinstance(links, dict):
+        return None
+    self_link = links.get("self")
+    if isinstance(self_link, dict):
+        web = self_link.get("web")
+        return str(web) if web else None
+    if isinstance(self_link, str):
+        return self_link
+    return None
+
+
+def _category_label(category_id: Any, fallback: str = "") -> str:
+    try:
+        cid = int(category_id)
+    except (TypeError, ValueError):
+        return fallback or "Other"
+    return _CATEGORY_LABELS.get(cid, fallback or "Other")
+
+
+# ---------------------------------------------------------------------------
+# search() builders
+# ---------------------------------------------------------------------------
+
+
+def _build_entity_result(item: Any) -> SearchResult | None:
+    attrs = _entity_attrs(item)
+    name = (attrs.get("name") or "").strip()
+    entity_id = attrs.get("id")
+    if not name or entity_id in (None, ""):
+        return None
+
+    primary_ext = (attrs.get("primary_ext") or "").strip()
+    types = attrs.get("types") or []
+    if not isinstance(types, list):
+        types = []
+
+    summary = (attrs.get("summary") or "").strip()
+    blurb = (attrs.get("blurb") or "").strip()
+    snippet = blurb or summary
+
+    url = _entity_self_link(item) or _entity_permalink(entity_id)
+
+    extras: dict[str, Any] = {
+        "entity_id": entity_id,
+        "primary_ext": primary_ext,
+        "types": list(types),
+        "summary": summary,
+        "blurb": blurb,
+    }
+    return SearchResult(
+        url=url,
+        title=name,
+        snippet=snippet,
+        published_at=None,
+        source_kind="littlesis",
+        extras=extras,
+    )
+
+
+def _build_relationship_result(rel: Any) -> SearchResult | None:
+    attrs = _entity_attrs(rel)
+    rel_id = attrs.get("id")
+    if rel_id in (None, ""):
+        return None
+
+    entity1_id = attrs.get("entity1_id")
+    entity2_id = attrs.get("entity2_id")
+    entity1_name = (attrs.get("entity1_name") or "").strip()
+    entity2_name = (attrs.get("entity2_name") or "").strip()
+    category_id = attrs.get("category_id")
+    category_label = _category_label(category_id)
+    description = (
+        attrs.get("description")
+        or attrs.get("description1")
+        or attrs.get("description2")
+        or ""
+    )
+    description = str(description).strip()
+    amount = attrs.get("amount")
+    start_date = (attrs.get("start_date") or "").strip() if attrs.get("start_date") else None
+    end_date = (attrs.get("end_date") or "").strip() if attrs.get("end_date") else None
+
+    if entity1_name and entity2_name:
+        title = f"{entity1_name} → {entity2_name}"
+    elif entity1_name or entity2_name:
+        title = entity1_name or entity2_name
+    else:
+        title = f"LittleSis relationship {rel_id}"
+
+    snippet_bits: list[str] = []
+    if category_label:
+        snippet_bits.append(category_label)
+    if description:
+        snippet_bits.append(description)
+    snippet = ": ".join(snippet_bits)
+
+    url = _entity_self_link(rel) or f"{_SITE_BASE}/relationship/{rel_id}"
+
+    extras: dict[str, Any] = {
+        "relationship_id": rel_id,
+        "category_id": category_id,
+        "category_label": category_label,
+        "entity1_id": entity1_id,
+        "entity2_id": entity2_id,
+        "entity1_name": entity1_name,
+        "entity2_name": entity2_name,
+        # ``related_*`` keeps a one-step-removed handle handy when the
+        # caller already knows which side they searched from.
+        "related_id": entity2_id,
+        "related_name": entity2_name,
+        "amount": amount,
+        "start_date": start_date,
+        "end_date": end_date,
+        "description": description,
+    }
+    return SearchResult(
+        url=url,
+        title=title,
+        snippet=snippet,
+        published_at=None,
+        source_kind="littlesis",
+        extras=extras,
+    )
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def _http_get_json(
+    url: str, *, params: dict[str, Any] | None, timeout: float
+) -> tuple[int | None, dict[str, Any] | None]:
+    """GET ``url`` and return ``(status, json)``. ``status=None`` on transport error."""
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=_headers(),
+        ) as client:
+            response = await client.get(url, params=params)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("littlesis GET failed for %s: %s", url, exc)
+        return None, None
+    if response.status_code != 200:
+        return response.status_code, None
+    try:
+        return response.status_code, response.json()
+    except ValueError as exc:
+        logger.warning("littlesis returned non-JSON for %s: %s", url, exc)
+        return response.status_code, None
+
+
+async def search(
+    query: str,
+    *,
+    kind: str = "entities",
+    max_results: int = 20,
+    timeout: float = 15.0,
+) -> list[SearchResult]:
+    """Run a LittleSis search and return up to ``max_results`` hits.
+
+    ``kind="entities"`` queries ``/api/entities/search``. ``kind="relationships"``
+    runs an entity search first, then surfaces the top hit's relationships
+    so a caller asking "who is this person connected to?" gets one round-trip
+    of network and a flat list of typed edges.
+
+    Returns ``[]`` on transport / HTTP error / non-JSON body or unknown
+    ``kind`` — connector failures must never crash the planner.
+    """
+    if kind not in _VALID_KINDS:
+        logger.warning(
+            "littlesis.search: unknown kind %r; expected one of %s",
+            kind,
+            sorted(_VALID_KINDS),
+        )
+        return []
+
+    await _rate_limit_gate()
+    search_url = urljoin(_BASE_URL, "entities/search")
+    status, payload = await _http_get_json(
+        search_url,
+        params={"q": query, "num": max_results},
+        timeout=timeout,
+    )
+    if status is None or status >= 400 or not isinstance(payload, dict):
+        if status is not None and status >= 400:
+            logger.warning(
+                "littlesis search HTTP %s for %r (%s)", status, query, kind
+            )
+        return []
+
+    raw_hits = payload.get("data") or payload.get("results") or []
+    if not isinstance(raw_hits, list):
+        return []
+
+    if kind == "entities":
+        out: list[SearchResult] = []
+        for hit in raw_hits[:max_results]:
+            result = _build_entity_result(hit)
+            if result is not None:
+                out.append(result)
+        return out
+
+    # kind == "relationships": follow the top entity hit and list its edges.
+    top_attrs: dict[str, Any] = {}
+    for hit in raw_hits:
+        attrs = _entity_attrs(hit)
+        if attrs.get("id") not in (None, ""):
+            top_attrs = attrs
+            break
+    top_id = top_attrs.get("id")
+    if top_id in (None, ""):
+        return []
+
+    await _rate_limit_gate()
+    rel_url = urljoin(_BASE_URL, f"entities/{top_id}/relationships")
+    status, rel_payload = await _http_get_json(
+        rel_url, params=None, timeout=timeout
+    )
+    if status is None or status >= 400 or not isinstance(rel_payload, dict):
+        if status is not None and status >= 400:
+            logger.warning(
+                "littlesis relationships HTTP %s for entity %s", status, top_id
+            )
+        return []
+    rel_hits = rel_payload.get("data") or rel_payload.get("results") or []
+    if not isinstance(rel_hits, list):
+        return []
+
+    out = []
+    for rel in rel_hits[:max_results]:
+        result = _build_relationship_result(rel)
+        if result is not None:
+            out.append(result)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+def _classify_url(url: str) -> str | None:
+    """Return the entity id when ``url`` is a LittleSis entity page.
+
+    Strict host match against ``_ACCEPTED_HOSTS`` so look-alikes like
+    ``littlesis.org.attacker.example`` are rejected. Accepts both the
+    human-facing ``/entity/<id>(-slug)?`` form and the API form
+    ``/api/entities/<id>``.
+    """
+    parsed = urlparse(url)
+    host = (parsed.netloc or "").lower().split(":", 1)[0]
+    if host not in _ACCEPTED_HOSTS:
+        return None
+    m = _ENTITY_URL_RE.match(parsed.path or "")
+    if not m:
+        return None
+    return m.group("id")
+
+
+def _roles_block(relationships: list[dict[str, Any]]) -> tuple[str, list[dict[str, Any]]]:
+    """Render the Position-category relationships as a roles list."""
+    rows = [r for r in relationships if r.get("category_label") == "Position"]
+    if not rows:
+        return "", rows
+    lines = ["## Roles / Positions", ""]
+    for r in rows:
+        label = r.get("entity2_name") or r.get("related_name") or ""
+        description = r.get("description") or ""
+        start = r.get("start_date") or ""
+        end = r.get("end_date") or ""
+        date_bits = []
+        if start:
+            date_bits.append(start)
+        if end:
+            date_bits.append(end)
+        date_str = "–".join(date_bits) if date_bits else ""
+        bits = [b for b in (description, label, date_str) if b]
+        if bits:
+            lines.append("- " + " — ".join(bits))
+    return "\n".join(lines), rows
+
+
+def _relationships_block(
+    relationships: list[dict[str, Any]],
+) -> str:
+    if not relationships:
+        return ""
+    by_cat: dict[str, list[dict[str, Any]]] = {}
+    for r in relationships:
+        label = r.get("category_label") or "Other"
+        by_cat.setdefault(label, []).append(r)
+
+    # Stable category order: known labels first (in canonical order), then
+    # any unknown labels alphabetically. Keeps diff-ability across runs.
+    canonical_order = list(_CATEGORY_LABELS.values())
+    ordered: list[str] = [c for c in canonical_order if c in by_cat]
+    extras = sorted(c for c in by_cat if c not in canonical_order)
+    ordered.extend(extras)
+
+    lines = ["## Relationships", ""]
+    for label in ordered:
+        lines.append(f"### {label}")
+        lines.append("")
+        for r in by_cat[label]:
+            counterpart = r.get("entity2_name") or r.get("related_name") or "?"
+            description = r.get("description") or ""
+            start = r.get("start_date") or ""
+            end = r.get("end_date") or ""
+            amount = r.get("amount")
+            bits: list[str] = [counterpart]
+            if description:
+                bits.append(description)
+            date_bits = []
+            if start:
+                date_bits.append(start)
+            if end:
+                date_bits.append(end)
+            if date_bits:
+                bits.append("–".join(date_bits))
+            if amount not in (None, "", "null"):
+                bits.append(f"amount={amount}")
+            lines.append("- " + " — ".join(bits))
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _connected_orgs_block(
+    relationships: list[dict[str, Any]],
+) -> tuple[str, list[str]]:
+    """De-duplicated list of org-side counterparts across all relationships."""
+    names: list[str] = []
+    seen: set[str] = set()
+    for r in relationships:
+        name = (r.get("entity2_name") or r.get("related_name") or "").strip()
+        if not name:
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        names.append(name)
+    if not names:
+        return "", names
+    lines = ["## Connected organizations", ""]
+    for name in names:
+        lines.append(f"- {name}")
+    return "\n".join(lines), names
+
+
+def _normalize_relationship(rel: Any) -> dict[str, Any] | None:
+    attrs = _entity_attrs(rel)
+    rel_id = attrs.get("id")
+    if rel_id in (None, ""):
+        return None
+    category_id = attrs.get("category_id")
+    return {
+        "relationship_id": rel_id,
+        "category_id": category_id,
+        "category_label": _category_label(category_id),
+        "entity1_id": attrs.get("entity1_id"),
+        "entity2_id": attrs.get("entity2_id"),
+        "entity1_name": (attrs.get("entity1_name") or "").strip(),
+        "entity2_name": (attrs.get("entity2_name") or "").strip(),
+        "related_id": attrs.get("entity2_id"),
+        "related_name": (attrs.get("entity2_name") or "").strip(),
+        "description": (
+            (attrs.get("description") or "")
+            or (attrs.get("description1") or "")
+            or (attrs.get("description2") or "")
+        ).strip(),
+        "amount": attrs.get("amount"),
+        "start_date": (attrs.get("start_date") or "").strip() if attrs.get("start_date") else None,
+        "end_date": (attrs.get("end_date") or "").strip() if attrs.get("end_date") else None,
+    }
+
+
+async def fetch(url: str, timeout: float = 30.0) -> Source | None:
+    """Open a LittleSis entity page and return a :class:`Source`.
+
+    Returns ``None`` for anything outside ``_ACCEPTED_HOSTS`` or paths other
+    than ``/entity/<id>`` / ``/api/entities/<id>``, and for any transport /
+    HTTP / parse failure.
+    """
+    if not url:
+        return None
+    entity_id = _classify_url(url)
+    if not entity_id:
+        return None
+
+    entity_url = urljoin(_BASE_URL, f"entities/{entity_id}")
+    await _rate_limit_gate()
+    status, payload = await _http_get_json(entity_url, params=None, timeout=timeout)
+    if status is None or status >= 400 or not isinstance(payload, dict):
+        if status is not None and status >= 400:
+            logger.warning("littlesis entity HTTP %s for %s", status, entity_url)
+        return None
+
+    data = payload.get("data") or payload
+    attrs = _entity_attrs(data)
+    name = (attrs.get("name") or "").strip()
+    if not name:
+        return None
+    primary_ext = (attrs.get("primary_ext") or "").strip()
+    types = attrs.get("types") or []
+    if not isinstance(types, list):
+        types = []
+    summary = (attrs.get("summary") or "").strip()
+    blurb = (attrs.get("blurb") or "").strip()
+
+    rel_url = urljoin(_BASE_URL, f"entities/{entity_id}/relationships")
+    await _rate_limit_gate()
+    rel_status, rel_payload = await _http_get_json(
+        rel_url, params=None, timeout=timeout
+    )
+    relationships: list[dict[str, Any]] = []
+    if rel_status == 200 and isinstance(rel_payload, dict):
+        raw_rels = rel_payload.get("data") or rel_payload.get("results") or []
+        if isinstance(raw_rels, list):
+            for rel in raw_rels:
+                norm = _normalize_relationship(rel)
+                if norm is not None:
+                    relationships.append(norm)
+
+    permalink = _entity_permalink(entity_id)
+    meta_bits = [b for b in (primary_ext, ", ".join(types) if types else "", permalink) if b]
+    meta_line = "_" + " · ".join(meta_bits) + "_" if meta_bits else ""
+
+    sections = [f"# {name}"]
+    if meta_line:
+        sections.append(meta_line)
+    summary_text = summary or blurb
+    if summary_text:
+        sections.append("## Summary\n\n" + summary_text)
+
+    roles_md, _roles_rows = _roles_block(relationships)
+    if roles_md:
+        sections.append(roles_md)
+
+    rels_md = _relationships_block(relationships)
+    if rels_md:
+        sections.append(rels_md.rstrip())
+
+    orgs_md, connected_orgs = _connected_orgs_block(relationships)
+    if orgs_md:
+        sections.append(orgs_md)
+
+    cleaned_text = "\n\n".join(sections).strip()
+    if not cleaned_text:
+        return None
+
+    metadata: dict[str, Any] = {
+        "entity_id": entity_id,
+        "primary_ext": primary_ext,
+        "types": list(types),
+        "summary": summary,
+        "blurb": blurb,
+        "relationships": relationships,
+        "connected_orgs": connected_orgs,
+    }
+
+    return Source(
+        url=url,
+        title=name,
+        cleaned_text=cleaned_text,
+        raw_html=None,
+        fetched_at=datetime.now(UTC),
+        source_kind="littlesis",
+        metadata=metadata,
+    )
+
+
+def reset_for_tests() -> None:
+    """Clear per-process rate-limit state. Test-only."""
+    global _last_call_monotonic, _rate_lock
+    _last_call_monotonic = None
+    _rate_lock = asyncio.Lock()
+
+
+__all__ = ["fetch", "reset_for_tests", "search"]

--- a/src/research_agent/tools/littlesis.py
+++ b/src/research_agent/tools/littlesis.py
@@ -118,7 +118,7 @@ def _entity_attrs(item: Any) -> dict[str, Any]:
     return item
 
 
-def _entity_permalink(entity_id: int | str) -> str:
+def _entity_permalink(entity_id: Any) -> str:
     return f"{_SITE_BASE}/entity/{entity_id}"
 
 

--- a/src/research_agent/tools/models.py
+++ b/src/research_agent/tools/models.py
@@ -39,6 +39,7 @@ SourceKind = Literal[
     "congress",
     "lda",
     "usaspending",
+    "littlesis",
 ]
 
 

--- a/tests/test_tools_littlesis.py
+++ b/tests/test_tools_littlesis.py
@@ -1,0 +1,523 @@
+"""Tests for `research_agent.tools.littlesis` (issue #97)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from research_agent.tools import littlesis
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    littlesis.reset_for_tests()
+    monkeypatch.setattr(littlesis.asyncio, "sleep", AsyncMock())
+    yield
+    littlesis.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Test payloads (modelled on LittleSis JSON:API envelopes)
+# ---------------------------------------------------------------------------
+
+
+_ENTITY_SEARCH_PAYLOAD = {
+    "data": [
+        {
+            "type": "entities",
+            "id": "12345",
+            "attributes": {
+                "id": 12345,
+                "name": "Peter Thiel",
+                "blurb": "American entrepreneur and venture capitalist",
+                "summary": "Co-founder of PayPal and Palantir; investor in Facebook.",
+                "primary_ext": "Person",
+                "types": ["Person", "Business Person"],
+            },
+            "links": {"self": "https://littlesis.org/entity/12345-Peter_Thiel"},
+        },
+        {
+            "type": "entities",
+            "id": "67890",
+            "attributes": {
+                "id": 67890,
+                "name": "Peter Thiel Foundation",
+                "blurb": "Philanthropic foundation",
+                "summary": "",
+                "primary_ext": "Org",
+                "types": ["Organization", "Foundation"],
+            },
+            "links": {"self": "https://littlesis.org/entity/67890-Peter_Thiel_Foundation"},
+        },
+    ]
+}
+
+
+_RELATIONSHIPS_PAYLOAD = {
+    "data": [
+        {
+            "type": "relationships",
+            "id": "1001",
+            "attributes": {
+                "id": 1001,
+                "entity1_id": 12345,
+                "entity2_id": 100,
+                "entity1_name": "Peter Thiel",
+                "entity2_name": "PayPal",
+                "category_id": 1,  # Position
+                "description1": "Co-founder",
+                "description2": "Co-founded by",
+                "start_date": "1998",
+                "end_date": "2002",
+                "amount": None,
+            },
+        },
+        {
+            "type": "relationships",
+            "id": "1002",
+            "attributes": {
+                "id": 1002,
+                "entity1_id": 12345,
+                "entity2_id": 200,
+                "entity1_name": "Peter Thiel",
+                "entity2_name": "Palantir Technologies",
+                "category_id": 1,  # Position
+                "description1": "Co-founder, Chairman",
+                "description2": None,
+                "start_date": "2003",
+                "end_date": None,
+                "amount": None,
+            },
+        },
+        {
+            "type": "relationships",
+            "id": "1003",
+            "attributes": {
+                "id": 1003,
+                "entity1_id": 12345,
+                "entity2_id": 300,
+                "entity1_name": "Peter Thiel",
+                "entity2_name": "Donald J. Trump for President",
+                "category_id": 5,  # Donation
+                "description": "Campaign donation",
+                "start_date": "2016-10-15",
+                "end_date": None,
+                "amount": 1250000,
+            },
+        },
+        {
+            "type": "relationships",
+            "id": "1004",
+            "attributes": {
+                "id": 1004,
+                "entity1_id": 12345,
+                "entity2_id": 400,
+                "entity1_name": "Peter Thiel",
+                "entity2_name": "Facebook",
+                "category_id": 10,  # Ownership
+                "description": "Early investor",
+                "start_date": "2004",
+                "end_date": None,
+                "amount": 500000,
+            },
+        },
+        # Second Facebook edge — board membership — exercises the dedup path
+        # for ``Connected organizations``.
+        {
+            "type": "relationships",
+            "id": "1005",
+            "attributes": {
+                "id": 1005,
+                "entity1_id": 12345,
+                "entity2_id": 400,
+                "entity1_name": "Peter Thiel",
+                "entity2_name": "Facebook",
+                "category_id": 1,  # Position
+                "description1": "Board member",
+                "description2": None,
+                "start_date": "2005",
+                "end_date": "2022",
+                "amount": None,
+            },
+        },
+    ]
+}
+
+
+_ENTITY_DETAIL_PAYLOAD = {
+    "data": {
+        "type": "entities",
+        "id": "12345",
+        "attributes": {
+            "id": 12345,
+            "name": "Peter Thiel",
+            "blurb": "American entrepreneur and venture capitalist",
+            "summary": "Co-founder of PayPal and Palantir; investor in Facebook.",
+            "primary_ext": "Person",
+            "types": ["Person", "Business Person"],
+        },
+        "links": {"self": "https://littlesis.org/entity/12345-Peter_Thiel"},
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# httpx mock plumbing
+# ---------------------------------------------------------------------------
+
+
+def _patch_httpx(monkeypatch, *, responder):
+    """Replace ``httpx.AsyncClient`` with a fake driven by ``responder(url, params)``.
+
+    Returns a dict capturing urls / headers / params per call.
+    """
+    captured: dict[str, list] = {"urls": [], "headers": [], "params": []}
+
+    class _FakeResp:
+        def __init__(self, status: int, text: str) -> None:
+            self.status_code = status
+            self.text = text
+
+        def json(self):
+            return json.loads(self.text)
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        captured["headers"].append(kwargs.get("headers"))
+
+        class _Client:
+            async def get(self, url, *, params=None, **_kwargs):
+                captured["urls"].append(url)
+                captured["params"].append(params)
+                status, text = responder(url, params)
+                return _FakeResp(status, text)
+
+        yield _Client()
+
+    monkeypatch.setattr(littlesis.httpx, "AsyncClient", _client_factory)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def test_search_entities_happy_path(monkeypatch):
+    """Entities search returns name, primary_ext, types, summary, permalink."""
+    payload = json.dumps(_ENTITY_SEARCH_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await littlesis.search("Peter Thiel", kind="entities", max_results=5)
+
+    assert captured["urls"][0].endswith("/api/entities/search")
+    params = captured["params"][0]
+    assert params["q"] == "Peter Thiel"
+    assert params["num"] == 5
+
+    assert len(results) == 2
+    hit = results[0]
+    assert hit.source_kind == "littlesis"
+    assert hit.title == "Peter Thiel"
+    assert hit.extras["entity_id"] == 12345
+    assert hit.extras["primary_ext"] == "Person"
+    assert "Person" in hit.extras["types"]
+    assert "PayPal" in hit.extras["summary"]
+    assert hit.url == "https://littlesis.org/entity/12345-Peter_Thiel"
+    assert "American entrepreneur" in hit.snippet
+
+
+async def test_search_entities_no_auth_header(monkeypatch):
+    """No API key needed — requests must not carry an Authorization header."""
+    payload = json.dumps({"data": []})
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+    await littlesis.search("anything")
+
+    headers = captured["headers"][0] or {}
+    assert "Authorization" not in headers
+
+
+async def test_search_relationships_happy_path(monkeypatch):
+    """Relationships search: entity lookup → top-hit relationships envelope."""
+
+    def _respond(url, params):
+        if url.endswith("/api/entities/search"):
+            return 200, json.dumps(_ENTITY_SEARCH_PAYLOAD)
+        if url.endswith("/api/entities/12345/relationships"):
+            return 200, json.dumps(_RELATIONSHIPS_PAYLOAD)
+        return 404, ""
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await littlesis.search(
+        "Peter Thiel", kind="relationships", max_results=10
+    )
+
+    # Two GETs: search, then relationships for the top hit.
+    assert len(captured["urls"]) == 2
+    assert captured["urls"][1].endswith("/api/entities/12345/relationships")
+
+    assert len(results) == 5
+    first = results[0]
+    assert first.source_kind == "littlesis"
+    assert first.title == "Peter Thiel → PayPal"
+    assert first.extras["category_id"] == 1
+    assert first.extras["category_label"] == "Position"
+    assert first.extras["entity1_id"] == 12345
+    assert first.extras["entity2_id"] == 100
+    assert first.extras["related_id"] == 100
+    assert first.extras["related_name"] == "PayPal"
+    assert first.extras["start_date"] == "1998"
+    assert first.extras["end_date"] == "2002"
+    assert "Position" in first.snippet
+    assert "Co-founder" in first.snippet
+
+    donation = results[2]
+    assert donation.extras["category_label"] == "Donation"
+    assert donation.extras["amount"] == 1250000
+
+
+async def test_search_unknown_kind_returns_empty(monkeypatch):
+    """Unknown kinds short-circuit to ``[]`` without an HTTP call."""
+    called = {"count": 0}
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        called["count"] += 1
+
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise AssertionError("should not be called")
+
+        yield _Client()
+
+    monkeypatch.setattr(littlesis.httpx, "AsyncClient", _client_factory)
+
+    assert await littlesis.search("anything", kind="bogus") == []
+    assert called["count"] == 0
+
+
+async def test_search_http_error_returns_empty(monkeypatch):
+    """A non-200 response returns ``[]``."""
+
+    def _respond(url, params):
+        return 500, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await littlesis.search("anything", kind="entities") == []
+
+
+async def test_search_transport_error_returns_empty(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(littlesis.httpx, "AsyncClient", _client_factory)
+
+    assert await littlesis.search("anything", kind="entities") == []
+
+
+async def test_search_non_json_returns_empty(monkeypatch):
+    def _respond(url, params):
+        return 200, "<html>not json</html>"
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await littlesis.search("anything", kind="entities") == []
+
+
+async def test_rate_limit_gate_enforces_one_rps(monkeypatch):
+    """Two concurrent search calls must space out by at least ~1s."""
+    clock = [100.0]
+
+    def fake_monotonic() -> float:
+        return clock[0]
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        clock[0] += seconds
+
+    monkeypatch.setattr(littlesis.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(littlesis.asyncio, "sleep", fake_sleep)
+
+    payload = json.dumps({"data": []})
+
+    def _respond(url, params):
+        return 200, payload
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    await asyncio.gather(
+        littlesis.search("a", kind="entities"),
+        littlesis.search("b", kind="entities"),
+    )
+
+    assert any(abs(s - 1.0) < 1e-6 for s in sleep_calls), (
+        f"expected a ~1s sleep through the rate gate; got {sleep_calls!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_entity_returns_markdown_sections(monkeypatch):
+    """Happy path: entity + relationships JSON renders to markdown."""
+
+    def _respond(url, params):
+        if url.endswith("/api/entities/12345"):
+            return 200, json.dumps(_ENTITY_DETAIL_PAYLOAD)
+        if url.endswith("/api/entities/12345/relationships"):
+            return 200, json.dumps(_RELATIONSHIPS_PAYLOAD)
+        return 404, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    url = "https://littlesis.org/entity/12345-Peter_Thiel"
+    source = await littlesis.fetch(url)
+
+    assert source is not None
+    assert source.source_kind == "littlesis"
+    assert source.url == url
+    assert source.title == "Peter Thiel"
+
+    body = source.cleaned_text
+    assert "# Peter Thiel" in body
+    assert "## Summary" in body
+    assert "PayPal and Palantir" in body
+    assert "## Roles / Positions" in body
+    # Both Position-category relationships should appear under roles.
+    assert "PayPal" in body
+    assert "Palantir Technologies" in body
+    assert "## Relationships" in body
+    # Categories are surfaced as subheadings.
+    assert "### Position" in body
+    assert "### Donation" in body
+    assert "### Ownership" in body
+    assert "## Connected organizations" in body
+    # Two distinct relationships point at "Facebook" but it should appear
+    # exactly once in the Connected organizations roll-up.
+    orgs_section = body.split("## Connected organizations", 1)[1]
+    assert orgs_section.count("- Facebook") == 1
+
+    md = source.metadata
+    assert md["entity_id"] == "12345"
+    assert md["primary_ext"] == "Person"
+    assert "Person" in md["types"]
+    assert len(md["relationships"]) == 5
+    assert "PayPal" in md["connected_orgs"]
+    assert "Facebook" in md["connected_orgs"]
+    # Connected orgs metadata must also be de-duplicated.
+    assert md["connected_orgs"].count("Facebook") == 1
+    # Donation relationship preserves the dollar amount.
+    donation = next(
+        r for r in md["relationships"] if r["category_label"] == "Donation"
+    )
+    assert donation["amount"] == 1250000
+
+
+async def test_fetch_accepts_api_path(monkeypatch):
+    """``/api/entities/<id>`` paths route through fetch the same way."""
+
+    def _respond(url, params):
+        if url.endswith("/api/entities/12345"):
+            return 200, json.dumps(_ENTITY_DETAIL_PAYLOAD)
+        if url.endswith("/api/entities/12345/relationships"):
+            return 200, json.dumps({"data": []})
+        return 404, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    url = "https://littlesis.org/api/entities/12345"
+    source = await littlesis.fetch(url)
+    assert source is not None
+    assert source.title == "Peter Thiel"
+
+
+async def test_fetch_rejects_disallowed_host(monkeypatch):
+    """A look-alike host must not pass."""
+
+    def _respond(url, params):
+        raise AssertionError("should not be called")
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    spoof = "https://littlesis.org.attacker.example/entity/12345-Peter_Thiel"
+    assert await littlesis.fetch(spoof) is None
+
+
+async def test_fetch_rejects_unrelated_path(monkeypatch):
+    """Paths that aren't entity URLs resolve to ``None``."""
+
+    def _respond(url, params):
+        raise AssertionError("should not be called")
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await littlesis.fetch("https://littlesis.org/about") is None
+    assert await littlesis.fetch("https://littlesis.org/relationship/1001") is None
+
+
+async def test_fetch_returns_none_for_empty_url():
+    assert await littlesis.fetch("") is None
+
+
+async def test_fetch_returns_none_on_404(monkeypatch):
+    def _respond(url, params):
+        return 404, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    url = "https://littlesis.org/entity/99999-Unknown"
+    assert await littlesis.fetch(url) is None
+
+
+async def test_fetch_returns_none_on_transport_error(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(littlesis.httpx, "AsyncClient", _client_factory)
+
+    url = "https://littlesis.org/entity/12345-Peter_Thiel"
+    assert await littlesis.fetch(url) is None
+
+
+# ---------------------------------------------------------------------------
+# Smoke registration
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_registry_includes_littlesis():
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "littlesis" in TOOL_REGISTRY

--- a/tests/test_tools_models.py
+++ b/tests/test_tools_models.py
@@ -33,6 +33,7 @@ EXPECTED_SOURCE_KINDS = (
     "congress",
     "lda",
     "usaspending",
+    "littlesis",
 )
 
 


### PR DESCRIPTION
Closes #97
Part of #107

## Summary

Automated implementation of **LittleSis connector (relational power-mapping database)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

LittleSis connector implements all ACs cleanly; tests pass (1005); fixed one mypy arg-type error.

- **WARNING** [FIXED] `src/research_agent/tools/littlesis.py`: mypy arg-type error: _entity_permalink declared as int|str but called with Any|None from attrs.get('id'). Relaxed to Any to match the loose-typed JSON conventions used elsewhere in the connector.
- **INFO** [OPEN] `src/research_agent/tools/littlesis.py`: _normalize_relationship always treats entity2 as the counterpart. If LittleSis /entities/<id>/relationships returns rows where the queried entity is sometimes entity2 (rather than always entity1), counterpart names/ids will display the queried entity itself. Test fixtures hard-code entity1=queried, so this isn't exercised. AC explicitly notes 'lead, not evidence' so non-blocking, but worth verifying with a live smoke run and adding a direction-aware normalization if needed.
- **INFO** [OPEN] `src/research_agent/tools/littlesis.py`: fetch() emits a '## Connected organizations' section that includes every entity2 counterpart (people, donors, family) rather than just orgs. Over-inclusion is fine for a lead-generation tool but the section heading is slightly misleading. Could filter on counterpart primary_ext when LittleSis returns it, but currently /entities/<id>/relationships does not expose that field, so a fix would require an extra fanout. Non-blocking.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*