### PR TITLE
feat: archive.today connector (Wayback fallback) (closes #106)

### DIFF
--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -946,6 +946,21 @@ def _smoke_youtube(query: str) -> str:
     return asyncio.run(_run())
 
 
+def _smoke_archive_today(url: str) -> str:
+    """Smoke wrapper: submit ``url`` to archive.today and return the archive URL.
+
+    Per AC: ``research _smoke-tool archive_today https://example.com`` should
+    return the resulting ``archive.today/<id>`` URL — or a clear "no URL"
+    message if archive.today served a captcha or otherwise refused.
+    """
+    from research_agent.tools import archive
+
+    archive_url = asyncio.run(archive.archive_today_save(url))
+    if archive_url is None:
+        return f"archive.today save returned no URL for {url}"
+    return archive_url
+
+
 def _smoke_web_fetch(url: str) -> str:
     """Smoke wrapper for web_fetch: print word count, path, preview, archive URL.
 
@@ -988,6 +1003,7 @@ def _smoke_web_fetch(url: str) -> str:
 TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "web_search": _smoke_web_search,
     "web_fetch": _smoke_web_fetch,
+    "archive_today": _smoke_archive_today,
     "local_corpus": _smoke_local_corpus,
     "arxiv": _smoke_arxiv,
     "audio": _smoke_audio,

--- a/src/research_agent/tools/archive.py
+++ b/src/research_agent/tools/archive.py
@@ -27,7 +27,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import time
+from urllib.parse import urlparse
 
 import httpx
 import tenacity
@@ -40,10 +42,29 @@ _WAYBACK_BASE = "https://web.archive.org"
 _RATE_LIMIT_INTERVAL = 5.0
 _RETRYABLE_STATUSES = frozenset({408, 425, 429, 500, 502, 503, 504})
 
+# archive.today is a small, easily-irritated service. The issue caps us at
+# 0.2 RPS per host (5s between submissions), with a separate gate from
+# Wayback so a slow archive.today doesn't starve Wayback saves.
+_ARCHIVE_TODAY_BASE = "https://archive.today"
+_ARCHIVE_TODAY_HOSTS = frozenset({"archive.today", "archive.ph"})
+_ARCHIVE_TODAY_RATE_INTERVAL = 5.0
+
+# Captcha pages on archive.today come back as HTML with an HTTP 429 status —
+# the body is the giveaway, not the status code. Sniffing the body lets us
+# bail before tenacity burns three retries on a challenge that only humans
+# can solve.
+_CAPTCHA_RE = re.compile(
+    r"\b(captcha|verify you are human|hcaptcha|recaptcha)\b",
+    re.IGNORECASE,
+)
+
 logger = logging.getLogger(__name__)
 
 _rate_lock = asyncio.Lock()
 _last_save_monotonic: float | None = None
+
+_archive_today_lock = asyncio.Lock()
+_last_archive_today_monotonic: float | None = None
 
 
 class _TransientError(Exception):
@@ -153,11 +174,163 @@ async def save(url: str, timeout: float = 30.0) -> str | None:
     return None
 
 
+async def _archive_today_rate_limit_gate() -> None:
+    """Block until at least ``_ARCHIVE_TODAY_RATE_INTERVAL`` has passed since
+    the last archive.today submission. Separate from Wayback's gate so the
+    two hosts don't share a queue.
+    """
+    global _last_archive_today_monotonic
+    async with _archive_today_lock:
+        if _last_archive_today_monotonic is not None:
+            elapsed = time.monotonic() - _last_archive_today_monotonic
+            wait = _ARCHIVE_TODAY_RATE_INTERVAL - elapsed
+            if wait > 0:
+                await asyncio.sleep(wait)
+        _last_archive_today_monotonic = time.monotonic()
+
+
+def _parse_refresh_header(value: str) -> str | None:
+    """Pull the URL out of an HTTP ``Refresh`` header.
+
+    archive.today replies with ``Refresh: 0; url=https://archive.today/<id>``
+    when a fresh save is finished. Format is ``<seconds>; url=<target>`` per
+    the de-facto WHATWG spec; tolerate quoting and whitespace.
+    """
+    if not value:
+        return None
+    parts = value.split(";", 1)
+    if len(parts) != 2:
+        return None
+    target = parts[1].strip()
+    if target.lower().startswith("url="):
+        target = target[4:].strip()
+    return target.strip("\"'") or None
+
+
+def _normalize_archive_today_url(url: str) -> str | None:
+    """Return ``https://archive.today/<id>`` for any archive.today/.ph link.
+
+    archive.ph and archive.today are the same service behind different
+    hostnames; the issue requires we surface the canonical archive.today
+    form. Returns None for non-archive hosts or for the bare ``/submit/``
+    form (which is what we POST'ed to, not an archive landing page).
+    """
+    if not url:
+        return None
+    parsed = urlparse(url)
+    if parsed.hostname not in _ARCHIVE_TODAY_HOSTS:
+        return None
+    path = parsed.path.strip("/")
+    if not path or path.startswith("submit"):
+        return None
+    return f"{_ARCHIVE_TODAY_BASE}/{path}"
+
+
+async def _attempt_archive_today(
+    url: str, headers: dict[str, str], timeout: float
+) -> str | None:
+    """Single archive.today submission. Raises ``_TransientError`` on retryable failures."""
+    submit_url = f"{_ARCHIVE_TODAY_BASE}/submit/"
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=headers,
+        ) as client:
+            # Form-encoded body — verified with curl per issue note.
+            # Query-string variant gets ignored by the server.
+            response = await client.post(submit_url, data={"url": url})
+    except (httpx.TimeoutException, httpx.NetworkError) as exc:
+        raise _TransientError(f"transport error: {exc}") from exc
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("archive.today save failed for %s: %s", url, exc)
+        return None
+
+    # Captcha sniff comes BEFORE the retryable-status check: archive.today
+    # serves its hcaptcha challenge with an HTTP 429, and re-submitting won't
+    # make a human appear. Skip the retry loop and surface a WARN.
+    body = response.text or ""
+    if _CAPTCHA_RE.search(body):
+        logger.warning("archive.today captcha; skipping for %s", url)
+        return None
+
+    if response.status_code in _RETRYABLE_STATUSES:
+        raise _TransientError(f"archive.today HTTP {response.status_code}")
+
+    if response.status_code >= 400:
+        logger.warning(
+            "archive.today save returned HTTP %s for %s",
+            response.status_code,
+            url,
+        )
+        return None
+
+    refresh = response.headers.get("Refresh")
+    if refresh:
+        target = _parse_refresh_header(refresh)
+        if target:
+            normalized = _normalize_archive_today_url(target)
+            if normalized:
+                return normalized
+
+    location = response.headers.get("Location")
+    if location:
+        normalized = _normalize_archive_today_url(location)
+        if normalized:
+            return normalized
+
+    final_url = str(response.url)
+    if final_url and final_url != submit_url:
+        normalized = _normalize_archive_today_url(final_url)
+        if normalized:
+            return normalized
+
+    return None
+
+
+async def archive_today_save(url: str, timeout: float = 30.0) -> str | None:
+    """Submit ``url`` to archive.today and return the canonical archive URL.
+
+    Used as a Wayback fallback for paywalled / JS-heavy / robots-blocked
+    sites where Save Page Now returns a 404 or refuses. Mirrors :func:`save`'s
+    contract: never raises, returns None on any error after retries.
+    Rate-limited at 0.2 RPS per host (separately from Wayback).
+    """
+    if not url:
+        return None
+
+    headers = {"User-Agent": _resolve_user_agent()}
+
+    await _archive_today_rate_limit_gate()
+
+    try:
+        async for attempt in tenacity.AsyncRetrying(
+            stop=tenacity.stop_after_attempt(3),
+            wait=tenacity.wait_exponential(multiplier=1, min=1, max=8),
+            retry=tenacity.retry_if_exception_type(_TransientError),
+            reraise=False,
+        ):
+            with attempt:
+                return await _attempt_archive_today(url, headers, timeout)
+    except tenacity.RetryError as exc:
+        underlying: BaseException | tenacity.RetryError = exc
+        if exc.last_attempt is not None and exc.last_attempt.failed:
+            underlying = exc.last_attempt.exception() or exc
+        logger.warning(
+            "archive.today save failed after retries for %s: %s", url, underlying
+        )
+
+    return None
+
+
 def reset_for_tests() -> None:
     """Clear per-process rate-limit state. Test-only."""
     global _last_save_monotonic, _rate_lock
+    global _last_archive_today_monotonic, _archive_today_lock
     _last_save_monotonic = None
     _rate_lock = asyncio.Lock()
+    _last_archive_today_monotonic = None
+    _archive_today_lock = asyncio.Lock()
 
 
-__all__ = ["save", "reset_for_tests"]
+__all__ = ["save", "archive_today_save", "reset_for_tests"]

--- a/src/research_agent/tools/web_fetch.py
+++ b/src/research_agent/tools/web_fetch.py
@@ -243,11 +243,13 @@ async def _fetch_via_playwright(url: str, timeout: float) -> str | None:
 
 
 def _spawn_archive_task(source: Source) -> asyncio.Task[None] | None:
-    """Kick off ``archive.save`` and write the result back onto ``source``.
+    """Kick off Wayback save (with archive.today fallback) and write the
+    result back onto ``source``.
 
-    Returns the spawned task so callers (and tests) can opt into awaiting it,
-    but the standard contract is fire-and-forget — Wayback failure never
-    blocks ``fetch`` from returning.
+    Wayback Save Page Now is the primary; on None (404, robots-block, repeated
+    timeout) we try archive.today before giving up. Both stay inside the same
+    fire-and-forget background task so ``fetch`` still returns immediately.
+    Returns the spawned task so tests can opt into awaiting it.
     """
     try:
         loop = asyncio.get_running_loop()
@@ -259,9 +261,25 @@ def _spawn_archive_task(source: Source) -> asyncio.Task[None] | None:
             archive_url = await archive.save(source.url)
         except Exception as exc:  # noqa: BLE001
             logger.debug("wayback save raised for %s: %s", source.url, exc)
-            return
+            archive_url = None
+
+        if archive_url is None:
+            try:
+                archive_url = await archive.archive_today_save(source.url)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "archive.today save raised for %s: %s", source.url, exc
+                )
+                archive_url = None
+
         if archive_url:
             source.archive_url = archive_url
+            return
+
+        logger.warning(
+            "archive_failed url=%s wayback=failed archive_today=failed",
+            source.url,
+        )
 
     return loop.create_task(_runner())
 

--- a/tests/test_tools_archive.py
+++ b/tests/test_tools_archive.py
@@ -19,10 +19,12 @@ class _FakeResponse:
         status_code: int = 200,
         headers: dict[str, str] | None = None,
         url: str = "",
+        text: str = "",
     ) -> None:
         self.status_code = status_code
         self.headers = headers or {}
         self.url = url
