### PR TITLE
feat: State licensing boards connector (CSLB-led, pluggable per state) (closes #91)

### DIFF
--- a/src/research_agent/__main__.py
+++ b/src/research_agent/__main__.py
@@ -1,0 +1,10 @@
+"""Allow ``python -m research_agent ...`` as an alternative to the ``research`` console script.
+
+Useful when the console script entry point isn't on ``PATH`` — e.g., CI / verification
+environments that shell out without ``uv tool install``-style binstubs.
+"""
+
+from research_agent.cli import app
+
+if __name__ == "__main__":
+    app()

--- a/src/research_agent/prompts/followup_recipes.md
+++ b/src/research_agent/prompts/followup_recipes.md
@@ -24,7 +24,12 @@ omit it; do not pad the section.
 - **Any licensed entity** (contractor, broker, attorney, physician, etc.)
   → check the relevant state licensing board's public discipline record,
   and recommend a FOIA / public-records request for the full disciplinary
-  file (board complaints, investigator notes, settlement agreements).
+  file (board complaints, investigator notes, settlement agreements). For
+  **California contractors** specifically, point operators at the CSLB
+  "Check License II" Disciplinary History tab
+  (`cslb.ca.gov/OnlineServices/CheckLicenseII/CheckLicense.aspx`) — board
+  complaints, citations, and license-status actions are visible there
+  without a public-records request.
 - **Any government action cited** (permit, contract award, enforcement
   letter) → recommend a FOIA / state public-records request for the
   underlying file (correspondence, internal memos, scoring sheets).

--- a/src/research_agent/prompts/planner.md
+++ b/src/research_agent/prompts/planner.md
@@ -93,6 +93,14 @@ Use `site:` operators when you actually want to scope a search to a
 known authoritative domain (e.g. `site:cslb.ca.gov "SBI Builders"`).
 Otherwise keep queries plain.
 
+**US construction / contracting companies.** When the goal names a
+California (or other US) construction or contracting company, include
+an early `web_search` task with a `site:cslb.ca.gov "<company>"` query
+so the loop surfaces the CSLB profile URL — license number, status,
+classification, and disciplinary history — before generic web hits.
+The `licensing` connector takes over from there once the URL is in
+hand; the planner only needs to seed the discovery query.
+
 ### Payload shapes
 
 - `web_search`: `{ query: "…", sub_question: "…", max_results: 10, engine: "auto", expand_top_k: 3 }`

--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -467,6 +467,64 @@ def _smoke_sos(query: str) -> str:
     return asyncio.run(_run())
 
 
+def _smoke_licensing(query: str) -> str:
+    """Smoke wrapper: California State License Board (CSLB) lookup.
+
+    Per AC: ``research _smoke-tool licensing "<license# or contractor>"``
+    should return the v1 record (license number, status, expiration). Lists
+    the top-5 hits with license number / status / classification / expiration
+    / URL, then attempts ``fetch()`` on the top hit and prints a Disciplinary
+    History excerpt — the primary due-diligence signal.
+    """
+    from research_agent.tools import browser, licensing
+
+    async def _run() -> str:
+        try:
+            results = await licensing.search(query, state="CA", max_results=5)
+            if not results:
+                return f"licensing search returned no results for {query!r}"
+            lines: list[str] = []
+            for hit in results:
+                number = hit.extras.get("license_number") or "?"
+                status = hit.extras.get("status") or "?"
+                classification = hit.extras.get("classification") or "?"
+                expiration = hit.extras.get("expiration") or "?"
+                snippet = hit.snippet.replace("\n", " ")
+                if len(snippet) > 200:
+                    snippet = snippet[:200] + "…"
+                lines.append(
+                    f"- {hit.title} — {number} — {classification} — {status} —"
+                    f" exp {expiration}\n"
+                    f"  {hit.url}\n"
+                    f"  {snippet}"
+                )
+
+            top = results[0]
+            source = await licensing.fetch(top.url)
+            if source is None:
+                lines.append(
+                    f"\nfetch({top.url}) returned None — profile unavailable"
+                )
+            else:
+                disciplinary = source.metadata.get("disciplinary_history") or "—"
+                excerpt = disciplinary.replace("\n", " ")
+                if len(excerpt) > 400:
+                    excerpt = excerpt[:400] + "…"
+                lines.append(f"\nProfile for {top.title}")
+                lines.append(f"  license_number: {source.metadata.get('license_number') or '?'}")
+                lines.append(f"  status: {source.metadata.get('status') or '?'}")
+                lines.append(f"  expiration: {source.metadata.get('expiration') or '?'}")
+                lines.append(f"  disciplinary_history: {excerpt}")
+            return "\n".join(lines)
+        finally:
+            try:
+                await browser.shutdown()
+            except Exception:  # noqa: BLE001 — best-effort cleanup
+                pass
+
+    return asyncio.run(_run())
+
+
 def _smoke_sanctions(query: str) -> str:
     """Smoke wrapper: OFAC SDN / EU / UK sanctions lookup.
 
@@ -838,6 +896,7 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "littlesis": _smoke_littlesis,
     "opencorporates": _smoke_opencorporates,
     "sos": _smoke_sos,
+    "licensing": _smoke_licensing,
     "sanctions": _smoke_sanctions,
     "usaspending": _smoke_usaspending,
     "gdelt": _smoke_gdelt,

--- a/src/research_agent/tools/licensing.py
+++ b/src/research_agent/tools/licensing.py
@@ -48,22 +48,36 @@ _LICENSE_NUMBER_RE = re.compile(r"^\d{6,8}$")
 # ---------------------------------------------------------------------------
 
 _STATE_RECIPES: dict[str, dict[str, Any]] = {
-    # California (CSLB) — fully wired. The "Check License II" form has a
-    # radio group that switches between "License Number" and "Business Name"
-    # search modes; the recipe formats ``{kind}`` into the radio selector so
-    # the connector can flip modes based on the query shape.
+    # California (CSLB) — fully wired against the live "Check License II"
+    # form. The form is **tabbed**: license-number search, business-name
+    # search, and personnel-name search each have their own input + submit
+    # button, with only the active tab's inputs visible. A tab button must
+    # be clicked first (the `tab_buttons_by_kind` mapping) to make the
+    # corresponding input visible before fill().
     "CA": {
         "host": "www.cslb.ca.gov",
         "search_url": (
             "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/CheckLicense.aspx"
         ),
-        "query_input": "input[name='txtLicNum']",
-        "submit_button": "input[name='btnSubmit']",
-        # Radio group: name="optSearch" with values "LIC" (license number)
-        # and "BUS" (business name). ``{kind}`` is replaced by "LIC" or "BUS"
-        # at call time.
-        "query_kind_selector": "input[name='optSearch'][value='{kind}']",
-        "query_kind_values": {"number": "LIC", "name": "BUS"},
+        # Tab buttons that switch which search input is visible.
+        # `LicNoButton` selects the license-number tab; `BusNameButton`
+        # selects the business-name tab. (HISNoButton / HISNameButton exist
+        # for salesperson registration searches and are not wired here.)
+        "tab_buttons_by_kind": {
+            "number": "#LicNoButton",
+            "name": "#BusNameButton",
+        },
+        # Per-mode input fields. ASP.NET WebForms naming — the visible IDs
+        # are stable; the `name` attributes are also the form-post keys.
+        "query_inputs_by_kind": {
+            "number": "#MainContent_LicNo",
+            "name": "#MainContent_NextName",
+        },
+        # Per-mode submit buttons — each tab has its own.
+        "submit_buttons_by_kind": {
+            "number": "#MainContent_Contractor_License_Number_Search",
+            "name": "#MainContent_Contractor_Business_Name_Button",
+        },
         # Result rows. CSLB's results page renders a single-license summary
         # for an exact match, or a table of links for multi-hit name searches.
         "row_selector": "table.searchresults tbody tr",
@@ -287,21 +301,35 @@ async def search(
             try:
                 await browser.navigate(page, search_url)
 
-                if recipe.get("query_kind_selector"):
-                    is_number = _looks_like_license_number(query)
-                    kind_key = "number" if is_number else "name"
-                    kind_value = recipe.get("query_kind_values", {}).get(
-                        kind_key, kind_key
-                    )
-                    selector = recipe["query_kind_selector"].format(kind=kind_value)
+                kind_key = (
+                    "number" if _looks_like_license_number(query) else "name"
+                )
+
+                tab_buttons = recipe.get("tab_buttons_by_kind") or {}
+                tab_selector = tab_buttons.get(kind_key)
+                if tab_selector:
                     try:
-                        await page.locator(selector).first.click()
-                    except Exception as exc:  # noqa: BLE001
-                        logger.debug("licensing query-kind toggle failed: %s", exc)
+                        await page.locator(tab_selector).first.click()
+                    except Exception as exc:  # noqa: BLE001 — tab miss is non-fatal
+                        logger.debug(
+                            "licensing tab toggle failed (%s): %s", tab_selector, exc
+                        )
+
+                inputs = recipe.get("query_inputs_by_kind") or {}
+                submits = recipe.get("submit_buttons_by_kind") or {}
+                input_selector = inputs.get(kind_key) or recipe.get("query_input")
+                submit_selector = submits.get(kind_key) or recipe.get("submit_button")
+                if not input_selector or not submit_selector:
+                    logger.warning(
+                        "licensing recipe missing input/submit for state=%s kind=%s",
+                        code,
+                        kind_key,
+                    )
+                    return []
 
                 try:
-                    await page.locator(recipe["query_input"]).first.fill(query)
-                    await page.locator(recipe["submit_button"]).first.click()
+                    await page.locator(input_selector).first.fill(query)
+                    await page.locator(submit_selector).first.click()
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "licensing search submit failed for state=%s: %s", code, exc

--- a/src/research_agent/tools/licensing.py
+++ b/src/research_agent/tools/licensing.py
@@ -1,0 +1,503 @@
+"""State licensing boards — Playwright-driven (issue #91).
+
+Public surface:
+
+* ``async def search(query, *, state="CA", max_results=25) -> list[SearchResult]``
+  runs a state contractor / professional licensing board search by license
+  number OR business name. Returns license number, status, classification,
+  expiration date, and a profile permalink.
+* ``async def fetch(url) -> Source | None`` opens the per-license profile and
+  rolls the four CSLB tabs (Personnel, Workers' Compensation, Bonds,
+  Disciplinary History) into a single markdown ``cleaned_text``.
+
+v1 ships **California State License Board (CSLB)** as the worked example;
+TX / FL / NY are config stubs that emit a WARN and return ``[]`` / ``None``.
+The module is structured so adding a state is a recipe entry, not new code.
+
+No APIs, no auth. Per-host rate gate at 0.5 RPS — CSLB has no public API
+and Playwright traffic is conspicuous, so be polite.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import playwright.async_api
+
+from research_agent.tools import browser
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+_DIAGNOSTICS_DIR = Path("data/diagnostics/licensing")
+_PER_HOST_RPS = 0.5
+
+# CSLB license numbers are 6–8 digits. When the recipe defines a
+# ``query_kind_selector`` the search radio is toggled accordingly so the
+# board's form interprets the value as a license number rather than a name.
+_LICENSE_NUMBER_RE = re.compile(r"^\d{6,8}$")
+
+
+# ---------------------------------------------------------------------------
+# Recipes — one per state.
+# ---------------------------------------------------------------------------
+
+_STATE_RECIPES: dict[str, dict[str, Any]] = {
+    # California (CSLB) — fully wired. The "Check License II" form has a
+    # radio group that switches between "License Number" and "Business Name"
+    # search modes; the recipe formats ``{kind}`` into the radio selector so
+    # the connector can flip modes based on the query shape.
+    "CA": {
+        "host": "www.cslb.ca.gov",
+        "search_url": (
+            "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/CheckLicense.aspx"
+        ),
+        "query_input": "input[name='txtLicNum']",
+        "submit_button": "input[name='btnSubmit']",
+        # Radio group: name="optSearch" with values "LIC" (license number)
+        # and "BUS" (business name). ``{kind}`` is replaced by "LIC" or "BUS"
+        # at call time.
+        "query_kind_selector": "input[name='optSearch'][value='{kind}']",
+        "query_kind_values": {"number": "LIC", "name": "BUS"},
+        # Result rows. CSLB's results page renders a single-license summary
+        # for an exact match, or a table of links for multi-hit name searches.
+        "row_selector": "table.searchresults tbody tr",
+        "name_selector": "td.business-name",
+        "link_selector": "td.business-name a",
+        "license_number_selector": "td.license-number",
+        "status_selector": "td.license-status",
+        "classification_selector": "td.classification",
+        "expiration_selector": "td.expiration",
+        # Profile detail tabs. Each ``*_tab_button`` is clicked before the
+        # corresponding ``*_section`` is scraped — eager-load every tab so the
+        # rolled-up Source contains all four sections in one shot.
+        "personnel_tab_button": "a#tabPersonnel, button#tabPersonnel",
+        "personnel_section": "#sectionPersonnel",
+        "workers_comp_tab_button": "a#tabWorkersComp, button#tabWorkersComp",
+        "workers_comp_section": "#sectionWorkersComp",
+        "bonds_tab_button": "a#tabBonds, button#tabBonds",
+        "bonds_section": "#sectionBonds",
+        "disciplinary_tab_button": "a#tabDisciplinary, button#tabDisciplinary",
+        "disciplinary_section": "#sectionDisciplinary",
+        # Header summary on the profile page (license number, status,
+        # classification, expiration) — populated from data attributes when
+        # present, otherwise scraped from the visible header.
+        "profile_license_number_selector": "[data-field='license-number']",
+        "profile_status_selector": "[data-field='license-status']",
+        "profile_classification_selector": "[data-field='classification']",
+        "profile_expiration_selector": "[data-field='expiration']",
+    },
+    # TX/FL/NY are stubs — selector recipes haven't been built yet. Emit a
+    # WARN and return [] / None so the planner gracefully routes around the
+    # gap rather than crashing.
+    "TX": {"stub": True, "host": "www.tdlr.texas.gov"},
+    "FL": {"stub": True, "host": "www.myfloridalicense.com"},
+    "NY": {"stub": True, "host": "www.dos.ny.gov"},
+}
+
+
+def _accepted_hosts() -> frozenset[str]:
+    return frozenset(
+        recipe["host"]
+        for recipe in _STATE_RECIPES.values()
+        if isinstance(recipe.get("host"), str)
+    )
+
+
+def _register_host_rates() -> None:
+    """Wire per-host rates for every recipe with a configured host."""
+    for recipe in _STATE_RECIPES.values():
+        host = recipe.get("host")
+        if isinstance(host, str) and host:
+            browser.set_host_rate(host, _PER_HOST_RPS)
+
+
+_register_host_rates()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _looks_like_license_number(query: str) -> bool:
+    """Heuristic: did the user paste a license number rather than a name?"""
+    cleaned = (query or "").strip()
+    if not cleaned:
+        return False
+    return bool(_LICENSE_NUMBER_RE.match(cleaned))
+
+
+# Short per-call timeout for selector reads. Playwright's default 30s auto-wait
+# is catastrophic on a page where most profile selectors may be absent — half
+# a dozen missing selectors in ``fetch()`` would hang the connector for minutes.
+_SELECTOR_READ_TIMEOUT_MS = 2_000
+
+
+async def _safe_inner_text(locator: Any) -> str:
+    try:
+        text = await locator.inner_text(timeout=_SELECTOR_READ_TIMEOUT_MS)
+    except TypeError:
+        try:
+            text = await locator.inner_text()
+        except Exception:  # noqa: BLE001
+            return ""
+    except Exception:  # noqa: BLE001 — selector miss should not raise
+        return ""
+    return (text or "").strip()
+
+
+async def _safe_attr(locator: Any, name: str) -> str:
+    try:
+        value = await locator.get_attribute(name, timeout=_SELECTOR_READ_TIMEOUT_MS)
+    except TypeError:
+        try:
+            value = await locator.get_attribute(name)
+        except Exception:  # noqa: BLE001
+            return ""
+    except Exception:  # noqa: BLE001
+        return ""
+    return (value or "").strip()
+
+
+async def _save_diagnostic_screenshot(page: Any, host: str) -> None:
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    target = _DIAGNOSTICS_DIR / f"{host}-{stamp}.png"
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        await page.screenshot(path=str(target))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("licensing diagnostic screenshot failed: %s", exc)
+
+
+def _absolute_url(base: str, href: str) -> str:
+    if not href:
+        return ""
+    if href.startswith("http://") or href.startswith("https://"):
+        return href
+    if href.startswith("/"):
+        parsed = urlparse(base)
+        return f"{parsed.scheme}://{parsed.netloc}{href}"
+    return base.rstrip("/") + "/" + href
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def _extract_row(
+    row: Any, recipe: dict[str, Any], *, search_url: str
+) -> SearchResult | None:
+    name = await _safe_inner_text(row.locator(recipe["name_selector"]).first)
+    if not name:
+        return None
+
+    href = await _safe_attr(row.locator(recipe["link_selector"]).first, "href")
+    license_number = await _safe_inner_text(
+        row.locator(recipe.get("license_number_selector") or "").first
+    ) if recipe.get("license_number_selector") else ""
+    status = await _safe_inner_text(row.locator(recipe["status_selector"]).first)
+    classification = await _safe_inner_text(
+        row.locator(recipe.get("classification_selector") or "").first
+    ) if recipe.get("classification_selector") else ""
+    expiration = await _safe_inner_text(
+        row.locator(recipe.get("expiration_selector") or "").first
+    ) if recipe.get("expiration_selector") else ""
+
+    state = next(
+        (
+            code
+            for code, r in _STATE_RECIPES.items()
+            if r.get("host") == recipe["host"]
+        ),
+        "",
+    )
+
+    if href:
+        profile_url = _absolute_url(search_url, href)
+    elif license_number:
+        profile_url = f"{search_url}?LicNum={license_number}"
+    else:
+        profile_url = search_url
+
+    snippet_bits = [b for b in (classification, status, expiration) if b]
+    snippet = " — ".join(snippet_bits)
+
+    extras: dict[str, Any] = {
+        "license_number": license_number,
+        "status": status,
+        "classification": classification,
+        "expiration": expiration,
+        "state": state,
+        "profile_url": profile_url,
+    }
+    return SearchResult(
+        url=profile_url,
+        title=name,
+        snippet=snippet,
+        source_kind="licensing",
+        extras=extras,
+    )
+
+
+async def search(
+    query: str,
+    *,
+    state: str = "CA",
+    max_results: int = 25,
+) -> list[SearchResult]:
+    """Run a state licensing-board search; return up to ``max_results`` hits.
+
+    ``state`` is the two-letter postal code (default ``"CA"`` for CSLB).
+    Unknown or stub states return ``[]`` after a WARN so callers can route
+    around the coverage gap rather than crashing the planner.
+
+    Detects license-number vs name queries by regex; when the recipe exposes
+    a ``query_kind_selector``, the matching radio is selected before
+    submission.
+    """
+    code = (state or "").strip().upper()
+    recipe = _STATE_RECIPES.get(code)
+    if recipe is None:
+        logger.warning("licensing: no recipe for state %r", state)
+        return []
+    if recipe.get("stub"):
+        logger.warning(
+            "licensing: state %s is a stub — coverage not yet wired (host=%s)",
+            code,
+            recipe.get("host"),
+        )
+        return []
+
+    if not query or not query.strip():
+        return []
+
+    search_url = recipe["search_url"]
+    host = recipe["host"]
+
+    try:
+        async with browser.browser_session() as ctx:
+            page = await ctx.new_page()
+            try:
+                await browser.navigate(page, search_url)
+
+                if recipe.get("query_kind_selector"):
+                    is_number = _looks_like_license_number(query)
+                    kind_key = "number" if is_number else "name"
+                    kind_value = recipe.get("query_kind_values", {}).get(
+                        kind_key, kind_key
+                    )
+                    selector = recipe["query_kind_selector"].format(kind=kind_value)
+                    try:
+                        await page.locator(selector).first.click()
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug("licensing query-kind toggle failed: %s", exc)
+
+                try:
+                    await page.locator(recipe["query_input"]).first.fill(query)
+                    await page.locator(recipe["submit_button"]).first.click()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "licensing search submit failed for state=%s: %s", code, exc
+                    )
+                    await _save_diagnostic_screenshot(page, host)
+                    return []
+
+                try:
+                    rows = await page.locator(recipe["row_selector"]).all()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "licensing search selector miss on %s: %s", search_url, exc
+                    )
+                    await _save_diagnostic_screenshot(page, host)
+                    return []
+
+                results: list[SearchResult] = []
+                for row in rows[:max_results]:
+                    try:
+                        result = await _extract_row(
+                            row, recipe, search_url=search_url
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning("licensing row parse failed: %s", exc)
+                        continue
+                    if result is not None:
+                        results.append(result)
+                return results
+            finally:
+                try:
+                    await page.close()
+                except Exception:  # noqa: BLE001
+                    pass
+    except playwright.async_api.Error as exc:
+        logger.warning("licensing search playwright error for state=%s: %s", code, exc)
+        return []
+    except Exception as exc:  # noqa: BLE001 — never crash the planner
+        logger.warning("licensing search unexpected error for state=%s: %s", code, exc)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+# Profile sections that fetch() rolls into the markdown body, in order.
+# Each entry maps a (heading, tab-button-recipe-key, section-recipe-key,
+# metadata-key) tuple — heading appears in cleaned_text, the tab button is
+# clicked before the section is scraped, and the scraped text is mirrored
+# under metadata[metadata_key] for structured callers.
+_PROFILE_SECTIONS: tuple[tuple[str, str, str, str], ...] = (
+    ("Personnel", "personnel_tab_button", "personnel_section", "personnel"),
+    (
+        "Workers' Compensation",
+        "workers_comp_tab_button",
+        "workers_comp_section",
+        "workers_comp",
+    ),
+    ("Bonds", "bonds_tab_button", "bonds_section", "bonds"),
+    (
+        "Disciplinary History",
+        "disciplinary_tab_button",
+        "disciplinary_section",
+        "disciplinary_history",
+    ),
+)
+
+
+def _resolve_recipe_for_host(host: str) -> dict[str, Any] | None:
+    for recipe in _STATE_RECIPES.values():
+        if recipe.get("host") == host and not recipe.get("stub"):
+            return recipe
+    return None
+
+
+async def _click_if_present(page: Any, selector: str | None) -> None:
+    if not selector:
+        return
+    try:
+        await page.locator(selector).first.click()
+    except Exception as exc:  # noqa: BLE001 — missing tab is non-fatal
+        logger.debug("licensing tab click miss (%s): %s", selector, exc)
+
+
+async def _collect_simple_text(page: Any, selector: str | None) -> str:
+    if not selector:
+        return ""
+    try:
+        return await _safe_inner_text(page.locator(selector).first)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("licensing profile selector miss (%s): %s", selector, exc)
+        return ""
+
+
+async def fetch(url: str) -> Source | None:
+    """Open a state licensing-board profile and return a :class:`Source`.
+
+    Strict host gate: only URLs whose host matches a non-stub recipe are
+    accepted; everything else returns ``None`` without a network call.
+    Eagerly clicks every detail tab (Personnel, Workers' Comp, Bonds,
+    Disciplinary History) before scraping so the rolled-up markdown contains
+    all four sections — Disciplinary History is the primary signal for
+    due-diligence runs.
+    """
+    if not url:
+        return None
+    parsed = urlparse(url)
+    host = (parsed.netloc or "").lower().split(":", 1)[0]
+    if host not in _accepted_hosts():
+        return None
+    recipe = _resolve_recipe_for_host(host)
+    if recipe is None:
+        return None
+
+    try:
+        async with browser.browser_session() as ctx:
+            page = await ctx.new_page()
+            try:
+                await browser.navigate(page, url)
+
+                title = await _safe_inner_text(page.locator("h1").first)
+                if not title:
+                    title = host
+
+                license_number = await _collect_simple_text(
+                    page, recipe.get("profile_license_number_selector")
+                )
+                status = await _collect_simple_text(
+                    page, recipe.get("profile_status_selector")
+                )
+                classification = await _collect_simple_text(
+                    page, recipe.get("profile_classification_selector")
+                )
+                expiration = await _collect_simple_text(
+                    page, recipe.get("profile_expiration_selector")
+                )
+
+                section_text: dict[str, str] = {}
+                for heading, tab_key, section_key, meta_key in _PROFILE_SECTIONS:
+                    await _click_if_present(page, recipe.get(tab_key))
+                    text = await _collect_simple_text(page, recipe.get(section_key))
+                    section_text[meta_key] = text
+                    section_text[f"_heading_{meta_key}"] = heading
+
+                meta_bits = [
+                    b for b in (license_number, classification, status, expiration) if b
+                ]
+                meta_line = "_" + " · ".join(meta_bits) + "_" if meta_bits else ""
+
+                sections: list[str] = [f"# {title}"]
+                if meta_line:
+                    sections.append(meta_line)
+
+                for _, _, _, meta_key in _PROFILE_SECTIONS:
+                    heading = section_text[f"_heading_{meta_key}"]
+                    body = section_text.get(meta_key) or "(not available)"
+                    sections.append(f"## {heading}\n\n{body}")
+
+                cleaned_text = "\n\n".join(sections).strip()
+                if not cleaned_text:
+                    return None
+
+                metadata: dict[str, Any] = {
+                    "license_number": license_number,
+                    "status": status,
+                    "classification": classification,
+                    "expiration": expiration,
+                }
+                for _, _, _, meta_key in _PROFILE_SECTIONS:
+                    metadata[meta_key] = section_text.get(meta_key, "")
+
+                return Source(
+                    url=url,
+                    title=title,
+                    cleaned_text=cleaned_text,
+                    raw_html=None,
+                    fetched_at=datetime.now(UTC),
+                    source_kind="licensing",
+                    metadata=metadata,
+                )
+            finally:
+                try:
+                    await page.close()
+                except Exception:  # noqa: BLE001
+                    pass
+    except playwright.async_api.Error as exc:
+        logger.warning("licensing fetch playwright error for %s: %s", url, exc)
+        return None
+    except Exception as exc:  # noqa: BLE001 — never crash the planner
+        logger.warning("licensing fetch unexpected error for %s: %s", url, exc)
+        return None
+
+
+def reset_for_tests() -> None:
+    """Re-register host rates after browser.reset_for_tests() drops them. Test-only."""
+    _register_host_rates()
+
+
+__all__ = ["fetch", "reset_for_tests", "search"]

--- a/src/research_agent/tools/models.py
+++ b/src/research_agent/tools/models.py
@@ -43,6 +43,7 @@ SourceKind = Literal[
     "opencorporates",
     "sanctions",
     "sos",
+    "licensing",
 ]
 
 

--- a/tests/test_tools_licensing.py
+++ b/tests/test_tools_licensing.py
@@ -157,20 +157,28 @@ def _build_row(
 def _ca_search_page(
     rows: list[_FakeLocator],
     *,
-    radio_locators: dict[str, _FakeLocator] | None = None,
+    kind: str = "name",
+    tab_locators: dict[str, _FakeLocator] | None = None,
     submit_locator: _FakeLocator | None = None,
 ) -> _FakePage:
+    """Build a fake CSLB search page wired for the ``kind`` tab.
+
+    ``kind`` is "name" (business name) or "number" (license number) and
+    determines which input/submit selector the fake exposes. ``tab_locators``
+    optionally maps ``"number"``/``"name"`` to per-tab fake locators so a
+    test can assert that the right tab button was clicked.
+    """
     recipe = licensing._STATE_RECIPES["CA"]
+    input_selector = recipe["query_inputs_by_kind"][kind]
+    submit_selector = recipe["submit_buttons_by_kind"][kind]
     selectors: dict[str, _FakeLocator] = {
-        recipe["query_input"]: _FakeLocator(),
-        recipe["submit_button"]: submit_locator or _FakeLocator(),
+        input_selector: _FakeLocator(),
+        submit_selector: submit_locator or _FakeLocator(),
         recipe["row_selector"]: _FakeLocator(items=rows),
     }
-    if radio_locators:
-        for value, locator in radio_locators.items():
-            selectors[
-                recipe["query_kind_selector"].format(kind=value)
-            ] = locator
+    if tab_locators:
+        for kind_key, locator in tab_locators.items():
+            selectors[recipe["tab_buttons_by_kind"][kind_key]] = locator
     return _FakePage(selectors)
 
 
@@ -276,9 +284,9 @@ async def test_search_returns_results_for_name_query(monkeypatch):
 
 
 async def test_search_toggles_query_kind_for_license_number(monkeypatch):
-    """A 7-digit license-number query should click the LIC radio, not BUS."""
-    lic_radio = _FakeLocator()
-    bus_radio = _FakeLocator()
+    """A numeric query should click the license-number tab, not the name tab."""
+    lic_tab = _FakeLocator()
+    bus_tab = _FakeLocator()
     page = _ca_search_page(
         [
             _build_row(
@@ -289,20 +297,21 @@ async def test_search_toggles_query_kind_for_license_number(monkeypatch):
                 expiration="2026-12-31",
             )
         ],
-        radio_locators={"LIC": lic_radio, "BUS": bus_radio},
+        kind="number",
+        tab_locators={"number": lic_tab, "name": bus_tab},
     )
     _stub_browser(monkeypatch, page)
 
     await licensing.search("1234567", state="CA", max_results=5)
 
-    assert lic_radio.click_calls == 1
-    assert bus_radio.click_calls == 0
+    assert lic_tab.click_calls == 1
+    assert bus_tab.click_calls == 0
 
 
 async def test_search_toggles_query_kind_for_business_name(monkeypatch):
-    """A non-numeric query should click the BUS radio, not LIC."""
-    lic_radio = _FakeLocator()
-    bus_radio = _FakeLocator()
+    """A non-numeric query should click the business-name tab, not the license-number tab."""
+    lic_tab = _FakeLocator()
+    bus_tab = _FakeLocator()
     page = _ca_search_page(
         [
             _build_row(
@@ -313,14 +322,15 @@ async def test_search_toggles_query_kind_for_business_name(monkeypatch):
                 expiration="2026-12-31",
             )
         ],
-        radio_locators={"LIC": lic_radio, "BUS": bus_radio},
+        kind="name",
+        tab_locators={"number": lic_tab, "name": bus_tab},
     )
     _stub_browser(monkeypatch, page)
 
     await licensing.search("Acme Construction", state="CA")
 
-    assert bus_radio.click_calls == 1
-    assert lic_radio.click_calls == 0
+    assert bus_tab.click_calls == 1
+    assert lic_tab.click_calls == 0
 
 
 async def test_license_number_regex_recognises_cslb_format():
@@ -363,10 +373,11 @@ async def test_search_empty_query_returns_empty(monkeypatch):
 
 async def test_search_selector_miss_saves_diagnostic(monkeypatch, caplog, tmp_path):
     recipe = licensing._STATE_RECIPES["CA"]
+    # "anything" is a non-numeric query, so the connector takes the name-tab path.
     page = _FakePage(
         {
-            recipe["query_input"]: _FakeLocator(),
-            recipe["submit_button"]: _FakeLocator(),
+            recipe["query_inputs_by_kind"]["name"]: _FakeLocator(),
+            recipe["submit_buttons_by_kind"]["name"]: _FakeLocator(),
             recipe["row_selector"]: _FakeLocator(raise_on_all=True),
         }
     )

--- a/tests/test_tools_licensing.py
+++ b/tests/test_tools_licensing.py
@@ -1,0 +1,602 @@
+"""Tests for `research_agent.tools.licensing` (issue #91)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from research_agent.tools import licensing
+
+# ---------------------------------------------------------------------------
+# Fakes — Playwright surface area sufficient to exercise licensing.py.
+# ---------------------------------------------------------------------------
+
+
+class _FakeLocator:
+    def __init__(
+        self,
+        *,
+        text: str = "",
+        attrs: dict[str, str] | None = None,
+        children: dict[str, _FakeLocator] | None = None,
+        items: list[_FakeLocator] | None = None,
+        on_fill: Any = None,
+        on_click: Any = None,
+        raise_on_locator: bool = False,
+        raise_on_all: bool = False,
+        raise_on_click: bool = False,
+        raise_on_inner_text: bool = False,
+    ) -> None:
+        self._text = text
+        self._attrs = attrs or {}
+        self._children = children or {}
+        self._items = items or []
+        self._on_fill = on_fill
+        self._on_click = on_click
+        self._raise_on_locator = raise_on_locator
+        self._raise_on_all = raise_on_all
+        self._raise_on_click = raise_on_click
+        self._raise_on_inner_text = raise_on_inner_text
+        self.fill_calls: list[str] = []
+        self.click_calls: int = 0
+
+    @property
+    def first(self) -> _FakeLocator:
+        return self
+
+    async def all(self) -> list[_FakeLocator]:
+        if self._raise_on_all:
+            raise RuntimeError("selector drift")
+        return list(self._items)
+
+    async def inner_text(self) -> str:
+        if self._raise_on_inner_text:
+            raise RuntimeError("selector miss")
+        return self._text
+
+    async def get_attribute(self, name: str) -> str | None:
+        return self._attrs.get(name)
+
+    async def fill(self, value: str) -> None:
+        self.fill_calls.append(value)
+        if self._on_fill is not None:
+            self._on_fill(value)
+
+    async def click(self) -> None:
+        self.click_calls += 1
+        if self._raise_on_click:
+            raise RuntimeError("click failed")
+        if self._on_click is not None:
+            self._on_click()
+
+    def locator(self, selector: str) -> _FakeLocator:
+        if self._raise_on_locator:
+            raise RuntimeError("selector drift")
+        return self._children.get(selector, _FakeLocator())
+
+
+class _FakePage:
+    def __init__(self, selector_map: dict[str, _FakeLocator]) -> None:
+        self._selector_map = selector_map
+        self.closed = False
+        self.screenshots: list[str] = []
+        self.locator_calls: list[str] = []
+        self.click_order: list[str] = []
+
+    def locator(self, selector: str) -> _FakeLocator:
+        self.locator_calls.append(selector)
+        loc = self._selector_map.get(selector, _FakeLocator())
+        # Track which selectors are clicked, in order, by hooking each click.
+        original = loc._on_click
+
+        def _on_click() -> None:
+            self.click_order.append(selector)
+            if original is not None:
+                original()
+
+        loc._on_click = _on_click
+        return loc
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def screenshot(self, *, path: str) -> None:
+        self.screenshots.append(path)
+
+
+class _FakeContext:
+    def __init__(self, page: _FakePage) -> None:
+        self._page = page
+
+    async def new_page(self) -> _FakePage:
+        return self._page
+
+
+def _stub_browser(monkeypatch, page: _FakePage) -> dict[str, list[str]]:
+    captured: dict[str, list[str]] = {"navigations": []}
+
+    @asynccontextmanager
+    async def _session(headful=None, block_media=True):
+        yield _FakeContext(page)
+
+    async def _navigate(p, url, **kwargs):
+        captured["navigations"].append(url)
+
+    monkeypatch.setattr(licensing.browser, "browser_session", _session)
+    monkeypatch.setattr(licensing.browser, "navigate", _navigate)
+    return captured
+
+
+def _build_row(
+    *,
+    name: str,
+    href: str = "",
+    license_number: str = "",
+    status: str = "",
+    classification: str = "",
+    expiration: str = "",
+) -> _FakeLocator:
+    recipe = licensing._STATE_RECIPES["CA"]
+    return _FakeLocator(
+        children={
+            recipe["name_selector"]: _FakeLocator(text=name),
+            recipe["link_selector"]: _FakeLocator(text=name, attrs={"href": href}),
+            recipe["license_number_selector"]: _FakeLocator(text=license_number),
+            recipe["status_selector"]: _FakeLocator(text=status),
+            recipe["classification_selector"]: _FakeLocator(text=classification),
+            recipe["expiration_selector"]: _FakeLocator(text=expiration),
+        }
+    )
+
+
+def _ca_search_page(
+    rows: list[_FakeLocator],
+    *,
+    radio_locators: dict[str, _FakeLocator] | None = None,
+    submit_locator: _FakeLocator | None = None,
+) -> _FakePage:
+    recipe = licensing._STATE_RECIPES["CA"]
+    selectors: dict[str, _FakeLocator] = {
+        recipe["query_input"]: _FakeLocator(),
+        recipe["submit_button"]: submit_locator or _FakeLocator(),
+        recipe["row_selector"]: _FakeLocator(items=rows),
+    }
+    if radio_locators:
+        for value, locator in radio_locators.items():
+            selectors[
+                recipe["query_kind_selector"].format(kind=value)
+            ] = locator
+    return _FakePage(selectors)
+
+
+def _ca_profile_page(
+    *,
+    title: str = "ACME CONSTRUCTION INC",
+    license_number: str = "1234567",
+    status: str = "Active",
+    classification: str = "B - General Building",
+    expiration: str = "2026-12-31",
+    personnel_text: str = "John Smith — Owner/Officer",
+    workers_comp_text: str = "Carrier: State Fund — Policy: WC-9000",
+    bonds_text: str = "Contractor's Bond: $25,000 — Surety: ABC Surety",
+    disciplinary_text: str = "No disciplinary actions on file.",
+    raise_on_personnel_click: bool = False,
+    raise_on_disciplinary_inner_text: bool = False,
+) -> _FakePage:
+    recipe = licensing._STATE_RECIPES["CA"]
+    disciplinary_loc = _FakeLocator(
+        text=disciplinary_text,
+        raise_on_inner_text=raise_on_disciplinary_inner_text,
+    )
+    selectors: dict[str, _FakeLocator] = {
+        "h1": _FakeLocator(text=title),
+        recipe["profile_license_number_selector"]: _FakeLocator(text=license_number),
+        recipe["profile_status_selector"]: _FakeLocator(text=status),
+        recipe["profile_classification_selector"]: _FakeLocator(text=classification),
+        recipe["profile_expiration_selector"]: _FakeLocator(text=expiration),
+        recipe["personnel_tab_button"]: _FakeLocator(
+            raise_on_click=raise_on_personnel_click
+        ),
+        recipe["personnel_section"]: _FakeLocator(text=personnel_text),
+        recipe["workers_comp_tab_button"]: _FakeLocator(),
+        recipe["workers_comp_section"]: _FakeLocator(text=workers_comp_text),
+        recipe["bonds_tab_button"]: _FakeLocator(),
+        recipe["bonds_section"]: _FakeLocator(text=bonds_text),
+        recipe["disciplinary_tab_button"]: _FakeLocator(),
+        recipe["disciplinary_section"]: disciplinary_loc,
+    }
+    return _FakePage(selectors)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    licensing.reset_for_tests()
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    yield
+    licensing.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def test_search_returns_results_for_name_query(monkeypatch):
+    rows = [
+        _build_row(
+            name="ACME CONSTRUCTION INC",
+            license_number="1234567",
+            status="Active",
+            classification="B - General Building",
+            expiration="2026-12-31",
+        ),
+        _build_row(
+            name="ACME ROOFING LLC",
+            license_number="9876543",
+            status="Expired",
+            classification="C-39 - Roofing",
+            expiration="2023-08-01",
+        ),
+    ]
+    page = _ca_search_page(rows)
+    captured = _stub_browser(monkeypatch, page)
+
+    results = await licensing.search("Acme Construction", state="CA", max_results=5)
+
+    assert captured["navigations"] == [
+        licensing._STATE_RECIPES["CA"]["search_url"]
+    ]
+    assert len(results) == 2
+
+    top = results[0]
+    assert top.source_kind == "licensing"
+    assert top.title == "ACME CONSTRUCTION INC"
+    # No href in fake row → URL is search-anchored on the license number.
+    assert top.url == (
+        "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/"
+        "CheckLicense.aspx?LicNum=1234567"
+    )
+    assert top.extras["license_number"] == "1234567"
+    assert top.extras["status"] == "Active"
+    assert top.extras["classification"] == "B - General Building"
+    assert top.extras["expiration"] == "2026-12-31"
+    assert top.extras["state"] == "CA"
+    assert "Active" in top.snippet
+    assert "B - General Building" in top.snippet
+
+
+async def test_search_toggles_query_kind_for_license_number(monkeypatch):
+    """A 7-digit license-number query should click the LIC radio, not BUS."""
+    lic_radio = _FakeLocator()
+    bus_radio = _FakeLocator()
+    page = _ca_search_page(
+        [
+            _build_row(
+                name="ACME CONSTRUCTION INC",
+                license_number="1234567",
+                status="Active",
+                classification="B",
+                expiration="2026-12-31",
+            )
+        ],
+        radio_locators={"LIC": lic_radio, "BUS": bus_radio},
+    )
+    _stub_browser(monkeypatch, page)
+
+    await licensing.search("1234567", state="CA", max_results=5)
+
+    assert lic_radio.click_calls == 1
+    assert bus_radio.click_calls == 0
+
+
+async def test_search_toggles_query_kind_for_business_name(monkeypatch):
+    """A non-numeric query should click the BUS radio, not LIC."""
+    lic_radio = _FakeLocator()
+    bus_radio = _FakeLocator()
+    page = _ca_search_page(
+        [
+            _build_row(
+                name="ACME CONSTRUCTION INC",
+                license_number="1234567",
+                status="Active",
+                classification="B",
+                expiration="2026-12-31",
+            )
+        ],
+        radio_locators={"LIC": lic_radio, "BUS": bus_radio},
+    )
+    _stub_browser(monkeypatch, page)
+
+    await licensing.search("Acme Construction", state="CA")
+
+    assert bus_radio.click_calls == 1
+    assert lic_radio.click_calls == 0
+
+
+async def test_license_number_regex_recognises_cslb_format():
+    assert licensing._looks_like_license_number("1234567")  # 7 digits
+    assert licensing._looks_like_license_number("123456")  # 6 digits
+    assert licensing._looks_like_license_number("12345678")  # 8 digits
+    assert not licensing._looks_like_license_number("12345")  # too short
+    assert not licensing._looks_like_license_number("123456789")  # too long
+    assert not licensing._looks_like_license_number("Acme Construction")
+    assert not licensing._looks_like_license_number("")
+
+
+async def test_search_returns_empty_for_unknown_state(monkeypatch, caplog):
+    page = _ca_search_page([])
+    _stub_browser(monkeypatch, page)
+
+    with caplog.at_level(logging.WARNING, logger=licensing.logger.name):
+        results = await licensing.search("anything", state="ZZ")
+    assert results == []
+    assert any("no recipe" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.parametrize("state", ["TX", "FL", "NY"])
+async def test_search_returns_empty_for_stub_states(monkeypatch, caplog, state):
+    page = _ca_search_page([])
+    _stub_browser(monkeypatch, page)
+
+    with caplog.at_level(logging.WARNING, logger=licensing.logger.name):
+        results = await licensing.search("anything", state=state)
+    assert results == []
+    assert any("stub" in rec.message.lower() for rec in caplog.records)
+
+
+async def test_search_empty_query_returns_empty(monkeypatch):
+    page = _ca_search_page([])
+    _stub_browser(monkeypatch, page)
+    assert await licensing.search("", state="CA") == []
+    assert await licensing.search("   ", state="CA") == []
+
+
+async def test_search_selector_miss_saves_diagnostic(monkeypatch, caplog, tmp_path):
+    recipe = licensing._STATE_RECIPES["CA"]
+    page = _FakePage(
+        {
+            recipe["query_input"]: _FakeLocator(),
+            recipe["submit_button"]: _FakeLocator(),
+            recipe["row_selector"]: _FakeLocator(raise_on_all=True),
+        }
+    )
+    _stub_browser(monkeypatch, page)
+    monkeypatch.setattr(licensing, "_DIAGNOSTICS_DIR", tmp_path / "diagnostics")
+
+    with caplog.at_level(logging.WARNING, logger=licensing.logger.name):
+        results = await licensing.search("anything", state="CA")
+
+    assert results == []
+    assert any("selector miss" in rec.message for rec in caplog.records)
+    assert page.screenshots, "expected a diagnostic screenshot path"
+    assert page.screenshots[0].endswith(".png")
+
+
+async def test_search_submit_failure_saves_diagnostic(monkeypatch, caplog, tmp_path):
+    """If the submit button click raises, the connector bails with a screenshot."""
+    recipe = licensing._STATE_RECIPES["CA"]
+    page = _ca_search_page(
+        [],
+        submit_locator=_FakeLocator(raise_on_click=True),
+    )
+    _stub_browser(monkeypatch, page)
+    monkeypatch.setattr(licensing, "_DIAGNOSTICS_DIR", tmp_path / "diagnostics")
+
+    with caplog.at_level(logging.WARNING, logger=licensing.logger.name):
+        results = await licensing.search("Acme Construction", state="CA")
+
+    assert results == []
+    assert any("submit failed" in rec.message for rec in caplog.records)
+    assert page.screenshots, "expected a diagnostic screenshot path"
+    # Sanity-check we exercised the recipe's row selector but never reached row parsing.
+    assert recipe["row_selector"] not in page.locator_calls
+
+
+async def test_search_respects_max_results(monkeypatch):
+    rows = [
+        _build_row(
+            name=f"Company {i}",
+            license_number=f"{i:07d}",
+            status="Active",
+            classification="B",
+            expiration="2026-12-31",
+        )
+        for i in range(10)
+    ]
+    page = _ca_search_page(rows)
+    _stub_browser(monkeypatch, page)
+
+    results = await licensing.search("anything", state="CA", max_results=3)
+    assert len(results) == 3
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_clicks_all_four_tabs_and_rolls_markdown(monkeypatch):
+    page = _ca_profile_page()
+    _stub_browser(monkeypatch, page)
+
+    url = "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1234567"
+    source = await licensing.fetch(url)
+
+    assert source is not None
+    assert source.source_kind == "licensing"
+    assert source.title == "ACME CONSTRUCTION INC"
+    assert source.url == url
+
+    recipe = licensing._STATE_RECIPES["CA"]
+    # Clicked all four tab buttons in the order Personnel → WC → Bonds → Disciplinary.
+    assert recipe["personnel_tab_button"] in page.click_order
+    assert recipe["workers_comp_tab_button"] in page.click_order
+    assert recipe["bonds_tab_button"] in page.click_order
+    assert recipe["disciplinary_tab_button"] in page.click_order
+    tab_order = [
+        s
+        for s in page.click_order
+        if s
+        in {
+            recipe["personnel_tab_button"],
+            recipe["workers_comp_tab_button"],
+            recipe["bonds_tab_button"],
+            recipe["disciplinary_tab_button"],
+        }
+    ]
+    assert tab_order == [
+        recipe["personnel_tab_button"],
+        recipe["workers_comp_tab_button"],
+        recipe["bonds_tab_button"],
+        recipe["disciplinary_tab_button"],
+    ]
+    # Each tab fake recorded exactly one click.
+    assert page._selector_map[recipe["personnel_tab_button"]].click_calls == 1
+    assert page._selector_map[recipe["workers_comp_tab_button"]].click_calls == 1
+    assert page._selector_map[recipe["bonds_tab_button"]].click_calls == 1
+    assert page._selector_map[recipe["disciplinary_tab_button"]].click_calls == 1
+
+    body = source.cleaned_text
+    assert "# ACME CONSTRUCTION INC" in body
+    assert "1234567" in body
+    assert "Active" in body
+    assert "## Personnel" in body
+    assert "John Smith" in body
+    assert "## Workers' Compensation" in body
+    assert "State Fund" in body
+    assert "## Bonds" in body
+    assert "Contractor's Bond" in body
+    assert "## Disciplinary History" in body
+    assert "No disciplinary actions" in body
+
+    md = source.metadata
+    assert md["license_number"] == "1234567"
+    assert md["status"] == "Active"
+    assert md["classification"] == "B - General Building"
+    assert md["expiration"] == "2026-12-31"
+    assert "John Smith" in md["personnel"]
+    assert "State Fund" in md["workers_comp"]
+    assert "Contractor's Bond" in md["bonds"]
+    assert "No disciplinary actions" in md["disciplinary_history"]
+
+
+async def test_fetch_rejects_unknown_host(monkeypatch):
+    """Look-alike hosts must be rejected without opening a browser."""
+
+    @asynccontextmanager
+    async def _no_session(headful=None, block_media=True):
+        raise AssertionError("should not open browser")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(licensing.browser, "browser_session", _no_session)
+
+    spoof = "https://www.cslb.ca.gov.attacker.example/license/1"
+    assert await licensing.fetch(spoof) is None
+    assert await licensing.fetch("https://example.com/license/1") is None
+
+
+async def test_fetch_rejects_stub_state_hosts(monkeypatch):
+    """TX / FL / NY stubs must not open the browser even on a host match."""
+
+    @asynccontextmanager
+    async def _no_session(headful=None, block_media=True):
+        raise AssertionError("should not open browser")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(licensing.browser, "browser_session", _no_session)
+
+    assert await licensing.fetch("https://www.tdlr.texas.gov/LicenseSearch/") is None
+    assert await licensing.fetch("https://www.myfloridalicense.com/wl11.asp") is None
+    assert await licensing.fetch("https://www.dos.ny.gov/licensing/search.html") is None
+
+
+async def test_fetch_returns_none_for_empty_url():
+    assert await licensing.fetch("") is None
+
+
+async def test_fetch_tolerates_missing_tabs_and_selector_misses(monkeypatch):
+    """A profile where one tab fails to click and another section fails to read
+    should still produce a Source — partial coverage, not a raise."""
+    page = _ca_profile_page(
+        raise_on_personnel_click=True,
+        raise_on_disciplinary_inner_text=True,
+    )
+    _stub_browser(monkeypatch, page)
+
+    url = "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1234567"
+    source = await licensing.fetch(url)
+
+    assert source is not None
+    body = source.cleaned_text
+    # Section headings still present even where data was missing.
+    assert "## Personnel" in body
+    assert "## Workers' Compensation" in body
+    assert "## Bonds" in body
+    assert "## Disciplinary History" in body
+    # Sections that failed to read fall back to "(not available)".
+    assert "(not available)" in body
+    # Sections that succeeded still carry their data.
+    assert "State Fund" in body
+    assert "Contractor's Bond" in body
+
+
+async def test_fetch_handles_minimal_profile(monkeypatch):
+    """A profile with only a title still rounds-trips through the markdown builder."""
+    recipe = licensing._STATE_RECIPES["CA"]
+    page = _FakePage(
+        {
+            "h1": _FakeLocator(text="ACME LLC"),
+            recipe["profile_license_number_selector"]: _FakeLocator(),
+            recipe["profile_status_selector"]: _FakeLocator(),
+            recipe["profile_classification_selector"]: _FakeLocator(),
+            recipe["profile_expiration_selector"]: _FakeLocator(),
+            recipe["personnel_tab_button"]: _FakeLocator(),
+            recipe["personnel_section"]: _FakeLocator(),
+            recipe["workers_comp_tab_button"]: _FakeLocator(),
+            recipe["workers_comp_section"]: _FakeLocator(),
+            recipe["bonds_tab_button"]: _FakeLocator(),
+            recipe["bonds_section"]: _FakeLocator(),
+            recipe["disciplinary_tab_button"]: _FakeLocator(),
+            recipe["disciplinary_section"]: _FakeLocator(),
+        }
+    )
+    _stub_browser(monkeypatch, page)
+
+    url = "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=000"
+    source = await licensing.fetch(url)
+    assert source is not None
+    assert source.title == "ACME LLC"
+    assert "# ACME LLC" in source.cleaned_text
+
+
+# ---------------------------------------------------------------------------
+# Source kind literal & smoke registration
+# ---------------------------------------------------------------------------
+
+
+def test_source_kind_literal():
+    from research_agent.tools.models import SearchResult
+
+    result = SearchResult(
+        url="https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/CheckLicense.aspx",
+        title="t",
+        snippet="s",
+        source_kind="licensing",
+    )
+    assert result.source_kind == "licensing"
+
+
+def test_smoke_registry_includes_licensing():
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "licensing" in TOOL_REGISTRY

--- a/tests/test_tools_models.py
+++ b/tests/test_tools_models.py
@@ -37,6 +37,7 @@ EXPECTED_SOURCE_KINDS = (
     "opencorporates",
     "sanctions",
     "sos",
+    "licensing",
 )
 
 


### PR DESCRIPTION
Closes #91
Part of #107

## Summary

Automated implementation of **State licensing boards connector (CSLB-led, pluggable per state)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

CSLB licensing connector cleanly implements all ACs (search/fetch/4-tab rollup/diagnostics/per-state recipe), 20 dedicated tests pass, full suite (1088) green.

- **INFO** [OPEN] `src/research_agent/prompts/planner.md`: AC #7 in the issue text reads 'emit a [licensing_search] task before [web_search]', but the placeholders were never filled in. The implementation took a consistent-with-codebase approach: planner.md (lines 96-103) instructs the planner to emit a `web_search` with `site:cslb.ca.gov "<company>"` for US construction/contracting goals, mirroring how sos/opencorporates connectors are surfaced. The `licensing` connector itself is wired through TOOL_REGISTRY and the smoke wrapper. Reasonable interpretation of an incomplete spec; flagging only as a design note.
- **INFO** [OPEN] `src/research_agent/tools/licensing.py`: In `_extract_row`, the `state` field is reverse-resolved by host lookup against `_STATE_RECIPES`. Since `search()` already knows the state code from its argument, the reverse lookup is unnecessary indirection. Minor; not worth a change.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*