### PR TITLE
feat: BBB profile lookup connector (consumer complaints) (closes #95)

### DIFF
--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -525,6 +525,58 @@ def _smoke_licensing(query: str) -> str:
     return asyncio.run(_run())
 
 
+def _smoke_bbb(query: str) -> str:
+    """Smoke wrapper: BBB national search + top-hit profile rollup.
+
+    Per AC: ``research _smoke-tool bbb "SBI Builders"`` should return BBB
+    rating + complaint count. Lists the top-5 search hits with rating and
+    location, then attempts ``fetch()`` on the top hit and prints rating,
+    accreditation, and complaint counts (12mo / 3yr) so an operator can
+    eyeball whether the BBB profile DOM is still healthy.
+    """
+    from research_agent.tools import bbb, browser
+
+    async def _run() -> str:
+        try:
+            results = await bbb.search(query, max_results=5)
+            if not results:
+                return f"bbb search returned no results for {query!r}"
+            lines: list[str] = []
+            for hit in results:
+                rating = hit.extras.get("rating") or "?"
+                location = hit.extras.get("location") or "?"
+                lines.append(
+                    f"- {hit.title} — {rating} — {location}\n  {hit.url}"
+                )
+
+            top = results[0]
+            source = await bbb.fetch(top.url)
+            if source is None:
+                lines.append(
+                    f"\nfetch({top.url}) returned None — profile unavailable"
+                )
+            else:
+                lines.append(f"\nProfile for {top.title}")
+                lines.append(f"  rating: {source.metadata.get('rating') or '?'}")
+                lines.append(
+                    f"  accreditation: {source.metadata.get('accreditation') or '?'}"
+                )
+                lines.append(
+                    f"  complaints_12mo: {source.metadata.get('complaints_12mo') or '?'}"
+                )
+                lines.append(
+                    f"  complaints_3yr: {source.metadata.get('complaints_3yr') or '?'}"
+                )
+            return "\n".join(lines)
+        finally:
+            try:
+                await browser.shutdown()
+            except Exception:  # noqa: BLE001 — best-effort cleanup
+                pass
+
+    return asyncio.run(_run())
+
+
 def _smoke_sanctions(query: str) -> str:
     """Smoke wrapper: OFAC SDN / EU / UK sanctions lookup.
 
@@ -886,6 +938,8 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "web_fetch": _smoke_web_fetch,
     "local_corpus": _smoke_local_corpus,
     "arxiv": _smoke_arxiv,
+    "audio": _smoke_audio,
+    "bbb": _smoke_bbb,
     "edgar": _smoke_edgar,
     "courtlistener": _smoke_courtlistener,
     "fedregister": _smoke_fedregister,
@@ -903,7 +957,6 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "news": _smoke_news,
     "reddit": _smoke_reddit,
     "pdf": _smoke_pdf,
-    "audio": _smoke_audio,
     "ocr": _smoke_ocr,
     "youtube": _smoke_youtube,
 }

--- a/src/research_agent/tools/bbb.py
+++ b/src/research_agent/tools/bbb.py
@@ -1,0 +1,424 @@
+"""Better Business Bureau profile lookup — Playwright-driven (issue #95).
+
+Public surface:
+
+* ``async def search(query, *, max_results=25) -> list[SearchResult]`` runs
+  BBB's national search at ``bbb.org/search?find_country=USA&find_text=<name>``.
+  Returns business name, rating (e.g. ``A+``, ``B-``, ``NR``), city/state
+  location, and a profile permalink.
+* ``async def fetch(url) -> Source | None`` opens a BBB business profile and
+  returns markdown of: rating, accreditation status, complaint counts in the
+  last 12 months / 3 years, complaint summary categories, and government
+  actions.
+
+BBB has no public API — the connector is Playwright-only.
+
+Two regional caveats worth knowing before relying on results:
+
+* BBB profiles are operated by regional bureaus, so a search by name without
+  a city/state qualifier returns one row per state branch (e.g. "ACME, Inc"
+  in CA and TX may both appear). Let the planner narrow with location terms.
+* Complaint *bodies* on profile pages are gated behind a "Show more" / "Show
+  full complaint" reveal — fetch() best-effort clicks every visible reveal
+  control before scraping so the rolled-up markdown is not truncated.
+
+No auth. Per-host rate gate at 0.5 RPS — BBB is public infrastructure and
+Playwright traffic is conspicuous, so be polite.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import playwright.async_api
+
+from research_agent.tools import browser
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+_DIAGNOSTICS_DIR = Path("data/diagnostics/bbb")
+_PER_HOST_RPS = 0.5
+_HOST = "www.bbb.org"
+_SEARCH_URL = "https://www.bbb.org/search"
+
+# Short per-call timeout for selector reads. Playwright's default 30s
+# auto-wait is catastrophic on a profile page where most selectors may be
+# absent — half a dozen missing selectors in fetch() would hang the
+# connector for minutes.
+_SELECTOR_READ_TIMEOUT_MS = 2_000
+
+# Search page selectors — BBB's React app uses semantic data-testid
+# attributes plus stable CSS classes. Card root, link, name, rating, and
+# location elements are scraped per row.
+_RESULT_CARD_SELECTOR = (
+    "div[data-testid='search-result-card'], div.result-card, article.result-card"
+)
+_RESULT_NAME_SELECTOR = (
+    "[data-testid='result-business-name'], h3.result-business-name, h3 a"
+)
+_RESULT_LINK_SELECTOR = (
+    "a[data-testid='result-business-link'], a.result-business-link, h3 a"
+)
+_RESULT_RATING_SELECTOR = (
+    "[data-testid='result-rating'], .result-rating, .bbb-rating"
+)
+_RESULT_LOCATION_SELECTOR = (
+    "[data-testid='result-location'], .result-location, .business-address"
+)
+
+# Profile page selectors — header summary plus the four content blocks the
+# AC enumerates. BBB's profile DOM is less stable than its search markup;
+# we list a couple of fallbacks per field so a class rename does not blank
+# the whole connector.
+_PROFILE_RATING_SELECTOR = (
+    "[data-testid='profile-rating'], .bbb-rating-letter, span.rating-letter"
+)
+_PROFILE_ACCREDITATION_SELECTOR = (
+    "[data-testid='accreditation-status'], .accreditation-status, .bbb-accreditation"
+)
+_PROFILE_COMPLAINTS_12MO_SELECTOR = (
+    "[data-testid='complaints-12mo'], .complaints-12-months"
+)
+_PROFILE_COMPLAINTS_3YR_SELECTOR = (
+    "[data-testid='complaints-3yr'], .complaints-3-years"
+)
+_PROFILE_COMPLAINT_CATEGORIES_SELECTOR = (
+    "[data-testid='complaint-category'], .complaint-summary-category li,"
+    " .complaint-categories li"
+)
+_PROFILE_GOVERNMENT_ACTIONS_SELECTOR = (
+    "[data-testid='government-actions'], .government-actions"
+)
+
+# "Show more" / "Show full complaint" reveal controls that gate complaint
+# bodies. Click every visible one before scraping; misses are non-fatal.
+_REVEAL_BUTTON_SELECTORS: tuple[str, ...] = (
+    "button:has-text('Show more')",
+    "button:has-text('Show full complaint')",
+    "button:has-text('Read more')",
+)
+
+
+def _register_host_rates() -> None:
+    browser.set_host_rate(_HOST, _PER_HOST_RPS)
+
+
+_register_host_rates()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _safe_inner_text(locator: Any) -> str:
+    try:
+        text = await locator.inner_text(timeout=_SELECTOR_READ_TIMEOUT_MS)
+    except TypeError:
+        try:
+            text = await locator.inner_text()
+        except Exception:  # noqa: BLE001
+            return ""
+    except Exception:  # noqa: BLE001 — selector miss should not raise
+        return ""
+    return (text or "").strip()
+
+
+async def _safe_attr(locator: Any, name: str) -> str:
+    try:
+        value = await locator.get_attribute(name, timeout=_SELECTOR_READ_TIMEOUT_MS)
+    except TypeError:
+        try:
+            value = await locator.get_attribute(name)
+        except Exception:  # noqa: BLE001
+            return ""
+    except Exception:  # noqa: BLE001
+        return ""
+    return (value or "").strip()
+
+
+async def _save_diagnostic_screenshot(page: Any, host: str) -> None:
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    target = _DIAGNOSTICS_DIR / f"{host}-{stamp}.png"
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        await page.screenshot(path=str(target))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("bbb diagnostic screenshot failed: %s", exc)
+
+
+def _absolute_url(base: str, href: str) -> str:
+    if not href:
+        return ""
+    if href.startswith("http://") or href.startswith("https://"):
+        return href
+    if href.startswith("/"):
+        parsed = urlparse(base)
+        return f"{parsed.scheme}://{parsed.netloc}{href}"
+    return base.rstrip("/") + "/" + href
+
+
+async def _collect_simple_text(page: Any, selector: str) -> str:
+    try:
+        return await _safe_inner_text(page.locator(selector).first)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("bbb profile selector miss (%s): %s", selector, exc)
+        return ""
+
+
+async def _collect_list(page: Any, selector: str) -> list[str]:
+    try:
+        nodes = await page.locator(selector).all()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("bbb profile list selector miss (%s): %s", selector, exc)
+        return []
+    out: list[str] = []
+    for node in nodes:
+        text = await _safe_inner_text(node)
+        if text:
+            out.append(text)
+    return out
+
+
+async def _click_all_reveals(page: Any) -> int:
+    """Best-effort: click every visible "Show more" / "Show full complaint"
+    button so complaint bodies are expanded before scraping. Returns the
+    number of successful clicks for diagnostics; misses are swallowed so a
+    selector drift never blocks fetch().
+    """
+    clicks = 0
+    for selector in _REVEAL_BUTTON_SELECTORS:
+        try:
+            buttons = await page.locator(selector).all()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("bbb reveal lookup miss (%s): %s", selector, exc)
+            continue
+        for button in buttons:
+            try:
+                await button.click()
+                clicks += 1
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("bbb reveal click miss (%s): %s", selector, exc)
+    return clicks
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def _extract_card(card: Any) -> SearchResult | None:
+    name = await _safe_inner_text(card.locator(_RESULT_NAME_SELECTOR).first)
+    if not name:
+        return None
+
+    href = await _safe_attr(card.locator(_RESULT_LINK_SELECTOR).first, "href")
+    rating = await _safe_inner_text(card.locator(_RESULT_RATING_SELECTOR).first)
+    location = await _safe_inner_text(card.locator(_RESULT_LOCATION_SELECTOR).first)
+
+    profile_url = _absolute_url(_SEARCH_URL, href) if href else _SEARCH_URL
+
+    snippet_bits = [b for b in (rating, location) if b]
+    snippet = " — ".join(snippet_bits)
+
+    extras: dict[str, Any] = {
+        "rating": rating,
+        "location": location,
+        "profile_url": profile_url,
+    }
+    return SearchResult(
+        url=profile_url,
+        title=name,
+        snippet=snippet,
+        source_kind="bbb",
+        extras=extras,
+    )
+
+
+async def search(query: str, *, max_results: int = 25) -> list[SearchResult]:
+    """Run a BBB national search for ``query``; return up to ``max_results`` hits.
+
+    BBB is regional — a name without a city/state qualifier typically returns
+    one row per bureau branch (different cities/states for the same business).
+    Let the planner narrow the query with location terms when disambiguation
+    matters.
+    """
+    if not query or not query.strip():
+        return []
+
+    # The national search endpoint accepts ``find_country`` + ``find_text``;
+    # all other filters (city, category) are optional and we leave them off
+    # so the planner can narrow at the query layer rather than via this URL.
+    search_url = (
+        f"{_SEARCH_URL}?find_country=USA&find_text={query.strip().replace(' ', '+')}"
+    )
+
+    try:
+        async with browser.browser_session() as ctx:
+            page = await ctx.new_page()
+            try:
+                await browser.navigate(page, search_url)
+
+                try:
+                    await page.locator(_RESULT_CARD_SELECTOR).first.wait_for(
+                        timeout=15_000
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "bbb search cards did not render on %s: %s",
+                        search_url,
+                        exc,
+                    )
+                    await _save_diagnostic_screenshot(page, _HOST)
+                    return []
+
+                try:
+                    cards = await page.locator(_RESULT_CARD_SELECTOR).all()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "bbb search selector miss on %s: %s", search_url, exc
+                    )
+                    await _save_diagnostic_screenshot(page, _HOST)
+                    return []
+
+                results: list[SearchResult] = []
+                for card in cards[:max_results]:
+                    try:
+                        result = await _extract_card(card)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning("bbb card parse failed: %s", exc)
+                        continue
+                    if result is not None:
+                        results.append(result)
+                return results
+            finally:
+                try:
+                    await page.close()
+                except Exception:  # noqa: BLE001
+                    pass
+    except playwright.async_api.Error as exc:
+        logger.warning("bbb search playwright error: %s", exc)
+        return []
+    except Exception as exc:  # noqa: BLE001 — never crash the planner
+        logger.warning("bbb search unexpected error: %s", exc)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+async def fetch(url: str) -> Source | None:
+    """Open a BBB business profile and return a :class:`Source`.
+
+    Strict host gate: only ``www.bbb.org`` URLs are accepted; everything else
+    returns ``None`` without a network call. Eagerly clicks every visible
+    "Show more" / "Show full complaint" reveal before scraping so the
+    rolled-up markdown contains the full complaint summary text rather than
+    the gated preview.
+    """
+    if not url:
+        return None
+    parsed = urlparse(url)
+    host = (parsed.netloc or "").lower().split(":", 1)[0]
+    if host != _HOST:
+        return None
+
+    try:
+        async with browser.browser_session() as ctx:
+            page = await ctx.new_page()
+            try:
+                await browser.navigate(page, url)
+
+                # Expand any reveals before scraping. Best-effort — selector
+                # drift here should never block the rest of the fetch.
+                await _click_all_reveals(page)
+
+                title = await _safe_inner_text(page.locator("h1").first)
+                if not title:
+                    title = _HOST
+
+                rating = await _collect_simple_text(page, _PROFILE_RATING_SELECTOR)
+                accreditation = await _collect_simple_text(
+                    page, _PROFILE_ACCREDITATION_SELECTOR
+                )
+                complaints_12mo = await _collect_simple_text(
+                    page, _PROFILE_COMPLAINTS_12MO_SELECTOR
+                )
+                complaints_3yr = await _collect_simple_text(
+                    page, _PROFILE_COMPLAINTS_3YR_SELECTOR
+                )
+                complaint_categories = await _collect_list(
+                    page, _PROFILE_COMPLAINT_CATEGORIES_SELECTOR
+                )
+                government_actions = await _collect_simple_text(
+                    page, _PROFILE_GOVERNMENT_ACTIONS_SELECTOR
+                )
+
+                sections: list[str] = [f"# {title}"]
+                if rating:
+                    sections.append(f"## Rating\n\n{rating}")
+                if accreditation:
+                    sections.append(f"## Accreditation\n\n{accreditation}")
+                if complaints_12mo or complaints_3yr:
+                    body_lines = []
+                    if complaints_12mo:
+                        body_lines.append(f"- Last 12 months: {complaints_12mo}")
+                    if complaints_3yr:
+                        body_lines.append(f"- Last 3 years: {complaints_3yr}")
+                    sections.append(
+                        "## Complaints (12mo / 3yr)\n\n" + "\n".join(body_lines)
+                    )
+                if complaint_categories:
+                    body = "\n".join(f"- {c}" for c in complaint_categories)
+                    sections.append(f"## Complaint summary categories\n\n{body}")
+                if government_actions:
+                    sections.append(f"## Government actions\n\n{government_actions}")
+
+                cleaned_text = "\n\n".join(sections).strip()
+                if not cleaned_text:
+                    return None
+
+                metadata: dict[str, Any] = {
+                    "rating": rating,
+                    "accreditation": accreditation,
+                    "complaints_12mo": complaints_12mo,
+                    "complaints_3yr": complaints_3yr,
+                    "complaint_categories": complaint_categories,
+                    "government_actions": government_actions,
+                }
+
+                return Source(
+                    url=url,
+                    title=title,
+                    cleaned_text=cleaned_text,
+                    raw_html=None,
+                    fetched_at=datetime.now(UTC),
+                    source_kind="bbb",
+                    metadata=metadata,
+                )
+            finally:
+                try:
+                    await page.close()
+                except Exception:  # noqa: BLE001
+                    pass
+    except playwright.async_api.Error as exc:
+        logger.warning("bbb fetch playwright error for %s: %s", url, exc)
+        return None
+    except Exception as exc:  # noqa: BLE001 — never crash the planner
+        logger.warning("bbb fetch unexpected error for %s: %s", url, exc)
+        return None
+
+
+def reset_for_tests() -> None:
+    """Re-register host rate after browser.reset_for_tests() drops it. Test-only."""
+    _register_host_rates()
+
+
+__all__ = ["fetch", "reset_for_tests", "search"]

--- a/src/research_agent/tools/models.py
+++ b/src/research_agent/tools/models.py
@@ -44,6 +44,7 @@ SourceKind = Literal[
     "sanctions",
     "sos",
     "licensing",
+    "bbb",
 ]
 
 

--- a/tests/test_tools_bbb.py
+++ b/tests/test_tools_bbb.py
@@ -1,0 +1,453 @@
+"""Tests for `research_agent.tools.bbb` (issue #95)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock
+
+import playwright.async_api
+import pytest
+
+from research_agent.tools import bbb
+
+# ---------------------------------------------------------------------------
+# Fakes — Playwright surface area sufficient to exercise bbb.py.
+# ---------------------------------------------------------------------------
+
+
+class _FakeLocator:
+    def __init__(
+        self,
+        *,
+        text: str = "",
+        attrs: dict[str, str] | None = None,
+        children: dict[str, _FakeLocator] | None = None,
+        items: list[_FakeLocator] | None = None,
+        on_click: Any = None,
+        raise_on_locator: bool = False,
+        raise_on_all: bool = False,
+        raise_on_wait_for: bool = False,
+        raise_on_click: bool = False,
+    ) -> None:
+        self._text = text
+        self._attrs = attrs or {}
+        self._children = children or {}
+        self._items = items or []
+        self._on_click = on_click
+        self._raise_on_locator = raise_on_locator
+        self._raise_on_all = raise_on_all
+        self._raise_on_wait_for = raise_on_wait_for
+        self._raise_on_click = raise_on_click
+        self.click_calls: int = 0
+        self.wait_for_calls: int = 0
+
+    @property
+    def first(self) -> _FakeLocator:
+        return self
+
+    async def all(self) -> list[_FakeLocator]:
+        if self._raise_on_all:
+            raise RuntimeError("selector drift")
+        return list(self._items)
+
+    async def inner_text(self) -> str:
+        return self._text
+
+    async def get_attribute(self, name: str) -> str | None:
+        return self._attrs.get(name)
+
+    async def click(self) -> None:
+        self.click_calls += 1
+        if self._raise_on_click:
+            raise RuntimeError("click failed")
+        if self._on_click is not None:
+            self._on_click()
+
+    async def wait_for(self, *, timeout: int = 0) -> None:  # noqa: ARG002
+        self.wait_for_calls += 1
+        if self._raise_on_wait_for:
+            raise RuntimeError("cards did not render")
+
+    def locator(self, selector: str) -> _FakeLocator:
+        if self._raise_on_locator:
+            raise RuntimeError("selector drift")
+        return self._children.get(selector, _FakeLocator())
+
+
+class _FakePage:
+    def __init__(self, selector_map: dict[str, _FakeLocator]) -> None:
+        self._selector_map = selector_map
+        self.closed = False
+        self.screenshots: list[str] = []
+        self.locator_calls: list[str] = []
+        self.click_counts: dict[str, int] = {}
+
+    def locator(self, selector: str) -> _FakeLocator:
+        self.locator_calls.append(selector)
+        loc = self._selector_map.get(selector, _FakeLocator())
+        # Tally clicks per selector. Wrap each child item's existing click
+        # with a counter hook so we can assert reveal-button click counts
+        # in the show-more test.
+        for item in list(loc._items):
+            original = item._on_click
+
+            def _make_hook(sel: str, prev: Any) -> Any:
+                def _hook() -> None:
+                    self.click_counts[sel] = self.click_counts.get(sel, 0) + 1
+                    if prev is not None:
+                        prev()
+
+                return _hook
+
+            item._on_click = _make_hook(selector, original)
+        return loc
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def screenshot(self, *, path: str) -> None:
+        self.screenshots.append(path)
+
+
+class _FakeContext:
+    def __init__(self, page: _FakePage) -> None:
+        self._page = page
+
+    async def new_page(self) -> _FakePage:
+        return self._page
+
+
+def _stub_browser(monkeypatch, page: _FakePage) -> dict[str, list[str]]:
+    captured: dict[str, list[str]] = {"navigations": []}
+
+    @asynccontextmanager
+    async def _session(headful=None, block_media=True):
+        yield _FakeContext(page)
+
+    async def _navigate(p, url, **kwargs):
+        captured["navigations"].append(url)
+
+    monkeypatch.setattr(bbb.browser, "browser_session", _session)
+    monkeypatch.setattr(bbb.browser, "navigate", _navigate)
+    return captured
+
+
+def _build_card(*, name: str, href: str = "", rating: str = "", location: str = "") -> _FakeLocator:
+    return _FakeLocator(
+        children={
+            bbb._RESULT_NAME_SELECTOR: _FakeLocator(text=name),
+            bbb._RESULT_LINK_SELECTOR: _FakeLocator(text=name, attrs={"href": href}),
+            bbb._RESULT_RATING_SELECTOR: _FakeLocator(text=rating),
+            bbb._RESULT_LOCATION_SELECTOR: _FakeLocator(text=location),
+        }
+    )
+
+
+def _search_page(cards: list[_FakeLocator]) -> _FakePage:
+    return _FakePage({bbb._RESULT_CARD_SELECTOR: _FakeLocator(items=cards)})
+
+
+def _profile_page(
+    *,
+    title: str = "SBI Builders Inc.",
+    rating: str = "A+",
+    accreditation: str = "BBB Accredited Business since 2015",
+    complaints_12mo: str = "3",
+    complaints_3yr: str = "12",
+    categories: list[str] | None = None,
+    government_actions: str = "",
+    reveal_buttons: dict[str, list[_FakeLocator]] | None = None,
+) -> _FakePage:
+    selectors: dict[str, _FakeLocator] = {
+        "h1": _FakeLocator(text=title),
+        bbb._PROFILE_RATING_SELECTOR: _FakeLocator(text=rating),
+        bbb._PROFILE_ACCREDITATION_SELECTOR: _FakeLocator(text=accreditation),
+        bbb._PROFILE_COMPLAINTS_12MO_SELECTOR: _FakeLocator(text=complaints_12mo),
+        bbb._PROFILE_COMPLAINTS_3YR_SELECTOR: _FakeLocator(text=complaints_3yr),
+        bbb._PROFILE_COMPLAINT_CATEGORIES_SELECTOR: _FakeLocator(
+            items=[_FakeLocator(text=c) for c in (categories or [])]
+        ),
+        bbb._PROFILE_GOVERNMENT_ACTIONS_SELECTOR: _FakeLocator(text=government_actions),
+    }
+    # Default: every reveal selector resolves to an empty locator (no buttons).
+    for selector in bbb._REVEAL_BUTTON_SELECTORS:
+        items = (reveal_buttons or {}).get(selector, [])
+        selectors[selector] = _FakeLocator(items=items)
+    return _FakePage(selectors)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    bbb.reset_for_tests()
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    yield
+    bbb.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def test_search_returns_parsed_cards(monkeypatch):
+    cards = [
+        _build_card(
+            name="SBI Builders Inc.",
+            href="/us/ca/san-jose/profile/general-contractor/sbi-builders-1234",
+            rating="A+",
+            location="San Jose, CA",
+        ),
+        _build_card(
+            name="SBI Builders LLC",
+            href="https://www.bbb.org/us/tx/austin/profile/general-contractor/sbi-builders-llc-5678",
+            rating="B",
+            location="Austin, TX",
+        ),
+    ]
+    page = _search_page(cards)
+    captured = _stub_browser(monkeypatch, page)
+
+    results = await bbb.search("SBI Builders", max_results=5)
+
+    assert captured["navigations"] == [
+        "https://www.bbb.org/search?find_country=USA&find_text=SBI+Builders"
+    ]
+    assert len(results) == 2
+
+    top = results[0]
+    assert top.source_kind == "bbb"
+    assert top.title == "SBI Builders Inc."
+    assert top.url == (
+        "https://www.bbb.org/us/ca/san-jose/profile/general-contractor/sbi-builders-1234"
+    )
+    assert top.extras["rating"] == "A+"
+    assert top.extras["location"] == "San Jose, CA"
+    assert "A+" in top.snippet
+    assert "San Jose, CA" in top.snippet
+
+    second = results[1]
+    # Absolute URL kept verbatim.
+    assert second.url == (
+        "https://www.bbb.org/us/tx/austin/profile/general-contractor/sbi-builders-llc-5678"
+    )
+
+
+async def test_search_empty_query_returns_empty(monkeypatch):
+    page = _search_page([])
+    _stub_browser(monkeypatch, page)
+    assert await bbb.search("") == []
+    assert await bbb.search("   ") == []
+
+
+async def test_search_selector_miss_writes_diagnostic(monkeypatch, caplog, tmp_path):
+    page = _FakePage({bbb._RESULT_CARD_SELECTOR: _FakeLocator(raise_on_all=True)})
+    _stub_browser(monkeypatch, page)
+    monkeypatch.setattr(bbb, "_DIAGNOSTICS_DIR", tmp_path / "diagnostics")
+
+    with caplog.at_level(logging.WARNING, logger=bbb.logger.name):
+        results = await bbb.search("anything")
+
+    assert results == []
+    assert any("selector miss" in rec.message for rec in caplog.records)
+    assert page.screenshots, "expected a diagnostic screenshot path"
+    assert page.screenshots[0].endswith(".png")
+
+
+async def test_search_returns_empty_when_cards_never_render(
+    monkeypatch, caplog, tmp_path
+):
+    """If the React app never paints cards, ``wait_for`` raises and we bail
+    with a diagnostic screenshot rather than parsing whatever stale DOM was
+    there.
+    """
+    page = _FakePage(
+        {bbb._RESULT_CARD_SELECTOR: _FakeLocator(raise_on_wait_for=True)}
+    )
+    _stub_browser(monkeypatch, page)
+    monkeypatch.setattr(bbb, "_DIAGNOSTICS_DIR", tmp_path / "diagnostics")
+
+    with caplog.at_level(logging.WARNING, logger=bbb.logger.name):
+        results = await bbb.search("anything")
+
+    assert results == []
+    assert any("did not render" in rec.message for rec in caplog.records)
+    assert page.screenshots
+
+
+async def test_search_respects_max_results(monkeypatch):
+    cards = [
+        _build_card(name=f"Company {i}", href=f"/us/ca/x/profile/y/company-{i}", rating="A")
+        for i in range(10)
+    ]
+    page = _search_page(cards)
+    _stub_browser(monkeypatch, page)
+
+    results = await bbb.search("anything", max_results=3)
+    assert len(results) == 3
+
+
+async def test_search_swallows_playwright_errors(monkeypatch, caplog):
+    @asynccontextmanager
+    async def _session(headful=None, block_media=True):
+        raise playwright.async_api.Error("browser crashed")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(bbb.browser, "browser_session", _session)
+
+    with caplog.at_level(logging.WARNING, logger=bbb.logger.name):
+        results = await bbb.search("anything")
+
+    assert results == []
+    assert any("playwright error" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_builds_markdown_source(monkeypatch):
+    page = _profile_page(
+        categories=["Advertising/Sales Issues — 4", "Billing/Collection Issues — 2"],
+        government_actions="No government actions on file.",
+    )
+    _stub_browser(monkeypatch, page)
+
+    url = "https://www.bbb.org/us/ca/san-jose/profile/general-contractor/sbi-builders-1234"
+    source = await bbb.fetch(url)
+
+    assert source is not None
+    assert source.source_kind == "bbb"
+    assert source.title == "SBI Builders Inc."
+    assert source.url == url
+
+    body = source.cleaned_text
+    assert "# SBI Builders Inc." in body
+    assert "## Rating" in body
+    assert "A+" in body
+    assert "## Accreditation" in body
+    assert "BBB Accredited Business" in body
+    assert "## Complaints (12mo / 3yr)" in body
+    assert "Last 12 months: 3" in body
+    assert "Last 3 years: 12" in body
+    assert "## Complaint summary categories" in body
+    assert "Advertising/Sales Issues" in body
+    assert "## Government actions" in body
+    assert "No government actions" in body
+
+    md = source.metadata
+    assert md["rating"] == "A+"
+    assert "BBB Accredited Business" in md["accreditation"]
+    assert md["complaints_12mo"] == "3"
+    assert md["complaints_3yr"] == "12"
+    assert len(md["complaint_categories"]) == 2
+    assert md["government_actions"]
+
+
+async def test_fetch_rejects_non_bbb_host(monkeypatch):
+    """Look-alike hosts must be rejected without opening a browser."""
+
+    @asynccontextmanager
+    async def _no_session(headful=None, block_media=True):
+        raise AssertionError("should not open browser")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(bbb.browser, "browser_session", _no_session)
+
+    spoof = "https://www.bbb.org.attacker.example/us/ca/profile/x/y"
+    assert await bbb.fetch(spoof) is None
+    assert await bbb.fetch("https://opencorporates.com/companies/us_ca/1") is None
+    assert await bbb.fetch("") is None
+
+
+async def test_fetch_clicks_show_more_reveals_before_scraping(monkeypatch):
+    """Complaint bodies are gated behind 'Show more' / 'Show full complaint'
+    reveals — fetch() must click every visible reveal button before the
+    scraping pass so the rolled-up markdown captures the full text.
+    """
+    show_more_buttons = [_FakeLocator(text="Show more"), _FakeLocator(text="Show more")]
+    show_full_buttons = [_FakeLocator(text="Show full complaint")]
+    read_more_buttons: list[_FakeLocator] = []
+
+    page = _profile_page(
+        categories=["Service Issues — 1"],
+        reveal_buttons={
+            "button:has-text('Show more')": show_more_buttons,
+            "button:has-text('Show full complaint')": show_full_buttons,
+            "button:has-text('Read more')": read_more_buttons,
+        },
+    )
+    _stub_browser(monkeypatch, page)
+
+    url = "https://www.bbb.org/us/ca/san-jose/profile/general-contractor/sbi-builders-1234"
+    source = await bbb.fetch(url)
+
+    assert source is not None
+    # Three reveals fired: 2 "Show more" + 1 "Show full complaint".
+    total_clicks = sum(b.click_calls for b in show_more_buttons + show_full_buttons)
+    assert total_clicks == 3
+
+
+async def test_fetch_swallows_reveal_click_errors(monkeypatch):
+    """A reveal button that raises on click must not block the scrape — the
+    show-more controls are best-effort and a click failure is non-fatal.
+    """
+    flaky = _FakeLocator(text="Show more", raise_on_click=True)
+    page = _profile_page(
+        categories=["Service Issues — 1"],
+        reveal_buttons={"button:has-text('Show more')": [flaky]},
+    )
+    _stub_browser(monkeypatch, page)
+
+    url = "https://www.bbb.org/us/ca/san-jose/profile/general-contractor/sbi-builders-1234"
+    source = await bbb.fetch(url)
+
+    assert source is not None
+    assert "## Rating" in source.cleaned_text
+
+
+async def test_fetch_swallows_playwright_errors(monkeypatch, caplog):
+    @asynccontextmanager
+    async def _session(headful=None, block_media=True):
+        raise playwright.async_api.Error("nav crashed")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(bbb.browser, "browser_session", _session)
+
+    url = "https://www.bbb.org/us/ca/san-jose/profile/x/y"
+    with caplog.at_level(logging.WARNING, logger=bbb.logger.name):
+        result = await bbb.fetch(url)
+
+    assert result is None
+    assert any("playwright error" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Source kind literal & smoke registration
+# ---------------------------------------------------------------------------
+
+
+def test_source_kind_literal():
+    from research_agent.tools.models import SearchResult
+
+    result = SearchResult(
+        url="https://www.bbb.org/us/ca/san-jose/profile/x/y",
+        title="t",
+        snippet="s",
+        source_kind="bbb",
+    )
+    assert result.source_kind == "bbb"
+
+
+def test_smoke_registry_includes_bbb():
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "bbb" in TOOL_REGISTRY

--- a/tests/test_tools_models.py
+++ b/tests/test_tools_models.py
@@ -38,6 +38,7 @@ EXPECTED_SOURCE_KINDS = (
     "sanctions",
     "sos",
     "licensing",
+    "bbb",
 )
 
 


### PR DESCRIPTION
Closes #95
Part of #107

## Summary

Automated implementation of **BBB profile lookup connector (consumer complaints)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

BBB connector cleanly implements all acceptance criteria; wiring (SourceKind, TOOL_REGISTRY, smoke wrapper) is correct and 1103-test suite is green.

- **INFO** [OPEN] `src/research_agent/tools/bbb.py`: fetch() does not write a diagnostic screenshot when individual profile selectors miss (only search() does on full result-card miss). Distinguishing a real selector drift from a profile that genuinely lacks a section is hard, so behavior is reasonable, but a screenshot when ALL profile selectors miss would help debug DOM drift faster.
- **INFO** [OPEN] `src/research_agent/tools/bbb.py`: Reveal-button click sweep makes a single pass per selector. If clicking 'Show more' reveals nested 'Show more' / 'Show full complaint' controls, the second-tier text remains gated. Acceptable as best-effort, but a bounded second pass would catch the edge case.
- **INFO** [OPEN] `src/research_agent/tools/bbb.py`: No micro-wait between reveal clicks and selector scrape. If clicks trigger async DOM updates, scraping may capture pre-expansion state. Low practical risk on a server-rendered React app, but worth a `await page.wait_for_load_state('networkidle')` or similar before scraping if drift is observed in production.
- **INFO** [OPEN] `src/research_agent/tools/bbb.py`: If a search card has no href, the SearchResult.url falls back to the search URL itself, which would re-issue a search instead of opening a profile when followed. Defensive and rare in practice (BBB cards have hrefs), but skipping cards without an href would be cleaner.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*