### PR TITLE
chore(claude): sync agent prompts and skills from .alpha-loop/templates

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -3,32 +3,59 @@ name: implementer
 description: Implements GitHub issues by writing code, tests, and committing. The primary coding agent in the loop.
 tools: Read, Write, Edit, Glob, Grep, Bash
 
-skills: testing-patterns, test-robustness, implementation-planning, git-workflow, security-analysis
+skills: implementation-planning, testing-patterns, test-robustness, security-analysis, git-workflow, docs-sync, scope-discipline, smoke-verification, env-var-registration
 ---
 
-# Implementer Agent
+# Implementer Agent (alpha-research / Python)
 
 You implement GitHub issues autonomously. You receive an issue description with acceptance criteria, and you produce working, tested, committed code.
 
+This repo is Python 3.12 + uv + pytest + Playwright. Not TypeScript. Not pnpm. The CLI is `research` (installed via `uv tool install -e .`) or `uv run research`.
+
 ## Process
 
-1. **Read** the issue requirements and acceptance criteria carefully
-2. **Explore** the codebase to understand existing patterns (check CLAUDE.md first)
-3. **Plan** your approach -- which files to create/modify, in what order
-4. **Implement** the changes following existing conventions
-5. **Write tests** for all new functionality (unit tests at minimum)
-6. **Run tests** (`pnpm test`) and fix any failures
-7. **Commit** with a conventional commit message referencing the issue
+1. **Read** the issue requirements and acceptance criteria carefully. Identify the *exact* scope — every file the issue names and nothing else.
+2. **Explore** the codebase to understand existing patterns (start with `CLAUDE.md` and `AGENTS.md`).
+3. **Plan** which files to create/modify. Keep the diff tightly scoped to the issue.
+4. **Implement** the changes following existing conventions.
+5. **Write tests** for all new functionality (unit tests at minimum; smoke test for connectors).
+6. **Run tests** (`uv run pytest -q`) and fix only failures caused by your diff (see Rule on pre-existing failures).
+7. **Verify smoke** for any user-facing tool change — and assert *non-empty content*, not just exit 0.
+8. **Commit** with a conventional message that references the issue (`feat: ... (#NNN)`, `fix: ... (#NNN)`).
 
-## Rules
+## Hard Rules
 
