### PR TITLE
feat: Google Scholar connector via SERPAPI (case law + academic) (closes #114)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,10 @@ LDA_API_KEY=
 # `?api_token=<key>`. Public-benefit access requires emailing service desk
 # (acceptance not guaranteed); commercial pricing £2,250–£12,000/yr.
 OPENCORPORATES_API_KEY=
+
+# Optional: SERPAPI key used by `tools/scholar.py` to hit Google Scholar
+# (case law + academic articles). Plans start at $75/mo for 5k searches
+# across all engines (Scholar is one); per-query ≈ $0.015. Sign up at
+# https://serpapi.com/. Required for the scholar connector — the smoke
+# verb fails loudly when unset.
+SERPAPI_KEY=

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ that list, so there is no drift.
 | `DATA_GOV_API_KEY` | no | api.data.gov key (free w/ signup at <https://api.data.gov/signup/>) — used by `tools/fec.py` (OpenFEC). Authenticated tier is 1,000 req/hr; falls back to `DEMO_KEY` (~40 req/hr per IP) when unset. |
 | `LDA_API_KEY` | no | Senate Lobbying Disclosure Act API key (free, optional, register at <https://lda.senate.gov/api/register/>) — used by `tools/lda.py`. Anonymous works for low-volume; authenticated raises rate limits. Sent via `Authorization: Token <key>`. |
 | `OPENCORPORATES_API_KEY` | no | OpenCorporates API token — used by `tools/opencorporates.py`. Anonymous tier is ~50 calls/day with limited fields; richer fields require a token (sent as `?api_token=<key>`). Public-benefit access by emailing service desk; commercial pricing £2,250–£12,000/yr. |
+| `SERPAPI_KEY` | no | SERPAPI key — required by `tools/scholar.py` (Google Scholar engine, case law + academic). Plans start at $75/mo for 5k searches across all engines; per-query ≈ $0.015. Sign up at <https://serpapi.com/>. |
 
 ## LM Studio
 

--- a/src/research_agent/config.py
+++ b/src/research_agent/config.py
@@ -127,6 +127,15 @@ EXPECTED_ENV_KEYS: tuple[EnvKey, ...] = (
             " pricing £2,250–£12,000/yr."
         ),
     ),
+    EnvKey(
+        name="SERPAPI_KEY",
+        required=False,
+        description=(
+            "SERPAPI key for tools/scholar.py (Google Scholar engine, case law"
+            " + academic). Plans start at $75/mo for 5k searches across all"
+            " engines; per-query ≈ $0.015. Sign up at https://serpapi.com/."
+        ),
+    ),
 )
 
 

--- a/src/research_agent/doctor.py
+++ b/src/research_agent/doctor.py
@@ -184,6 +184,30 @@ def check_sqlite_wal() -> CheckResult:
     )
 
 
+def check_serpapi_cost_note() -> CheckResult:
+    """Surface the per-query SERPAPI cost so the operator sees the spend trajectory.
+
+    SERPAPI bills per call (≈ $0.015 against the $75/mo / 5k-search plan), so
+    ``research doctor`` calls this out when ``SERPAPI_KEY`` is set. When the
+    key is unset the check skips — the scholar connector can't run anyway.
+    """
+    name = "serpapi_cost_note"
+    raw = os.environ.get("SERPAPI_KEY")
+    if not raw:
+        return CheckResult(
+            name,
+            "skip",
+            required=False,
+            detail="SERPAPI_KEY unset — scholar connector disabled",
+        )
+    return CheckResult(
+        name,
+        "ok",
+        required=False,
+        detail="per-query ≈ $0.015 against SERPAPI plan (5k/mo @ $75)",
+    )
+
+
 def check_models_yaml(path: Path) -> CheckResult:
     """Parse ``config/models.yaml`` — fail if missing or invalid YAML."""
     name = "models_yaml"