+        self.text = text
 
 
 def _patch_client(monkeypatch, on_get):
@@ -315,4 +317,243 @@ async def test_save_rate_limits_concurrent_calls(monkeypatch):
     # rate-limit interval (no real time passed between the two acquires).
     assert any(s >= archive._RATE_LIMIT_INTERVAL for s in sleep_calls), (
         f"expected a sleep ≥ {archive._RATE_LIMIT_INTERVAL}s, got {sleep_calls!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #106 — archive.today fallback
+# ---------------------------------------------------------------------------
+
+
+def _patch_client_post(monkeypatch, on_post):
+    """Replace ``httpx.AsyncClient`` with a fake whose ``post`` is ``on_post``.
+
+    ``on_post(url, data, headers)`` returns a :class:`_FakeResponse`.
+    Mirrors :func:`_patch_client` but for archive.today's POST submission.
+    """
+    captured: dict[str, object] = {"call_count": 0, "posts": []}
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        captured["init_kwargs"] = kwargs
+        init_headers = kwargs.get("headers", {})
+
+        class _Client:
+            async def post(self, url, *args, data=None, **kwargs):
+                captured["call_count"] = int(captured["call_count"]) + 1
+                captured["last_url"] = url
+                captured["last_data"] = data
+                merged = dict(init_headers)
+                merged.update(kwargs.get("headers", {}))
+                captured["last_headers"] = merged
+                posts_list = captured.setdefault("posts", [])
+                assert isinstance(posts_list, list)
+                posts_list.append({"url": url, "data": data})
+                return on_post(url, data, merged)
+
+        yield _Client()
+
+    monkeypatch.setattr(archive.httpx, "AsyncClient", _client_factory)
+    return captured
+
+
+async def test_archive_today_save_returns_url_from_refresh_header(monkeypatch):
+    captured = _patch_client_post(
+        monkeypatch,
+        lambda url, data, _h: _FakeResponse(
+            headers={"Refresh": "0; url=https://archive.today/abc12"},
+        ),
+    )
+
+    result = await archive.archive_today_save("https://x.example/y")
+    assert result == "https://archive.today/abc12"
+    assert captured["last_url"] == "https://archive.today/submit/"
+    # Must be form-encoded body (passed via ``data``), NOT a query string.
+    assert captured["last_data"] == {"url": "https://x.example/y"}
+
+
+async def test_archive_today_save_returns_url_from_location_header(monkeypatch):
+    _patch_client_post(
+        monkeypatch,
+        lambda url, data, _h: _FakeResponse(
+            headers={"Location": "https://archive.today/abc12"},
+        ),
+    )
+    assert (
+        await archive.archive_today_save("https://x.example/y")
+        == "https://archive.today/abc12"
+    )
+
+
+async def test_archive_today_save_normalises_archive_ph_to_today(monkeypatch):
+    _patch_client_post(
+        monkeypatch,
+        lambda url, data, _h: _FakeResponse(
+            headers={"Location": "https://archive.ph/abc12"},
+        ),
+    )
+    # archive.ph and archive.today are aliases; only archive.today is canonical.
+    assert (
+        await archive.archive_today_save("https://x.example/y")
+        == "https://archive.today/abc12"
+    )
+
+
+async def test_archive_today_save_uses_response_url_when_no_headers(monkeypatch):
+    final = "https://archive.today/abc12"
+    _patch_client_post(
+        monkeypatch,
+        lambda url, data, _h: _FakeResponse(headers={}, url=final),
+    )
+    assert await archive.archive_today_save("https://x.example/y") == final
+
+
+async def test_archive_today_save_sends_user_agent_header(monkeypatch):
+    monkeypatch.setenv("RESEARCH_USER_AGENT", "custom-bot/3.0")
+    seen: dict[str, str] = {}
+
+    def _on_post(url, data, headers):
+        seen.update(headers)
+        return _FakeResponse(headers={"Location": "https://archive.today/abc"})
+
+    _patch_client_post(monkeypatch, _on_post)
+    await archive.archive_today_save("https://x.example")
+    assert seen.get("User-Agent") == "custom-bot/3.0"
+
+
+async def test_archive_today_save_returns_none_on_4xx(monkeypatch):
+    _patch_client_post(monkeypatch, lambda url, data, _h: _FakeResponse(status_code=404))
+    assert await archive.archive_today_save("https://x.example/y") is None
+
+
+async def test_archive_today_save_returns_none_on_5xx_after_retries(monkeypatch, caplog):
+    captured = _patch_client_post(
+        monkeypatch, lambda url, data, _h: _FakeResponse(status_code=503)
+    )
+    with caplog.at_level(logging.WARNING, logger=archive.logger.name):
+        result = await archive.archive_today_save("https://x.example/y")
+    assert result is None
+    assert captured["call_count"] == 3
+    assert any(
+        "archive.today save failed after retries" in rec.getMessage()
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING
+    )
+
+
+async def test_archive_today_save_returns_none_on_timeout(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def post(self, url, *args, **kwargs):
+                raise archive.httpx.TimeoutException("slow")
+
+        yield _Client()
+
+    monkeypatch.setattr(archive.httpx, "AsyncClient", _client_factory)
+    assert await archive.archive_today_save("https://x.example/y") is None
+
+
+async def test_archive_today_save_returns_none_on_connect_error(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def post(self, url, *args, **kwargs):
+                raise archive.httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(archive.httpx, "AsyncClient", _client_factory)
+    assert await archive.archive_today_save("https://x.example/y") is None
+
+
+async def test_archive_today_save_returns_none_for_empty_url(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        raise AssertionError("client should not be created for empty URL")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(archive.httpx, "AsyncClient", _client_factory)
+    assert await archive.archive_today_save("") is None
+
+
+async def test_archive_today_save_skips_on_captcha_body(monkeypatch, caplog):
+    """Captcha body in a 429 response must be detected and short-circuit retries.
+
+    archive.today serves its hcaptcha challenge with HTTP 429 + an HTML body
+    containing the word ``captcha``. Without sniffing the body we'd loop
+    through three retries on a challenge no automation can solve.
+    """
+    captcha_html = (
+        "<html><body><h1>One more step</h1>"
+        "<p>Please complete the security check (hcaptcha) to continue.</p>"
+        "</body></html>"
+    )
+    captured = _patch_client_post(
+        monkeypatch,
+        lambda url, data, _h: _FakeResponse(
+            status_code=429, text=captcha_html, headers={}
+        ),
+    )
+
+    with caplog.at_level(logging.WARNING, logger=archive.logger.name):
+        result = await archive.archive_today_save("https://x.example/y")
+
+    assert result is None
+    # Captcha must skip retries — exactly one POST, not three.
+    assert captured["call_count"] == 1
+    assert any(
+        "archive.today captcha" in rec.getMessage()
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING
+    )
+
+
+async def test_archive_today_save_ignores_submit_url_as_archive(monkeypatch):
+    """If the final response.url is the bare /submit/ form, that's not an
+    archive landing page — return None rather than a fake archive link."""
+    _patch_client_post(
+        monkeypatch,
+        lambda url, data, _h: _FakeResponse(
+            headers={}, url="https://archive.today/submit/"
+        ),
+    )
+    assert await archive.archive_today_save("https://x.example/y") is None
+
+
+async def test_archive_today_save_rate_limits_concurrent_calls(monkeypatch):
+    """Two concurrent archive.today calls must serialise, with the second
+    sleeping at least ``_ARCHIVE_TODAY_RATE_INTERVAL`` before its submission."""
+    clock = [100.0]
+
+    def fake_monotonic() -> float:
+        return clock[0]
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        clock[0] += seconds
+
+    monkeypatch.setattr(archive.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(archive.asyncio, "sleep", fake_sleep)
+
+    _patch_client_post(
+        monkeypatch,
+        lambda url, data, _h: _FakeResponse(
+            headers={"Location": "https://archive.today/" + str(data["url"])[-3:]},
+        ),
+    )
+
+    results = await asyncio.gather(
+        archive.archive_today_save("https://a.example"),
+        archive.archive_today_save("https://b.example"),
+    )
+
+    assert all(r is not None for r in results)
+    assert any(
+        s >= archive._ARCHIVE_TODAY_RATE_INTERVAL for s in sleep_calls
+    ), (
+        f"expected a sleep ≥ {archive._ARCHIVE_TODAY_RATE_INTERVAL}s, "
+        f"got {sleep_calls!r}"
     )

--- a/tests/test_tools_web_fetch.py
+++ b/tests/test_tools_web_fetch.py
@@ -210,12 +210,21 @@ def _disable_robots(monkeypatch):
 
 
 def _stub_archive(monkeypatch, archive_url: str | None = None):
-    """Replace the Wayback save with an instant no-op (or a fixed return)."""
+    """Replace Wayback save (and the archive.today fallback) with no-ops.
+
+    Both saves are stubbed because :func:`_spawn_archive_task` falls through
+    to archive.today when Wayback returns None — without a stub the test
+    would hit the real archive.today endpoint.
+    """
 
     async def _save(url, timeout: float = 30.0):
         return archive_url
 
+    async def _archive_today_save(url, timeout: float = 30.0):
+        return None
+
     monkeypatch.setattr(web_fetch.archive, "save", _save)
+    monkeypatch.setattr(web_fetch.archive, "archive_today_save", _archive_today_save)
 
 
 async def test_fetch_returns_source_via_httpx(monkeypatch):
@@ -383,7 +392,11 @@ async def test_fetch_does_not_crash_when_archive_save_raises(monkeypatch):
     async def _boom(url, timeout: float = 30.0):
         raise RuntimeError("wayback exploded")
 
+    async def _archive_today_none(url, timeout: float = 30.0):
+        return None
+
     monkeypatch.setattr(web_fetch.archive, "save", _boom)
+    monkeypatch.setattr(web_fetch.archive, "archive_today_save", _archive_today_none)
 
     async def _fake_httpx(url, timeout, user_agent):
         return 200, ARTICLE_HTML, ARTICLE_HTML.encode("utf-8"), "text/html"
@@ -396,6 +409,75 @@ async def test_fetch_does_not_crash_when_archive_save_raises(monkeypatch):
     await asyncio.sleep(0)
     await asyncio.sleep(0)
     assert source.archive_url is None
+
+
+async def test_fetch_falls_back_to_archive_today_when_wayback_fails(monkeypatch):
+    """Wayback returning None must trigger the archive.today fallback, with
+    the archive.today URL written back onto the Source."""
+    _disable_robots(monkeypatch)
+
+    archive_today_completed = asyncio.Event()
+
+    async def _wayback_save(url, timeout: float = 30.0):
+        return None  # Wayback refuses (404, robots-blocked, etc.)
+
+    async def _archive_today_save(url, timeout: float = 30.0):
+        archive_today_completed.set()
+        return "https://archive.today/abc12"
+
+    monkeypatch.setattr(web_fetch.archive, "save", _wayback_save)
+    monkeypatch.setattr(web_fetch.archive, "archive_today_save", _archive_today_save)
+
+    async def _fake_httpx(url, timeout, user_agent):
+        return 200, ARTICLE_HTML, ARTICLE_HTML.encode("utf-8"), "text/html"
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _fake_httpx)
+
+    source = await web_fetch.fetch("https://x.example/y")
+    assert source is not None
+    await archive_today_completed.wait()
+    await asyncio.sleep(0)
+    assert source.archive_url == "https://archive.today/abc12"
+
+
+async def test_fetch_logs_warning_when_both_archives_fail(monkeypatch, caplog):
+    """When both Wayback and archive.today return None, we surface a WARN
+    with both errors so the operator can see the archive_failed signal."""
+    import logging
+
+    _disable_robots(monkeypatch)
+
+    failures_complete = asyncio.Event()
+
+    async def _wayback_save(url, timeout: float = 30.0):
+        return None
+
+    async def _archive_today_save(url, timeout: float = 30.0):
+        failures_complete.set()
+        return None
+
+    monkeypatch.setattr(web_fetch.archive, "save", _wayback_save)
+    monkeypatch.setattr(web_fetch.archive, "archive_today_save", _archive_today_save)
+
+    async def _fake_httpx(url, timeout, user_agent):
+        return 200, ARTICLE_HTML, ARTICLE_HTML.encode("utf-8"), "text/html"
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _fake_httpx)
+
+    with caplog.at_level(logging.WARNING, logger=web_fetch.logger.name):
+        source = await web_fetch.fetch("https://x.example/y")
+        assert source is not None
+        await failures_complete.wait()
+        await asyncio.sleep(0)
+
+    assert source.archive_url is None
+    assert any(
+        "archive_failed" in rec.getMessage()
+        and "wayback=failed" in rec.getMessage()
+        and "archive_today=failed" in rec.getMessage()
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #106
Part of #107

## Summary

Automated implementation of **archive.today connector (Wayback fallback)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

archive.today fallback connector fully implemented and wired into web_fetch; all 30 archive tests + 31 web_fetch tests pass; ACs satisfied.

- **INFO** [OPEN] `src/research_agent/tools/web_fetch.py`: Unified archive_failed WARN line emits 'wayback=failed archive_today=failed' without per-path error detail. Underlying functions log their own WARN with specifics, so signal is still surfaced — but a single grep on 'archive_failed' won't show which mode each path failed in. Minor logging refinement only.
- **INFO** [OPEN] `src/research_agent/tools/archive.py`: _normalize_archive_today_url accepts any non-/submit path on archive.today/.ph (e.g. /wip/<id>, /newest/<host>). For save flows this is the right behavior since archive.today redirects to /wip/<id> while a snapshot is processing, but a future extension that uses lookup endpoints should add stricter path validation.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*