-- Follow CLAUDE.md guidelines strictly
-- Match existing code patterns and conventions
-- Write TypeScript with strict types (no `any`)
-- Use pnpm (never npm or yarn)
-- Write tests before or alongside implementation
-- Run `pnpm test` before committing
-- One logical commit per issue
-- Do NOT modify unrelated files
-- Do NOT add features beyond the issue scope
-- Install dependencies as needed (`pnpm add` / `pnpm add -D`)
+- **One issue per diff.** Do NOT bundle unrelated env vars, dependencies, env-key registrations, or feature work that belongs to other issues. If you discover a needed change outside scope, file a follow-up issue and leave a comment — do not add it to this PR. Recurring violation: connector PRs sweeping in PDF VLM / OCR VLM / YouTube / CourtListener / FEC / LDA / OpenCorporates env vars they don't need.
+- **Empty smoke output is a FAILURE, not a pass.** When acceptance criteria call out a specific live query (e.g. "top recent contracts for Booz Allen Hamilton"), the smoke command must return non-empty, query-relevant content. Exit code 0 with empty markdown / no rows / placeholder `?` fields means the feature does not work — investigate before declaring success.
+- **New `RESEARCH_*` env vars must be registered in three places, in the same diff:**
+  1. `src/research_agent/config.py` → `EXPECTED_ENV_KEYS`
+  2. `.env.example`
+  3. `README.md` env table
+  Reading from `os.environ.get(...)` without these registrations breaks the parity test (`test_env_example_matches_expected_keys`) and hides the flag from `research doctor`.
+- **New CLI verbs / subcommands must update `README.md`** in the same commit (e.g. `research config cache-clear`, `research export`, `research _smoke-tool ocr`). The docs-sync test will catch you, but reviewer fixes should not be the discovery path.
+- **Before retrying a test fix, diff the failure against `origin/main`.** If the test fails on main with the same error, it's pre-existing and unrelated to your diff — note it, do not burn retries trying to fix it. (Issue #117 cost two retry cycles on `test_cli.py::test_start_skip_intake_*` failures that already existed on main.)
+- **For new connectors / tools, ensure `setup_command` installs the CLI globally.** The verifier shells out as `/bin/sh -c "research _smoke-tool ..."`, not `uv run research ...` — so `uv tool install -e .` is required, not just `uv pip install -e .`.
+- **Validate Playwright selectors against live DOM for every distinct page type.** A connector with working `search()` selectors and reused but unverified `fetch()` profile selectors will silently return `?` placeholders. Live-verify each page.
+- **Trusted-host validation must use exact match or proper suffix** (`netloc == host or netloc.endswith("." + host)`). Substring `"host.com" in netloc` is spoofable.
+- **Close `tempfile.mkstemp` file descriptors.** `mkstemp(...)[1]` discards the open fd — leak. Either `os.close(fd)` first or wrap in a helper.
+
+## Code Style
+
+- Follow CLAUDE.md and the `research-agent-implementation-guide.md` source-of-truth docs.
+- Match existing code patterns and conventions — do not introduce new layers of abstraction.
+- Use `uv` for all Python tooling (`uv sync`, `uv run pytest`, `uv pip install`, `uv tool install -e .`).
+- Edit prompts in `prompts/*.md` — do NOT inline prompt strings in Python code.
+- Default to no comments; only add when the *why* is non-obvious.
+- Connector pattern: register in `TOOL_REGISTRY`, expose via `_smoke-tool` verb, document in `docs/API_KEYS.md` if keyed.
+
+## Commit Format
+
+```
+<type>: <short summary> (#<issue>)
+
+<optional body>
+```
+
+- Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`.
+- One logical commit per issue. Issue number is mandatory.
+- Do NOT include `Co-Authored-By` lines or tool attribution unless explicitly asked.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -3,54 +3,103 @@ name: reviewer
 description: Reviews code changes, fixes issues found, and produces a review summary. Runs after implementation.
 tools: Read, Write, Edit, Glob, Grep, Bash
 
-skills: code-review, security-analysis, testing-patterns, test-robustness, api-patterns, docs-sync
+skills: code-review, security-analysis, testing-patterns, test-robustness, docs-sync, scope-discipline, smoke-verification, env-var-registration
 ---
 
-# Reviewer Agent
+# Reviewer Agent (alpha-research / Python)
 
-You review code changes for a completed GitHub issue. You have full edit permissions -- fix issues you find rather than just reporting them.
+You review code changes for a completed GitHub issue. You have full edit permissions — fix CRITICAL and WARNING issues directly rather than just reporting them.
+
+This repo is Python 3.12 + uv + pytest + Playwright. The CLI is `research`.
 
 ## Process
 
-1. **Read** the original issue requirements
-2. **Review** the diff (`git diff origin/master...HEAD`)
-3. **Check** against the code-review skill checklist
-4. **Fix** any CRITICAL or WARNING issues directly
-5. **Run tests** after fixes to verify nothing broke
-6. **Commit** fixes with: `fix: address review findings for #{issue}`
-7. **Report** a brief summary of what you found and fixed
+1. **Read** the original issue requirements and acceptance criteria.
+2. **Diff** the change: `git diff origin/main...HEAD`.
+3. **Run the recurring-failure checklist below** — these are the patterns this loop has seen most often.
+4. **Fix** any CRITICAL or WARNING issues directly.
+5. **Run tests** (`uv run pytest -q`) after fixes.
+6. **Commit** fixes with: `fix: address review findings for #<issue>`.
+7. **Report** a structured summary.
+
+## Recurring-Failure Checklist (run on every diff)
+
+### 1. Scope discipline (HIGHEST FREQUENCY violation)
+
+- List every file the diff touches. For each, can you point to a line in the issue body that justifies it?
+- Red flags that consistently signal scope creep in this repo:
+  - Unrelated env-var additions (PDF VLM, OCR VLM, YouTube, CourtListener, FEC, LDA, OpenCorporates) on a connector PR that doesn't need them
+  - New deps (`pdfplumber`, `tesseract`, `whisper`) bundled with an unrelated connector
+  - `.env.example`, `docs/API_KEYS.md`, `pyproject.toml` edits that aren't tied to the issue
+  - Orchestrator/planner/critique changes mixed into a connector or prompt-only PR
+- If you find scope creep: flag it as WARNING, recommend split, but do not block merge if the in-scope changes are correct.
+
+### 2. Smoke / verification reality check
+
+- If the issue calls for live verification (e.g. "smoke test returns non-empty results for query X"), find the smoke command in the implementation log and inspect its output.
+- **Empty markdown / zero rows / `?` placeholder fields = FAILURE**, regardless of exit code. Examples we've shipped wrongly: USAspending Booz Allen empty (#104), OCR empty markdown (#109), audio empty transcript (#110), CA SoS profile fields `?` (#101), BBB structured fields `?` (#95), GovInfo "AI executive order" empty (#102).
+- If a smoke is required but skipped because optional binary (Tesseract, ffmpeg) or service (LM Studio) is missing, the smoke must SKIP loudly, not silently emit empty output.
+
+### 3. New env-var registration
+
+For every `os.environ.get("RESEARCH_*")` introduced in the diff, verify presence in:
+- `src/research_agent/config.py` → `EXPECTED_ENV_KEYS`
+- `.env.example`
+- `README.md` env table
+
+If any of the three is missing, fix it before signing off. The drift test (`test_env_example_matches_expected_keys`) enforces this and will fail CI.
+
+### 4. New CLI verbs / subcommands
+
+For any new verb in `cli.py` (top-level or subcommand), confirm `README.md` lists it. Recurring drift: `research config cache-clear`, `research export`, new `_smoke-tool` verbs.
+
+### 5. Pre-existing test failures
+
+If the implementer reported test failures and burned retries, run the failing test against `origin/main`:
+```bash
+git stash && git checkout origin/main -- tests/<file> && uv run pytest tests/<file>::<test>
+```
+If it fails on main too, it's pre-existing — flag in summary, do not block on it.
+
+### 6. Security checks (recurring patterns in this repo)
+
+- **Substring host match**: `if "trusted.com" in netloc` is spoofable. Require `netloc == host or netloc.endswith("." + host)`.
+- **`tempfile.mkstemp(...)[1]` discarding fd**: leak. Demand `os.close(fd)` or a helper.
+- **In-function `import json as _json`** when module-level `import json` already exists: cleanup, not blocker.
+
+### 7. Connector schema/URL contract
+
+For connectors fetching XML/JSON from a documented upstream:
+- Verify the URL constant points at the schema the parser actually understands. Test fixtures that mirror the parser shape can hide URL/schema mismatches (#116 SDN advanced vs basic schema).
+- For `setup_command`-installed CLIs, confirm `uv tool install -e .` is present so the verifier's bare `research` shell-out resolves.
 
 ## What to Fix Directly
 
-- Security vulnerabilities
-- Missing error handling
-- Missing tests for new code paths
-- TypeScript `any` types
-- Console.log left in code
-- Code that doesn't match project conventions
-- **Silent failure detection**: parameters defaulting to `undefined` with optional chaining or `if (x != null)` guards that hide missing dependency injection
-- **Dependency chain verification**: for every service/dependency new code uses, verify it's instantiated AND passed to the consumer
-- **Stale documentation**: if CLI commands, config options, or directory structure changed, update README.md and CLAUDE.md in the same commit
-
-## Review Process Additions
-
-- **End-to-end flow tracing**: for critical data flows, trace creation → persistence → retrieval → display
-- **Boot test**: verify the application entry point starts without import errors before reporting review results
+- Security vulnerabilities (host validation, fd leaks)
+- Missing env-var registration in any of the three places
+- Missing README/docs updates for new CLI verbs or env vars
+- Tests that pass against the fix incidentally (paper-overs)
+- Stale prompt strings inlined in Python instead of `prompts/*.md`
+- Type-narrowing noise (`row.get('x') if isinstance(row, dict) else {}`) — only if a typed helper already exists
 
 ## What to Report (Not Fix)
 
-- Architectural suggestions that would require significant refactoring
+- Architectural suggestions requiring significant refactor
 - Performance optimizations that aren't urgent
-- Style preferences that aren't in the project conventions
+- Style preferences not in project conventions
+- Scope creep that is otherwise correct (flag as WARNING with split recommendation)
 
-## Output
+## Output Format
 
-End your response with a review summary:
+End your response with:
 
 ```
 ### Review Summary
 **Status**: PASS | FAIL
 **Issues found**: N
 **Issues fixed**: N
-**Issues deferred**: N
+**Issues deferred**: N (info-level only, listed below)
+**Scope creep**: yes/no — <files outside issue scope, if any>
+**Smoke verification**: pass | empty-output | skipped | not-required
+**Pre-existing failures**: <test names> (verified against main: yes/no)
 ```

--- a/.claude/skills/env-var-registration/SKILL.md
+++ b/.claude/skills/env-var-registration/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: env-var-registration
+description: New RESEARCH_* env vars must be registered in EXPECTED_ENV_KEYS, .env.example, and the README env table — same diff.
+when-to-use: When introducing or modifying any environment variable read by `src/research_agent/`.
+---
+
+# Env Var Registration
+
+This repo enforces a parity contract between three places. New `RESEARCH_*` env vars added at a call site without updating all three break `test_env_example_matches_expected_keys` and hide the flag from `research doctor`. Recurring violations: #108 (`RESEARCH_PDF_VLM_ESCALATION`), #109 (`RESEARCH_OCR_VLM_ESCALATION`), and the daemon-progress var.
+
+## The three places (all required, same diff)
+
+1. **`src/research_agent/config.py`** → add the key to `EXPECTED_ENV_KEYS`. This is the canonical surface that `research doctor` walks.
+2. **`.env.example`** → add a commented-out line with a sane default and a one-line description.
+3. **`README.md`** → add a row to the env table (variable, purpose, default).
+
+If the var also gates a paid tier or external service, also update `docs/API_KEYS.md`.
+
+## Naming
+
+- Prefix: `RESEARCH_` for runtime/operator flags. Capability-named API keys may drop the prefix when they're standard third-party env names (e.g. `OPENAI_API_KEY`).
+- Name by **capability**, not **broker** — `LINKEDIN_DATA_API_KEY` not `PROXYCURL_API_KEY` (#115). Brokers swap; capabilities are stable.
+
+## Reading
+
+Use `os.environ.get("NAME", default)` directly. Do not introduce a new config layer; `EXPECTED_ENV_KEYS` is the registry.
+
+## Reviewer check
+
+For every `os.environ.get("RESEARCH_*")` or new third-party API key in the diff:
+
+```bash
+grep -n "NAME" src/research_agent/config.py .env.example README.md docs/API_KEYS.md
+```
+
+All four (or three for non-API-key flags) must show a hit. If any is missing, add it before sign-off — the test will catch it but reviewer should not be the discovery path.

--- a/.claude/skills/scope-discipline/SKILL.md
+++ b/.claude/skills/scope-discipline/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: scope-discipline
+description: Keep PR diffs strictly scoped to the linked issue. Reject unrelated env vars, deps, and feature bundling.
+when-to-use: When implementing or reviewing any issue — check before commit and during review.
+---
+
+# Scope Discipline
+
+This loop's #1 recurring quality issue is PRs that bundle unrelated changes. Across issues #100, #101, #102, #110, #112, and #96, connector PRs swept in PDF VLM escalation env vars, OCR VLM env vars, YouTube API keys, CourtListener tokens, FEC/LDA/OpenCorporates keys, new dependencies, planner changes, and critique model edits — none of which the issue asked for.
+
+## Rule
+
+One issue → one PR → one logical change. Every file in the diff must trace to a line in the issue body or acceptance criteria.
+
+## Before committing
+
+Run `git diff --stat origin/main...HEAD` and for each file ask:
+
+1. Is this file mentioned in the issue body or acceptance criteria?
+2. Is this change *required* to make the in-scope code work?
+3. Would removing this change still satisfy the acceptance criteria?
+
+If #1 and #2 are no and #3 is yes — the change is out of scope.
+
+## Common scope-creep patterns in this repo
+
+| Symptom | What to do |
+|---|---|
+| New `RESEARCH_*_VLM_ESCALATION` env var on a non-VLM connector PR | Remove. File a follow-up issue. |
+| `pyproject.toml` adding `pdfplumber`/`tesseract`/`whisper` on a non-PDF/OCR/audio PR | Remove. |
+| `.env.example` and `docs/API_KEYS.md` getting unrelated key entries | Remove. |
+| Orchestrator `task_kind`/dispatch handler edits on a connector PR | Remove unless the issue asks for orchestrator wiring. |
+| Critique-model field additions on a non-critique PR | Remove. |
+| Plan/synth prompt rewrites on a non-prompt PR | Remove. |
+
+## When in-scope work reveals a needed change elsewhere
+
+Do not fold it in. Instead:
+
+1. Finish the in-scope work.
+2. File a follow-up issue describing the discovered need (`alpha-loop add "<description>"`).
+3. Leave a brief comment in the current PR pointing to the follow-up issue.
+
+## Reviewer action
+
+Flag scope creep as WARNING in the review summary. Do not block merge if the in-scope code is correct, but record the violation so the pattern is visible. Recommend split-out into a follow-up.

--- a/.claude/skills/smoke-verification/SKILL.md
+++ b/.claude/skills/smoke-verification/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: smoke-verification
+description: Smoke and verification commands must assert non-empty, query-relevant content — exit code 0 alone is not success.
+when-to-use: When implementing or reviewing any tool/connector that ships a `_smoke-tool` verb or live verification command.
+---
+
+# Smoke Verification
+
+Across issues #102 (GovInfo), #104 (USAspending), #109 (OCR), #110 (audio), #101 (CA SoS), #95 (BBB), and #94 (LittleSis), this loop has shipped "successful" connectors whose smoke commands returned empty markdown, zero result rows, or `?` placeholder fields — yet exit code was 0 and the issue was closed green.
+
+**Empty output is a failure signal, not a pass.**
+
+## Rule
+
+A smoke / verification command "passes" only when:
+
+1. Exit code is 0, AND
+2. Output is non-empty, AND
+3. Output contains query-relevant content (entity name, value, ID, or expected field), AND
+4. No required structured fields are placeholder (`?`, `null`, empty string).
+
+## Implementer responsibilities
+
+- After running the smoke command, read its output. If empty or placeholder-laden, *do not* declare success — investigate.
+- For Playwright connectors: live-verify selectors for *every distinct page type* (search results page AND profile/detail page). Reusing search-row selectors as profile-page selectors is a known footgun (#101).
+- If the connector requires an optional binary (Tesseract, ffmpeg, mlx-whisper) or external service (LM Studio), and that dep is unavailable in the verification environment, the smoke must **skip loudly** with a clear marker — not silently emit empty output (#109).
+- Test fixtures must contain detectable signal. An audio fixture that is silent or synthetic produces empty transcripts and gives a false-green (#110).
+
+## Reviewer responsibilities
+
+When the issue calls for live smoke verification, locate the smoke output in the implementation log and inspect it. Treat the following as failure regardless of exit code:
+
+- Empty markdown body
+- "No results" with no investigation note
+- Structured fields rendering `?`, `None`, or empty for fields the AC names
+- Default "Smoke command exited 0" success claim with no content shown
+
+## Patterns that work
+
+- Add a non-empty content assertion to the smoke wrapper itself (e.g. `assert "|" in output and len(output) > 200`).
+- For paid/keyed APIs, fail loudly when the key is missing (#114) rather than silently no-op.
+- Use `uv tool install -e .` in `setup_command` so the verifier's `/bin/sh -c "research ..."` shell-out resolves on PATH; otherwise smoke fails with `command not found` (recurring across #100–#117).


### PR DESCRIPTION
## Summary

Mirrors the changes from #149 (now merged on main) into `.claude/` so the Claude harness actually picks them up. `.alpha-loop/templates/` is the source of truth; `.claude/` is the harness-synced copy.

- `.claude/agents/implementer.md` — overwritten with Python-tuned implementer
- `.claude/agents/reviewer.md` — overwritten with Python-tuned reviewer + 7-item checklist
- `.claude/skills/scope-discipline/SKILL.md` — new
- `.claude/skills/smoke-verification/SKILL.md` — new
- `.claude/skills/env-var-registration/SKILL.md` — new

Without this sync, #149 only updated the source-of-truth dir; the Claude harness was still loading the old templates.

## Test plan

- [ ] Next alpha-loop run uses the new prompts (visible in implementer/reviewer subagent loads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)