@@ -213,6 +237,7 @@ def run_all_checks(
     results.append(check_writable_dirs(root))
     results.append(check_sqlite_wal())
     results.append(check_models_yaml(root / "config" / "models.yaml"))
+    results.append(check_serpapi_cost_note())
     return results
 
 

--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -146,6 +146,41 @@ def _smoke_courtlistener(query: str) -> str:
     return asyncio.run(_run())
 
 
+def _smoke_scholar(query: str) -> str:
+    """Smoke wrapper: SERPAPI Google Scholar (case law) returning the top-5 hits.
+
+    Per AC: ``research _smoke-tool scholar "first amendment retaliation Ninth
+    Circuit"`` should surface case-law hits. Each line shows the case name,
+    court / journal summary, year, cited-by count, permalink, and snippet so
+    an operator can eyeball whether the SERPAPI key is healthy and the
+    Scholar engine is reachable.
+    """
+    from research_agent.tools import scholar
+
+    async def _run() -> str:
+        results = await scholar.search(query, kind="case_law", max_results=5)
+        if not results:
+            return f"scholar search returned no results for {query!r}"
+        lines: list[str] = []
+        for hit in results:
+            court_or_journal = hit.extras.get("court_or_journal") or "?"
+            year = (
+                hit.published_at.year if hit.published_at is not None else "?"
+            )
+            cited_by = hit.extras.get("citation") or 0
+            snippet = hit.snippet.replace("\n", " ")
+            if len(snippet) > 200:
+                snippet = snippet[:200] + "…"
+            lines.append(
+                f"- {hit.title} — {court_or_journal} — {year} — cited-by {cited_by}\n"
+                f"  {hit.url}\n"
+                f"  {snippet}"
+            )
+        return "\n".join(lines)
+
+    return asyncio.run(_run())
+
+
 def _smoke_fedregister(query: str) -> str:
     """Smoke wrapper: Federal Register search returning the top-5 hits.
 
@@ -1011,6 +1046,7 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "calaccess": _smoke_calaccess,
     "edgar": _smoke_edgar,
     "courtlistener": _smoke_courtlistener,
+    "scholar": _smoke_scholar,
     "fedregister": _smoke_fedregister,
     "nonprofits": _smoke_nonprofits,
     "fec": _smoke_fec,

--- a/src/research_agent/tools/models.py
+++ b/src/research_agent/tools/models.py
@@ -46,6 +46,7 @@ SourceKind = Literal[
     "licensing",
     "bbb",
     "calaccess",
+    "scholar",
 ]
 
 

--- a/src/research_agent/tools/scholar.py
+++ b/src/research_agent/tools/scholar.py
@@ -1,0 +1,430 @@
+"""Google Scholar connector via SERPAPI (issue #114).
+
+Public surface:
+
+* ``async def search(query, *, kind="case_law", max_results=20)`` — hits
+  SERPAPI's Google Scholar engine. ``kind`` selects ``case_law`` (court
+  opinions, ``as_sdt=2006``) vs ``articles`` (papers).
+* ``async def fetch(url, timeout=30.0)`` — opens a Scholar result. PDFs are
+  routed through :mod:`research_agent.tools.pdf`; HTML pages are extracted
+  with trafilatura. Returns a :class:`Source` with ``source_kind="scholar"``.
+
+SERPAPI bills per call (per-query ≈ $0.015 against the 5k/mo $75 plan), so
+the operator sees the spend trajectory via ``research doctor`` before
+launching a goal. ``SERPAPI_KEY`` is required and the connector raises
+``RuntimeError`` with a signup pointer when missing.
+
+A polite 1 RPS per-process gate sits in front of every call — SERPAPI itself
+doesn't throttle on the per-query axis but burning through the monthly
+quota in a tight loop is the same outcome with extra steps.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+import trafilatura
+
+from research_agent import config
+from research_agent.tools import pdf as pdf_tool
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://serpapi.com/search.json"
+# Only ``case_law`` adds ``as_sdt`` — articles search omits it.
+_KIND_TO_SDT: dict[str, str] = {"case_law": "2006"}
+_VALID_KINDS = frozenset({"case_law", "articles"})
+
+_RATE_LIMIT_INTERVAL = 1.0
+_CACHE_DIR = Path("corpus/.cache/scholar")
+
+# Per-query cost on SERPAPI's $75/mo / 5k-search plan. Surface via doctor.py
+# so an operator sees the spend trajectory before launching a goal.
+_SCHOLAR_COST_USD = 0.015
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+_YEAR_RE = re.compile(r"(?<!\d)(19\d{2}|20\d{2})(?!\d)")
+
+_rate_lock = asyncio.Lock()
+_last_call_monotonic: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Config / rate-limit helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_key() -> str:
+    """Return the configured SERPAPI key. Raise ``RuntimeError`` if missing.
+
+    SERPAPI is the only path to Google Scholar in this connector — a missing
+    key is a configuration error, not something to silently degrade.
+    """
+    key = config.get("SERPAPI_KEY") or ""
+    if not key.strip():
+        raise RuntimeError(
+            "Google Scholar connector requires a SERPAPI key. Sign up at "
+            "https://serpapi.com/ and set SERPAPI_KEY in your .env."
+        )
+    return key.strip()
+
+
+def _user_agent() -> str:
+    return config.get("RESEARCH_USER_AGENT") or (
+        "research-agent/0.1 (+local; contact unset)"
+    )
+
+
+async def _rate_limit_gate() -> None:
+    """Block until ``_RATE_LIMIT_INTERVAL`` seconds have elapsed since last call."""
+    global _last_call_monotonic
+    async with _rate_lock:
+        if _last_call_monotonic is not None:
+            elapsed = time.monotonic() - _last_call_monotonic
+            wait = _RATE_LIMIT_INTERVAL - elapsed
+            if wait > 0:
+                await asyncio.sleep(wait)
+        _last_call_monotonic = time.monotonic()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _strip_html(html: str) -> str:
+    return _WS_RE.sub(" ", _TAG_RE.sub(" ", html)).strip()
+
+
+def _extract_html_text(html: str) -> str:
+    if not html:
+        return ""
+    try:
+        extracted = trafilatura.extract(
+            html,
+            include_comments=False,
+            include_tables=True,
+            favor_recall=True,
+        )
+    except Exception:  # noqa: BLE001 — never crash on extractor errors
+        extracted = None
+    if extracted and extracted.strip():
+        return extracted.strip()
+    return _strip_html(html)
+
+
+def _parse_year(value: Any) -> datetime | None:
+    """Pull a 4-digit year out of ``value`` and return Jan 1 of that year UTC.
+
+    SERPAPI's ``publication_info.summary`` looks like
+    ``"Supreme Court, 2018 - scholar.google.com"`` for case law and
+    ``"J Smith, A Jones - Nature, 2021"`` for articles — both expose the
+    year, but the leading authors / court / journal vary, so a regex on the
+    whole string is the path of least resistance.
+    """
+    if not value:
+        return None
+    match = _YEAR_RE.search(str(value))
+    if not match:
+        return None
+    return datetime(int(match.group(1)), 1, 1, tzinfo=UTC)
+
+
+def _extract_title_from_html(html: str) -> str:
+    """Best-effort title extraction: ``og:title`` then ``<title>``."""
+    if not html:
+        return ""
+    og = re.search(
+        r'<meta[^>]+property=["\']og:title["\'][^>]+content=["\']([^"\']+)["\']',
+        html,
+        re.IGNORECASE,
+    )
+    if og:
+        return _strip_html(og.group(1))
+    title = re.search(r"<title[^>]*>([^<]+)</title>", html, re.IGNORECASE)
+    if title:
+        return _strip_html(title.group(1))
+    return ""
+
+
+def _build_search_result(
+    item: dict[str, Any], *, kind: str
+) -> SearchResult | None:
+    url = item.get("link") or ""
+    if not isinstance(url, str) or not url:
+        return None
+
+    title = item.get("title") or url
+    snippet_raw = item.get("snippet") or ""
+    snippet = _strip_html(str(snippet_raw))
+
+    pub_info = item.get("publication_info") or {}
+    summary = ""
+    if isinstance(pub_info, dict):
+        summary = str(pub_info.get("summary") or "")
+
+    published_at = _parse_year(summary)
+
+    inline_links = item.get("inline_links") or {}
+    cited_by_total: int = 0
+    if isinstance(inline_links, dict):
+        cited_by = inline_links.get("cited_by")
+        if isinstance(cited_by, dict):
+            total = cited_by.get("total")
+            if isinstance(total, int):
+                cited_by_total = total
+            elif isinstance(total, str) and total.isdigit():
+                cited_by_total = int(total)
+
+    raw_resources = item.get("resources") or []
+    resources: list[dict[str, Any]] = []
+    if isinstance(raw_resources, list):
+        for r in raw_resources:
+            if not isinstance(r, dict):
+                continue
+            resources.append(
+                {
+                    "title": r.get("title") or "",
+                    "link": r.get("link") or "",
+                    "file_format": r.get("file_format") or "",
+                }
+            )
+
+    extras: dict[str, Any] = {
+        "kind": kind,
+        "court_or_journal": summary,
+        "citation": cited_by_total,
+        "result_id": item.get("result_id") or "",
+        "resources": resources,
+    }
+
+    return SearchResult(
+        url=url,
+        title=str(title),
+        snippet=snippet,
+        published_at=published_at,
+        source_kind="scholar",
+        extras=extras,
+    )
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def search(
+    query: str,
+    *,
+    kind: str = "case_law",
+    max_results: int = 20,
+    timeout: float = 15.0,
+) -> list[SearchResult]:
+    """Run a Google Scholar search via SERPAPI and return up to ``max_results`` hits.
+
+    ``kind="case_law"`` adds ``as_sdt=2006`` to scope to court opinions;
+    ``kind="articles"`` is the unfiltered Scholar search. Returns ``[]`` on
+    transport / HTTP / JSON errors — connector failures must never crash the
+    planner.
+    """
+    if kind not in _VALID_KINDS:
+        raise ValueError(
+            f"unknown kind {kind!r}; expected one of {sorted(_VALID_KINDS)}"
+        )
+
+    api_key = _resolve_key()
+    params: dict[str, str] = {
+        "engine": "google_scholar",
+        "q": query,
+        "api_key": api_key,
+        # SERPAPI's google_scholar engine maxes out at 20 results per call.
+        "num": str(min(max(max_results, 1), 20)),
+    }
+    sdt = _KIND_TO_SDT.get(kind)
+    if sdt is not None:
+        params["as_sdt"] = sdt
+
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": _user_agent(),
+    }
+
+    await _rate_limit_gate()
+
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=headers,
+        ) as client:
+            response = await client.get(_BASE_URL, params=params)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("scholar search failed for %r: %s", query, exc)
+        return []
+
+    if response.status_code != 200:
+        logger.warning(
+            "scholar search returned HTTP %s for %r",
+            response.status_code,
+            query,
+        )
+        return []
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        logger.warning("scholar search returned non-JSON for %r: %s", query, exc)
+        return []
+
+    raw_hits = payload.get("organic_results") or []
+    out: list[SearchResult] = []
+    for hit in raw_hits[:max_results]:
+        if not isinstance(hit, dict):
+            continue
+        result = _build_search_result(hit, kind=kind)
+        if result is not None:
+            out.append(result)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+def _looks_like_pdf(url: str, content_type: str | None) -> bool:
+    if content_type and "application/pdf" in content_type.lower():
+        return True
+    parsed = urlparse(url)
+    return parsed.path.lower().endswith(".pdf")
+
+
+async def _probe_content_type(
+    client: httpx.AsyncClient, url: str
+) -> str | None:
+    """HEAD ``url`` to read ``Content-Type``. Falls back to a small GET on 405/403.
+
+    Some hosts (notably JSTOR mirrors) reject HEAD outright — when the response
+    isn't usable we let the caller fall through to a normal GET below.
+    """
+    try:
+        head = await client.head(url)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.debug("scholar HEAD failed for %s: %s", url, exc)
+        return None
+    if head.status_code in (403, 405, 501):
+        return None
+    if head.status_code >= 400:
+        return None
+    return head.headers.get("content-type")
+
+
+async def fetch(url: str, timeout: float = 30.0) -> Source | None:
+    """Open a Google Scholar result and return a :class:`Source`.
+
+    PDF results route through :func:`research_agent.tools.pdf.extract` (which
+    handles the layered text → tables → OCR → VLM pipeline) so we don't
+    duplicate caching / OCR logic here. HTML results go through trafilatura.
+
+    Returns ``None`` on any transport / HTTP / parse failure.
+    """
+    if not url:
+        return None
+
+    headers = {
+        "Accept": (
+            "text/html,application/xhtml+xml,application/xml;q=0.9,"
+            "application/pdf;q=0.8,*/*;q=0.5"
+        ),
+        "User-Agent": _user_agent(),
+    }
+
+    await _rate_limit_gate()
+
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=headers,
+        ) as client:
+            content_type = await _probe_content_type(client, url)
+            if _looks_like_pdf(url, content_type):
+                cleaned_text = await pdf_tool.extract(url)
+                if not cleaned_text:
+                    return None
+                return Source(
+                    url=url,
+                    title=url.rsplit("/", 1)[-1] or url,
+                    cleaned_text=cleaned_text,
+                    raw_html=None,
+                    fetched_at=datetime.now(UTC),
+                    source_kind="scholar",
+                    metadata={"content_type": "application/pdf"},
+                )
+
+            response = await client.get(url)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("scholar fetch failed for %s: %s", url, exc)
+        return None
+
+    if response.status_code >= 400:
+        logger.warning(
+            "scholar fetch returned HTTP %s for %s", response.status_code, url
+        )
+        return None
+
+    response_ct = response.headers.get("content-type") or ""
+    if _looks_like_pdf(url, response_ct):
+        # Server didn't expose Content-Type on HEAD but the GET body is a PDF;
+        # hand the raw bytes to the pdf module so we don't re-download.
+        cleaned_text = pdf_tool.extract_from_bytes(
+            response.content, source_label=url
+        )
+        if not cleaned_text:
+            return None
+        return Source(
+            url=url,
+            title=url.rsplit("/", 1)[-1] or url,
+            cleaned_text=cleaned_text,
+            raw_html=None,
+            fetched_at=datetime.now(UTC),
+            source_kind="scholar",
+            metadata={"content_type": "application/pdf"},
+        )
+
+    html = response.text or ""
+    cleaned_text = _extract_html_text(html)
+    if not cleaned_text:
+        return None
+
+    title = _extract_title_from_html(html) or url
+
+    return Source(
+        url=url,
+        title=title,
+        cleaned_text=cleaned_text,
+        raw_html=None,
+        fetched_at=datetime.now(UTC),
+        source_kind="scholar",
+        metadata={"content_type": response_ct},
+    )
+
+
+def reset_for_tests() -> None:
+    """Clear per-process rate-limit state. Test-only."""
+    global _last_call_monotonic, _rate_lock
+    _last_call_monotonic = None
+    _rate_lock = asyncio.Lock()
+
+
+__all__ = ["fetch", "reset_for_tests", "search"]

