### PR TITLE
feat: Secretary of State business registries (CA bizfileonline first) (closes #101)

### DIFF
--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -409,42 +409,60 @@ def _smoke_sos(query: str) -> str:
 
     Per AC: ``research _smoke-tool sos "SBI Builders"`` should return the
     LLC entry with its registered agent. Lists the top-5 entity hits with
-    their entity number / type / status / formed date, then follows up on
-    the top hit with ``fetch()`` so the registered agent surfaces too.
+    their entity number / type / status / formed date / agent — bizfileonline
+    renders the registered agent directly in the search row, so the AC is
+    satisfied from search() alone. Also attempts ``fetch()`` on the top hit
+    for richer detail; the per-entity panel is now Okta-gated so
+    unauthenticated fetch() typically returns a near-empty Source.
     """
-    from research_agent.tools import sos
+    from research_agent.tools import browser, sos
 
     async def _run() -> str:
-        results = await sos.search(query, state="CA", max_results=5)
-        if not results:
-            return f"sos search returned no results for {query!r}"
-        lines: list[str] = []
-        for hit in results:
-            number = hit.extras.get("entity_number") or "?"
-            entity_type = hit.extras.get("entity_type") or "?"
-            status = hit.extras.get("status") or "?"
-            formed = hit.extras.get("formed_date") or "?"
-            snippet = hit.snippet.replace("\n", " ")
-            if len(snippet) > 200:
-                snippet = snippet[:200] + "…"
-            lines.append(
-                f"- {hit.title} — {number} — {entity_type} — {status} —"
-                f" formed {formed}\n"
-                f"  {hit.url}\n"
-                f"  {snippet}"
-            )
+        try:
+            results = await sos.search(query, state="CA", max_results=5)
+            if not results:
+                return f"sos search returned no results for {query!r}"
+            lines: list[str] = []
+            for hit in results:
+                number = hit.extras.get("entity_number") or "?"
+                entity_type = hit.extras.get("entity_type") or "?"
+                status = hit.extras.get("status") or "?"
+                formed = hit.extras.get("formed_date") or "?"
+                agent = hit.extras.get("registered_agent") or "?"
+                snippet = hit.snippet.replace("\n", " ")
+                if len(snippet) > 200:
+                    snippet = snippet[:200] + "…"
+                lines.append(
+                    f"- {hit.title} — {number} — {entity_type} — {status} —"
+                    f" formed {formed} — agent {agent}\n"
+                    f"  {hit.url}\n"
+                    f"  {snippet}"
+                )
 
-        top = results[0]
-        source = await sos.fetch(top.url)
-        if source is None:
-            lines.append(f"\nfetch({top.url}) returned None — agent unavailable")
-        else:
-            agent = source.metadata.get("registered_agent") or "?"
-            principal = source.metadata.get("principal_address") or "?"
-            lines.append(f"\nProfile for {top.title}")
-            lines.append(f"  registered_agent: {agent}")
-            lines.append(f"  principal_address: {principal}")
-        return "\n".join(lines)
+            top = results[0]
+            source = await sos.fetch(top.url)
+            if source is None:
+                lines.append(
+                    f"\nfetch({top.url}) returned None — profile is auth-gated"
+                    " (Okta); registered agent shown above is from the search"
+                    " row."
+                )
+            else:
+                agent = source.metadata.get("registered_agent") or "?"
+                principal = source.metadata.get("principal_address") or "?"
+                lines.append(f"\nProfile for {top.title}")
+                lines.append(f"  registered_agent: {agent}")
+                lines.append(f"  principal_address: {principal}")
+            return "\n".join(lines)
+        finally:
+            # Close the shared Playwright context inside the same event loop
+            # we used to open it. The atexit hook tries to shut down on a
+            # *new* loop, which deadlocks against the still-pending Chromium
+            # IPC and hangs the smoke run after stdout has already flushed.
+            try:
+                await browser.shutdown()
+            except Exception:  # noqa: BLE001 — best-effort cleanup
+                pass
 
     return asyncio.run(_run())
 

--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -404,6 +404,51 @@ def _smoke_opencorporates(query: str) -> str:
     return asyncio.run(_run())
 
 
+def _smoke_sos(query: str) -> str:
+    """Smoke wrapper: California Secretary of State business registry.
+
+    Per AC: ``research _smoke-tool sos "SBI Builders"`` should return the
+    LLC entry with its registered agent. Lists the top-5 entity hits with
+    their entity number / type / status / formed date, then follows up on
+    the top hit with ``fetch()`` so the registered agent surfaces too.
+    """
+    from research_agent.tools import sos
+
+    async def _run() -> str:
+        results = await sos.search(query, state="CA", max_results=5)
+        if not results:
+            return f"sos search returned no results for {query!r}"
+        lines: list[str] = []
+        for hit in results:
+            number = hit.extras.get("entity_number") or "?"
+            entity_type = hit.extras.get("entity_type") or "?"
+            status = hit.extras.get("status") or "?"
+            formed = hit.extras.get("formed_date") or "?"
+            snippet = hit.snippet.replace("\n", " ")
+            if len(snippet) > 200:
+                snippet = snippet[:200] + "…"
+            lines.append(
+                f"- {hit.title} — {number} — {entity_type} — {status} —"
+                f" formed {formed}\n"
+                f"  {hit.url}\n"
+                f"  {snippet}"
+            )
+
+        top = results[0]
+        source = await sos.fetch(top.url)
+        if source is None:
+            lines.append(f"\nfetch({top.url}) returned None — agent unavailable")
+        else:
+            agent = source.metadata.get("registered_agent") or "?"
+            principal = source.metadata.get("principal_address") or "?"
+            lines.append(f"\nProfile for {top.title}")
+            lines.append(f"  registered_agent: {agent}")
+            lines.append(f"  principal_address: {principal}")
+        return "\n".join(lines)
+
+    return asyncio.run(_run())
+
+
 def _smoke_sanctions(query: str) -> str:
     """Smoke wrapper: OFAC SDN / EU / UK sanctions lookup.
 
@@ -774,6 +819,7 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "lda": _smoke_lda,
     "littlesis": _smoke_littlesis,
     "opencorporates": _smoke_opencorporates,
+    "sos": _smoke_sos,
     "sanctions": _smoke_sanctions,
     "usaspending": _smoke_usaspending,
     "gdelt": _smoke_gdelt,

--- a/src/research_agent/tools/models.py
+++ b/src/research_agent/tools/models.py
@@ -42,6 +42,7 @@ SourceKind = Literal[
     "littlesis",
     "opencorporates",
     "sanctions",
+    "sos",
 ]
 
 

--- a/src/research_agent/tools/sos.py
+++ b/src/research_agent/tools/sos.py
@@ -1,0 +1,463 @@
+"""Secretary of State business registries — Playwright-driven (issue #101).
+
+Public surface:
+
+* ``async def search(query, *, state="CA", max_results=25) -> list[SearchResult]``
+  runs a state SoS business search by entity name OR entity number.
+  Returns the business name, entity number, type, status, formed date, and
+  profile URL.
+* ``async def fetch(url) -> Source | None`` opens an entity profile page and
+  returns markdown of: registered agent, principal address, officers (when
+  listed), statement-of-information history, and filing history.
+
+v1 ships **California** (``bizfileonline.sos.ca.gov``) — highest-volume
+jurisdiction for the user's likely targets. Module is pluggable per state via
+``_STATE_RECIPES``: DE / NV / WY / FL / NY each ship as config stubs that
+return ``[]`` / ``None`` with a single WARN until selectors are wired.
+
+No APIs, no auth. Per-host rate gate at 0.5 RPS — the SoS sites are public
+infrastructure and Playwright traffic is conspicuous, so be polite.
+
+Statements of Information for CA include the registered agent — this is the
+direct unmask path before paying for OpenCorporates.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import playwright.async_api
+
+from research_agent.tools import browser
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+_DIAGNOSTICS_DIR = Path("data/diagnostics/sos")
+_PER_HOST_RPS = 0.5
+
+# CA bizfileonline entity numbers: usually a 7-digit corp number prefixed by a
+# letter (e.g. ``C1234567``) for corporations, or a 12-digit numeric LLC id
+# (e.g. ``201234567890``). Matching either flavour is sufficient to switch the
+# search input from "name" to "entity number" mode where the recipe supports it.
+_CA_ENTITY_NUMBER_RE = re.compile(r"^(?:[A-Z]\d{6,8}|\d{10,14})$")
+
+
+# ---------------------------------------------------------------------------
+# Recipes — one per state.
+# ---------------------------------------------------------------------------
+
+_STATE_RECIPES: dict[str, dict[str, Any]] = {
+    # California — fully wired. bizfileonline.sos.ca.gov is a React SPA;
+    # selectors target stable role/aria attributes where possible so a UI
+    # tweak doesn't blank the connector.
+    "CA": {
+        "host": "bizfileonline.sos.ca.gov",
+        "search_url": "https://bizfileonline.sos.ca.gov/search/business",
+        "query_input": "input[placeholder*='Search' i]",
+        "submit_button": "button[type='submit']",
+        # Optional: if/when the UI exposes name-vs-number tabs, route here.
+        "query_kind_selector": None,
+        # Result rows.
+        "row_selector": "table tbody tr",
+        "name_selector": "td:nth-child(1)",
+        "link_selector": "td:nth-child(1) a",
+        "entity_number_selector": "td:nth-child(2)",
+        "type_selector": "td:nth-child(3)",
+        "status_selector": "td:nth-child(4)",
+        "formed_date_selector": "td:nth-child(5)",
+        # Entity profile.
+        "agent_selector": "[data-field='registered-agent'], .registered-agent",
+        "principal_address_selector": "[data-field='principal-address'], .principal-address",
+        "officers_selector": "[data-field='officers'] li, .officers li",
+        "soi_history_selector": "[data-field='soi-history'] tr, .soi-history tr",
+        "filing_history_selector": "[data-field='filing-history'] tr, .filing-history tr",
+    },
+    # Delaware — STUB. The Division of Corporations charges $10 per name-search
+    # certificate; the free public search at icis.corp.delaware.gov returns
+    # only the entity name + file number, with no agent / officer / filings.
+    # An operator should know coverage is shallow before relying on it.
+    "DE": {"stub": True, "host": "icis.corp.delaware.gov"},
+    "NV": {"stub": True, "host": "esos.nv.gov"},
+    "WY": {"stub": True, "host": "wyobiz.wyo.gov"},
+    "FL": {"stub": True, "host": "search.sunbiz.org"},
+    "NY": {"stub": True, "host": "apps.dos.ny.gov"},
+}
+
+
+def _accepted_hosts() -> frozenset[str]:
+    return frozenset(
+        recipe["host"]
+        for recipe in _STATE_RECIPES.values()
+        if isinstance(recipe.get("host"), str)
+    )
+
+
+def _register_host_rates() -> None:
+    """Wire per-host rates for every recipe with a configured host."""
+    for recipe in _STATE_RECIPES.values():
+        host = recipe.get("host")
+        if isinstance(host, str) and host:
+            browser.set_host_rate(host, _PER_HOST_RPS)
+
+
+_register_host_rates()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _looks_like_entity_number(query: str) -> bool:
+    """Heuristic: did the user paste an entity number rather than a name?"""
+    cleaned = (query or "").strip().upper()
+    if not cleaned:
+        return False
+    return bool(_CA_ENTITY_NUMBER_RE.match(cleaned))
+
+
+async def _safe_inner_text(locator: Any) -> str:
+    try:
+        text = await locator.inner_text()
+    except Exception:  # noqa: BLE001 — selector miss should not raise
+        return ""
+    return (text or "").strip()
+
+
+async def _safe_attr(locator: Any, name: str) -> str:
+    try:
+        value = await locator.get_attribute(name)
+    except Exception:  # noqa: BLE001
+        return ""
+    return (value or "").strip()
+
+
+async def _save_diagnostic_screenshot(page: Any, host: str) -> None:
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    target = _DIAGNOSTICS_DIR / f"{host}-{stamp}.png"
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        await page.screenshot(path=str(target))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("sos diagnostic screenshot failed: %s", exc)
+
+
+def _absolute_url(base: str, href: str) -> str:
+    if not href:
+        return ""
+    if href.startswith("http://") or href.startswith("https://"):
+        return href
+    if href.startswith("/"):
+        parsed = urlparse(base)
+        return f"{parsed.scheme}://{parsed.netloc}{href}"
+    return base.rstrip("/") + "/" + href
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def _extract_row(
+    row: Any, recipe: dict[str, Any], *, search_url: str
+) -> SearchResult | None:
+    name = await _safe_inner_text(row.locator(recipe["name_selector"]).first)
+    href = await _safe_attr(row.locator(recipe["link_selector"]).first, "href")
+    if not name:
+        return None
+
+    entity_number = await _safe_inner_text(
+        row.locator(recipe["entity_number_selector"]).first
+    )
+    entity_type = await _safe_inner_text(row.locator(recipe["type_selector"]).first)
+    status = await _safe_inner_text(row.locator(recipe["status_selector"]).first)
+    formed_date = await _safe_inner_text(
+        row.locator(recipe["formed_date_selector"]).first
+    )
+
+    profile_url = _absolute_url(search_url, href) if href else search_url
+    state = next(
+        (
+            code
+            for code, r in _STATE_RECIPES.items()
+            if r.get("host") == recipe["host"]
+        ),
+        "",
+    )
+
+    snippet_bits = [b for b in (entity_type, status, formed_date) if b]
+    snippet = " — ".join(snippet_bits)
+
+    extras: dict[str, Any] = {
+        "entity_number": entity_number,
+        "entity_type": entity_type,
+        "status": status,
+        "formed_date": formed_date,
+        "state": state,
+        "profile_url": profile_url,
+    }
+    return SearchResult(
+        url=profile_url,
+        title=name,
+        snippet=snippet,
+        source_kind="sos",
+        extras=extras,
+    )
+
+
+async def search(
+    query: str,
+    *,
+    state: str = "CA",
+    max_results: int = 25,
+) -> list[SearchResult]:
+    """Run a Secretary of State business search; return up to ``max_results`` hits.
+
+    ``state`` is the two-letter postal code (default ``"CA"``). Unknown or
+    stub states return ``[]`` after a WARN so callers can route around the
+    coverage gap rather than crashing the planner.
+
+    Detects entity-number vs name queries by regex; when the recipe exposes
+    a ``query_kind_selector``, the matching tab/radio is selected before
+    submission.
+    """
+    code = (state or "").strip().upper()
+    recipe = _STATE_RECIPES.get(code)
+    if recipe is None:
+        logger.warning("sos: no recipe for state %r", state)
+        return []
+    if recipe.get("stub"):
+        logger.warning(
+            "sos: state %s is a stub — coverage not yet wired (host=%s)",
+            code,
+            recipe.get("host"),
+        )
+        return []
+
+    if not query or not query.strip():
+        return []
+
+    search_url = recipe["search_url"]
+    host = recipe["host"]
+
+    try:
+        async with browser.browser_session() as ctx:
+            page = await ctx.new_page()
+            try:
+                await browser.navigate(page, search_url)
+
+                if recipe.get("query_kind_selector"):
+                    kind = "number" if _looks_like_entity_number(query) else "name"
+                    selector = recipe["query_kind_selector"].format(kind=kind)
+                    try:
+                        await page.locator(selector).first.click()
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug("sos query-kind toggle failed: %s", exc)
+
+                try:
+                    await page.locator(recipe["query_input"]).first.fill(query)
+                    await page.locator(recipe["submit_button"]).first.click()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "sos search submit failed for state=%s: %s", code, exc
+                    )
+                    await _save_diagnostic_screenshot(page, host)
+                    return []
+
+                try:
+                    rows = await page.locator(recipe["row_selector"]).all()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "sos search selector miss on %s: %s", search_url, exc
+                    )
+                    await _save_diagnostic_screenshot(page, host)
+                    return []
+
+                results: list[SearchResult] = []
+                for row in rows[:max_results]:
+                    try:
+                        result = await _extract_row(
+                            row, recipe, search_url=search_url
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning("sos row parse failed: %s", exc)
+                        continue
+                    if result is not None:
+                        results.append(result)
+                return results
+            finally:
+                try:
+                    await page.close()
+                except Exception:  # noqa: BLE001
+                    pass
+    except playwright.async_api.Error as exc:
+        logger.warning("sos search playwright error for state=%s: %s", code, exc)
+        return []
+    except Exception as exc:  # noqa: BLE001 — never crash the planner
+        logger.warning("sos search unexpected error for state=%s: %s", code, exc)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+def _resolve_recipe_for_host(host: str) -> dict[str, Any] | None:
+    for recipe in _STATE_RECIPES.values():
+        if recipe.get("host") == host and not recipe.get("stub"):
+            return recipe
+    return None
+
+
+async def _collect_simple_text(page: Any, selector: str | None) -> str:
+    if not selector:
+        return ""
+    try:
+        return await _safe_inner_text(page.locator(selector).first)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("sos profile selector miss (%s): %s", selector, exc)
+        return ""
+
+
+async def _collect_list(page: Any, selector: str | None) -> list[str]:
+    if not selector:
+        return []
+    try:
+        nodes = await page.locator(selector).all()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("sos profile list selector miss (%s): %s", selector, exc)
+        return []
+    out: list[str] = []
+    for node in nodes:
+        text = await _safe_inner_text(node)
+        if text:
+            out.append(text)
+    return out
+
+
+def _markdown_section(heading: str, lines: list[str]) -> str:
+    if not lines:
+        return ""
+    body = "\n".join(f"- {line}" for line in lines)
+    return f"## {heading}\n\n{body}"
+
+
+async def fetch(url: str) -> Source | None:
+    """Open a state SoS entity profile and return a :class:`Source`.
+
+    Strict host gate: only URLs whose host matches a non-stub recipe are
+    accepted; everything else returns ``None`` without a network call.
+    """
+    if not url:
+        return None
+    parsed = urlparse(url)
+    host = (parsed.netloc or "").lower().split(":", 1)[0]
+    if host not in _accepted_hosts():
+        return None
+    recipe = _resolve_recipe_for_host(host)
+    if recipe is None:
+        return None
+
+    try:
+        async with browser.browser_session() as ctx:
+            page = await ctx.new_page()
+            try:
+                await browser.navigate(page, url)
+
+                title = await _safe_inner_text(page.locator("h1").first)
+                if not title:
+                    title = host
+
+                entity_number = await _collect_simple_text(
+                    page, recipe.get("entity_number_selector")
+                )
+                entity_type = await _collect_simple_text(
+                    page, recipe.get("type_selector")
+                )
+                status = await _collect_simple_text(page, recipe.get("status_selector"))
+                formed_date = await _collect_simple_text(
+                    page, recipe.get("formed_date_selector")
+                )
+
+                agent = await _collect_simple_text(page, recipe.get("agent_selector"))
+                principal_address = await _collect_simple_text(
+                    page, recipe.get("principal_address_selector")
+                )
+                officers = await _collect_list(page, recipe.get("officers_selector"))
+                soi_rows = await _collect_list(page, recipe.get("soi_history_selector"))
+                filing_rows = await _collect_list(
+                    page, recipe.get("filing_history_selector")
+                )
+
+                meta_bits = [b for b in (entity_number, entity_type, status, formed_date) if b]
+                meta_line = "_" + " · ".join(meta_bits) + "_" if meta_bits else ""
+
+                sections: list[str] = [f"# {title}"]
+                if meta_line:
+                    sections.append(meta_line)
+
+                if agent:
+                    sections.append(f"## Registered agent\n\n{agent}")
+                if principal_address:
+                    sections.append(f"## Principal address\n\n{principal_address}")
+                officers_md = _markdown_section("Officers", officers)
+                if officers_md:
+                    sections.append(officers_md)
+                soi_md = _markdown_section("Statements of Information", soi_rows)
+                if soi_md:
+                    sections.append(soi_md)
+                filings_md = _markdown_section("Filing history", filing_rows)
+                if filings_md:
+                    sections.append(filings_md)
+
+                cleaned_text = "\n\n".join(sections).strip()
+                if not cleaned_text:
+                    return None
+
+                metadata: dict[str, Any] = {
+                    "entity_number": entity_number,
+                    "entity_type": entity_type,
+                    "status": status,
+                    "formed_date": formed_date,
+                    "registered_agent": agent,
+                    "principal_address": principal_address,
+                    "officers": officers,
+                    "statements_of_information": soi_rows,
+                    "filings": filing_rows,
+                }
+
+                return Source(
+                    url=url,
+                    title=title,
+                    cleaned_text=cleaned_text,
+                    raw_html=None,
+                    fetched_at=datetime.now(UTC),
+                    source_kind="sos",
+                    metadata=metadata,
+                )
+            finally:
+                try:
+                    await page.close()
+                except Exception:  # noqa: BLE001
+                    pass
+    except playwright.async_api.Error as exc:
+        logger.warning("sos fetch playwright error for %s: %s", url, exc)
+        return None
+    except Exception as exc:  # noqa: BLE001 — never crash the planner
+        logger.warning("sos fetch unexpected error for %s: %s", url, exc)
+        return None
+
+
+def reset_for_tests() -> None:
+    """Re-register host rates after browser.reset_for_tests() drops them. Test-only."""
+    _register_host_rates()
+
+
+__all__ = ["fetch", "reset_for_tests", "search"]

--- a/src/research_agent/tools/sos.py
+++ b/src/research_agent/tools/sos.py
@@ -42,10 +42,17 @@ _DIAGNOSTICS_DIR = Path("data/diagnostics/sos")
 _PER_HOST_RPS = 0.5
 
 # CA bizfileonline entity numbers: usually a 7-digit corp number prefixed by a
-# letter (e.g. ``C1234567``) for corporations, or a 12-digit numeric LLC id
-# (e.g. ``201234567890``). Matching either flavour is sufficient to switch the
-# search input from "name" to "entity number" mode where the recipe supports it.
-_CA_ENTITY_NUMBER_RE = re.compile(r"^(?:[A-Z]\d{6,8}|\d{10,14})$")
+# letter (e.g. ``C1234567``) for corporations, or a 7–12-digit numeric LLC id
+# (e.g. ``201234567890`` or shorter legacy stock-corp numbers like ``2741233``).
+# Matching either flavour is sufficient to switch the search input from "name"
+# to "entity number" mode where the recipe supports it.
+_CA_ENTITY_NUMBER_RE = re.compile(r"^(?:[A-Z]\d{6,8}|\d{6,14})$")
+
+# Cell-1 of every search row reads ``"<NAME> (<entity_number>)"`` followed by
+# a "Click to expand" hint string. The trailing parenthetical is the only
+# place the entity number is rendered in the search results, so we have to
+# parse it out of the visible text rather than read a separate column.
+_CA_NAME_NUMBER_RE = re.compile(r"^(.*?)\s*\((\d{6,14})\)\s*$")
 
 
 # ---------------------------------------------------------------------------
@@ -59,19 +66,38 @@ _STATE_RECIPES: dict[str, dict[str, Any]] = {
     "CA": {
         "host": "bizfileonline.sos.ca.gov",
         "search_url": "https://bizfileonline.sos.ca.gov/search/business",
+        # Live DOM (verified 2026-05): the search input has placeholder
+        # "Search by name or file number"; the submit control is a button
+        # with aria-label="Execute search" and no type attribute.
         "query_input": "input[placeholder*='Search' i]",
-        "submit_button": "button[type='submit']",
+        "submit_button": "button[aria-label='Execute search']",
         # Optional: if/when the UI exposes name-vs-number tabs, route here.
         "query_kind_selector": None,
-        # Result rows.
+        # Result rows. The table has 6 columns: cell-1 is the entity name
+        # with the entity number embedded in parentheses ("ACME LLC (1234567)")
+        # plus a "Click to expand" hint; cells 2–6 are date/status/type/
+        # formation-jurisdiction/agent. There is NO anchor tag — cell-1 is a
+        # div[role=button] that opens an Okta-gated detail panel, so search
+        # results have to be parsed in place and a synthetic profile URL is
+        # composed from the entity number.
         "row_selector": "table tbody tr",
         "name_selector": "td:nth-child(1)",
-        "link_selector": "td:nth-child(1) a",
-        "entity_number_selector": "td:nth-child(2)",
-        "type_selector": "td:nth-child(3)",
-        "status_selector": "td:nth-child(4)",
+        "link_selector": "td:nth-child(1) a",  # absent in current DOM; fallback only
+        "filing_date_selector": "td:nth-child(2)",
+        "status_selector": "td:nth-child(3)",
+        "type_selector": "td:nth-child(4)",
         "formed_date_selector": "td:nth-child(5)",
-        # Entity profile.
+        "row_agent_selector": "td:nth-child(6)",
+        # Entity profile. NOTE: bizfileonline now redirects entity-detail
+        # clicks to Okta SSO (idm.sos.ca.gov) — the per-entity panel is
+        # auth-gated. fetch() degrades to a near-empty Source for
+        # unauthenticated traffic; the search row already exposes the
+        # registered agent so the smoke AC ("returns the LLC entry with
+        # its registered agent") is satisfied via search() alone.
+        "profile_entity_number_selector": "[data-field='entity-number']",
+        "profile_type_selector": "[data-field='entity-type']",
+        "profile_status_selector": "[data-field='entity-status']",
+        "profile_formed_date_selector": "[data-field='formed-date']",
         "agent_selector": "[data-field='registered-agent'], .registered-agent",
         "principal_address_selector": "[data-field='principal-address'], .principal-address",
         "officers_selector": "[data-field='officers'] li, .officers li",
@@ -122,9 +148,22 @@ def _looks_like_entity_number(query: str) -> bool:
     return bool(_CA_ENTITY_NUMBER_RE.match(cleaned))
 
 
+# Short per-call timeout for selector reads. Playwright's default 30s auto-wait
+# is catastrophic on a SPA where most profile selectors are absent — six
+# missing selectors in ``fetch()`` would hang the connector for >3 minutes.
+# Two seconds is more than enough for an element that has actually rendered.
+_SELECTOR_READ_TIMEOUT_MS = 2_000
+
+
 async def _safe_inner_text(locator: Any) -> str:
     try:
-        text = await locator.inner_text()
+        text = await locator.inner_text(timeout=_SELECTOR_READ_TIMEOUT_MS)
+    except TypeError:
+        # Fakes in unit tests don't accept the timeout kwarg — fall back.
+        try:
+            text = await locator.inner_text()
+        except Exception:  # noqa: BLE001
+            return ""
     except Exception:  # noqa: BLE001 — selector miss should not raise
         return ""
     return (text or "").strip()
@@ -132,7 +171,12 @@ async def _safe_inner_text(locator: Any) -> str:
 
 async def _safe_attr(locator: Any, name: str) -> str:
     try:
-        value = await locator.get_attribute(name)
+        value = await locator.get_attribute(name, timeout=_SELECTOR_READ_TIMEOUT_MS)
+    except TypeError:
+        try:
+            value = await locator.get_attribute(name)
+        except Exception:  # noqa: BLE001
+            return ""
     except Exception:  # noqa: BLE001
         return ""
     return (value or "").strip()
@@ -164,24 +208,48 @@ def _absolute_url(base: str, href: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _split_name_and_number(cell_text: str) -> tuple[str, str]:
+    """Strip the "Click to expand" hint and split "<NAME> (<number>)".
+
+    bizfileonline renders cell-1 as ``"SBI BUILDERS, INC. (2741233)\\nClick to
+    expand"`` — the only way to recover the entity number from the visible
+    DOM is to parse the trailing parenthetical out of the cell text.
+    """
+    # First line only — drops the "Click to expand" affordance text and any
+    # screen-reader hints rendered in the same cell.
+    first = (cell_text or "").splitlines()[0].strip() if cell_text else ""
+    if not first:
+        return "", ""
+    match = _CA_NAME_NUMBER_RE.match(first)
+    if match:
+        return match.group(1).strip(), match.group(2)
+    return first, ""
+
+
 async def _extract_row(
     row: Any, recipe: dict[str, Any], *, search_url: str
 ) -> SearchResult | None:
-    name = await _safe_inner_text(row.locator(recipe["name_selector"]).first)
-    href = await _safe_attr(row.locator(recipe["link_selector"]).first, "href")
+    raw_name = await _safe_inner_text(row.locator(recipe["name_selector"]).first)
+    if not raw_name:
+        return None
+
+    name, parsed_number = _split_name_and_number(raw_name)
     if not name:
         return None
 
-    entity_number = await _safe_inner_text(
-        row.locator(recipe["entity_number_selector"]).first
-    )
-    entity_type = await _safe_inner_text(row.locator(recipe["type_selector"]).first)
+    href = await _safe_attr(row.locator(recipe["link_selector"]).first, "href")
+    filing_date = await _safe_inner_text(
+        row.locator(recipe.get("filing_date_selector") or "").first
+    ) if recipe.get("filing_date_selector") else ""
     status = await _safe_inner_text(row.locator(recipe["status_selector"]).first)
+    entity_type = await _safe_inner_text(row.locator(recipe["type_selector"]).first)
     formed_date = await _safe_inner_text(
         row.locator(recipe["formed_date_selector"]).first
     )
+    registered_agent = await _safe_inner_text(
+        row.locator(recipe.get("row_agent_selector") or "").first
+    ) if recipe.get("row_agent_selector") else ""
 
-    profile_url = _absolute_url(search_url, href) if href else search_url
     state = next(
         (
             code
@@ -191,14 +259,27 @@ async def _extract_row(
         "",
     )
 
+    # No anchor tag in the live DOM — synth a search-anchored URL keyed on
+    # the parsed entity number so the result still round-trips through the
+    # planner's URL-keyed dedup. Falls back to the raw search URL if the
+    # number didn't parse out.
+    if href:
+        profile_url = _absolute_url(search_url, href)
+    elif parsed_number:
+        profile_url = f"{search_url}?q={parsed_number}"
+    else:
+        profile_url = search_url
+
     snippet_bits = [b for b in (entity_type, status, formed_date) if b]
     snippet = " — ".join(snippet_bits)
 
     extras: dict[str, Any] = {
-        "entity_number": entity_number,
+        "entity_number": parsed_number,
         "entity_type": entity_type,
         "status": status,
+        "filing_date": filing_date,
         "formed_date": formed_date,
+        "registered_agent": registered_agent,
         "state": state,
         "profile_url": profile_url,
     }
@@ -266,6 +347,22 @@ async def search(
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "sos search submit failed for state=%s: %s", code, exc
+                    )
+                    await _save_diagnostic_screenshot(page, host)
+                    return []
+
+                # bizfileonline is a React SPA — the result rows render after
+                # an XHR completes. Wait for at least one row to appear before
+                # reading; bail to a diagnostic screenshot rather than racing.
+                try:
+                    await page.locator(recipe["row_selector"]).first.wait_for(
+                        timeout=15_000
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "sos search rows did not render on %s: %s",
+                        search_url,
+                        exc,
                     )
                     await _save_diagnostic_screenshot(page, host)
                     return []
@@ -376,14 +473,16 @@ async def fetch(url: str) -> Source | None:
                     title = host
 
                 entity_number = await _collect_simple_text(
-                    page, recipe.get("entity_number_selector")
+                    page, recipe.get("profile_entity_number_selector")
                 )
                 entity_type = await _collect_simple_text(
-                    page, recipe.get("type_selector")
+                    page, recipe.get("profile_type_selector")
                 )
-                status = await _collect_simple_text(page, recipe.get("status_selector"))
+                status = await _collect_simple_text(
+                    page, recipe.get("profile_status_selector")
+                )
                 formed_date = await _collect_simple_text(
-                    page, recipe.get("formed_date_selector")
+                    page, recipe.get("profile_formed_date_selector")
                 )
 
                 agent = await _collect_simple_text(page, recipe.get("agent_selector"))

--- a/tests/test_tools_models.py
+++ b/tests/test_tools_models.py
@@ -36,6 +36,7 @@ EXPECTED_SOURCE_KINDS = (
     "littlesis",
     "opencorporates",
     "sanctions",
+    "sos",
 )
 
 

--- a/tests/test_tools_sos.py
+++ b/tests/test_tools_sos.py
@@ -1,0 +1,468 @@
+"""Tests for `research_agent.tools.sos` (issue #101)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from research_agent.tools import sos
+
+# ---------------------------------------------------------------------------
+# Fakes — Playwright surface area sufficient to exercise sos.py.
+# ---------------------------------------------------------------------------
+
+
+class _FakeLocator:
+    def __init__(
+        self,
+        *,
+        text: str = "",
+        attrs: dict[str, str] | None = None,
+        children: dict[str, _FakeLocator] | None = None,
+        items: list[_FakeLocator] | None = None,
+        on_fill: Any = None,
+        on_click: Any = None,
+        raise_on_locator: bool = False,
+        raise_on_all: bool = False,
+    ) -> None:
+        self._text = text
+        self._attrs = attrs or {}
+        self._children = children or {}
+        self._items = items or []
+        self._on_fill = on_fill
+        self._on_click = on_click
+        self._raise_on_locator = raise_on_locator
+        self._raise_on_all = raise_on_all
+        self.fill_calls: list[str] = []
+        self.click_calls: int = 0
+
+    @property
+    def first(self) -> _FakeLocator:
+        return self
+
+    async def all(self) -> list[_FakeLocator]:
+        if self._raise_on_all:
+            raise RuntimeError("selector drift")
+        return list(self._items)
+
+    async def inner_text(self) -> str:
+        return self._text
+
+    async def get_attribute(self, name: str) -> str | None:
+        return self._attrs.get(name)
+
+    async def fill(self, value: str) -> None:
+        self.fill_calls.append(value)
+        if self._on_fill is not None:
+            self._on_fill(value)
+
+    async def click(self) -> None:
+        self.click_calls += 1
+        if self._on_click is not None:
+            self._on_click()
+
+    def locator(self, selector: str) -> _FakeLocator:
+        if self._raise_on_locator:
+            raise RuntimeError("selector drift")
+        return self._children.get(selector, _FakeLocator())
+
+
+class _FakePage:
+    def __init__(self, selector_map: dict[str, _FakeLocator]) -> None:
+        self._selector_map = selector_map
+        self.closed = False
+        self.screenshots: list[str] = []
+        self.locator_calls: list[str] = []
+
+    def locator(self, selector: str) -> _FakeLocator:
+        self.locator_calls.append(selector)
+        return self._selector_map.get(selector, _FakeLocator())
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def screenshot(self, *, path: str) -> None:
+        self.screenshots.append(path)
+
+
+class _FakeContext:
+    def __init__(self, page: _FakePage) -> None:
+        self._page = page
+
+    async def new_page(self) -> _FakePage:
+        return self._page
+
+
+def _stub_browser(monkeypatch, page: _FakePage) -> dict[str, list[str]]:
+    captured: dict[str, list[str]] = {"navigations": []}
+
+    @asynccontextmanager
+    async def _session(headful=None, block_media=True):
+        yield _FakeContext(page)
+
+    async def _navigate(p, url, **kwargs):
+        captured["navigations"].append(url)
+
+    monkeypatch.setattr(sos.browser, "browser_session", _session)
+    monkeypatch.setattr(sos.browser, "navigate", _navigate)
+    return captured
+
+
+def _build_row(
+    *,
+    name: str,
+    href: str,
+    entity_number: str = "",
+    entity_type: str = "",
+    status: str = "",
+    formed: str = "",
+) -> _FakeLocator:
+    """Build a row whose child selectors mirror the CA recipe."""
+    recipe = sos._STATE_RECIPES["CA"]
+    return _FakeLocator(
+        children={
+            recipe["name_selector"]: _FakeLocator(text=name),
+            recipe["link_selector"]: _FakeLocator(text=name, attrs={"href": href}),
+            recipe["entity_number_selector"]: _FakeLocator(text=entity_number),
+            recipe["type_selector"]: _FakeLocator(text=entity_type),
+            recipe["status_selector"]: _FakeLocator(text=status),
+            recipe["formed_date_selector"]: _FakeLocator(text=formed),
+        }
+    )
+
+
+def _ca_search_page(rows: list[_FakeLocator]) -> _FakePage:
+    recipe = sos._STATE_RECIPES["CA"]
+    return _FakePage(
+        {
+            recipe["query_input"]: _FakeLocator(),
+            recipe["submit_button"]: _FakeLocator(),
+            recipe["row_selector"]: _FakeLocator(items=rows),
+        }
+    )
+
+
+def _ca_profile_page(
+    *,
+    title: str = "SBI BUILDERS, LLC",
+    entity_number: str = "201234567890",
+    entity_type: str = "Limited Liability Company",
+    status: str = "Active",
+    formed: str = "2012-03-15",
+    agent: str = "Jane Q Agent — 5678 Agent Way, Sacramento, CA",
+    principal: str = "1234 Main St, San Jose, CA 95110",
+    officers: list[str] | None = None,
+    soi_rows: list[str] | None = None,
+    filing_rows: list[str] | None = None,
+) -> _FakePage:
+    recipe = sos._STATE_RECIPES["CA"]
+    selectors: dict[str, _FakeLocator] = {
+        "h1": _FakeLocator(text=title),
+        recipe["entity_number_selector"]: _FakeLocator(text=entity_number),
+        recipe["type_selector"]: _FakeLocator(text=entity_type),
+        recipe["status_selector"]: _FakeLocator(text=status),
+        recipe["formed_date_selector"]: _FakeLocator(text=formed),
+        recipe["agent_selector"]: _FakeLocator(text=agent),
+        recipe["principal_address_selector"]: _FakeLocator(text=principal),
+        recipe["officers_selector"]: _FakeLocator(
+            items=[_FakeLocator(text=t) for t in (officers or [])]
+        ),
+        recipe["soi_history_selector"]: _FakeLocator(
+            items=[_FakeLocator(text=t) for t in (soi_rows or [])]
+        ),
+        recipe["filing_history_selector"]: _FakeLocator(
+            items=[_FakeLocator(text=t) for t in (filing_rows or [])]
+        ),
+    }
+    return _FakePage(selectors)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    sos.reset_for_tests()
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    yield
+    sos.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def test_search_returns_results_for_name_query(monkeypatch):
+    rows = [
+        _build_row(
+            name="SBI BUILDERS, LLC",
+            href="/business/201234567890",
+            entity_number="201234567890",
+            entity_type="Limited Liability Company",
+            status="Active",
+            formed="2012-03-15",
+        ),
+        _build_row(
+            name="SBI BUILDERS INC",
+            href="/business/C9876543",
+            entity_number="C9876543",
+            entity_type="Domestic Stock",
+            status="Dissolved",
+            formed="1998-07-22",
+        ),
+    ]
+    page = _ca_search_page(rows)
+    captured = _stub_browser(monkeypatch, page)
+
+    results = await sos.search("SBI Builders", state="CA", max_results=5)
+
+    assert captured["navigations"] == [sos._STATE_RECIPES["CA"]["search_url"]]
+    assert len(results) == 2
+
+    top = results[0]
+    assert top.source_kind == "sos"
+    assert top.title == "SBI BUILDERS, LLC"
+    assert top.url == "https://bizfileonline.sos.ca.gov/business/201234567890"
+    assert top.extras["entity_number"] == "201234567890"
+    assert top.extras["entity_type"] == "Limited Liability Company"
+    assert top.extras["status"] == "Active"
+    assert top.extras["formed_date"] == "2012-03-15"
+    assert top.extras["state"] == "CA"
+    assert "Active" in top.snippet
+
+
+async def test_search_handles_entity_number_query(monkeypatch):
+    rows = [
+        _build_row(
+            name="SBI BUILDERS INC",
+            href="/business/C9876543",
+            entity_number="C9876543",
+            entity_type="Domestic Stock",
+            status="Active",
+            formed="1998-07-22",
+        ),
+    ]
+    page = _ca_search_page(rows)
+    _stub_browser(monkeypatch, page)
+
+    results = await sos.search("C9876543", state="CA", max_results=5)
+    assert len(results) == 1
+    assert results[0].extras["entity_number"] == "C9876543"
+    # Query input still got the entity number string filled in.
+    query_locator = page._selector_map[sos._STATE_RECIPES["CA"]["query_input"]]
+    assert query_locator.fill_calls == ["C9876543"]
+
+
+async def test_entity_number_regex_recognises_ca_formats():
+    assert sos._looks_like_entity_number("C1234567")
+    assert sos._looks_like_entity_number("201234567890")
+    assert not sos._looks_like_entity_number("SBI Builders")
+    assert not sos._looks_like_entity_number("")
+
+
+async def test_search_returns_empty_for_unknown_state(monkeypatch, caplog):
+    page = _ca_search_page([])
+    _stub_browser(monkeypatch, page)
+
+    with caplog.at_level(logging.WARNING, logger=sos.logger.name):
+        results = await sos.search("anything", state="ZZ")
+    assert results == []
+    assert any("no recipe" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.parametrize("state", ["DE", "NV", "WY", "FL", "NY"])
+async def test_search_returns_empty_for_stub_states(monkeypatch, caplog, state):
+    page = _ca_search_page([])
+    _stub_browser(monkeypatch, page)
+
+    with caplog.at_level(logging.WARNING, logger=sos.logger.name):
+        results = await sos.search("anything", state=state)
+    assert results == []
+    assert any("stub" in rec.message.lower() for rec in caplog.records)
+
+
+async def test_search_empty_query_returns_empty(monkeypatch):
+    page = _ca_search_page([])
+    _stub_browser(monkeypatch, page)
+    assert await sos.search("", state="CA") == []
+    assert await sos.search("   ", state="CA") == []
+
+
+async def test_search_selector_miss_returns_empty_and_logs(
+    monkeypatch, caplog, tmp_path
+):
+    recipe = sos._STATE_RECIPES["CA"]
+    page = _FakePage(
+        {
+            recipe["query_input"]: _FakeLocator(),
+            recipe["submit_button"]: _FakeLocator(),
+            recipe["row_selector"]: _FakeLocator(raise_on_all=True),
+        }
+    )
+    _stub_browser(monkeypatch, page)
+    monkeypatch.setattr(sos, "_DIAGNOSTICS_DIR", tmp_path / "diagnostics")
+
+    with caplog.at_level(logging.WARNING, logger=sos.logger.name):
+        results = await sos.search("anything", state="CA")
+
+    assert results == []
+    assert any("selector miss" in rec.message for rec in caplog.records)
+    assert page.screenshots, "expected a diagnostic screenshot path"
+    assert page.screenshots[0].endswith(".png")
+
+
+async def test_search_respects_max_results(monkeypatch):
+    rows = [
+        _build_row(
+            name=f"Company {i}",
+            href=f"/business/{i}",
+            entity_number=f"{i:012d}",
+            entity_type="LLC",
+            status="Active",
+            formed="2020-01-01",
+        )
+        for i in range(10)
+    ]
+    page = _ca_search_page(rows)
+    _stub_browser(monkeypatch, page)
+
+    results = await sos.search("anything", state="CA", max_results=3)
+    assert len(results) == 3
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_builds_markdown_source(monkeypatch):
+    page = _ca_profile_page(
+        officers=["Alice Builder — Manager", "Bob Builder — Member"],
+        soi_rows=["2024-03-12 — Statement of Information", "2023-03-08 — SOI"],
+        filing_rows=["2024-03-12 — SI-LLC", "2012-03-15 — Articles of Organization"],
+    )
+    _stub_browser(monkeypatch, page)
+
+    url = "https://bizfileonline.sos.ca.gov/business/201234567890"
+    source = await sos.fetch(url)
+
+    assert source is not None
+    assert source.source_kind == "sos"
+    assert source.title == "SBI BUILDERS, LLC"
+    assert source.url == url
+
+    body = source.cleaned_text
+    assert "# SBI BUILDERS, LLC" in body
+    assert "201234567890" in body
+    assert "Active" in body
+    assert "## Registered agent" in body
+    assert "Jane Q Agent" in body
+    assert "## Principal address" in body
+    assert "1234 Main St" in body
+    assert "## Officers" in body
+    assert "Alice Builder" in body
+    assert "## Statements of Information" in body
+    assert "Statement of Information" in body
+    assert "## Filing history" in body
+    assert "Articles of Organization" in body
+
+    md = source.metadata
+    assert md["entity_number"] == "201234567890"
+    assert md["entity_type"] == "Limited Liability Company"
+    assert md["status"] == "Active"
+    assert md["formed_date"] == "2012-03-15"
+    assert "Jane Q Agent" in md["registered_agent"]
+    assert "1234 Main St" in md["principal_address"]
+    assert len(md["officers"]) == 2
+    assert len(md["statements_of_information"]) == 2
+    assert len(md["filings"]) == 2
+
+
+async def test_fetch_rejects_unknown_host(monkeypatch):
+    """Look-alike hosts must be rejected without opening a browser."""
+
+    @asynccontextmanager
+    async def _no_session(headful=None, block_media=True):
+        raise AssertionError("should not open browser")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(sos.browser, "browser_session", _no_session)
+
+    spoof = "https://bizfileonline.sos.ca.gov.attacker.example/business/1"
+    assert await sos.fetch(spoof) is None
+    assert await sos.fetch("https://opencorporates.com/companies/us_ca/1") is None
+
+
+async def test_fetch_rejects_stub_state_hosts(monkeypatch):
+    """DE / NV / WY / FL / NY are stubs — fetch must not open them."""
+
+    @asynccontextmanager
+    async def _no_session(headful=None, block_media=True):
+        raise AssertionError("should not open browser")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(sos.browser, "browser_session", _no_session)
+
+    # icis.corp.delaware.gov is in the DE recipe but flagged as a stub.
+    assert await sos.fetch("https://icis.corp.delaware.gov/eCorp/EntitySearch") is None
+
+
+async def test_fetch_returns_none_for_empty_url():
+    assert await sos.fetch("") is None
+
+
+async def test_fetch_handles_minimal_profile(monkeypatch):
+    """A profile with only a title still rounds-trips through the markdown builder."""
+    recipe = sos._STATE_RECIPES["CA"]
+    page = _FakePage(
+        {
+            "h1": _FakeLocator(text="ACME LLC"),
+            recipe["entity_number_selector"]: _FakeLocator(),
+            recipe["type_selector"]: _FakeLocator(),
+            recipe["status_selector"]: _FakeLocator(),
+            recipe["formed_date_selector"]: _FakeLocator(),
+            recipe["agent_selector"]: _FakeLocator(),
+            recipe["principal_address_selector"]: _FakeLocator(),
+            recipe["officers_selector"]: _FakeLocator(items=[]),
+            recipe["soi_history_selector"]: _FakeLocator(items=[]),
+            recipe["filing_history_selector"]: _FakeLocator(items=[]),
+        }
+    )
+    _stub_browser(monkeypatch, page)
+
+    url = "https://bizfileonline.sos.ca.gov/business/000"
+    source = await sos.fetch(url)
+    assert source is not None
+    assert source.title == "ACME LLC"
+    assert "# ACME LLC" in source.cleaned_text
+
+
+# ---------------------------------------------------------------------------
+# Source kind literal & smoke registration
+# ---------------------------------------------------------------------------
+
+
+def test_source_kind_literal():
+    from research_agent.tools.models import SearchResult
+
+    result = SearchResult(
+        url="https://bizfileonline.sos.ca.gov/business/1",
+        title="t",
+        snippet="s",
+        source_kind="sos",
+    )
+    assert result.source_kind == "sos"
+
+
+def test_smoke_registry_includes_sos():
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "sos" in TOOL_REGISTRY

--- a/tests/test_tools_sos.py
+++ b/tests/test_tools_sos.py
@@ -29,6 +29,7 @@ class _FakeLocator:
         on_click: Any = None,
         raise_on_locator: bool = False,
         raise_on_all: bool = False,
+        raise_on_wait_for: bool = False,
     ) -> None:
         self._text = text
         self._attrs = attrs or {}
@@ -38,8 +39,10 @@ class _FakeLocator:
         self._on_click = on_click
         self._raise_on_locator = raise_on_locator
         self._raise_on_all = raise_on_all
+        self._raise_on_wait_for = raise_on_wait_for
         self.fill_calls: list[str] = []
         self.click_calls: int = 0
+        self.wait_for_calls: int = 0
 
     @property
     def first(self) -> _FakeLocator:
@@ -65,6 +68,11 @@ class _FakeLocator:
         self.click_calls += 1
         if self._on_click is not None:
             self._on_click()
+
+    async def wait_for(self, *, timeout: int = 0) -> None:  # noqa: ARG002
+        self.wait_for_calls += 1
+        if self._raise_on_wait_for:
+            raise RuntimeError("rows did not render")
 
     def locator(self, selector: str) -> _FakeLocator:
         if self._raise_on_locator:
@@ -116,22 +124,33 @@ def _stub_browser(monkeypatch, page: _FakePage) -> dict[str, list[str]]:
 def _build_row(
     *,
     name: str,
-    href: str,
+    href: str = "",
     entity_number: str = "",
     entity_type: str = "",
     status: str = "",
     formed: str = "",
+    filing_date: str = "",
+    registered_agent: str = "",
 ) -> _FakeLocator:
-    """Build a row whose child selectors mirror the CA recipe."""
+    """Build a row whose child selectors mirror the live bizfileonline DOM.
+
+    Cell-1 is rendered as ``"<NAME> (<entity_number>)\\nClick to expand"`` —
+    the test mirrors that, since the connector parses the entity number
+    out of the displayed text rather than reading a separate column.
+    """
     recipe = sos._STATE_RECIPES["CA"]
+    cell_1_text = (
+        f"{name} ({entity_number})\nClick to expand" if entity_number else name
+    )
     return _FakeLocator(
         children={
-            recipe["name_selector"]: _FakeLocator(text=name),
+            recipe["name_selector"]: _FakeLocator(text=cell_1_text),
             recipe["link_selector"]: _FakeLocator(text=name, attrs={"href": href}),
-            recipe["entity_number_selector"]: _FakeLocator(text=entity_number),
-            recipe["type_selector"]: _FakeLocator(text=entity_type),
+            recipe["filing_date_selector"]: _FakeLocator(text=filing_date),
             recipe["status_selector"]: _FakeLocator(text=status),
+            recipe["type_selector"]: _FakeLocator(text=entity_type),
             recipe["formed_date_selector"]: _FakeLocator(text=formed),
+            recipe["row_agent_selector"]: _FakeLocator(text=registered_agent),
         }
     )
 
@@ -163,10 +182,10 @@ def _ca_profile_page(
     recipe = sos._STATE_RECIPES["CA"]
     selectors: dict[str, _FakeLocator] = {
         "h1": _FakeLocator(text=title),
-        recipe["entity_number_selector"]: _FakeLocator(text=entity_number),
-        recipe["type_selector"]: _FakeLocator(text=entity_type),
-        recipe["status_selector"]: _FakeLocator(text=status),
-        recipe["formed_date_selector"]: _FakeLocator(text=formed),
+        recipe["profile_entity_number_selector"]: _FakeLocator(text=entity_number),
+        recipe["profile_type_selector"]: _FakeLocator(text=entity_type),
+        recipe["profile_status_selector"]: _FakeLocator(text=status),
+        recipe["profile_formed_date_selector"]: _FakeLocator(text=formed),
         recipe["agent_selector"]: _FakeLocator(text=agent),
         recipe["principal_address_selector"]: _FakeLocator(text=principal),
         recipe["officers_selector"]: _FakeLocator(
@@ -204,19 +223,21 @@ async def test_search_returns_results_for_name_query(monkeypatch):
     rows = [
         _build_row(
             name="SBI BUILDERS, LLC",
-            href="/business/201234567890",
             entity_number="201234567890",
             entity_type="Limited Liability Company",
             status="Active",
             formed="2012-03-15",
+            filing_date="04/14/2012",
+            registered_agent="Jane Q Agent",
         ),
         _build_row(
             name="SBI BUILDERS INC",
-            href="/business/C9876543",
-            entity_number="C9876543",
-            entity_type="Domestic Stock",
+            entity_number="9876543",
+            entity_type="Stock Corporation - CA - General",
             status="Dissolved",
             formed="1998-07-22",
+            filing_date="07/22/1998",
+            registered_agent="Bob Builder",
         ),
     ]
     page = _ca_search_page(rows)
@@ -229,12 +250,19 @@ async def test_search_returns_results_for_name_query(monkeypatch):
 
     top = results[0]
     assert top.source_kind == "sos"
+    # "Click to expand" hint and trailing parenthetical are stripped from the title.
     assert top.title == "SBI BUILDERS, LLC"
-    assert top.url == "https://bizfileonline.sos.ca.gov/business/201234567890"
+    # No anchor href in the live DOM; URL is a synthetic search-anchored link
+    # keyed on the parsed entity number.
+    assert top.url == (
+        "https://bizfileonline.sos.ca.gov/search/business?q=201234567890"
+    )
     assert top.extras["entity_number"] == "201234567890"
     assert top.extras["entity_type"] == "Limited Liability Company"
     assert top.extras["status"] == "Active"
     assert top.extras["formed_date"] == "2012-03-15"
+    assert top.extras["filing_date"] == "04/14/2012"
+    assert top.extras["registered_agent"] == "Jane Q Agent"
     assert top.extras["state"] == "CA"
     assert "Active" in top.snippet
 
@@ -243,9 +271,8 @@ async def test_search_handles_entity_number_query(monkeypatch):
     rows = [
         _build_row(
             name="SBI BUILDERS INC",
-            href="/business/C9876543",
-            entity_number="C9876543",
-            entity_type="Domestic Stock",
+            entity_number="9876543",
+            entity_type="Stock Corporation - CA - General",
             status="Active",
             formed="1998-07-22",
         ),
@@ -255,7 +282,8 @@ async def test_search_handles_entity_number_query(monkeypatch):
 
     results = await sos.search("C9876543", state="CA", max_results=5)
     assert len(results) == 1
-    assert results[0].extras["entity_number"] == "C9876543"
+    # Entity number parsed from the cell-1 parenthetical, not the query.
+    assert results[0].extras["entity_number"] == "9876543"
     # Query input still got the entity number string filled in.
     query_locator = page._selector_map[sos._STATE_RECIPES["CA"]["query_input"]]
     assert query_locator.fill_calls == ["C9876543"]
@@ -264,8 +292,28 @@ async def test_search_handles_entity_number_query(monkeypatch):
 async def test_entity_number_regex_recognises_ca_formats():
     assert sos._looks_like_entity_number("C1234567")
     assert sos._looks_like_entity_number("201234567890")
+    assert sos._looks_like_entity_number("2741233")  # 7-digit stock-corp number
     assert not sos._looks_like_entity_number("SBI Builders")
     assert not sos._looks_like_entity_number("")
+
+
+async def test_split_name_and_number_strips_hint_and_parses_number():
+    """Cell-1 reads "<NAME> (<entity_number>)\\nClick to expand" — title is
+    cleaned and the trailing parenthetical is parsed into a separate field.
+    """
+    name, number = sos._split_name_and_number(
+        "SBI BUILDERS, INC. (2741233)\nClick to expand"
+    )
+    assert name == "SBI BUILDERS, INC."
+    assert number == "2741233"
+
+    # No parens: name kept verbatim, number empty.
+    name2, number2 = sos._split_name_and_number("PLAIN COMPANY NAME")
+    assert name2 == "PLAIN COMPANY NAME"
+    assert number2 == ""
+
+    # Empty input: both empty.
+    assert sos._split_name_and_number("") == ("", "")
 
 
 async def test_search_returns_empty_for_unknown_state(monkeypatch, caplog):
@@ -323,7 +371,6 @@ async def test_search_respects_max_results(monkeypatch):
     rows = [
         _build_row(
             name=f"Company {i}",
-            href=f"/business/{i}",
             entity_number=f"{i:012d}",
             entity_type="LLC",
             status="Active",
@@ -336,6 +383,31 @@ async def test_search_respects_max_results(monkeypatch):
 
     results = await sos.search("anything", state="CA", max_results=3)
     assert len(results) == 3
+
+
+async def test_search_returns_empty_when_rows_never_render(
+    monkeypatch, caplog, tmp_path
+):
+    """If the React table never paints, ``wait_for`` raises and we bail with a
+    diagnostic screenshot rather than parsing whatever stale DOM was there.
+    """
+    recipe = sos._STATE_RECIPES["CA"]
+    page = _FakePage(
+        {
+            recipe["query_input"]: _FakeLocator(),
+            recipe["submit_button"]: _FakeLocator(),
+            recipe["row_selector"]: _FakeLocator(raise_on_wait_for=True),
+        }
+    )
+    _stub_browser(monkeypatch, page)
+    monkeypatch.setattr(sos, "_DIAGNOSTICS_DIR", tmp_path / "diagnostics")
+
+    with caplog.at_level(logging.WARNING, logger=sos.logger.name):
+        results = await sos.search("anything", state="CA")
+
+    assert results == []
+    assert any("did not render" in rec.message for rec in caplog.records)
+    assert page.screenshots, "expected a diagnostic screenshot path"
 
 
 # ---------------------------------------------------------------------------
@@ -425,10 +497,10 @@ async def test_fetch_handles_minimal_profile(monkeypatch):
     page = _FakePage(
         {
             "h1": _FakeLocator(text="ACME LLC"),
-            recipe["entity_number_selector"]: _FakeLocator(),
-            recipe["type_selector"]: _FakeLocator(),
-            recipe["status_selector"]: _FakeLocator(),
-            recipe["formed_date_selector"]: _FakeLocator(),
+            recipe["profile_entity_number_selector"]: _FakeLocator(),
+            recipe["profile_type_selector"]: _FakeLocator(),
+            recipe["profile_status_selector"]: _FakeLocator(),
+            recipe["profile_formed_date_selector"]: _FakeLocator(),
             recipe["agent_selector"]: _FakeLocator(),
             recipe["principal_address_selector"]: _FakeLocator(),
             recipe["officers_selector"]: _FakeLocator(items=[]),


### PR DESCRIPTION
Closes #101
Part of #107

## Summary

Automated implementation of **Secretary of State business registries (CA bizfileonline first)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

SoS connector ships per-state recipe pattern with CA fully wired, stubs for DE/NV/WY/FL/NY, strict host gate on fetch(), 0.5 RPS, smoke verb registered, 19 dedicated tests pass, full suite green (1064 passed).

- **INFO** [OPEN] `src/research_agent/tools/sos.py`: The CA recipe reuses the search-row CSS selectors (e.g. td:nth-child(2)) as profile-page metadata selectors inside fetch(). The connector degrades gracefully (returns a minimal Source with just the title) when those selectors don't match a profile DOM, and the agent/recipe selectors (data-field='registered-agent', .registered-agent) are the primary ones. Selectors will need live tuning against bizfileonline once a real profile URL is hit during smoke testing.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*