### PR TITLE
feat: OpenCorporates connector (LLC unmasking, 200+ jurisdictions) (closes #92)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,10 @@ DATA_GOV_API_KEY=
 # (free at https://lda.senate.gov/api/register/) raises rate limits. The
 # key is sent via the `Authorization: Token <key>` header.
 LDA_API_KEY=
+
+# Optional: OpenCorporates API token used by `tools/opencorporates.py`.
+# Anonymous tier is ~50 calls/day with limited fields; setting a token
+# unlocks richer fields per the OpenCorporates docs and is sent as
+# `?api_token=<key>`. Public-benefit access requires emailing service desk
+# (acceptance not guaranteed); commercial pricing £2,250–£12,000/yr.
+OPENCORPORATES_API_KEY=

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ that list, so there is no drift.
 | `COURTLISTENER_API_TOKEN` | no | CourtListener API token (free w/ signup) — required by `tools/courtlistener.py`. Authenticated tier is 5,000 req/hr; anonymous traffic is throttled to the point of unusability. |
 | `DATA_GOV_API_KEY` | no | api.data.gov key (free w/ signup at <https://api.data.gov/signup/>) — used by `tools/fec.py` (OpenFEC). Authenticated tier is 1,000 req/hr; falls back to `DEMO_KEY` (~40 req/hr per IP) when unset. |
 | `LDA_API_KEY` | no | Senate Lobbying Disclosure Act API key (free, optional, register at <https://lda.senate.gov/api/register/>) — used by `tools/lda.py`. Anonymous works for low-volume; authenticated raises rate limits. Sent via `Authorization: Token <key>`. |
+| `OPENCORPORATES_API_KEY` | no | OpenCorporates API token — used by `tools/opencorporates.py`. Anonymous tier is ~50 calls/day with limited fields; richer fields require a token (sent as `?api_token=<key>`). Public-benefit access by emailing service desk; commercial pricing £2,250–£12,000/yr. |
 
 ## LM Studio
 

--- a/src/research_agent/config.py
+++ b/src/research_agent/config.py
@@ -117,6 +117,16 @@ EXPECTED_ENV_KEYS: tuple[EnvKey, ...] = (
             " key raises rate limits. Sent as `Authorization: Token <key>`."
         ),
     ),
+    EnvKey(
+        name="OPENCORPORATES_API_KEY",
+        required=False,
+        description=(
+            "OpenCorporates API token (?api_token=...). Anonymous tier is"
+            " ~50 calls/day with limited fields; richer fields require a key."
+            " Public-benefit access by emailing service desk; commercial"
+            " pricing £2,250–£12,000/yr."
+        ),
+    ),
 )
 
 

--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -369,6 +369,41 @@ def _smoke_littlesis(query: str) -> str:
     return asyncio.run(_run())
 
 
+def _smoke_opencorporates(query: str) -> str:
+    """Smoke wrapper: OpenCorporates company search returning the top-5 hits.
+
+    Per AC: ``research _smoke-tool opencorporates "SBI Builders"`` should
+    surface the California LLC entry alongside its registered agent. Each
+    line shows the company number, name, jurisdiction, status, agent name,
+    and permalink so an operator can eyeball whether the public API is
+    reachable on the anonymous tier.
+    """
+    from research_agent.tools import opencorporates
+
+    async def _run() -> str:
+        results = await opencorporates.search(query, max_results=5)
+        if not results:
+            return f"opencorporates search returned no results for {query!r}"
+        lines: list[str] = []
+        for hit in results:
+            number = hit.extras.get("company_number") or "?"
+            jurisdiction = hit.extras.get("jurisdiction_code") or "?"
+            status = hit.extras.get("current_status") or "?"
+            agent = hit.extras.get("registered_agent_name") or "?"
+            snippet = hit.snippet.replace("\n", " ")
+            if len(snippet) > 200:
+                snippet = snippet[:200] + "…"
+            lines.append(
+                f"- {hit.title} — {number} — {jurisdiction} — {status} —"
+                f" agent: {agent}\n"
+                f"  {hit.url}\n"
+                f"  {snippet}"
+            )
+        return "\n".join(lines)
+
+    return asyncio.run(_run())
+
+
 def _smoke_usaspending(query: str) -> str:
     """Smoke wrapper: USAspending awards search returning the top-5 hits.
 
@@ -700,6 +735,7 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "congress": _smoke_congress,
     "lda": _smoke_lda,
     "littlesis": _smoke_littlesis,
+    "opencorporates": _smoke_opencorporates,
     "usaspending": _smoke_usaspending,
     "gdelt": _smoke_gdelt,
     "news": _smoke_news,

--- a/src/research_agent/tools/models.py
+++ b/src/research_agent/tools/models.py
@@ -40,6 +40,7 @@ SourceKind = Literal[
     "lda",
     "usaspending",
     "littlesis",
+    "opencorporates",
 ]
 
 

--- a/src/research_agent/tools/opencorporates.py
+++ b/src/research_agent/tools/opencorporates.py
@@ -1,0 +1,543 @@
+"""OpenCorporates connector — global company registry across 200+ jurisdictions (issue #92).
+
+Public surface:
+
+* ``async def search(query, *, jurisdiction=None, max_results=20)
+  -> list[SearchResult]`` hits ``api.opencorporates.com/v0.4/companies/search``
+  and returns hits with company number, name, jurisdiction, status, and
+  registered agent (when available).
+* ``async def fetch(url) -> Source | None`` opens a company page
+  (``https://opencorporates.com/companies/<jurisdiction>/<id>``) and returns
+  markdown of officers, filings history, registered agent + address, and any
+  associated entities.
+
+OpenCorporates is the canonical free-tier global registry. Critical for
+**shell-company unmasking**: same registered agent across multiple LLCs at
+one address is a classic red flag for political/financial investigations.
+
+Auth: anonymous tier (~50 calls/day, limited fields) works for v1; setting
+``OPENCORPORATES_API_KEY`` adds the token as ``?api_token=<key>`` (richer
+fields per the OpenCorporates docs). Free public-benefit access requires
+emailing service desk; commercial pricing £2,250–£12,000/yr.
+
+Per AC: 0.5 RPS per-host gate to be safe on the anonymous tier.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from datetime import UTC, date, datetime
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from research_agent import config
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.opencorporates.com/v0.4/"
+_SITE_BASE = "https://opencorporates.com"
+_ACCEPTED_HOSTS = frozenset({"opencorporates.com", "www.opencorporates.com"})
+# AC: per-host rate of 0.5 RPS — anonymous tier is fragile.
+_RATE_LIMIT_INTERVAL = 2.0
+
+# Company URLs look like /companies/<jurisdiction>/<id> with optional trailing
+# slash. Jurisdiction is a lower-case alpha-numeric ISO-ish code (e.g. ``us_ca``,
+# ``gb``, ``de``). Company id is mostly alpha-numeric but jurisdictions vary;
+# allow a permissive set rather than locking ourselves out of edge codes.
+_COMPANY_URL_RE = re.compile(
+    r"^/companies/(?P<jurisdiction>[a-z0-9_]+)/(?P<id>[A-Za-z0-9._-]+)/?$"
+)
+
+_rate_lock = asyncio.Lock()
+_last_call_monotonic: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Config / rate-limit helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_api_key() -> str | None:
+    """Return the configured OpenCorporates API token, or ``None`` for anonymous."""
+    raw = config.get("OPENCORPORATES_API_KEY") or ""
+    key = raw.strip()
+    return key or None
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Accept": "application/json",
+        "User-Agent": config.get("RESEARCH_USER_AGENT")
+        or "research-agent/0.1 (+local; contact unset)",
+    }
+
+
+async def _rate_limit_gate() -> None:
+    """Block until at least ``_RATE_LIMIT_INTERVAL`` has passed since the last call."""
+    global _last_call_monotonic
+    async with _rate_lock:
+        if _last_call_monotonic is not None:
+            elapsed = time.monotonic() - _last_call_monotonic
+            wait = _RATE_LIMIT_INTERVAL - elapsed
+            if wait > 0:
+                await asyncio.sleep(wait)
+        _last_call_monotonic = time.monotonic()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso_date(value: Any) -> datetime | None:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=UTC)
+    text = str(value).strip()
+    if not text:
+        return None
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%d"):
+        try:
+            parsed = datetime.strptime(text, fmt)
+            return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed
+        except ValueError:
+            continue
+    head = text.split("T", 1)[0]
+    try:
+        return datetime.strptime(head, "%Y-%m-%d").replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def _company_permalink(jurisdiction: str, company_number: str) -> str:
+    return f"{_SITE_BASE}/companies/{jurisdiction}/{company_number}"
+
+
+def _registered_agent(company: dict[str, Any]) -> tuple[str, str]:
+    """Return ``(name, address)`` for the registered agent, if surfaced.
+
+    OpenCorporates places the agent under ``registered_agent`` (a dict on
+    detail pages) but on search rows it sometimes flattens to
+    ``registered_agent_name``/``registered_agent_address``. Tolerate both.
+    """
+    agent = company.get("registered_agent")
+    if isinstance(agent, dict):
+        name = (agent.get("name") or "").strip()
+        address = (
+            agent.get("address")
+            or agent.get("registered_address_in_full")
+            or ""
+        )
+        return name, str(address).strip()
+    name = (company.get("registered_agent_name") or "").strip()
+    address = (company.get("registered_agent_address") or "").strip()
+    return name, address
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+def _build_search_result(item: Any) -> SearchResult | None:
+    """Extract a ``SearchResult`` from one envelope row.
+
+    OpenCorporates wraps each hit as ``{"company": {...}}`` — unwrap it then
+    pull the canonical fields.
+    """
+    if not isinstance(item, dict):
+        return None
+    company = item.get("company")
+    if not isinstance(company, dict):
+        return None
+
+    name = (company.get("name") or "").strip()
+    company_number = (company.get("company_number") or "").strip()
+    jurisdiction_code = (company.get("jurisdiction_code") or "").strip()
+    if not name or not company_number:
+        return None
+
+    current_status = (company.get("current_status") or "").strip()
+    incorporation_date = company.get("incorporation_date")
+    company_type = (company.get("company_type") or "").strip()
+    registered_address = (
+        company.get("registered_address_in_full")
+        or company.get("registered_address")
+        or ""
+    )
+    if isinstance(registered_address, dict):
+        registered_address = registered_address.get("in_full") or ""
+    registered_address = str(registered_address).strip()
+
+    agent_name, agent_address = _registered_agent(company)
+
+    permalink = company.get("opencorporates_url") or _company_permalink(
+        jurisdiction_code, company_number
+    )
+
+    snippet_bits: list[str] = []
+    if jurisdiction_code:
+        snippet_bits.append(jurisdiction_code)
+    if current_status:
+        snippet_bits.append(current_status)
+    if agent_name:
+        snippet_bits.append(f"Agent: {agent_name}")
+    elif registered_address:
+        snippet_bits.append(registered_address)
+    snippet = " — ".join(snippet_bits)
+
+    extras: dict[str, Any] = {
+        "company_number": company_number,
+        "name": name,
+        "jurisdiction_code": jurisdiction_code,
+        "current_status": current_status,
+        "company_type": company_type,
+        "incorporation_date": incorporation_date,
+        "registered_address_in_full": registered_address,
+        "registered_agent_name": agent_name,
+        "agent_address": agent_address,
+    }
+    return SearchResult(
+        url=permalink,
+        title=name,
+        snippet=snippet,
+        published_at=_parse_iso_date(incorporation_date),
+        source_kind="opencorporates",
+        extras=extras,
+    )
+
+
+async def _http_get_json(
+    url: str, *, params: dict[str, Any] | None, timeout: float
+) -> tuple[int | None, dict[str, Any] | None]:
+    """GET ``url`` and return ``(status, json)``. ``status=None`` on transport error."""
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=_headers(),
+        ) as client:
+            response = await client.get(url, params=params)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("opencorporates GET failed for %s: %s", url, exc)
+        return None, None
+    if response.status_code != 200:
+        return response.status_code, None
+    try:
+        return response.status_code, response.json()
+    except ValueError as exc:
+        logger.warning("opencorporates returned non-JSON for %s: %s", url, exc)
+        return response.status_code, None
+
+
+async def search(
+    query: str,
+    *,
+    jurisdiction: str | None = None,
+    max_results: int = 20,
+    timeout: float = 15.0,
+) -> list[SearchResult]:
+    """Run an OpenCorporates company search and return up to ``max_results`` hits.
+
+    ``jurisdiction`` is the OpenCorporates jurisdiction code (e.g. ``us_ca``
+    for California, ``gb`` for the UK). When ``OPENCORPORATES_API_KEY`` is
+    set, the token is appended as ``?api_token=...`` to unlock richer fields
+    on the response.
+
+    Returns ``[]`` on transport / HTTP error or non-JSON body — connector
+    failures must never crash the planner.
+    """
+    params: dict[str, Any] = {
+        "q": query,
+        "per_page": min(max_results, 100),
+    }
+    if jurisdiction:
+        params["jurisdiction_code"] = jurisdiction
+    api_key = _resolve_api_key()
+    if api_key:
+        params["api_token"] = api_key
+
+    await _rate_limit_gate()
+    url = urljoin(_BASE_URL, "companies/search")
+    status, payload = await _http_get_json(url, params=params, timeout=timeout)
+    if status is None or status >= 400 or not isinstance(payload, dict):
+        if status is not None and status >= 400:
+            logger.warning("opencorporates search HTTP %s for %r", status, query)
+        return []
+
+    results_envelope = payload.get("results")
+    if not isinstance(results_envelope, dict):
+        return []
+    raw_hits = results_envelope.get("companies") or []
+    if not isinstance(raw_hits, list):
+        return []
+
+    out: list[SearchResult] = []
+    for hit in raw_hits[:max_results]:
+        result = _build_search_result(hit)
+        if result is not None:
+            out.append(result)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+def _classify_url(url: str) -> tuple[str, str] | None:
+    """Return ``(jurisdiction, company_number)`` for OpenCorporates company URLs.
+
+    Strict host match against ``_ACCEPTED_HOSTS`` so look-alikes like
+    ``opencorporates.com.attacker.example`` are rejected.
+    """
+    parsed = urlparse(url)
+    host = (parsed.netloc or "").lower().split(":", 1)[0]
+    if host not in _ACCEPTED_HOSTS:
+        return None
+    m = _COMPANY_URL_RE.match(parsed.path or "")
+    if not m:
+        return None
+    return m.group("jurisdiction"), m.group("id")
+
+
+def _officers_block(officers: Any) -> tuple[str, list[dict[str, Any]]]:
+    """Render the ``officers[]`` list as a markdown section."""
+    if not isinstance(officers, list) or not officers:
+        return "", []
+    rows: list[dict[str, Any]] = []
+    for entry in officers:
+        if not isinstance(entry, dict):
+            continue
+        officer = entry.get("officer") if isinstance(entry.get("officer"), dict) else entry
+        if not isinstance(officer, dict):
+            continue
+        name = (officer.get("name") or "").strip()
+        position = (officer.get("position") or "").strip()
+        start = (officer.get("start_date") or "").strip() if officer.get("start_date") else ""
+        end = (officer.get("end_date") or "").strip() if officer.get("end_date") else ""
+        if not name:
+            continue
+        rows.append(
+            {
+                "name": name,
+                "position": position,
+                "start_date": start or None,
+                "end_date": end or None,
+            }
+        )
+    if not rows:
+        return "", rows
+    lines = ["## Officers", ""]
+    for r in rows:
+        bits: list[str] = [r["name"]]
+        if r["position"]:
+            bits.append(r["position"])
+        date_bits = [d for d in (r["start_date"], r["end_date"]) if d]
+        if date_bits:
+            bits.append("–".join(date_bits))
+        lines.append("- " + " — ".join(bits))
+    return "\n".join(lines), rows
+
+
+def _filings_block(filings: Any) -> tuple[str, list[dict[str, Any]]]:
+    """Render the ``filings[]`` history as a markdown section."""
+    if not isinstance(filings, list) or not filings:
+        return "", []
+    rows: list[dict[str, Any]] = []
+    for entry in filings:
+        if not isinstance(entry, dict):
+            continue
+        filing = entry.get("filing") if isinstance(entry.get("filing"), dict) else entry
+        if not isinstance(filing, dict):
+            continue
+        title = (filing.get("title") or filing.get("description") or "").strip()
+        filing_date = (filing.get("date") or "").strip() if filing.get("date") else ""
+        filing_type = (
+            filing.get("filing_type_name")
+            or filing.get("filing_type") or ""
+        ).strip()
+        if not title and not filing_type:
+            continue
+        rows.append(
+            {
+                "title": title,
+                "filing_type": filing_type,
+                "date": filing_date or None,
+            }
+        )
+    if not rows:
+        return "", rows
+    lines = ["## Filings", ""]
+    for r in rows:
+        bits: list[str] = []
+        if r["date"]:
+            bits.append(r["date"])
+        if r["filing_type"]:
+            bits.append(r["filing_type"])
+        if r["title"]:
+            bits.append(r["title"])
+        lines.append("- " + " — ".join(bits))
+    return "\n".join(lines), rows
+
+
+def _registered_agent_block(agent_name: str, agent_address: str) -> str:
+    if not agent_name and not agent_address:
+        return ""
+    lines = ["## Registered agent", ""]
+    if agent_name:
+        lines.append(f"- **Name:** {agent_name}")
+    if agent_address:
+        lines.append(f"- **Address:** {agent_address}")
+    return "\n".join(lines)
+
+
+def _associated_entities_block(
+    company: dict[str, Any],
+) -> tuple[str, list[str]]:
+    """Roll up previous_names + alternative_names into one section."""
+    names: list[str] = []
+    seen: set[str] = set()
+    for key in ("previous_names", "alternative_names"):
+        raw = company.get(key) or []
+        if not isinstance(raw, list):
+            continue
+        for entry in raw:
+            if isinstance(entry, dict):
+                value = (entry.get("company_name") or entry.get("name") or "").strip()
+            else:
+                value = str(entry or "").strip()
+            if not value or value in seen:
+                continue
+            seen.add(value)
+            names.append(value)
+    if not names:
+        return "", names
+    lines = ["## Associated entities", ""]
+    for name in names:
+        lines.append(f"- {name}")
+    return "\n".join(lines), names
+
+
+async def fetch(url: str, timeout: float = 30.0) -> Source | None:
+    """Open an OpenCorporates company page and return a :class:`Source`.
+
+    Returns ``None`` for anything outside ``_ACCEPTED_HOSTS`` or paths other
+    than ``/companies/<jurisdiction>/<id>``, and for any transport / HTTP /
+    parse failure.
+    """
+    if not url:
+        return None
+    parts = _classify_url(url)
+    if parts is None:
+        return None
+    jurisdiction, company_number = parts
+
+    api_url = urljoin(_BASE_URL, f"companies/{jurisdiction}/{company_number}")
+    params: dict[str, Any] = {}
+    api_key = _resolve_api_key()
+    if api_key:
+        params["api_token"] = api_key
+
+    await _rate_limit_gate()
+    status, payload = await _http_get_json(
+        api_url, params=params or None, timeout=timeout
+    )
+    if status is None or status >= 400 or not isinstance(payload, dict):
+        if status is not None and status >= 400:
+            logger.warning(
+                "opencorporates company HTTP %s for %s", status, api_url
+            )
+        return None
+
+    results_envelope = payload.get("results")
+    if not isinstance(results_envelope, dict):
+        return None
+    company = results_envelope.get("company")
+    if not isinstance(company, dict):
+        return None
+
+    name = (company.get("name") or "").strip()
+    if not name:
+        return None
+    current_status = (company.get("current_status") or "").strip()
+    incorporation_date = (company.get("incorporation_date") or "").strip()
+    company_type = (company.get("company_type") or "").strip()
+    jurisdiction_code = (company.get("jurisdiction_code") or jurisdiction).strip()
+
+    agent_name, agent_address = _registered_agent(company)
+    officers_md, officers_rows = _officers_block(company.get("officers"))
+    filings_md, filings_rows = _filings_block(company.get("filings"))
+    associated_md, associated_names = _associated_entities_block(company)
+    agent_md = _registered_agent_block(agent_name, agent_address)
+
+    meta_bits = [
+        b
+        for b in (
+            jurisdiction_code,
+            current_status,
+            incorporation_date,
+            company_type,
+        )
+        if b
+    ]
+    meta_line = "_" + " · ".join(meta_bits) + "_" if meta_bits else ""
+
+    sections = [f"# {name}"]
+    if meta_line:
+        sections.append(meta_line)
+    if agent_md:
+        sections.append(agent_md)
+    if officers_md:
+        sections.append(officers_md)
+    if filings_md:
+        sections.append(filings_md)
+    if associated_md:
+        sections.append(associated_md)
+
+    cleaned_text = "\n\n".join(sections).strip()
+    if not cleaned_text:
+        return None
+
+    metadata: dict[str, Any] = {
+        "company_number": company_number,
+        "jurisdiction_code": jurisdiction_code,
+        "current_status": current_status,
+        "incorporation_date": incorporation_date,
+        "company_type": company_type,
+        "registered_agent": {"name": agent_name, "address": agent_address},
+        "registered_agent_name": agent_name,
+        "registered_agent_address": agent_address,
+        "officers": officers_rows,
+        "filings": filings_rows,
+        "associated_entities": associated_names,
+    }
+
+    return Source(
+        url=url,
+        title=name,
+        cleaned_text=cleaned_text,
+        raw_html=None,
+        fetched_at=datetime.now(UTC),
+        source_kind="opencorporates",
+        metadata=metadata,
+    )
+
+
+def reset_for_tests() -> None:
+    """Clear per-process rate-limit state. Test-only."""
+    global _last_call_monotonic, _rate_lock
+    _last_call_monotonic = None
+    _rate_lock = asyncio.Lock()
+
+
+__all__ = ["fetch", "reset_for_tests", "search"]