--- a/src/research_agent/tools/scholar.py
+++ b/src/research_agent/tools/scholar.py
@@ -26,7 +26,6 @@ import logging
 import re
 import time
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
@@ -45,7 +44,6 @@ _KIND_TO_SDT: dict[str, str] = {"case_law": "2006"}
 _VALID_KINDS = frozenset({"case_law", "articles"})
 
 _RATE_LIMIT_INTERVAL = 1.0
-_CACHE_DIR = Path("corpus/.cache/scholar")
 
 # Per-query cost on SERPAPI's $75/mo / 5k-search plan. Surface via doctor.py
 # so an operator sees the spend trajectory before launching a goal.

--- a/tests/test_tools_models.py
+++ b/tests/test_tools_models.py
@@ -40,6 +40,7 @@ EXPECTED_SOURCE_KINDS = (
     "licensing",
     "bbb",
     "calaccess",
+    "scholar",
 )
 
 

--- a/tests/test_tools_scholar.py
+++ b/tests/test_tools_scholar.py
@@ -1,0 +1,401 @@
+"""Tests for `research_agent.tools.scholar` (issue #114)."""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from research_agent.tools import scholar
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _set_key(monkeypatch):
+    monkeypatch.setenv("SERPAPI_KEY", "serp-test-1234567890abcdef")
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    scholar.reset_for_tests()
+    monkeypatch.setattr(scholar.asyncio, "sleep", AsyncMock())
+    yield
+    scholar.reset_for_tests()
+
+
+# Sample SERPAPI google_scholar payload — case_law shape.
+_SEARCH_PAYLOAD_CASES = {
+    "search_metadata": {"id": "abc"},
+    "organic_results": [
+        {
+            "position": 1,
+            "title": "Lozman v. City of Riviera Beach",
+            "result_id": "12345-lozman",
+            "link": (
+                "https://scholar.google.com/scholar_case?case=12345&hl=en"
+            ),
+            "snippet": (
+                "First Amendment <em>retaliation</em> arrest claim — held "
+                "probable cause does not bar the suit."
+            ),
+            "publication_info": {
+                "summary": "Supreme Court, 2018 - scholar.google.com",
+            },
+            "inline_links": {
+                "cited_by": {
+                    "total": 142,
+                    "link": "https://scholar.google.com/scholar?cites=12345",
+                }
+            },
+            "resources": [
+                {
+                    "title": "supremecourt.gov",
+                    "link": "https://www.supremecourt.gov/opinions/17pdf/17-21.pdf",
+                    "file_format": "PDF",
+                }
+            ],
+        },
+        {
+            "position": 2,
+            "title": "Doe v. Roe",
+            "result_id": "67890-doe",
+            "link": "https://scholar.google.com/scholar_case?case=67890",
+            "snippet": "9th Circuit retaliation case",
+            "publication_info": {
+                "summary": "9th Cir., 2021 - scholar.google.com",
+            },
+            "inline_links": {"cited_by": {"total": 8}},
+        },
+    ],
+}
+
+
+# Articles-shape payload — no court suffix, year embedded in publication info.
+_SEARCH_PAYLOAD_ARTICLES = {
+    "organic_results": [
+        {
+            "position": 1,
+            "title": "Sample Paper",
+            "result_id": "paper-1",
+            "link": "https://example.org/paper.pdf",
+            "snippet": "Abstract goes here",
+            "publication_info": {"summary": "J Smith, A Jones - Nature, 2022"},
+            "inline_links": {"cited_by": {"total": 3}},
+        }
+    ]
+}
+
+
+def _patch_httpx(monkeypatch, *, responder, head_responder=None):
+    """Replace ``httpx.AsyncClient`` with a fake driven by ``responder``.
+
+    ``responder(url, params)`` returns ``(status_code, body_text, headers)``.
+    ``head_responder`` is invoked for ``client.head(url)``; falls back to
+    ``responder`` when omitted.
+    """
+    captured: dict[str, list] = {
+        "urls": [],
+        "headers": [],
+        "params": [],
+        "head_urls": [],
+    }
+
+    class _FakeResp:
+        def __init__(
+            self,
+            status: int,
+            text: str,
+            headers: dict[str, str] | None = None,
+            content: bytes | None = None,
+        ) -> None:
+            self.status_code = status
+            self.text = text
+            self.headers = headers or {}
+            self.content = content if content is not None else text.encode()
+
+        def json(self):
+            return json.loads(self.text)
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        captured["headers"].append(kwargs.get("headers"))
+
+        class _Client:
+            async def get(self, url, *, params=None, **_kwargs):
+                captured["urls"].append(url)
+                captured["params"].append(params)
+                result = responder(url, params)
+                if len(result) == 3:
+                    status, text, headers = result
+                    return _FakeResp(status, text, headers)
+                if len(result) == 4:
+                    status, text, headers, content = result
+                    return _FakeResp(status, text, headers, content)
+                status, text = result
+                return _FakeResp(status, text)
+
+            async def head(self, url, **_kwargs):
+                captured["head_urls"].append(url)
+                fn = head_responder or responder
+                result = fn(url, None)
+                if len(result) == 3:
+                    status, text, headers = result
+                    return _FakeResp(status, text, headers)
+                status, text = result
+                return _FakeResp(status, text)
+
+        yield _Client()
+
+    monkeypatch.setattr(scholar.httpx, "AsyncClient", _client_factory)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def test_search_case_law_includes_as_sdt_and_parses_fields(monkeypatch):
+    payload = json.dumps(_SEARCH_PAYLOAD_CASES)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await scholar.search(
+        "first amendment retaliation Ninth Circuit", kind="case_law"
+    )
+
+    assert len(results) == 2
+    params = captured["params"][0]
+    assert params["engine"] == "google_scholar"
+    assert params["q"] == "first amendment retaliation Ninth Circuit"
+    assert params["api_key"] == "serp-test-1234567890abcdef"
+    assert params["as_sdt"] == "2006"
+    assert captured["urls"][0] == scholar._BASE_URL
+
+    first = results[0]
+    assert first.source_kind == "scholar"
+    assert first.url == (
+        "https://scholar.google.com/scholar_case?case=12345&hl=en"
+    )
+    assert first.title == "Lozman v. City of Riviera Beach"
+    # Snippet is HTML-stripped.
+    assert "<em>" not in first.snippet
+    assert "retaliation" in first.snippet
+    assert first.published_at is not None
+    assert first.published_at.year == 2018
+    assert first.extras["kind"] == "case_law"
+    assert "Supreme Court" in first.extras["court_or_journal"]
+    assert first.extras["citation"] == 142
+    assert first.extras["result_id"] == "12345-lozman"
+    assert first.extras["resources"][0]["file_format"] == "PDF"
+
+
+async def test_search_articles_omits_as_sdt(monkeypatch):
+    payload = json.dumps(_SEARCH_PAYLOAD_ARTICLES)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await scholar.search("attention is all you need", kind="articles")
+
+    params = captured["params"][0]
+    assert "as_sdt" not in params
+    assert params["engine"] == "google_scholar"
+    assert len(results) == 1
+    assert results[0].extras["kind"] == "articles"
+    assert results[0].published_at is not None
+    assert results[0].published_at.year == 2022
+
+
+async def test_search_unknown_kind_raises():
+    with pytest.raises(ValueError, match="unknown kind"):
+        await scholar.search("anything", kind="bogus")
+
+
+async def test_search_returns_empty_on_500(monkeypatch):
+    def _respond(url, params):
+        return 500, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await scholar.search("anything") == []
+
+
+async def test_search_returns_empty_on_non_json(monkeypatch):
+    def _respond(url, params):
+        return 200, "<html>not json</html>"
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await scholar.search("anything") == []
+
+
+async def test_search_returns_empty_on_transport_error(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(scholar.httpx, "AsyncClient", _client_factory)
+
+    assert await scholar.search("anything") == []
+
+
+async def test_search_raises_when_key_missing(monkeypatch):
+    monkeypatch.delenv("SERPAPI_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="serpapi.com"):
+        await scholar.search("anything")
+
+
+async def test_search_max_results_caps_output(monkeypatch):
+    payload = json.dumps(_SEARCH_PAYLOAD_CASES)
+
+    def _respond(url, params):
+        return 200, payload
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await scholar.search("anything", max_results=1)
+
+    assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+_HTML_BODY = (
+    "<html>"
+    "<head>"
+    '<meta property="og:title" content="Sample Opinion"/>'
+    "<title>fallback title</title>"
+    "</head>"
+    "<body>"
+    "<article><p>This is the body of the opinion. It is long enough that"
+    " trafilatura's recall mode will pick it up as the main content of the"
+    " page rather than discarding the document.</p></article>"
+    "</body>"
+    "</html>"
+)
+
+
+async def test_fetch_html_returns_source(monkeypatch):
+    def _respond(url, params):
+        return 200, _HTML_BODY, {"content-type": "text/html; charset=utf-8"}
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await scholar.fetch("https://scholar.google.com/example")
+
+    assert source is not None
+    assert source.source_kind == "scholar"
+    assert source.url == "https://scholar.google.com/example"
+    assert source.title == "Sample Opinion"
+    assert "body of the opinion" in source.cleaned_text
+    assert source.metadata["content_type"].startswith("text/html")
+
+
+async def test_fetch_pdf_routes_through_pdf_module(monkeypatch):
+    extracted = "## Page 1\n\nMarkdown rendition of the PDF body."
+
+    async def _fake_extract(url, **_kwargs):
+        return extracted
+
+    monkeypatch.setattr(scholar.pdf_tool, "extract", _fake_extract)
+
+    def _respond(url, params):
+        # HEAD returns Content-Type: application/pdf so the fetch short-circuits
+        # before the full GET.
+        return 200, "", {"content-type": "application/pdf"}
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await scholar.fetch("https://example.org/doc.pdf")
+
+    assert source is not None
+    assert source.source_kind == "scholar"
+    assert source.cleaned_text == extracted
+    assert source.metadata["content_type"] == "application/pdf"
+    # We never issued a GET — only a HEAD probe.
+    assert captured["head_urls"] == ["https://example.org/doc.pdf"]
+    assert captured["urls"] == []
+
+
+async def test_fetch_pdf_via_url_extension_when_head_blocked(monkeypatch):
+    extracted = "## Page 1\n\nFallback PDF body."
+
+    async def _fake_extract(url, **_kwargs):
+        return extracted
+
+    monkeypatch.setattr(scholar.pdf_tool, "extract", _fake_extract)
+
+    def _respond(url, params):
+        # HEAD returns 405; the URL ends with .pdf so we still treat as PDF.
+        return 405, "", {}
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await scholar.fetch("https://example.org/paper.pdf")
+
+    assert source is not None
+    assert source.cleaned_text == extracted
+    assert source.metadata["content_type"] == "application/pdf"
+
+
+async def test_fetch_returns_none_on_http_error(monkeypatch):
+    def _respond(url, params):
+        return 500, "", {"content-type": "text/html"}
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await scholar.fetch("https://scholar.google.com/example")
+    assert source is None
+
+
+async def test_fetch_returns_none_on_transport_error(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def head(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(scholar.httpx, "AsyncClient", _client_factory)
+
+    assert await scholar.fetch("https://scholar.google.com/example") is None
+
+
+async def test_fetch_empty_url_returns_none():
+    assert await scholar.fetch("") is None
+
+
+# ---------------------------------------------------------------------------
+# Smoke registration
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_registry_includes_scholar():
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "scholar" in TOOL_REGISTRY


### PR DESCRIPTION
Closes #114
Part of #107

## Summary

Automated implementation of **Google Scholar connector via SERPAPI (case law + academic)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

All AC met for #114 (search/fetch/SERPAPI auth/rate-limit/smoke/doctor cost note); removed one dead-code constant.

- **INFO** [FIXED] `src/research_agent/tools/scholar.py`: Unused _CACHE_DIR constant (and Path import) in tools/scholar.py — copy-pasta from sibling paid-API connectors that actually persist responses; scholar.py never reads or writes to it.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*