### PR TITLE
feat: LinkedIn connector via Proxycurl / Lix (employment + networks) (closes #115)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,3 +71,19 @@ OPENCORPORATES_API_KEY=
 # https://serpapi.com/. Required for the scholar connector — the smoke
 # verb fails loudly when unset.
 SERPAPI_KEY=
+
+# Optional: LinkedIn data-broker key used by `tools/linkedin.py`. Default
+# broker is Proxycurl (https://nubela.co/proxycurl/), per-lookup ≈
+# $0.01–$0.05. Required for the linkedin connector — gate fetches behind
+# explicit planner tasks; synth/critique should NOT auto-fetch every
+# profile mentioned. Switch to Lix by setting LINKEDIN_BROKER=lix and
+# providing LIX_API_KEY instead.
+LINKEDIN_DATA_API_KEY=
+
+# Optional: broker recipe used by `tools/linkedin.py`. 'proxycurl'
+# (default) consults LINKEDIN_DATA_API_KEY; 'lix' consults LIX_API_KEY.
+LINKEDIN_BROKER=
+
+# Optional: Lix data-broker key (https://lix-it.com/) — only consulted
+# when LINKEDIN_BROKER=lix. Similar per-lookup pricing to Proxycurl.
+LIX_API_KEY=

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ that list, so there is no drift.
 | `LDA_API_KEY` | no | Senate Lobbying Disclosure Act API key (free, optional, register at <https://lda.senate.gov/api/register/>) — used by `tools/lda.py`. Anonymous works for low-volume; authenticated raises rate limits. Sent via `Authorization: Token <key>`. |
 | `OPENCORPORATES_API_KEY` | no | OpenCorporates API token — used by `tools/opencorporates.py`. Anonymous tier is ~50 calls/day with limited fields; richer fields require a token (sent as `?api_token=<key>`). Public-benefit access by emailing service desk; commercial pricing £2,250–£12,000/yr. |
 | `SERPAPI_KEY` | no | SERPAPI key — required by `tools/scholar.py` (Google Scholar engine, case law + academic). Plans start at $75/mo for 5k searches across all engines; per-query ≈ $0.015. Sign up at <https://serpapi.com/>. |
+| `LINKEDIN_DATA_API_KEY` | no | LinkedIn data-broker key (default broker: Proxycurl) — required by `tools/linkedin.py`. Per-lookup ≈ $0.01–$0.05; gate fetches behind explicit planner tasks. Sign up at <https://nubela.co/proxycurl/>. |
+| `LINKEDIN_BROKER` | no | Broker recipe used by `tools/linkedin.py`. `proxycurl` (default) or `lix`; switching to `lix` consults `LIX_API_KEY` instead of `LINKEDIN_DATA_API_KEY`. |
+| `LIX_API_KEY` | no | Lix data-broker key (<https://lix-it.com/>) — only consulted when `LINKEDIN_BROKER=lix`. Similar per-lookup pricing to Proxycurl. |
 
 ## LM Studio
 

--- a/docs/API_KEYS.md
+++ b/docs/API_KEYS.md
@@ -77,12 +77,14 @@ explicitly per #113).
 | Connector | Issue | Env var | Where to get it | Approx cost |
 |---|---|---|---|---|
 | Google Scholar via SERPAPI | #114 | `SERPAPI_KEY` | <https://serpapi.com/users/sign_up> | $75/mo for 5K queries (Scholar is one engine of many they offer) |
-| LinkedIn via Proxycurl | #115 | `PROXYCURL_API_KEY` (or `LINKEDIN_DATA_API_KEY` if using a different broker) | <https://nubela.co/proxycurl/> → Sign up → API Key | $0.01–$0.05 per profile lookup |
+| LinkedIn via Proxycurl (default broker) | #115 | `LINKEDIN_DATA_API_KEY` | <https://nubela.co/proxycurl/> → Sign up → API Key | $0.01–$0.05 per profile lookup |
+| LinkedIn via Lix (alternate broker) | #115 | `LIX_API_KEY` (set `LINKEDIN_BROKER=lix` to switch) | <https://lix-it.com/> → Sign up | Similar per-lookup pricing to Proxycurl |
 
-For LinkedIn specifically, brokers other than Proxycurl (Lix, RapidAPI
-LinkedIn proxies, etc.) work too — the connector should be
-broker-pluggable. Use whichever broker your wallet and TOS comfort
-allow.
+For LinkedIn the connector is **broker-pluggable**: `LINKEDIN_BROKER`
+selects the recipe (`proxycurl` by default, or `lix`). Each broker
+reads its own key — see the rows above. Adding another broker is a
+recipe-layer change in `tools/linkedin.py`. Use whichever broker your
+wallet and TOS comfort allow.
 
 ---
 

--- a/src/research_agent/config.py
+++ b/src/research_agent/config.py
@@ -136,6 +136,33 @@ EXPECTED_ENV_KEYS: tuple[EnvKey, ...] = (
             " engines; per-query ≈ $0.015. Sign up at https://serpapi.com/."
         ),
     ),
+    EnvKey(
+        name="LINKEDIN_DATA_API_KEY",
+        required=False,
+        description=(
+            "LinkedIn data-broker key for tools/linkedin.py (default broker:"
+            " Proxycurl). Per-lookup billing ≈ $0.01–$0.05; gate fetches"
+            " behind explicit planner tasks. Sign up at https://nubela.co/proxycurl/."
+        ),
+    ),
+    EnvKey(
+        name="LINKEDIN_BROKER",
+        required=False,
+        description=(
+            "Broker recipe used by tools/linkedin.py. 'proxycurl' (default)"
+            " or 'lix'. Switching to lix consults LIX_API_KEY instead of"
+            " LINKEDIN_DATA_API_KEY."
+        ),
+        default="proxycurl",
+    ),
+    EnvKey(
+        name="LIX_API_KEY",
+        required=False,
+        description=(
+            "Lix data-broker key (https://lix-it.com/) consulted only when"
+            " LINKEDIN_BROKER=lix. Similar per-lookup pricing to Proxycurl."
+        ),
+    ),
 )
 
 

--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -251,6 +251,64 @@ def _smoke_nonprofits(query: str) -> str:
     return asyncio.run(_run())
 
 
+def _smoke_linkedin(query: str) -> str:
+    """Smoke wrapper: LinkedIn person search + top-hit profile rollup.
+
+    Per AC: ``research _smoke-tool linkedin "George Santos"`` should
+    return the canonical profile via the configured broker (Proxycurl by
+    default). Lists the top-5 person hits with current title / company /
+    location / permalink, then attempts ``fetch()`` on the top hit and
+    prints current title, current company, employment count, and
+    education count so an operator can eyeball broker health.
+    """
+    from research_agent.tools import linkedin
+
+    async def _run() -> str:
+        results = await linkedin.search(query, kind="person", max_results=5)
+        if not results:
+            return f"linkedin search returned no results for {query!r}"
+        lines: list[str] = []
+        for hit in results:
+            current_title = hit.extras.get("current_title") or "?"
+            current_company = hit.extras.get("current_company") or "?"
+            location = hit.extras.get("location") or "?"
+            broker = hit.extras.get("broker") or "?"
+            snippet = hit.snippet.replace("\n", " ")
+            if len(snippet) > 200:
+                snippet = snippet[:200] + "…"
+            lines.append(
+                f"- {hit.title} — {current_title} @ {current_company} —"
+                f" {location} — broker {broker}\n"
+                f"  {hit.url}\n"
+                f"  {snippet}"
+            )
+
+        top = results[0]
+        source = await linkedin.fetch(top.url)
+        if source is None:
+            lines.append(
+                f"\nfetch({top.url}) returned None — broker call failed"
+            )
+        else:
+            employment = source.metadata.get("employment_history") or []
+            education = source.metadata.get("education") or []
+            current_title = ""
+            current_company = ""
+            if employment:
+                first = employment[0]
+                if isinstance(first, dict):
+                    current_title = str(first.get("title") or "")
+                    current_company = str(first.get("company") or "")
+            lines.append(f"\nProfile for {top.title}")
+            lines.append(f"  current_title: {current_title or '?'}")
+            lines.append(f"  current_company: {current_company or '?'}")
+            lines.append(f"  employment_count: {len(employment)}")
+            lines.append(f"  education_count: {len(education)}")
+        return "\n".join(lines)
+
+    return asyncio.run(_run())
+
+
 def _smoke_fec(query: str) -> str:
     """Smoke wrapper: FEC OpenFEC candidate search + top-hit cycle totals.
 
@@ -1047,6 +1105,7 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "edgar": _smoke_edgar,
     "courtlistener": _smoke_courtlistener,
     "scholar": _smoke_scholar,
+    "linkedin": _smoke_linkedin,
     "fedregister": _smoke_fedregister,
     "nonprofits": _smoke_nonprofits,
     "fec": _smoke_fec,

--- a/src/research_agent/tools/linkedin.py
+++ b/src/research_agent/tools/linkedin.py
@@ -1,0 +1,893 @@
+"""LinkedIn connector via third-party data broker (Proxycurl / Lix) — issue #115.
+
+Public surface:
+
+* ``async def search(query, *, kind="person", max_results=10)`` — hits the
+  configured broker's person/company search endpoint and returns
+  :class:`SearchResult` rows (name / company name, headline, location,
+  profile URL).
+* ``async def fetch(url)`` — accepts a ``linkedin.com/in/<slug>`` or
+  ``linkedin.com/company/<slug>`` URL and returns a :class:`Source` with
+  the rolled-up profile (employment, education, certifications, skills, or
+  the parallel company facts: headcount, industry, locations).
+
+LinkedIn has no official public API and direct scraping is TOS-blocked, so
+we route through a data broker. The connector is **broker-pluggable**: the
+default broker is Proxycurl (``LINKEDIN_BROKER=proxycurl``, key
+``LINKEDIN_DATA_API_KEY``) and an alternate Lix recipe is wired in
+(``LINKEDIN_BROKER=lix``, key ``LIX_API_KEY``). New brokers slot in by
+adding a recipe to ``_BROKERS``.
+
+**Per-lookup cost matters.** Both Proxycurl and Lix bill ≈ $0.01–$0.05 per
+profile lookup. The orchestrator's synth/critique passes must NOT
+auto-fetch every LinkedIn URL they encounter — fetches happen only when
+the planner explicitly emits a ``linkedin_fetch`` task in
+``tactical_replan`` after seeing the initial search results. A 1 RPS
+per-process gate sits in front of every call as cheap insurance against
+runaway loops.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from research_agent import config
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+_FETCH_INTERVAL = 1.0
+
+_PERSON_URL_RE = re.compile(r"^https?://(www\.)?linkedin\.com/in/[^/?#]+/?", re.IGNORECASE)
+_COMPANY_URL_RE = re.compile(
+    r"^https?://(www\.)?linkedin\.com/company/[^/?#]+/?", re.IGNORECASE
+)
+
+_VALID_KINDS = frozenset({"person", "company"})
+
+_rate_lock = asyncio.Lock()
+_last_call_monotonic: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Broker recipes
+# ---------------------------------------------------------------------------
+#
+# Each broker entry exposes the same callable shape so the upper layer can
+# stay broker-agnostic. Adding a new broker means dropping a new entry into
+# ``_BROKERS`` — the rest of the module reads only via these recipe hooks.
+
+
+def _split_query(query: str) -> tuple[str, str]:
+    parts = query.strip().split()
+    if not parts:
+        return "", ""
+    if len(parts) == 1:
+        return parts[0], ""
+    return parts[0], " ".join(parts[1:])
+
+
+# --- Proxycurl ----------------------------------------------------------------
+
+
+_PROXYCURL_PERSON_SEARCH = "https://nubela.co/proxycurl/api/v2/search/person/"
+_PROXYCURL_COMPANY_SEARCH = "https://nubela.co/proxycurl/api/v2/search/company/"
+_PROXYCURL_PERSON_FETCH = "https://nubela.co/proxycurl/api/v2/linkedin"
+_PROXYCURL_COMPANY_FETCH = "https://nubela.co/proxycurl/api/linkedin/company"
+
+
+def _proxycurl_headers(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def _proxycurl_search_person_params(query: str, max_results: int) -> dict[str, str]:
+    first, last = _split_query(query)
+    params: dict[str, str] = {
+        "country": "us",
+        "page_size": str(min(max(max_results, 1), 100)),
+    }
+    if first:
+        params["first_name"] = first
+    if last:
+        params["last_name"] = last
+    return params
+
+
+def _proxycurl_search_company_params(query: str, max_results: int) -> dict[str, str]:
+    return {
+        "country": "us",
+        "name": query,
+        "page_size": str(min(max(max_results, 1), 100)),
+    }
+
+
+def _proxycurl_fetch_person_params(profile_url: str) -> dict[str, str]:
+    return {"url": profile_url, "use_cache": "if-present"}
+
+
+def _proxycurl_fetch_company_params(profile_url: str) -> dict[str, str]:
+    return {"url": profile_url, "use_cache": "if-present"}
+
+
+def _proxycurl_parse_search_person(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    raw = payload.get("results") or []
+    if not isinstance(raw, list):
+        return out
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        url = str(row.get("linkedin_profile_url") or "")
+        if not url:
+            continue
+        profile = row.get("profile") if isinstance(row.get("profile"), dict) else {}
+        full_name = str(
+            profile.get("full_name")
+            or " ".join(
+                p
+                for p in [profile.get("first_name"), profile.get("last_name")]
+                if p
+            )
+            or url.rsplit("/", 1)[-1]
+        )
+        headline = str(profile.get("headline") or profile.get("occupation") or "")
+        location = str(
+            profile.get("city")
+            or profile.get("country_full_name")
+            or profile.get("country")
+            or ""
+        )
+        current_company, current_title = _proxycurl_pick_current_role(profile)
+        out.append(
+            {
+                "url": url,
+                "title": full_name,
+                "snippet": headline,
+                "location": location,
+                "current_company": current_company,
+                "current_title": current_title,
+            }
+        )
+    return out
+
+
+def _proxycurl_pick_current_role(profile: dict[str, Any]) -> tuple[str, str]:
+    experiences = profile.get("experiences")
+    if isinstance(experiences, list):
+        for exp in experiences:
+            if not isinstance(exp, dict):
+                continue
+            ends_at = exp.get("ends_at")
+            if ends_at in (None, {}):
+                return str(exp.get("company") or ""), str(exp.get("title") or "")
+        # Fall back to the first row if everything has an end-date.
+        for exp in experiences:
+            if isinstance(exp, dict):
+                return str(exp.get("company") or ""), str(exp.get("title") or "")
+    occupation = str(profile.get("occupation") or "")
+    return "", occupation
+
+
+def _proxycurl_parse_search_company(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    raw = payload.get("results") or []
+    if not isinstance(raw, list):
+        return out
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        url = str(row.get("linkedin_profile_url") or "")
+        if not url:
+            continue
+        profile = row.get("profile") if isinstance(row.get("profile"), dict) else {}
+        name = str(profile.get("name") or url.rsplit("/", 1)[-1])
+        tagline = str(profile.get("tagline") or profile.get("description") or "")
+        industry = str(profile.get("industry") or "")
+        size = profile.get("company_size") or profile.get("company_size_on_linkedin")
+        headcount = ""
+        if isinstance(size, list) and size:
+            headcount = "-".join(str(s) for s in size if s is not None)
+        elif isinstance(size, int | str):
+            headcount = str(size)
+        hq = profile.get("hq") if isinstance(profile.get("hq"), dict) else {}
+        hq_location = ", ".join(
+            p for p in [hq.get("city"), hq.get("state"), hq.get("country")] if p
+        )
+        out.append(
+            {
+                "url": url,
+                "title": name,
+                "snippet": tagline,
+                "industry": industry,
+                "headcount": headcount,
+                "hq_location": hq_location,
+            }
+        )
+    return out
+
+
+def _proxycurl_parse_fetch_person(payload: dict[str, Any]) -> dict[str, Any]:
+    name = str(payload.get("full_name") or "")
+    headline = str(payload.get("headline") or payload.get("occupation") or "")
+
+    experiences: list[dict[str, Any]] = []
+    raw_exp = payload.get("experiences") or []
+    if isinstance(raw_exp, list):
+        for exp in raw_exp:
+            if not isinstance(exp, dict):
+                continue
+            experiences.append(
+                {
+                    "title": str(exp.get("title") or ""),
+                    "company": str(exp.get("company") or ""),
+                    "starts_at": _proxycurl_format_date(exp.get("starts_at")),
+                    "ends_at": _proxycurl_format_date(exp.get("ends_at")),
+                    "description": str(exp.get("description") or ""),
+                    "location": str(exp.get("location") or ""),
+                }
+            )
+
+    education: list[dict[str, Any]] = []
+    raw_edu = payload.get("education") or []
+    if isinstance(raw_edu, list):
+        for edu in raw_edu:
+            if not isinstance(edu, dict):
+                continue
+            education.append(
+                {
+                    "school": str(edu.get("school") or ""),
+                    "degree": str(edu.get("degree_name") or ""),
+                    "field": str(edu.get("field_of_study") or ""),
+                    "starts_at": _proxycurl_format_date(edu.get("starts_at")),
+                    "ends_at": _proxycurl_format_date(edu.get("ends_at")),
+                }
+            )
+
+    certifications: list[dict[str, Any]] = []
+    raw_certs = payload.get("certifications") or []
+    if isinstance(raw_certs, list):
+        for c in raw_certs:
+            if not isinstance(c, dict):
+                continue
+            certifications.append(
+                {
+                    "name": str(c.get("name") or ""),
+                    "authority": str(c.get("authority") or ""),
+                    "starts_at": _proxycurl_format_date(c.get("starts_at")),
+                    "ends_at": _proxycurl_format_date(c.get("ends_at")),
+                }
+            )
+
+    skills: list[str] = []
+    raw_skills = payload.get("skills") or []
+    if isinstance(raw_skills, list):
+        skills = [str(s) for s in raw_skills if s]
+
+    return {
+        "name": name,
+        "headline": headline,
+        "experiences": experiences,
+        "education": education,
+        "certifications": certifications,
+        "skills": skills,
+    }
+
+
+def _proxycurl_parse_fetch_company(payload: dict[str, Any]) -> dict[str, Any]:
+    name = str(payload.get("name") or "")
+    tagline = str(payload.get("tagline") or "")
+    industry = str(payload.get("industry") or "")
+    description = str(payload.get("description") or "")
+
+    size = payload.get("company_size") or payload.get("company_size_on_linkedin")
+    headcount = ""
+    if isinstance(size, list) and size:
+        headcount = "-".join(str(s) for s in size if s is not None)
+    elif isinstance(size, int | str):
+        headcount = str(size)
+
+    employee_count = payload.get("employee_count")
+
+    hq = payload.get("hq") if isinstance(payload.get("hq"), dict) else {}
+    hq_location = ", ".join(
+        p for p in [hq.get("city"), hq.get("state"), hq.get("country")] if p
+    )
+
+    locations: list[str] = []
+    raw_locs = payload.get("locations") or []
+    if isinstance(raw_locs, list):
+        for loc in raw_locs:
+            if isinstance(loc, dict):
+                locations.append(
+                    ", ".join(
+                        p for p in [loc.get("city"), loc.get("state"), loc.get("country")] if p
+                    )
+                )
+            elif isinstance(loc, str):
+                locations.append(loc)
+
+    specialities = payload.get("specialities") or []
+    if not isinstance(specialities, list):
+        specialities = []
+    specialities = [str(s) for s in specialities if s]
+
+    updates: list[str] = []
+    raw_updates = payload.get("updates") or []
+    if isinstance(raw_updates, list):
+        for u in raw_updates:
+            if isinstance(u, dict):
+                text = u.get("text") or u.get("posted_on")
+                if text:
+                    updates.append(str(text))
+
+    return {
+        "name": name,
+        "tagline": tagline,
+        "industry": industry,
+        "description": description,
+        "headcount": headcount,
+        "employee_count": employee_count,
+        "hq_location": hq_location,
+        "locations": locations,
+        "specialities": specialities,
+        "updates": updates,
+    }
+
+
+def _proxycurl_format_date(value: Any) -> str:
+    if not isinstance(value, dict):
+        return ""
+    year = value.get("year")
+    month = value.get("month")
+    if not year:
+        return ""
+    if month:
+        return f"{int(year):04d}-{int(month):02d}"
+    return f"{int(year):04d}"
+
+
+# --- Lix (alternate broker) ---------------------------------------------------
+#
+# Lix uses a different REST surface. The shape below mirrors the public
+# pricing-page docs and is wired in so the broker layer is exercised even
+# before a Lix engagement lands a real key — tests can switch
+# ``LINKEDIN_BROKER=lix`` and verify the recipe routes correctly. Endpoints
+# and parameter names map to Lix's `/v1` profile + search endpoints.
+
+
+_LIX_PERSON_SEARCH = "https://api.lix-it.com/v1/li/linkedin/search/people"
+_LIX_COMPANY_SEARCH = "https://api.lix-it.com/v1/li/linkedin/search/companies"
+_LIX_PERSON_FETCH = "https://api.lix-it.com/v1/person"
+_LIX_COMPANY_FETCH = "https://api.lix-it.com/v1/organisations/by-linkedin-url"
+
+
+def _lix_headers(api_key: str) -> dict[str, str]:
+    return {"Authorization": api_key}
+
+
+def _lix_search_person_params(query: str, max_results: int) -> dict[str, str]:
+    return {"query": query, "limit": str(min(max(max_results, 1), 100))}
+
+
+def _lix_search_company_params(query: str, max_results: int) -> dict[str, str]:
+    return {"query": query, "limit": str(min(max(max_results, 1), 100))}
+
+
+def _lix_fetch_person_params(profile_url: str) -> dict[str, str]:
+    return {"profile_link": profile_url}
+
+
+def _lix_fetch_company_params(profile_url: str) -> dict[str, str]:
+    return {"linkedin_url": profile_url}
+
+
+def _lix_parse_search_person(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    raw = payload.get("people") or payload.get("results") or []
+    if not isinstance(raw, list):
+        return out
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        url = str(row.get("link") or row.get("linkedin_url") or "")
+        if not url:
+            continue
+        out.append(
+            {
+                "url": url,
+                "title": str(row.get("name") or row.get("full_name") or ""),
+                "snippet": str(row.get("headline") or row.get("title") or ""),
+                "location": str(row.get("location") or ""),
+                "current_company": str(row.get("company") or ""),
+                "current_title": str(row.get("position") or row.get("title") or ""),
+            }
+        )
+    return out
+
+
+def _lix_parse_search_company(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    raw = payload.get("companies") or payload.get("results") or []
+    if not isinstance(raw, list):
+        return out
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        url = str(row.get("link") or row.get("linkedin_url") or "")
+        if not url:
+            continue
+        out.append(
+            {
+                "url": url,
+                "title": str(row.get("name") or ""),
+                "snippet": str(row.get("description") or row.get("tagline") or ""),
+                "industry": str(row.get("industry") or ""),
+                "headcount": str(row.get("employee_count") or row.get("size") or ""),
+                "hq_location": str(row.get("location") or ""),
+            }
+        )
+    return out
+
+
+def _lix_parse_fetch_person(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": str(payload.get("name") or payload.get("full_name") or ""),
+        "headline": str(payload.get("headline") or ""),
+        "experiences": list(payload.get("positions") or payload.get("experience") or []),
+        "education": list(payload.get("education") or []),
+        "certifications": list(payload.get("certifications") or []),
+        "skills": list(payload.get("skills") or []),
+    }
+
+
+def _lix_parse_fetch_company(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": str(payload.get("name") or ""),
+        "tagline": str(payload.get("tagline") or ""),
+        "industry": str(payload.get("industry") or ""),
+        "description": str(payload.get("description") or ""),
+        "headcount": str(payload.get("employee_count") or ""),
+        "employee_count": payload.get("employee_count"),
+        "hq_location": str(payload.get("location") or ""),
+        "locations": list(payload.get("locations") or []),
+        "specialities": list(payload.get("specialities") or []),
+        "updates": list(payload.get("updates") or []),
+    }
+
+
+# --- Recipe registry ----------------------------------------------------------
+
+
+_BROKERS: dict[str, dict[str, Any]] = {
+    "proxycurl": {
+        "key_env": "LINKEDIN_DATA_API_KEY",
+        "signup_url": "https://nubela.co/proxycurl/",
+        "build_headers": _proxycurl_headers,
+        "search_person_url": _PROXYCURL_PERSON_SEARCH,
+        "search_company_url": _PROXYCURL_COMPANY_SEARCH,
+        "fetch_person_url": _PROXYCURL_PERSON_FETCH,
+        "fetch_company_url": _PROXYCURL_COMPANY_FETCH,
+        "build_search_person_params": _proxycurl_search_person_params,
+        "build_search_company_params": _proxycurl_search_company_params,
+        "build_fetch_person_params": _proxycurl_fetch_person_params,
+        "build_fetch_company_params": _proxycurl_fetch_company_params,
+        "parse_search_person": _proxycurl_parse_search_person,
+        "parse_search_company": _proxycurl_parse_search_company,
+        "parse_fetch_person": _proxycurl_parse_fetch_person,
+        "parse_fetch_company": _proxycurl_parse_fetch_company,
+    },
+    "lix": {
+        "key_env": "LIX_API_KEY",
+        "signup_url": "https://lix-it.com/",
+        "build_headers": _lix_headers,
+        "search_person_url": _LIX_PERSON_SEARCH,
+        "search_company_url": _LIX_COMPANY_SEARCH,
+        "fetch_person_url": _LIX_PERSON_FETCH,
+        "fetch_company_url": _LIX_COMPANY_FETCH,
+        "build_search_person_params": _lix_search_person_params,
+        "build_search_company_params": _lix_search_company_params,
+        "build_fetch_person_params": _lix_fetch_person_params,
+        "build_fetch_company_params": _lix_fetch_company_params,
+        "parse_search_person": _lix_parse_search_person,
+        "parse_search_company": _lix_parse_search_company,
+        "parse_fetch_person": _lix_parse_fetch_person,
+        "parse_fetch_company": _lix_parse_fetch_company,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Config / rate-limit helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_broker() -> tuple[str, dict[str, Any]]:
+    name = (config.get("LINKEDIN_BROKER") or "proxycurl").strip().lower()
+    recipe = _BROKERS.get(name)
+    if recipe is None:
+        raise RuntimeError(
+            f"Unknown LINKEDIN_BROKER {name!r}; expected one of "
+            f"{sorted(_BROKERS)}."
+        )
+    return name, recipe
+
+
+def _resolve_key(broker: str, recipe: dict[str, Any]) -> str:
+    env_name = recipe["key_env"]
+    key = config.get(env_name) or ""
+    if not key.strip():
+        raise RuntimeError(
+            f"LinkedIn connector requires a {env_name} (broker={broker}). "
+            f"Sign up at {recipe['signup_url']} and set {env_name} in your .env."
+        )
+    return key.strip()
+
+
+def _user_agent() -> str:
+    return config.get("RESEARCH_USER_AGENT") or (
+        "research-agent/0.1 (+local; contact unset)"
+    )
+
+
+async def _rate_limit_gate() -> None:
+    global _last_call_monotonic
+    async with _rate_lock:
+        if _last_call_monotonic is not None:
+            elapsed = time.monotonic() - _last_call_monotonic
+            wait = _FETCH_INTERVAL - elapsed
+            if wait > 0:
+                await asyncio.sleep(wait)
+        _last_call_monotonic = time.monotonic()
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def search(
+    query: str,
+    *,
+    kind: str = "person",
+    max_results: int = 10,
+    timeout: float = 15.0,
+) -> list[SearchResult]:
+    """Run a LinkedIn person/company search through the configured broker."""
+    if kind not in _VALID_KINDS:
+        raise ValueError(
+            f"unknown kind {kind!r}; expected one of {sorted(_VALID_KINDS)}"
+        )
+
+    broker, recipe = _resolve_broker()
+    api_key = _resolve_key(broker, recipe)
+
+    if kind == "person":
+        url = recipe["search_person_url"]
+        params = recipe["build_search_person_params"](query, max_results)
+        parser = recipe["parse_search_person"]
+    else:
+        url = recipe["search_company_url"]
+        params = recipe["build_search_company_params"](query, max_results)
+        parser = recipe["parse_search_company"]
+
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": _user_agent(),
+        **recipe["build_headers"](api_key),
+    }
+
+    await _rate_limit_gate()
+
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=headers,
+        ) as client:
+            response = await client.get(url, params=params)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("linkedin search failed for %r: %s", query, exc)
+        return []
+
+    if response.status_code != 200:
+        logger.warning(
+            "linkedin search returned HTTP %s for %r",
+            response.status_code,
+            query,
+        )
+        return []
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        logger.warning("linkedin search returned non-JSON for %r: %s", query, exc)
+        return []
+
+    if not isinstance(payload, dict):
+        return []
+
+    rows = parser(payload)
+    out: list[SearchResult] = []
+    for row in rows[:max_results]:
+        extras: dict[str, Any] = {"kind": kind, "broker": broker}
+        if kind == "person":
+            extras.update(
+                {
+                    "location": row.get("location") or "",
+                    "current_company": row.get("current_company") or "",
+                    "current_title": row.get("current_title") or "",
+                }
+            )
+        else:
+            extras.update(
+                {
+                    "industry": row.get("industry") or "",
+                    "headcount": row.get("headcount") or "",
+                    "hq_location": row.get("hq_location") or "",
+                }
+            )
+        out.append(
+            SearchResult(
+                url=str(row.get("url") or ""),
+                title=str(row.get("title") or ""),
+                snippet=str(row.get("snippet") or ""),
+                source_kind="linkedin",
+                extras=extras,
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+def _classify_url(url: str) -> str | None:
+    if _PERSON_URL_RE.match(url):
+        return "person"
+    if _COMPANY_URL_RE.match(url):
+        return "company"
+    return None
+
+
+def _looks_like_linkedin(url: str) -> bool:
+    parsed = urlparse(url)
+    host = parsed.netloc.split("@")[-1].split(":", 1)[0].lower()
+    return host == "linkedin.com" or host.endswith(".linkedin.com")
+
+
+def _render_person_markdown(facts: dict[str, Any]) -> str:
+    lines: list[str] = [f"# {facts.get('name') or '(unknown)'}"]
+    headline = facts.get("headline") or ""
+    if headline:
+        lines.append(headline)
+
+    experiences = facts.get("experiences") or []
+    if experiences:
+        lines.append("")
+        lines.append("## Experience")
+        for exp in experiences:
+            title = exp.get("title") or "?"
+            company = exp.get("company") or "?"
+            starts = exp.get("starts_at") or "?"
+            ends = exp.get("ends_at") or "present"
+            entry = f"- {title} @ {company} ({starts} – {ends})"
+            location = exp.get("location") or ""
+            if location:
+                entry += f" — {location}"
+            lines.append(entry)
+
+    education = facts.get("education") or []
+    if education:
+        lines.append("")
+        lines.append("## Education")
+        for edu in education:
+            school = edu.get("school") or "?"
+            degree = edu.get("degree") or ""
+            field = edu.get("field") or ""
+            starts = edu.get("starts_at") or ""
+            ends = edu.get("ends_at") or ""
+            extras = ", ".join(p for p in [degree, field] if p)
+            range_str = " – ".join(p for p in [starts, ends] if p)
+            entry = f"- {school}"
+            if extras:
+                entry += f" — {extras}"
+            if range_str:
+                entry += f" ({range_str})"
+            lines.append(entry)
+
+    certifications = facts.get("certifications") or []
+    if certifications:
+        lines.append("")
+        lines.append("## Certifications")
+        for c in certifications:
+            name = c.get("name") or "?"
+            authority = c.get("authority") or ""
+            entry = f"- {name}"
+            if authority:
+                entry += f" — {authority}"
+            lines.append(entry)
+
+    skills = facts.get("skills") or []
+    if skills:
+        lines.append("")
+        lines.append("## Skills")
+        lines.append(", ".join(str(s) for s in skills))
+
+    return "\n".join(lines)
+
+
+def _render_company_markdown(facts: dict[str, Any]) -> str:
+    lines: list[str] = [f"# {facts.get('name') or '(unknown company)'}"]
+    tagline = facts.get("tagline") or ""
+    if tagline:
+        lines.append(tagline)
+
+    summary_parts: list[str] = []
+    industry = facts.get("industry") or ""
+    if industry:
+        summary_parts.append(f"Industry: {industry}")
+    employee_count = facts.get("employee_count")
+    if employee_count:
+        summary_parts.append(f"Employees: {employee_count}")
+    headcount = facts.get("headcount") or ""
+    if headcount and not employee_count:
+        summary_parts.append(f"Headcount range: {headcount}")
+    hq = facts.get("hq_location") or ""
+    if hq:
+        summary_parts.append(f"HQ: {hq}")
+    if summary_parts:
+        lines.append("")
+        lines.append(" · ".join(summary_parts))
+
+    description = facts.get("description") or ""
+    if description:
+        lines.append("")
+        lines.append("## About")
+        lines.append(description)
+
+    locations = facts.get("locations") or []
+    if locations:
+        lines.append("")
+        lines.append("## Locations")
+        for loc in locations:
+            lines.append(f"- {loc}")
+
+    specialities = facts.get("specialities") or []
+    if specialities:
+        lines.append("")
+        lines.append("## Specialities")
+        lines.append(", ".join(str(s) for s in specialities))
+
+    updates = facts.get("updates") or []
+    if updates:
+        lines.append("")
+        lines.append("## Recent updates")
+        for u in updates:
+            lines.append(f"- {u}")
+
+    return "\n".join(lines)
+
+
+async def fetch(url: str, timeout: float = 30.0) -> Source | None:
+    """Fetch a LinkedIn person/company profile and return a :class:`Source`.
+
+    Returns ``None`` when ``url`` is not a LinkedIn person/company URL or
+    when the broker call fails for any reason — the planner must never
+    crash on a connector error.
+    """
+    if not url or not _looks_like_linkedin(url):
+        return None
+
+    kind = _classify_url(url)
+    if kind is None:
+        return None
+
+    broker, recipe = _resolve_broker()
+    api_key = _resolve_key(broker, recipe)
+
+    if kind == "person":
+        endpoint = recipe["fetch_person_url"]
+        params = recipe["build_fetch_person_params"](url)
+        parser = recipe["parse_fetch_person"]
+    else:
+        endpoint = recipe["fetch_company_url"]
+        params = recipe["build_fetch_company_params"](url)
+        parser = recipe["parse_fetch_company"]
+
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": _user_agent(),
+        **recipe["build_headers"](api_key),
+    }
+
+    await _rate_limit_gate()
+
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=headers,
+        ) as client:
+            response = await client.get(endpoint, params=params)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("linkedin fetch failed for %s: %s", url, exc)
+        return None
+
+    if response.status_code >= 400:
+        logger.warning(
+            "linkedin fetch returned HTTP %s for %s",
+            response.status_code,
+            url,
+        )
+        return None
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        logger.warning("linkedin fetch returned non-JSON for %s: %s", url, exc)
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    facts = parser(payload)
+    if kind == "person":
+        cleaned_text = _render_person_markdown(facts)
+        title = facts.get("name") or url
+        metadata: dict[str, Any] = {
+            "broker": broker,
+            "broker_payload": payload,
+            "profile_url": url,
+            "kind": "person",
+            "headline": facts.get("headline") or "",
+            "employment_history": facts.get("experiences") or [],
+            "education": facts.get("education") or [],
+            "certifications": facts.get("certifications") or [],
+            "skills": facts.get("skills") or [],
+        }
+    else:
+        cleaned_text = _render_company_markdown(facts)
+        title = facts.get("name") or url
+        metadata = {
+            "broker": broker,
+            "broker_payload": payload,
+            "profile_url": url,
+            "kind": "company",
+            "industry": facts.get("industry") or "",
+            "headcount": facts.get("headcount") or "",
+            "employee_count": facts.get("employee_count"),
+            "hq_location": facts.get("hq_location") or "",
+            "locations": facts.get("locations") or [],
+            "specialities": facts.get("specialities") or [],
+            "updates": facts.get("updates") or [],
+        }
+
+    return Source(
+        url=url,
+        title=str(title),
+        cleaned_text=cleaned_text,
+        raw_html=None,
+        fetched_at=datetime.now(UTC),
+        source_kind="linkedin",
+        metadata=metadata,
+    )
+
+
+def reset_for_tests() -> None:
+    """Clear per-process rate-limit state. Test-only."""
+    global _last_call_monotonic, _rate_lock
+    _last_call_monotonic = None
+    _rate_lock = asyncio.Lock()
+
+
+__all__ = ["fetch", "reset_for_tests", "search"]

--- a/src/research_agent/tools/models.py
+++ b/src/research_agent/tools/models.py
@@ -47,6 +47,7 @@ SourceKind = Literal[
     "bbb",
     "calaccess",
     "scholar",
+    "linkedin",
 ]
 
 

--- a/tests/test_tools_linkedin.py
+++ b/tests/test_tools_linkedin.py
@@ -1,0 +1,460 @@
+"""Tests for `research_agent.tools.linkedin` (issue #115)."""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from research_agent.tools import linkedin
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _set_key(monkeypatch):
+    monkeypatch.setenv("LINKEDIN_DATA_API_KEY", "proxycurl-test-1234567890abcdef")
+    monkeypatch.delenv("LINKEDIN_BROKER", raising=False)
+    monkeypatch.delenv("LIX_API_KEY", raising=False)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    linkedin.reset_for_tests()
+    monkeypatch.setattr(linkedin.asyncio, "sleep", AsyncMock())
+    yield
+    linkedin.reset_for_tests()
+
+
+_PERSON_SEARCH_PAYLOAD = {
+    "results": [
+        {
+            "linkedin_profile_url": "https://www.linkedin.com/in/george-santos-1/",
+            "profile": {
+                "first_name": "George",
+                "last_name": "Santos",
+                "full_name": "George Santos",
+                "headline": "U.S. Representative-Elect for NY-03",
+                "city": "New York",
+                "country_full_name": "United States",
+                "occupation": "U.S. Representative-Elect at U.S. House",
+                "experiences": [
+                    {
+                        "title": "Representative",
+                        "company": "U.S. House of Representatives",
+                        "starts_at": {"year": 2023, "month": 1},
+                        "ends_at": None,
+                    }
+                ],
+            },
+        },
+        {
+            "linkedin_profile_url": "https://www.linkedin.com/in/george-santos-2/",
+            "profile": {
+                "full_name": "George Santos",
+                "headline": "Independent Consultant",
+                "city": "Queens, NY",
+                "occupation": "Consultant",
+                "experiences": [
+                    {
+                        "title": "Consultant",
+                        "company": "Self Employed",
+                        "starts_at": {"year": 2020, "month": 5},
+                        "ends_at": {"year": 2022, "month": 12},
+                    }
+                ],
+            },
+        },
+    ]
+}
+
+
+_COMPANY_SEARCH_PAYLOAD = {
+    "results": [
+        {
+            "linkedin_profile_url": "https://www.linkedin.com/company/anthropic/",
+            "profile": {
+                "name": "Anthropic",
+                "tagline": "AI safety company",
+                "industry": "Research",
+                "company_size": [501, 1000],
+                "hq": {
+                    "city": "San Francisco",
+                    "state": "California",
+                    "country": "US",
+                },
+            },
+        }
+    ]
+}
+
+
+_FETCH_PERSON_PAYLOAD = {
+    "public_identifier": "george-santos-1",
+    "full_name": "George Santos",
+    "headline": "U.S. Representative-Elect",
+    "country_full_name": "United States",
+    "city": "New York",
+    "experiences": [
+        {
+            "title": "Representative",
+            "company": "U.S. House of Representatives",
+            "starts_at": {"year": 2023, "month": 1},
+            "ends_at": None,
+            "description": "Member of Congress representing NY-03.",
+            "location": "Washington, DC",
+        },
+        {
+            "title": "Founder",
+            "company": "Devolder Organization",
+            "starts_at": {"year": 2021, "month": 5},
+            "ends_at": {"year": 2022, "month": 11},
+            "description": "Family LLC.",
+            "location": "New York",
+        },
+    ],
+    "education": [
+        {
+            "school": "Baruch College",
+            "degree_name": "BA",
+            "field_of_study": "Finance",
+            "starts_at": {"year": 2010},
+            "ends_at": {"year": 2014},
+        }
+    ],
+    "certifications": [
+        {
+            "name": "FINRA Series 7",
+            "authority": "FINRA",
+            "starts_at": {"year": 2014},
+            "ends_at": None,
+        }
+    ],
+    "skills": ["Public Speaking", "Finance"],
+}
+
+
+_FETCH_COMPANY_PAYLOAD = {
+    "linkedin_internal_id": "12345",
+    "name": "Anthropic",
+    "tagline": "AI safety company",
+    "industry": "Research Services",
+    "description": "Anthropic builds reliable, interpretable, steerable AI.",
+    "company_size": [501, 1000],
+    "employee_count": 850,
+    "hq": {"city": "San Francisco", "state": "California", "country": "US"},
+    "locations": [
+        {"city": "San Francisco", "state": "California", "country": "US"},
+        {"city": "London", "country": "GB"},
+    ],
+    "specialities": ["AI safety", "Large language models"],
+    "updates": [{"text": "We released a new model."}],
+}
+
+
+def _patch_httpx(monkeypatch, *, responder):
+    captured: dict[str, list] = {
+        "urls": [],
+        "headers": [],
+        "params": [],
+    }
+
+    class _FakeResp:
+        def __init__(self, status: int, text: str, headers: dict[str, str] | None = None) -> None:
+            self.status_code = status
+            self.text = text
+            self.headers = headers or {}
+            self.content = text.encode()
+
+        def json(self):
+            return json.loads(self.text)
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        captured["headers"].append(kwargs.get("headers"))
+
+        class _Client:
+            async def get(self, url, *, params=None, **_kwargs):
+                captured["urls"].append(url)
+                captured["params"].append(params)
+                result = responder(url, params)
+                if len(result) == 3:
+                    status, text, headers = result
+                    return _FakeResp(status, text, headers)
+                status, text = result
+                return _FakeResp(status, text)
+
+        yield _Client()
+
+    monkeypatch.setattr(linkedin.httpx, "AsyncClient", _client_factory)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def test_search_person_parses_proxycurl_payload(monkeypatch):
+    payload = json.dumps(_PERSON_SEARCH_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await linkedin.search("George Santos", kind="person")
+
+    assert len(results) == 2
+    assert captured["urls"][0] == linkedin._PROXYCURL_PERSON_SEARCH
+    params = captured["params"][0]
+    assert params["first_name"] == "George"
+    assert params["last_name"] == "Santos"
+    assert params["country"] == "us"
+    headers = captured["headers"][0]
+    assert headers["Authorization"].startswith("Bearer proxycurl-test-")
+
+    first = results[0]
+    assert first.source_kind == "linkedin"
+    assert first.url == "https://www.linkedin.com/in/george-santos-1/"
+    assert first.title == "George Santos"
+    assert "Representative-Elect" in first.snippet
+    assert first.extras["kind"] == "person"
+    assert first.extras["broker"] == "proxycurl"
+    assert first.extras["location"].startswith("New York")
+    assert first.extras["current_company"] == "U.S. House of Representatives"
+    assert first.extras["current_title"] == "Representative"
+
+
+async def test_search_company_hits_company_endpoint(monkeypatch):
+    payload = json.dumps(_COMPANY_SEARCH_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await linkedin.search("Anthropic", kind="company")
+
+    assert captured["urls"][0] == linkedin._PROXYCURL_COMPANY_SEARCH
+    assert captured["params"][0]["name"] == "Anthropic"
+    assert len(results) == 1
+    hit = results[0]
+    assert hit.title == "Anthropic"
+    assert hit.extras["kind"] == "company"
+    assert hit.extras["industry"] == "Research"
+    assert hit.extras["headcount"] == "501-1000"
+    assert "San Francisco" in hit.extras["hq_location"]
+
+
+async def test_search_unknown_kind_raises():
+    with pytest.raises(ValueError, match="unknown kind"):
+        await linkedin.search("anything", kind="bogus")
+
+
+async def test_search_raises_when_key_missing(monkeypatch):
+    monkeypatch.delenv("LINKEDIN_DATA_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="LINKEDIN_DATA_API_KEY"):
+        await linkedin.search("anyone")
+
+
+async def test_search_returns_empty_on_500(monkeypatch):
+    def _respond(url, params):
+        return 500, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await linkedin.search("anyone") == []
+
+
+async def test_search_returns_empty_on_non_json(monkeypatch):
+    def _respond(url, params):
+        return 200, "<html>not json</html>"
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await linkedin.search("anyone") == []
+
+
+async def test_search_returns_empty_on_transport_error(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(linkedin.httpx, "AsyncClient", _client_factory)
+
+    assert await linkedin.search("anyone") == []
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_person_returns_markdown_rollup(monkeypatch):
+    payload = json.dumps(_FETCH_PERSON_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await linkedin.fetch("https://www.linkedin.com/in/george-santos-1/")
+
+    assert source is not None
+    assert source.source_kind == "linkedin"
+    assert source.title == "George Santos"
+    assert "## Experience" in source.cleaned_text
+    assert "Representative @ U.S. House of Representatives" in source.cleaned_text
+    assert "## Education" in source.cleaned_text
+    assert "Baruch College" in source.cleaned_text
+    assert "## Certifications" in source.cleaned_text
+    assert source.metadata["broker"] == "proxycurl"
+    assert source.metadata["broker_payload"]["full_name"] == "George Santos"
+    assert source.metadata["profile_url"].endswith("/george-santos-1/")
+    assert len(source.metadata["employment_history"]) == 2
+    assert source.metadata["education"][0]["school"] == "Baruch College"
+
+    assert captured["urls"][0] == linkedin._PROXYCURL_PERSON_FETCH
+    assert captured["params"][0]["url"].endswith("/george-santos-1/")
+
+
+async def test_fetch_company_returns_markdown_rollup(monkeypatch):
+    payload = json.dumps(_FETCH_COMPANY_PAYLOAD)
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await linkedin.fetch("https://www.linkedin.com/company/anthropic/")
+
+    assert source is not None
+    assert source.source_kind == "linkedin"
+    assert source.title == "Anthropic"
+    assert "Industry: Research Services" in source.cleaned_text
+    assert "Employees: 850" in source.cleaned_text
+    assert "## Locations" in source.cleaned_text
+    assert "London" in source.cleaned_text
+    assert "## Specialities" in source.cleaned_text
+    assert source.metadata["industry"] == "Research Services"
+    assert source.metadata["employee_count"] == 850
+    assert source.metadata["broker"] == "proxycurl"
+
+    assert captured["urls"][0] == linkedin._PROXYCURL_COMPANY_FETCH
+
+
+async def test_fetch_non_linkedin_url_returns_none(monkeypatch):
+    # No HTTP call should fire — assertion-by-absence: if it did, the
+    # responder would never be invoked anyway, but we verify None.
+    source = await linkedin.fetch("https://example.org/some-page")
+    assert source is None
+
+
+async def test_fetch_unsupported_linkedin_url_returns_none(monkeypatch):
+    # /pulse/<slug> is not /in/ or /company/ — connector should bail.
+    source = await linkedin.fetch("https://www.linkedin.com/pulse/some-article/")
+    assert source is None
+
+
+async def test_fetch_returns_none_on_http_error(monkeypatch):
+    def _respond(url, params):
+        return 500, ""
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await linkedin.fetch("https://www.linkedin.com/in/someone/")
+    assert source is None
+
+
+async def test_fetch_returns_none_on_transport_error(monkeypatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(linkedin.httpx, "AsyncClient", _client_factory)
+
+    assert await linkedin.fetch("https://www.linkedin.com/in/someone/") is None
+
+
+# ---------------------------------------------------------------------------
+# Broker switch
+# ---------------------------------------------------------------------------
+
+
+async def test_search_routes_to_lix_when_broker_set(monkeypatch):
+    monkeypatch.setenv("LINKEDIN_BROKER", "lix")
+    monkeypatch.setenv("LIX_API_KEY", "lix-test-key")
+    monkeypatch.delenv("LINKEDIN_DATA_API_KEY", raising=False)
+
+    payload = json.dumps(
+        {
+            "people": [
+                {
+                    "link": "https://www.linkedin.com/in/jane-doe/",
+                    "name": "Jane Doe",
+                    "headline": "Software Engineer",
+                    "location": "Brooklyn, NY",
+                    "company": "Acme",
+                    "position": "Software Engineer",
+                }
+            ]
+        }
+    )
+
+    def _respond(url, params):
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await linkedin.search("Jane Doe", kind="person")
+
+    assert captured["urls"][0] == linkedin._LIX_PERSON_SEARCH
+    headers = captured["headers"][0]
+    # Lix uses raw token in Authorization header (no Bearer prefix).
+    assert headers["Authorization"] == "lix-test-key"
+    assert len(results) == 1
+    hit = results[0]
+    assert hit.extras["broker"] == "lix"
+    assert hit.extras["current_company"] == "Acme"
+
+
+async def test_search_unknown_broker_raises(monkeypatch):
+    monkeypatch.setenv("LINKEDIN_BROKER", "wonkacurl")
+
+    with pytest.raises(RuntimeError, match="Unknown LINKEDIN_BROKER"):
+        await linkedin.search("anyone")
+
+
+async def test_search_lix_broker_missing_key_raises(monkeypatch):
+    monkeypatch.setenv("LINKEDIN_BROKER", "lix")
+    monkeypatch.delenv("LIX_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="LIX_API_KEY"):
+        await linkedin.search("anyone")
+
+
+# ---------------------------------------------------------------------------
+# Smoke registration
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_registry_includes_linkedin():
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "linkedin" in TOOL_REGISTRY

--- a/tests/test_tools_models.py
+++ b/tests/test_tools_models.py
@@ -41,6 +41,7 @@ EXPECTED_SOURCE_KINDS = (
     "bbb",
     "calaccess",
     "scholar",
+    "linkedin",
 )
 
 


### PR DESCRIPTION
Closes #115
Part of #107

## Summary

Automated implementation of **LinkedIn connector via Proxycurl / Lix (employment + networks)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

LinkedIn connector (Proxycurl default, Lix alternate) meets all ACs; fixed one doc mismatch in API_KEYS.md.

- **WARNING** [FIXED] `docs/API_KEYS.md`: docs/API_KEYS.md listed PROXYCURL_API_KEY as the env var, but tools/linkedin.py reads LINKEDIN_DATA_API_KEY for the Proxycurl broker and LIX_API_KEY for Lix. Updated the table to a per-broker row layout matching the recipe registry, and added a clarifying note about LINKEDIN_BROKER.
- **INFO** [OPEN] `src/research_agent/tools/linkedin.py`: tools/linkedin.py has 14 mypy union-attr warnings on the dict-narrowing pattern `row.get('profile') if isinstance(...) else {}`. Runtime is correct; mypy isn't enforced in CI and other connectors (e.g. fec.py) carry similar warnings, so left as-is.
- **INFO** [OPEN] `src/research_agent/orchestrator/loop.py`: The connector is registered in TOOL_REGISTRY for `_smoke-tool` and is callable directly, but is not yet wired into the orchestrator loop (loop.py only routes to web/arxiv/news/reddit/local). This matches the pattern of every other paid connector in the epic and is consistent with the issue note that fetches must only fire from explicit planner `linkedin_fetch` tasks; orchestrator wiring is a follow-up concern, not in this issue's ACs.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*