--- a/tests/test_tools_models.py
+++ b/tests/test_tools_models.py
@@ -34,6 +34,7 @@ EXPECTED_SOURCE_KINDS = (
     "lda",
     "usaspending",
     "littlesis",
+    "opencorporates",
 )
 
 

--- a/tests/test_tools_opencorporates.py
+++ b/tests/test_tools_opencorporates.py
@@ -1,0 +1,463 @@
+"""Tests for `research_agent.tools.opencorporates` (issue #92)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from research_agent.tools import opencorporates
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    opencorporates.reset_for_tests()
+    monkeypatch.setattr(opencorporates.asyncio, "sleep", AsyncMock())
+    # Default: no API key set so anonymous-tier behaviour is exercised by
+    # default. Tests that need a token set it explicitly via monkeypatch.
+    monkeypatch.delenv("OPENCORPORATES_API_KEY", raising=False)
+    yield
+    opencorporates.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Test payloads (modelled on OpenCorporates v0.4 envelopes)
+# ---------------------------------------------------------------------------
+
+
+_SEARCH_PAYLOAD = {
+    "results": {
+        "companies": [
+            {
+                "company": {
+                    "name": "SBI BUILDERS, LLC",
+                    "company_number": "201234567890",
+                    "jurisdiction_code": "us_ca",
+                    "current_status": "Active",
+                    "company_type": "Limited Liability Company",
+                    "incorporation_date": "2012-03-15",
+                    "registered_address_in_full": (
+                        "1234 Main St, San Jose, CA 95110, USA"
+                    ),
+                    "registered_agent_name": "Jane Q Agent",
+                    "registered_agent_address": "5678 Agent Way, Sacramento, CA",
+                    "opencorporates_url": (
+                        "https://opencorporates.com/companies/us_ca/201234567890"
+                    ),
+                }
+            },
+            {
+                "company": {
+                    "name": "SBI BUILDERS INC",
+                    "company_number": "C9876543",
+                    "jurisdiction_code": "us_ca",
+                    "current_status": "Dissolved",
+                    "company_type": "Domestic Stock",
+                    "incorporation_date": "1998-07-22",
+                    "registered_address_in_full": "100 Old St, Oakland, CA",
+                    "registered_agent_name": "",
+                    "registered_agent_address": "",
+                    "opencorporates_url": (
+                        "https://opencorporates.com/companies/us_ca/C9876543"
+                    ),
+                }
+            },
+        ]
+    }
+}
+
+
+_COMPANY_DETAIL_PAYLOAD = {
+    "results": {
+        "company": {
+            "name": "SBI BUILDERS, LLC",
+            "company_number": "201234567890",
+            "jurisdiction_code": "us_ca",
+            "current_status": "Active",
+            "company_type": "Limited Liability Company",
+            "incorporation_date": "2012-03-15",
+            "registered_address_in_full": (
+                "1234 Main St, San Jose, CA 95110, USA"
+            ),
+            "registered_agent": {
+                "name": "Jane Q Agent",
+                "address": "5678 Agent Way, Sacramento, CA",
+            },
+            "officers": [
+                {
+                    "officer": {
+                        "name": "Alice Builder",
+                        "position": "Manager",
+                        "start_date": "2012-03-15",
+                        "end_date": None,
+                    }
+                },
+                {
+                    "officer": {
+                        "name": "Bob Builder",
+                        "position": "Member",
+                        "start_date": "2015-01-01",
+                        "end_date": "2020-06-30",
+                    }
+                },
+            ],
+            "filings": [
+                {
+                    "filing": {
+                        "title": "Statement of Information",
+                        "filing_type_name": "SI-LLC",
+                        "date": "2024-03-12",
+                    }
+                },
+                {
+                    "filing": {
+                        "title": "LLC-12 Statement",
+                        "filing_type_name": "Annual Report",
+                        "date": "2023-03-08",
+                    }
+                },
+            ],
+            "previous_names": [
+                {"company_name": "SBI Construction LLC"},
+            ],
+            "alternative_names": [
+                {"name": "SBI Builders"},
+            ],
+        }
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# httpx mock plumbing
+# ---------------------------------------------------------------------------
+
+
+def _patch_httpx(monkeypatch, *, responder):
+    """Replace ``httpx.AsyncClient`` with a fake driven by ``responder(url, params)``.
+
+    Returns a dict capturing urls / headers / params per call.
+    """
+    captured: dict[str, list] = {"urls": [], "headers": [], "params": []}
+
+    class _FakeResp:
+        def __init__(self, status: int, text: str) -> None:
+            self.status_code = status
+            self.text = text
+
+        def json(self):
+            return json.loads(self.text)
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        captured["headers"].append(kwargs.get("headers"))
+
+        class _Client:
+            async def get(self, url, *, params=None, **_kwargs):
+                captured["urls"].append(url)
+                captured["params"].append(params)
+                status, text = responder(url, params)
+                return _FakeResp(status, text)
+
+        yield _Client()
+
+    monkeypatch.setattr(opencorporates.httpx, "AsyncClient", _client_factory)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def test_search_returns_results(monkeypatch):
+    """Happy path: search returns canonical fields including registered agent."""
+    payload = json.dumps(_SEARCH_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await opencorporates.search("SBI Builders", max_results=5)
+
+    assert captured["urls"][0].endswith("/companies/search")
+    params = captured["params"][0]
+    assert params["q"] == "SBI Builders"
+    assert params["per_page"] == 5
+
+    assert len(results) == 2
+    top = results[0]
+    assert top.source_kind == "opencorporates"
+    assert top.title == "SBI BUILDERS, LLC"
+    assert top.extras["company_number"] == "201234567890"
+    assert top.extras["jurisdiction_code"] == "us_ca"
+    assert top.extras["current_status"] == "Active"
+    assert top.extras["registered_agent_name"] == "Jane Q Agent"
+    assert top.extras["agent_address"] == "5678 Agent Way, Sacramento, CA"
+    assert top.url == (
+        "https://opencorporates.com/companies/us_ca/201234567890"
+    )
+    assert "us_ca" in top.snippet
+    assert "Active" in top.snippet
+    assert "Jane Q Agent" in top.snippet
+
+
+async def test_search_with_jurisdiction_filter(monkeypatch):
+    """``jurisdiction`` is forwarded as ``jurisdiction_code``."""
+    payload = json.dumps(_SEARCH_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+    await opencorporates.search("SBI Builders", jurisdiction="us_ca")
+    params = captured["params"][0]
+    assert params["jurisdiction_code"] == "us_ca"
+
+
+async def test_search_no_key_omits_api_token(monkeypatch):
+    """Anonymous-tier requests must not include ``api_token`` in params."""
+    payload = json.dumps({"results": {"companies": []}})
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+    await opencorporates.search("anything")
+    params = captured["params"][0]
+    assert "api_token" not in params
+
+
+async def test_search_with_key_includes_api_token(monkeypatch):
+    """When the env var is set, the token is sent as ``?api_token=...``."""
+    payload = json.dumps({"results": {"companies": []}})
+
+    def _respond(url, params):
+        return 200, payload
+
+    monkeypatch.setenv("OPENCORPORATES_API_KEY", "secret-token-abc")
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    await opencorporates.search("anything")
+
+    params = captured["params"][0]
+    assert params["api_token"] == "secret-token-abc"
+    # API token must travel as a query param, NOT an Authorization header.
+    headers = captured["headers"][0] or {}
+    assert "Authorization" not in headers
+
+
+async def test_search_returns_empty_on_500(monkeypatch):
+    def _respond(url, params):
+        return 500, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+    assert await opencorporates.search("anything") == []
+
+
+async def test_search_handles_non_json(monkeypatch):
+    def _respond(url, params):
+        return 200, "<html>not json</html>"
+
+    _patch_httpx(monkeypatch, responder=_respond)
+    assert await opencorporates.search("anything") == []
+
+
+async def test_search_returns_empty_on_transport_error(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(opencorporates.httpx, "AsyncClient", _client_factory)
+    assert await opencorporates.search("anything") == []
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_returns_source_with_officers_and_filings(monkeypatch):
+    """Happy path: company detail renders agent/officers/filings/associated."""
+
+    def _respond(url, params):
+        if url.endswith("/companies/us_ca/201234567890"):
+            return 200, json.dumps(_COMPANY_DETAIL_PAYLOAD)
+        return 404, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    url = "https://opencorporates.com/companies/us_ca/201234567890"
+    source = await opencorporates.fetch(url)
+
+    assert source is not None
+    assert source.source_kind == "opencorporates"
+    assert source.title == "SBI BUILDERS, LLC"
+    assert source.url == url
+
+    body = source.cleaned_text
+    assert "# SBI BUILDERS, LLC" in body
+    assert "us_ca" in body
+    assert "Active" in body
+    assert "## Registered agent" in body
+    assert "Jane Q Agent" in body
+    assert "5678 Agent Way" in body
+    assert "## Officers" in body
+    assert "Alice Builder" in body
+    assert "Bob Builder" in body
+    assert "Manager" in body
+    assert "## Filings" in body
+    assert "Statement of Information" in body
+    assert "## Associated entities" in body
+    assert "SBI Construction LLC" in body
+    assert "SBI Builders" in body
+
+    md = source.metadata
+    assert md["company_number"] == "201234567890"
+    assert md["jurisdiction_code"] == "us_ca"
+    assert md["registered_agent"]["name"] == "Jane Q Agent"
+    assert md["registered_agent"]["address"] == "5678 Agent Way, Sacramento, CA"
+    assert md["registered_agent_name"] == "Jane Q Agent"
+    assert len(md["officers"]) == 2
+    assert md["officers"][0]["name"] == "Alice Builder"
+    assert md["officers"][0]["position"] == "Manager"
+    assert len(md["filings"]) == 2
+    assert "SBI Construction LLC" in md["associated_entities"]
+    assert "SBI Builders" in md["associated_entities"]
+
+
+async def test_fetch_rejects_unknown_host(monkeypatch):
+    """Look-alike hosts must be rejected without an HTTP call."""
+
+    def _respond(url, params):
+        raise AssertionError("should not be called")
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    spoof = (
+        "https://opencorporates.com.attacker.example/companies/us_ca/201234567890"
+    )
+    assert await opencorporates.fetch(spoof) is None
+
+
+async def test_fetch_rejects_non_company_path(monkeypatch):
+    """Non-company paths short-circuit to ``None``."""
+
+    def _respond(url, params):
+        raise AssertionError("should not be called")
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await opencorporates.fetch("https://opencorporates.com/about") is None
+    assert (
+        await opencorporates.fetch(
+            "https://opencorporates.com/officers/12345"
+        )
+        is None
+    )
+
+
+async def test_fetch_returns_none_on_404(monkeypatch):
+    def _respond(url, params):
+        return 404, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    url = "https://opencorporates.com/companies/us_ca/does-not-exist"
+    assert await opencorporates.fetch(url) is None
+
+
+async def test_fetch_returns_none_for_empty_url():
+    assert await opencorporates.fetch("") is None
+
+
+async def test_fetch_with_key_sends_api_token(monkeypatch):
+    """When set, the token rides along on the detail call as well."""
+
+    def _respond(url, params):
+        return 200, json.dumps(_COMPANY_DETAIL_PAYLOAD)
+
+    monkeypatch.setenv("OPENCORPORATES_API_KEY", "secret-token-abc")
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    url = "https://opencorporates.com/companies/us_ca/201234567890"
+    source = await opencorporates.fetch(url)
+    assert source is not None
+    params = captured["params"][0]
+    assert params is not None
+    assert params["api_token"] == "secret-token-abc"
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting
+# ---------------------------------------------------------------------------
+
+
+async def test_rate_limit_gate_sleeps_between_calls(monkeypatch):
+    """Two concurrent search calls must space out by ~2s (0.5 RPS)."""
+    clock = [100.0]
+
+    def fake_monotonic() -> float:
+        return clock[0]
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        clock[0] += seconds
+
+    monkeypatch.setattr(opencorporates.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(opencorporates.asyncio, "sleep", fake_sleep)
+
+    payload = json.dumps({"results": {"companies": []}})
+
+    def _respond(url, params):
+        return 200, payload
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    await asyncio.gather(
+        opencorporates.search("a"),
+        opencorporates.search("b"),
+    )
+
+    assert any(abs(s - 2.0) < 1e-6 for s in sleep_calls), (
+        f"expected a ~2s sleep through the rate gate; got {sleep_calls!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source kind literal & smoke registration
+# ---------------------------------------------------------------------------
+
+
+def test_source_kind_literal():
+    """``opencorporates`` must be a valid SourceKind literal."""
+    from research_agent.tools.models import SearchResult
+
+    result = SearchResult(
+        url="https://opencorporates.com/companies/us_ca/1",
+        title="t",
+        snippet="s",
+        source_kind="opencorporates",
+    )
+    assert result.source_kind == "opencorporates"
+
+
+def test_smoke_registry_includes_opencorporates():
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "opencorporates" in TOOL_REGISTRY


### PR DESCRIPTION
Closes #92
Part of #107

## Summary

Automated implementation of **OpenCorporates connector (LLC unmasking, 200+ jurisdictions)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

OpenCorporates connector meets all 5 ACs (search, fetch, auth, 0.5 RPS gate, smoke), 16/16 module tests + 964 suite tests pass, wiring matches sibling connectors.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*