### PR TITLE
feat: fix: licensing returns no results for known-good 'SBI Builders' (closes #155)

### DIFF
--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -591,25 +591,51 @@ def _smoke_licensing(query: str) -> str:
     the top-5 hits with license number / status / classification / expiration
     / URL, then attempts ``fetch()`` on the top hit and prints a Disciplinary
     History excerpt — the primary due-diligence signal.
+
+    On a zero-result run, the message distinguishes 'CSLB returned 0 hits'
+    from 'parser missed every row' so an operator can tell apart a real
+    no-such-contractor result from selector drift without re-running.
     """
     from research_agent.tools import browser, licensing
 
     async def _run() -> str:
         try:
-            results = await licensing.search(query, state="CA", max_results=5)
+            results, status = await licensing.search(
+                query, state="CA", max_results=5, return_diagnostic=True
+            )
             if not results:
-                return f"licensing search returned no results for {query!r}"
+                if status == "no-hits":
+                    return (
+                        f"CSLB returned 0 hits for {query!r} "
+                        f"(board's results table rendered empty)"
+                    )
+                if status == "submit-failed":
+                    return (
+                        f"CSLB search submit failed for {query!r} — "
+                        f"diagnostic dump under data/diagnostics/cslb/"
+                    )
+                if status == "parser-miss":
+                    return (
+                        f"CSLB result page parser found 0 rows for {query!r}"
+                        f" — selector drift suspected; diagnostic dump under "
+                        f"data/diagnostics/cslb/"
+                    )
+                # page-error / unexpected — surface the status code.
+                return (
+                    f"CSLB licensing search aborted for {query!r} "
+                    f"(status={status}); see data/diagnostics/cslb/"
+                )
             lines: list[str] = []
             for hit in results:
                 number = hit.extras.get("license_number") or "?"
-                status = hit.extras.get("status") or "?"
+                hit_status = hit.extras.get("status") or "?"
                 classification = hit.extras.get("classification") or "?"
                 expiration = hit.extras.get("expiration") or "?"
                 snippet = hit.snippet.replace("\n", " ")
                 if len(snippet) > 200:
                     snippet = snippet[:200] + "…"
                 lines.append(
-                    f"- {hit.title} — {number} — {classification} — {status} —"
+                    f"- {hit.title} — {number} — {classification} — {hit_status} —"
                     f" exp {expiration}\n"
                     f"  {hit.url}\n"
                     f"  {snippet}"
@@ -627,9 +653,18 @@ def _smoke_licensing(query: str) -> str:
                 if len(excerpt) > 400:
                     excerpt = excerpt[:400] + "…"
                 lines.append(f"\nProfile for {top.title}")
-                lines.append(f"  license_number: {source.metadata.get('license_number') or '?'}")
-                lines.append(f"  status: {source.metadata.get('status') or '?'}")
-                lines.append(f"  expiration: {source.metadata.get('expiration') or '?'}")
+                lines.append(
+                    f"  license_number: {source.metadata.get('license_number') or '?'}"
+                )
+                lines.append(
+                    f"  status: {source.metadata.get('status') or '?'}"
+                )
+                lines.append(
+                    f"  classification: {source.metadata.get('classification') or '?'}"
+                )
+                lines.append(
+                    f"  expiration: {source.metadata.get('expiration') or '?'}"
+                )
                 lines.append(f"  disciplinary_history: {excerpt}")
             return "\n".join(lines)
         finally:

--- a/src/research_agent/tools/licensing.py
+++ b/src/research_agent/tools/licensing.py
@@ -4,11 +4,15 @@ Public surface:
 
 * ``async def search(query, *, state="CA", max_results=25) -> list[SearchResult]``
   runs a state contractor / professional licensing board search by license
-  number OR business name. Returns license number, status, classification,
-  expiration date, and a profile permalink.
+  number OR business name. Returns license number, status, and a profile
+  permalink. Pass ``return_diagnostic=True`` to get a status string back
+  alongside the rows so callers (e.g. the smoke wrapper) can distinguish
+  "board returned 0 hits" from "parser missed every row".
 * ``async def fetch(url) -> Source | None`` opens the per-license profile and
-  rolls the four CSLB tabs (Personnel, Workers' Compensation, Bonds,
-  Disciplinary History) into a single markdown ``cleaned_text``.
+  rolls the Business Information / Status / Classifications / Bonding /
+  Workers' Compensation / Other sections (plus a Disciplinary History note
+  derived from the PublicComplaintDisclosure link) into a single markdown
+  ``cleaned_text``.
 
 v1 ships **California State License Board (CSLB)** as the worked example;
 TX / FL / NY are config stubs that emit a WARN and return ``[]`` / ``None``.
@@ -24,7 +28,7 @@ import logging
 import re
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 import playwright.async_api
@@ -34,7 +38,10 @@ from research_agent.tools.models import SearchResult, Source
 
 logger = logging.getLogger(__name__)
 
-_DIAGNOSTICS_DIR = Path("data/diagnostics/licensing")
+# Diagnostics ship under data/diagnostics/cslb/ per issue #155 acceptance
+# criteria — both a screenshot AND a page.content() HTML dump so future
+# selector drift is visible without re-running.
+_DIAGNOSTICS_DIR = Path("data/diagnostics/cslb")
 _PER_HOST_RPS = 0.5
 
 # CSLB license numbers are 6–8 digits. When the recipe defines a
@@ -42,69 +49,64 @@ _PER_HOST_RPS = 0.5
 # board's form interprets the value as a license number rather than a name.
 _LICENSE_NUMBER_RE = re.compile(r"^\d{6,8}$")
 
+# CSLB's results page uses ASP.NET WebForms IDs of the form
+# ``MainContent_dlMain_<field>_<index>`` where <index> is 0..N for each row.
+_RESULT_ID_RE = re.compile(r"_(\d+)$")
+
 
 # ---------------------------------------------------------------------------
 # Recipes — one per state.
 # ---------------------------------------------------------------------------
 
 _STATE_RECIPES: dict[str, dict[str, Any]] = {
-    # California (CSLB) — fully wired against the live "Check License II"
-    # form. The form is **tabbed**: license-number search, business-name
-    # search, and personnel-name search each have their own input + submit
-    # button, with only the active tab's inputs visible. A tab button must
-    # be clicked first (the `tab_buttons_by_kind` mapping) to make the
-    # corresponding input visible before fill().
+    # California (CSLB) — verified against the live "Check License II"
+    # search page on 2026-05-06. The form is **tabbed**: license-number
+    # search, business-name search, and personnel-name search each have
+    # their own input + submit button, with only the active tab's inputs
+    # visible. A tab button must be clicked first (the
+    # ``tab_buttons_by_kind`` mapping) to make the corresponding input
+    # visible before fill().
+    #
+    # The submit posts back to ``NameSearch.aspx`` (or
+    # ``LicenseDetail.aspx`` for license-number search) and the results
+    # render as a single ``MainContent_dlMain`` table whose rows carry
+    # numbered ``MainContent_dlMain_<field>_<N>`` spans/links — there is
+    # no class-based row layout. The detail page (``LicenseDetail.aspx``)
+    # is a single stacked table; CSLB does NOT use tabbed sections for the
+    # detail view, despite what the prior recipe assumed.
     "CA": {
         "host": "www.cslb.ca.gov",
         "search_url": (
             "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/CheckLicense.aspx"
         ),
-        # Tab buttons that switch which search input is visible.
-        # `LicNoButton` selects the license-number tab; `BusNameButton`
-        # selects the business-name tab. (HISNoButton / HISNameButton exist
-        # for salesperson registration searches and are not wired here.)
         "tab_buttons_by_kind": {
             "number": "#LicNoButton",
             "name": "#BusNameButton",
         },
-        # Per-mode input fields. ASP.NET WebForms naming — the visible IDs
-        # are stable; the `name` attributes are also the form-post keys.
         "query_inputs_by_kind": {
             "number": "#MainContent_LicNo",
             "name": "#MainContent_NextName",
         },
-        # Per-mode submit buttons — each tab has its own.
         "submit_buttons_by_kind": {
             "number": "#MainContent_Contractor_License_Number_Search",
             "name": "#MainContent_Contractor_Business_Name_Button",
         },
-        # Result rows. CSLB's results page renders a single-license summary
-        # for an exact match, or a table of links for multi-hit name searches.
-        "row_selector": "table.searchresults tbody tr",
-        "name_selector": "td.business-name",
-        "link_selector": "td.business-name a",
-        "license_number_selector": "td.license-number",
-        "status_selector": "td.license-status",
-        "classification_selector": "td.classification",
-        "expiration_selector": "td.expiration",
-        # Profile detail tabs. Each ``*_tab_button`` is clicked before the
-        # corresponding ``*_section`` is scraped — eager-load every tab so the
-        # rolled-up Source contains all four sections in one shot.
-        "personnel_tab_button": "a#tabPersonnel, button#tabPersonnel",
-        "personnel_section": "#sectionPersonnel",
-        "workers_comp_tab_button": "a#tabWorkersComp, button#tabWorkersComp",
-        "workers_comp_section": "#sectionWorkersComp",
-        "bonds_tab_button": "a#tabBonds, button#tabBonds",
-        "bonds_section": "#sectionBonds",
-        "disciplinary_tab_button": "a#tabDisciplinary, button#tabDisciplinary",
-        "disciplinary_section": "#sectionDisciplinary",
-        # Header summary on the profile page (license number, status,
-        # classification, expiration) — populated from data attributes when
-        # present, otherwise scraped from the visible header.
-        "profile_license_number_selector": "[data-field='license-number']",
-        "profile_status_selector": "[data-field='license-status']",
-        "profile_classification_selector": "[data-field='classification']",
-        "profile_expiration_selector": "[data-field='expiration']",
+        # The outer results container — used to distinguish 'CSLB
+        # rendered the results table but had no rows' from 'page error /
+        # the user got bounced back to the search form'.
+        "results_table_id": "MainContent_dlMain",
+        # Profile detail (LicenseDetail.aspx) selectors — single stacked
+        # table, no tabs.
+        "profile_license_number_id": "MainContent_Header2Detail",
+        "profile_status_id": "MainContent_Status",
+        "profile_classifications_id": "MainContent_ClassCellTable",
+        "profile_expiration_id": "MainContent_ExpDt",
+        "profile_issue_date_id": "MainContent_IssDt",
+        "profile_entity_id": "MainContent_Entity",
+        "profile_business_info_id": "MainContent_BusInfo",
+        "profile_bonding_id": "MainContent_BondingCellTable",
+        "profile_workers_comp_id": "MainContent_WCStatus",
+        "profile_other_id": "MainContent_MultiLicDisplay",
     },
     # TX/FL/NY are stubs — selector recipes haven't been built yet. Emit a
     # WARN and return [] / None so the planner gracefully routes around the
@@ -139,54 +141,21 @@ _register_host_rates()
 # ---------------------------------------------------------------------------
 
 
+SearchStatus = Literal[
+    "ok",
+    "no-hits",
+    "parser-miss",
+    "submit-failed",
+    "page-error",
+]
+
+
 def _looks_like_license_number(query: str) -> bool:
     """Heuristic: did the user paste a license number rather than a name?"""
     cleaned = (query or "").strip()
     if not cleaned:
         return False
     return bool(_LICENSE_NUMBER_RE.match(cleaned))
-
-
-# Short per-call timeout for selector reads. Playwright's default 30s auto-wait
-# is catastrophic on a page where most profile selectors may be absent — half
-# a dozen missing selectors in ``fetch()`` would hang the connector for minutes.
-_SELECTOR_READ_TIMEOUT_MS = 2_000
-
-
-async def _safe_inner_text(locator: Any) -> str:
-    try:
-        text = await locator.inner_text(timeout=_SELECTOR_READ_TIMEOUT_MS)
-    except TypeError:
-        try:
-            text = await locator.inner_text()
-        except Exception:  # noqa: BLE001
-            return ""
-    except Exception:  # noqa: BLE001 — selector miss should not raise
-        return ""
-    return (text or "").strip()
-
-
-async def _safe_attr(locator: Any, name: str) -> str:
-    try:
-        value = await locator.get_attribute(name, timeout=_SELECTOR_READ_TIMEOUT_MS)
-    except TypeError:
-        try:
-            value = await locator.get_attribute(name)
-        except Exception:  # noqa: BLE001
-            return ""
-    except Exception:  # noqa: BLE001
-        return ""
-    return (value or "").strip()
-
-
-async def _save_diagnostic_screenshot(page: Any, host: str) -> None:
-    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-    target = _DIAGNOSTICS_DIR / f"{host}-{stamp}.png"
-    try:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        await page.screenshot(path=str(target))
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("licensing diagnostic screenshot failed: %s", exc)
 
 
 def _absolute_url(base: str, href: str) -> str:
@@ -200,64 +169,267 @@ def _absolute_url(base: str, href: str) -> str:
     return base.rstrip("/") + "/" + href
 
 
+async def _save_diagnostic_dump(page: Any, host: str, *, label: str = "") -> None:
+    """Persist a screenshot AND the rendered HTML for operator inspection.
+
+    The previous implementation wrote only a PNG; future selector drift then
+    required a re-run with attach-to-running-browser. Dumping the actual HTML
+    the parser saw closes that loop — operators can diff against the in-tree
+    fixture (`tests/fixtures/cslb/sbi_builders_results.html`) to spot the
+    change immediately.
+    """
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    suffix = f"-{label}" if label else ""
+    base = _DIAGNOSTICS_DIR / f"{host}-{stamp}{suffix}"
+    try:
+        base.parent.mkdir(parents=True, exist_ok=True)
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.debug("licensing diagnostic mkdir failed: %s", exc)
+        return
+    try:
+        await page.screenshot(path=str(base.with_suffix(".png")))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("licensing diagnostic screenshot failed: %s", exc)
+    try:
+        html = await page.content()
+        base.with_suffix(".html").write_text(html or "", encoding="utf-8")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("licensing diagnostic html dump failed: %s", exc)
+
+
 # ---------------------------------------------------------------------------
-# search()
+# Pure parsers — testable without a live browser.
 # ---------------------------------------------------------------------------
 
 
-async def _extract_row(
-    row: Any, recipe: dict[str, Any], *, search_url: str
-) -> SearchResult | None:
-    name = await _safe_inner_text(row.locator(recipe["name_selector"]).first)
-    if not name:
-        return None
+def _parse_search_results(
+    html: str,
+    *,
+    recipe: dict[str, Any],
+    search_url: str,
+    state: str,
+    max_results: int = 25,
+) -> tuple[list[SearchResult], SearchStatus]:
+    """Parse a CSLB Name/License Search results page into ``SearchResult`` rows.
 
-    href = await _safe_attr(row.locator(recipe["link_selector"]).first, "href")
-    license_number = await _safe_inner_text(
-        row.locator(recipe.get("license_number_selector") or "").first
-    ) if recipe.get("license_number_selector") else ""
-    status = await _safe_inner_text(row.locator(recipe["status_selector"]).first)
-    classification = await _safe_inner_text(
-        row.locator(recipe.get("classification_selector") or "").first
-    ) if recipe.get("classification_selector") else ""
-    expiration = await _safe_inner_text(
-        row.locator(recipe.get("expiration_selector") or "").first
-    ) if recipe.get("expiration_selector") else ""
+    Returns ``(results, status)``. ``status`` distinguishes 'CSLB returned 0
+    hits' from 'parser missed all rows' from 'CSLB never rendered the
+    results table' — the smoke wrapper uses this to print a truthful
+    one-liner without re-running the search.
+    """
+    from bs4 import BeautifulSoup  # lazy
 
-    state = next(
-        (
-            code
-            for code, r in _STATE_RECIPES.items()
-            if r.get("host") == recipe["host"]
-        ),
-        "",
+    table_id = recipe.get("results_table_id") or ""
+    soup = BeautifulSoup(html or "", "html.parser")
+    table = soup.find(id=table_id) if table_id else None
+    if table is None:
+        return [], "page-error"
+
+    name_spans = soup.select(f"span[id^='{table_id}_lblName_']")
+    if not name_spans:
+        return [], "no-hits"
+
+    results: list[SearchResult] = []
+    for span in name_spans:
+        if len(results) >= max_results:
+            break
+        idx_match = _RESULT_ID_RE.search(span.get("id", ""))
+        if idx_match is None:
+            continue
+        idx = idx_match.group(1)
+        name = span.get_text(strip=True)
+        if not name:
+            continue
+        license_link = soup.find(id=f"{table_id}_hlLicense_{idx}")
+        href = license_link.get("href", "") if license_link else ""
+        license_number = (
+            license_link.get_text(strip=True) if license_link else ""
+        )
+        status_span = soup.find(id=f"{table_id}_lblLicenseStatus_{idx}")
+        status = status_span.get_text(strip=True) if status_span else ""
+        city_span = soup.find(id=f"{table_id}_lblCity_{idx}")
+        city = city_span.get_text(strip=True) if city_span else ""
+        type_span = soup.find(id=f"{table_id}_lblType_{idx}")
+        name_type = type_span.get_text(strip=True) if type_span else ""
+
+        if href:
+            profile_url = _absolute_url(search_url, str(href))
+        elif license_number:
+            profile_url = f"{search_url}?LicNum={license_number}"
+        else:
+            profile_url = search_url
+
+        snippet_bits = [b for b in (name_type, city, status) if b]
+        snippet = " — ".join(snippet_bits)
+
+        extras: dict[str, Any] = {
+            "license_number": license_number,
+            "status": status,
+            # Classification + expiration aren't on the search-results
+            # page — they live on the per-license detail page. fetch()
+            # populates them. Keeping the keys present preserves the
+            # downstream contract (extras is a stable dict shape).
+            "classification": "",
+            "expiration": "",
+            "city": city,
+            "name_type": name_type,
+            "state": state,
+            "profile_url": profile_url,
+        }
+        results.append(
+            SearchResult(
+                url=profile_url,
+                title=name,
+                snippet=snippet,
+                source_kind="licensing",
+                extras=extras,
+            )
+        )
+
+    if not results:
+        return [], "parser-miss"
+    return results, "ok"
+
+
+# Profile sections in render order. Each tuple: (heading, recipe key,
+# metadata key). The detail page stacks these in a single table, so we
+# scrape by ID rather than navigating tabs.
+_PROFILE_SECTIONS: tuple[tuple[str, str, str], ...] = (
+    ("Business Information", "profile_business_info_id", "business_info"),
+    ("License Status", "profile_status_id", "status_section"),
+    ("Classifications", "profile_classifications_id", "classifications"),
+    ("Bonding Information", "profile_bonding_id", "bonding"),
+    ("Workers' Compensation", "profile_workers_comp_id", "workers_comp"),
+    ("Other", "profile_other_id", "other"),
+)
+
+
+def _parse_profile(html: str, url: str, *, recipe: dict[str, Any]) -> Source | None:
+    """Parse a CSLB LicenseDetail.aspx page into a :class:`Source`.
+
+    Pulls the stacked Business Information / Status / Classifications /
+    Bonding / Workers' Comp / Other sections by their stable
+    ``MainContent_*`` IDs. Disciplinary history isn't a stacked section on
+    CSLB — it's gated behind a ``PublicComplaintDisclosure.aspx`` link
+    that only renders when the contractor has disclosable actions. The
+    parser surfaces that link (or a 'no actions' note) under a
+    ``Disciplinary History`` heading so the metadata key remains stable
+    for the smoke wrapper.
+    """
+    from bs4 import BeautifulSoup  # lazy
+
+    soup = BeautifulSoup(html or "", "html.parser")
+
+    license_number_id = recipe.get("profile_license_number_id")
+    license_number = ""
+    if license_number_id:
+        node = soup.find(id=license_number_id)
+        if node:
+            license_number = node.get_text(strip=True)
+
+    expire_node = soup.find(id=recipe.get("profile_expiration_id"))
+    expiration = expire_node.get_text(strip=True) if expire_node else ""
+
+    classification_node = soup.find(id=recipe.get("profile_classifications_id"))
+    classification = (
+        classification_node.get_text(" ", strip=True) if classification_node else ""
     )
 
-    if href:
-        profile_url = _absolute_url(search_url, href)
-    elif license_number:
-        profile_url = f"{search_url}?LicNum={license_number}"
+    status_node = soup.find(id=recipe.get("profile_status_id"))
+    status_text = status_node.get_text(" ", strip=True) if status_node else ""
+    # Take the leading sentence as the compact status — the cell often
+    # bundles a follow-up reminder like "All information below should be
+    # reviewed." that's not useful in the metadata key.
+    status = ""
+    if status_text:
+        first, sep, _ = status_text.partition(".")
+        status = (first.strip() + (sep or "")).strip()
+
+    title = ""
+    h1 = soup.find("h1")
+    if h1:
+        title = h1.get_text(" ", strip=True)
+    if not title and license_number:
+        title = f"License #{license_number}"
+    if not title:
+        parsed = urlparse(url)
+        title = parsed.netloc or "License Detail"
+
+    # The legal-disclaimer block always carries a "click here for a
+    # definition of disclosable actions" link; it's NOT an actual
+    # disclosure. The real disclosure link only renders when the
+    # contractor has disclosable actions, and it lives outside the
+    # `#disclaimer` ul. Filter the disclaimer's link out so we don't
+    # falsely flag every active license as having a complaint history.
+    real_disclosure_link = None
+    for link in soup.select("a[href*='PublicComplaintDisclosure']"):
+        if link.find_parent(id="disclaimer") is not None:
+            continue
+        real_disclosure_link = link
+        break
+    if real_disclosure_link is not None:
+        link_text = (
+            real_disclosure_link.get_text(strip=True) or "Public complaint disclosure"
+        )
+        href = real_disclosure_link.get("href", "")
+        disciplinary_history = (
+            f"{link_text} — see {href}" if href else link_text
+        )
     else:
-        profile_url = search_url
+        disciplinary_history = "No disclosable actions reported on this profile."
 
-    snippet_bits = [b for b in (classification, status, expiration) if b]
-    snippet = " — ".join(snippet_bits)
+    sections: list[str] = [f"# {title}"]
+    meta_bits = [b for b in (license_number, classification, status, expiration) if b]
+    if meta_bits:
+        sections.append("_" + " · ".join(meta_bits) + "_")
 
-    extras: dict[str, Any] = {
+    section_text: dict[str, str] = {}
+    for heading, recipe_key, meta_key in _PROFILE_SECTIONS:
+        sel_id = recipe.get(recipe_key)
+        body = ""
+        if sel_id:
+            node = soup.find(id=sel_id)
+            if node:
+                body = node.get_text("\n", strip=True)
+        section_text[meta_key] = body
+        sections.append(f"## {heading}\n\n{body or '(not available)'}")
+
+    sections.append(f"## Disciplinary History\n\n{disciplinary_history}")
+
+    cleaned_text = "\n\n".join(sections).strip()
+    # Empty profile = nothing besides the title heading, which means CSLB
+    # served us something other than a license detail page.
+    has_any_section = any(section_text.values())
+    has_signal = (
+        bool(meta_bits) or has_any_section or real_disclosure_link is not None
+    )
+    if not has_signal:
+        return None
+
+    metadata: dict[str, Any] = {
         "license_number": license_number,
         "status": status,
         "classification": classification,
         "expiration": expiration,
-        "state": state,
-        "profile_url": profile_url,
+        "disciplinary_history": disciplinary_history,
     }
-    return SearchResult(
-        url=profile_url,
-        title=name,
-        snippet=snippet,
+    for _, _, meta_key in _PROFILE_SECTIONS:
+        metadata[meta_key] = section_text.get(meta_key, "")
+
+    return Source(
+        url=url,
+        title=title,
+        cleaned_text=cleaned_text,
+        raw_html=None,
+        fetched_at=datetime.now(UTC),
         source_kind="licensing",
-        extras=extras,
+        metadata=metadata,
     )
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
 
 
 async def search(
@@ -265,35 +437,43 @@ async def search(
     *,
     state: str = "CA",
     max_results: int = 25,
-) -> list[SearchResult]:
+    return_diagnostic: bool = False,
+) -> list[SearchResult] | tuple[list[SearchResult], SearchStatus]:
     """Run a state licensing-board search; return up to ``max_results`` hits.
 
     ``state`` is the two-letter postal code (default ``"CA"`` for CSLB).
     Unknown or stub states return ``[]`` after a WARN so callers can route
     around the coverage gap rather than crashing the planner.
 
-    Detects license-number vs name queries by regex; when the recipe exposes
-    a ``query_kind_selector``, the matching radio is selected before
-    submission.
+    Detects license-number vs name queries by regex; the matching tab/input
+    pair is selected before submission.
+
+    When ``return_diagnostic=True`` returns ``(results, status)`` so callers
+    can distinguish 'CSLB returned 0 hits' from 'parser missed every row'
+    from 'submit failed'. Default ``False`` keeps the historical
+    list-only return shape.
     """
     code = (state or "").strip().upper()
     recipe = _STATE_RECIPES.get(code)
     if recipe is None:
         logger.warning("licensing: no recipe for state %r", state)
-        return []
+        return ([], "page-error") if return_diagnostic else []
     if recipe.get("stub"):
         logger.warning(
             "licensing: state %s is a stub — coverage not yet wired (host=%s)",
             code,
             recipe.get("host"),
         )
-        return []
+        return ([], "page-error") if return_diagnostic else []
 
     if not query or not query.strip():
-        return []
+        return ([], "no-hits") if return_diagnostic else []
 
     search_url = recipe["search_url"]
     host = recipe["host"]
+
+    status: SearchStatus = "page-error"
+    results: list[SearchResult] = []
 
     try:
         async with browser.browser_session() as ctx:
@@ -325,7 +505,7 @@ async def search(
                         code,
                         kind_key,
                     )
-                    return []
+                    return ([], "page-error") if return_diagnostic else []
 
                 try:
                     await page.locator(input_selector).first.fill(query)
@@ -334,68 +514,76 @@ async def search(
                     logger.warning(
                         "licensing search submit failed for state=%s: %s", code, exc
                     )
-                    await _save_diagnostic_screenshot(page, host)
-                    return []
+                    await _save_diagnostic_dump(page, host, label="submit-failed")
+                    return ([], "submit-failed") if return_diagnostic else []
+
+                # ASP.NET WebForms postback can still be in flight when we
+                # read content — wait for the network to settle. If the
+                # board is slow we fall back on a best-effort read; the
+                # parser will surface a 'page-error' status and dump
+                # diagnostics for the operator.
+                try:
+                    await page.wait_for_load_state(
+                        "networkidle", timeout=15_000
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(
+                        "licensing wait_for_load_state failed: %s", exc
+                    )
 
                 try:
-                    rows = await page.locator(recipe["row_selector"]).all()
+                    html = await page.content()
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
-                        "licensing search selector miss on %s: %s", search_url, exc
+                        "licensing search page.content() failed for %s: %s",
+                        search_url,
+                        exc,
                     )
-                    await _save_diagnostic_screenshot(page, host)
-                    return []
+                    await _save_diagnostic_dump(page, host, label="content-failed")
+                    return ([], "page-error") if return_diagnostic else []
 
-                results: list[SearchResult] = []
-                for row in rows[:max_results]:
-                    try:
-                        result = await _extract_row(
-                            row, recipe, search_url=search_url
-                        )
-                    except Exception as exc:  # noqa: BLE001
-                        logger.warning("licensing row parse failed: %s", exc)
-                        continue
-                    if result is not None:
-                        results.append(result)
-                return results
+                results, status = _parse_search_results(
+                    html,
+                    recipe=recipe,
+                    search_url=search_url,
+                    state=code,
+                    max_results=max_results,
+                )
+                if status in ("parser-miss", "page-error"):
+                    logger.warning(
+                        "licensing search %s on %s for query=%r",
+                        status,
+                        search_url,
+                        query,
+                    )
+                    await _save_diagnostic_dump(page, host, label=status)
+                elif status == "no-hits":
+                    logger.info(
+                        "licensing search returned 0 hits on %s for query=%r",
+                        search_url,
+                        query,
+                    )
             finally:
                 try:
                     await page.close()
                 except Exception:  # noqa: BLE001
                     pass
     except playwright.async_api.Error as exc:
-        logger.warning("licensing search playwright error for state=%s: %s", code, exc)
-        return []
+        logger.warning(
+            "licensing search playwright error for state=%s: %s", code, exc
+        )
+        return ([], "page-error") if return_diagnostic else []
     except Exception as exc:  # noqa: BLE001 — never crash the planner
-        logger.warning("licensing search unexpected error for state=%s: %s", code, exc)
-        return []
+        logger.warning(
+            "licensing search unexpected error for state=%s: %s", code, exc
+        )
+        return ([], "page-error") if return_diagnostic else []
+    return (results, status) if return_diagnostic else results
 
 
 # ---------------------------------------------------------------------------
 # fetch()
 # ---------------------------------------------------------------------------
-
-# Profile sections that fetch() rolls into the markdown body, in order.
-# Each entry maps a (heading, tab-button-recipe-key, section-recipe-key,
-# metadata-key) tuple — heading appears in cleaned_text, the tab button is
-# clicked before the section is scraped, and the scraped text is mirrored
-# under metadata[metadata_key] for structured callers.
-_PROFILE_SECTIONS: tuple[tuple[str, str, str, str], ...] = (
-    ("Personnel", "personnel_tab_button", "personnel_section", "personnel"),
-    (
-        "Workers' Compensation",
-        "workers_comp_tab_button",
-        "workers_comp_section",
-        "workers_comp",
-    ),
-    ("Bonds", "bonds_tab_button", "bonds_section", "bonds"),
-    (
-        "Disciplinary History",
-        "disciplinary_tab_button",
-        "disciplinary_section",
-        "disciplinary_history",
-    ),
-)
 
 
 def _resolve_recipe_for_host(host: str) -> dict[str, Any] | None:
@@ -405,34 +593,11 @@ def _resolve_recipe_for_host(host: str) -> dict[str, Any] | None:
     return None
 
 
-async def _click_if_present(page: Any, selector: str | None) -> None:
-    if not selector:
-        return
-    try:
-        await page.locator(selector).first.click()
-    except Exception as exc:  # noqa: BLE001 — missing tab is non-fatal
-        logger.debug("licensing tab click miss (%s): %s", selector, exc)
-
-
-async def _collect_simple_text(page: Any, selector: str | None) -> str:
-    if not selector:
-        return ""
-    try:
-        return await _safe_inner_text(page.locator(selector).first)
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("licensing profile selector miss (%s): %s", selector, exc)
-        return ""
-
-
 async def fetch(url: str) -> Source | None:
     """Open a state licensing-board profile and return a :class:`Source`.
 
     Strict host gate: only URLs whose host matches a non-stub recipe are
     accepted; everything else returns ``None`` without a network call.
-    Eagerly clicks every detail tab (Personnel, Workers' Comp, Bonds,
-    Disciplinary History) before scraping so the rolled-up markdown contains
-    all four sections — Disciplinary History is the primary signal for
-    due-diligence runs.
     """
     if not url:
         return None
@@ -448,68 +613,40 @@ async def fetch(url: str) -> Source | None:
         async with browser.browser_session() as ctx:
             page = await ctx.new_page()
             try:
+                # CSLB's LicenseDetail.aspx redirects back to the search
+                # form when the request lacks a same-origin referer — so
+                # set one before navigating, mimicking the click-from-
+                # results-page flow a real user would take. Without this,
+                # fetch() silently receives the search form HTML and
+                # ``_parse_profile`` returns None.
+                referer = recipe.get("search_url")
+                if referer:
+                    try:
+                        await page.set_extra_http_headers({"Referer": referer})
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug(
+                            "licensing fetch set_extra_http_headers failed: %s",
+                            exc,
+                        )
                 await browser.navigate(page, url)
-
-                title = await _safe_inner_text(page.locator("h1").first)
-                if not title:
-                    title = host
-
-                license_number = await _collect_simple_text(
-                    page, recipe.get("profile_license_number_selector")
-                )
-                status = await _collect_simple_text(
-                    page, recipe.get("profile_status_selector")
-                )
-                classification = await _collect_simple_text(
-                    page, recipe.get("profile_classification_selector")
-                )
-                expiration = await _collect_simple_text(
-                    page, recipe.get("profile_expiration_selector")
-                )
-
-                section_text: dict[str, str] = {}
-                for heading, tab_key, section_key, meta_key in _PROFILE_SECTIONS:
-                    await _click_if_present(page, recipe.get(tab_key))
-                    text = await _collect_simple_text(page, recipe.get(section_key))
-                    section_text[meta_key] = text
-                    section_text[f"_heading_{meta_key}"] = heading
-
-                meta_bits = [
-                    b for b in (license_number, classification, status, expiration) if b
-                ]
-                meta_line = "_" + " · ".join(meta_bits) + "_" if meta_bits else ""
-
-                sections: list[str] = [f"# {title}"]
-                if meta_line:
-                    sections.append(meta_line)
-
-                for _, _, _, meta_key in _PROFILE_SECTIONS:
-                    heading = section_text[f"_heading_{meta_key}"]
-                    body = section_text.get(meta_key) or "(not available)"
-                    sections.append(f"## {heading}\n\n{body}")
-
-                cleaned_text = "\n\n".join(sections).strip()
-                if not cleaned_text:
+                try:
+                    await page.wait_for_load_state(
+                        "networkidle", timeout=15_000
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(
+                        "licensing fetch wait_for_load_state failed: %s", exc
+                    )
+                try:
+                    html = await page.content()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "licensing fetch page.content() failed for %s: %s",
+                        url,
+                        exc,
+                    )
                     return None
-
-                metadata: dict[str, Any] = {
-                    "license_number": license_number,
-                    "status": status,
-                    "classification": classification,
-                    "expiration": expiration,
-                }
-                for _, _, _, meta_key in _PROFILE_SECTIONS:
-                    metadata[meta_key] = section_text.get(meta_key, "")
-
-                return Source(
-                    url=url,
-                    title=title,
-                    cleaned_text=cleaned_text,
-                    raw_html=None,
-                    fetched_at=datetime.now(UTC),
-                    source_kind="licensing",
-                    metadata=metadata,
-                )
+                return _parse_profile(html, url, recipe=recipe)
             finally:
                 try:
                     await page.close()
@@ -528,4 +665,4 @@ def reset_for_tests() -> None:
     _register_host_rates()
 
 
-__all__ = ["fetch", "reset_for_tests", "search"]
+__all__ = ["SearchStatus", "fetch", "reset_for_tests", "search"]

--- a/tests/fixtures/cslb/license_detail_860997.html
+++ b/tests/fixtures/cslb/license_detail_860997.html
@@ -1,0 +1,511 @@
+<!DOCTYPE html><html class="js flexbox" lang="en" style="font-size: 1rem; height: 100%;"><!--<![endif]--><head>
+    <!--
+California State Template
+Version 5.0.8
+ 
+Based on Twitter Bootstrap
+-->
+    <meta charset="utf-8">
+    <!-- TemplateBeginEditable name="doctitle" -->
+    <title>
+	Check A License - License Detail -CSLB 
+</title>
+    <!-- TemplateEndEditable -->
+    <!-- TemplateBeginEditable name="MetaTags" -->
+    <meta name="Author" content="State of California"><meta name="Description" content="State of California"><meta name="Keywords" content="California, government">
+    <!-- TemplateEndEditable -->
+    <!-- head content, for all pages -->
+<!-- Use highest compatibility mode -->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+<!-- http://t.co/dKP3o1e -->
+<meta name="HandheldFriendly" content="True">
+<!-- for Blackberry, AvantGo -->
+<meta name="MobileOptimized" content="320">
+<!-- for Windows mobile -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+
+<!-- Google Fonts -->
+<link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700" rel="stylesheet" type="text/css">
+
+<!-- For all browsers -->
+<link rel="stylesheet" href="/css/cagov.core.css">
+
+<script type="text/javascript" async="" src="https://ssl.google-analytics.com/ga.js"></script><script type="text/javascript" async="" charset="utf-8" src="https://www.gstatic.com/recaptcha/releases/dNfi_jsbkQb4Hbw7F1b82Uia/recaptcha__en.js" crossorigin="anonymous" integrity="sha384-+G6Xc2VWk0h3y/trIZ/88xq1v+qBGtS7mMiYmmMRUbqZrVu8JAdvMFNru0CGP9mg"></script><script type="text/javascript" async="" src="https://ssl.google-analytics.com/ga.js"></script><script type="text/javascript" async="" src="https://ssl.google-analytics.com/ga.js"></script><script src="/js/search.js"></script>
+<!--
+Step 3
+Select a color scheme:
+<link rel="stylesheet" href="/css/colorscheme-eureka.css" /><link rel="stylesheet" href="/css/colorscheme-mono.css" /><link rel="stylesheet" href="/css/colorscheme-oceanside.css" /><link rel="stylesheet" href="/css/colorscheme-orangecounty.css" /><link rel="stylesheet" href="/css/colorscheme-pasorobles.css" /><link rel="stylesheet" href="/css/colorscheme-santabarbara.css" /><link rel="stylesheet" href="/css/colorscheme-sacramento.css" /><link rel="stylesheet" href="/css/colorscheme-sierra.css" /><link rel="stylesheet" href="/css/colorscheme-trinity.css" />
+-->
+
+<link rel="stylesheet" href="/css/colorscheme-oceanside.css">
+
+<!-- selectivizr.com, emulates CSS3 pseudo-classes and attribute selectors in Internet Explorer 6-8 -->
+<!--[if (lt IE 9) & (!IEMobile)]>
+<script src="/js/libs/selectivizr-min.js"></script>
+<![endif]-->
+<!-- Load jQuery from CDN with fallback to local copy -->
+<script src="https://code.jquery.com/jquery-3.6.1.min.js" integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ=" crossorigin="anonymous"></script>
+<script>
+    //Fall back to local copy if no jquery found
+    if (typeof jQuery == 'undefined') {
+        document.write(unescape("%3Cscript src='/js/libs/jquery.js' type='text/javascript'%3E%3C/script%3E"));
+    }
+</script>
+<!-- Load jQuery migrate from CDN with fallback to local copy -->
+<script src="https://code.jquery.com/jquery-migrate-3.4.0.min.js" integrity="sha256-mBCu5+bVfYzOqpYyK4jm30ZxAZRomuErKEFJFIyrwvM=" crossorigin="anonymous"></script>
+<script>
+    //Fall back to local copy if no jQuery migrate found
+    if (typeof jQuery.migrateWarnings == 'undefined') { // or typeof jQuery.fn.live == 'undefined'
+        document.write(unescape("%3Cscript src='/js/libs/jquery-migrate-3.3.2.js' type='text/javascript'%3E%3C/script%3E"));
+    }
+
+</script>
+
+
+
+<!-- apple touch icons -->
+<link rel="apple-touch-icon-precomposed" sizes="100x100" href="/images/apple-touch-icon-precomposed.png"><link rel="icon" sizes="192x192" href="/images/apple-touch-icon-192x192.png"><link rel="apple-touch-icon-precomposed" sizes="180x180" href="/images/apple-touch-icon-180x180.png"><link rel="apple-touch-icon-precomposed" sizes="152x152" href="/images/apple-touch-icon-152x152.png"><link rel="apple-touch-icon-precomposed" sizes="144x144" href="/images/apple-touch-icon-144x144.png"><link rel="apple-touch-icon-precomposed" sizes="120x120" href="/images/apple-touch-icon-120x120.png"><link rel="apple-touch-icon-precomposed" sizes="114x114" href="/images/apple-touch-icon-114x114.png"><link rel="apple-touch-icon-precomposed" sizes="72x72" href="/images/apple-touch-icon-72x72.png"><link rel="apple-touch-icon-precomposed" href="/images/apple-touch-icon-57x57.png"><link rel="shortcut icon" href="/images/apple-touch-icon-57x57.png"><link rel="apple-touch-icon" href="/images/apple-touch-icon.png">
+
+<!-- For everything else -->
+<link rel="shortcut icon" href="/favicon.ico">
+
+<!-- Activate ClearType for Mobile IE -->
+<!--[if IE]>
+<meta http-equiv="cleartype" content="on" />
+<![endif]-->
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+  <script src="/js/libs/html5shiv.min.js"></script>
+  <script src="/js/libs/respond.min.js"></script>
+<![endif]-->
+<!-- Include Google Analytics -->
+<script async="" src="https://www.googletagmanager.com/gtag/js?id=G-1W465E5H9H"></script>
+<script>window.dataLayer = window.dataLayer || []; function gtag() { dataLayer.push(arguments); } gtag('js', new Date()); gtag('config', 'G-1W465E5H9H');</script>
+<script defer="" src="https://alert.cdt.ca.gov"></script>
+<script type="text/javascript">
+
+    var _gaq = _gaq || [];
+    _gaq.push(['_setAccount', 'UA-8901380-1']); // Step 4: your google analytics profile code, either from your own google account, or contact eServices to have one set up for you
+    _gaq.push(['_gat._anonymizeIp']);
+    _gaq.push(['_setDomainName', '.ca.gov']);
+    _gaq.push(['_trackPageview']);
+
+    _gaq.push(['b._setAccount', 'UA-3419582-2']); // statewide analytics - do not remove or change
+    _gaq.push(['b._setDomainName', '.ca.gov']);
+    _gaq.push(['b._trackPageview']);
+
+    (function () {
+        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+    })();
+
+</script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.min.js"></script><link rel="stylesheet" href="/css/custom.css">
+    <!-- TemplateBeginEditable name="head" -->
+    <!-- TemplateEndEditable -->
+    <!-- TemplateParam name="OptionalSlideshow" type="boolean" value="true" -->
+    <script src="/javascript/CSLB/LicenseCheck.js"></script>
+    <script src="https://www.google.com/recaptcha/api.js"></script>
+<link type="text/css" rel="stylesheet" charset="UTF-8" href="https://www.gstatic.com/_/translate_http/_/ss/k=translate_http.tr.q1Bok6-RzC4.L.X.O/am=BBA4/d=0/rs=AN8SPfrnV_jM_9sBWRVNTTBM-yEfR6BoEQ/m=el_main_css"><script type="text/javascript" charset="UTF-8" src="https://translate.googleapis.com/_/translate_http/_/js/k=translate_http.tr.en_US.1DHSvysgfBo.O/am=AAAAAQ/d=1/exm=el_conf/ed=1/rs=AN8SPfq5_DGQW29zYz3S7KVlonNpjOwk8w/m=el_main"></script><style type="text/css">.fancybox-margin{margin-right:0px;}</style></head>
+
+<!-- possible body classes are "primary" and "two-column" -->
+<body class="two-column" style="position: relative; min-height: 100%; top: 0px;">
+
+    <header role="banner" id="header" class="global-header fixed noPrint">
+        <div id="skip-to-content"><a href="#main-content">Skip to Main Content</a></div>
+
+        <!-- Include Utility Header -->
+        <div class="utility-header">
+    <div class="container">
+        <div class="group flex-row">
+            <div class="social-media-links" role="navigation" aria-label="media sites">
+                <div class="header-cagov-logo"><a href="https://ca.gov"><span class="sr-only">CA.gov</span><img src="/images/Ca-Gov-Logo-White.svg" class="pos-rel" alt="" aria-hidden="true"></a></div>
+                <a href="/" class="ca-gov-icon-home"><span class="sr-only">Home</span></a>
+                <a href="https://www.facebook.com/CSLB.CA?ref=ts" class="ca-gov-icon-facebook"><span class="sr-only">Facebook</span></a>
+                <a href="https://twitter.com/CSLB" class="bi bi-twitter-x">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-twitter-x" viewBox="0 0 16 16">
+                        <path d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865z"></path>
+                    </svg><span class="sr-only">Twitter</span>
+                </a>
+                <a href="https://www.instagram.com/CaContractorsBoard" class="ca-gov-icon-instagram"><span class="sr-only">Instagram</span></a>
+                <a href="https://www.linkedin.com/company/contractors-state-license-board" class="ca-gov-icon-linkedin"><span class="sr-only">LinkedIn</span></a>
+                <a href="http://www.youtube.com/user/ContractorsBoard/" class="ca-gov-icon-youtube"><span class="sr-only">YouTube</span></a>
+            </div>
+            <div class="settings-links" role="tablist" aria-label="CSLB Information" aria-owns="settingsTab">
+                <a href="/OnlineServices/CheckLicenseII/CheckLicense.aspx">✔ License Check</a>
+                <a href="/OnlineServices/MailList/MailSignUp.aspx"><span class="ca-gov-icon-bell" style="font-size: 12px; vertical-align:middle"></span> Subscribe</a>
+
+                <a href="/About_us/">About CSLB</a>
+                <a href="/Media_Room/Board_and_Committee_meetings/">Public Meetings</a>
+                <a href="/About_us/Contact_CSLB.aspx">Contact Us</a>
+                <!--<a href="/OnlineServices/MailList/MailSignUp.aspx">Join Our Mailing Lists</a>-->
+                <ul class="utility-links">
+                    <li style="color:white;" title="This Google translation feature is provided for informational purposes only as CSLB is unable to guarantee the accuracy of this translation. Please consult a translator for accuracy if you are relying on the translation or are using this site for official business.">Translate this site:</li>
+                    <li>
+                        <div id="google_translate_element"><div class="skiptranslate goog-te-gadget" dir="ltr" style=""><div id=":0.targetLanguage" class="goog-te-gadget-simple" style="white-space: nowrap;"><img src="https://www.google.com/images/cleardot.gif" class="goog-te-gadget-icon" alt="" style="background-image: url(&quot;https://translate.googleapis.com/translate_static/img/te_ctrl3.gif&quot;); background-position: -65px 0px;"><span style="vertical-align: middle;"><a aria-haspopup="true" class="VIpgJd-ZVi9od-xl07Ob-lTBxed" href="#"><span>Select Language</span><img src="https://www.google.com/images/cleardot.gif" alt="" width="1" height="1"><span style="border-left: 1px solid rgb(187, 187, 187);">​</span><img src="https://www.google.com/images/cleardot.gif" alt="" width="1" height="1"><span aria-hidden="true" style="color: rgb(118, 118, 118);">▼</span></a></span></div></div></div>
+                        <script type="text/javascript">
+                            function googleTranslateElementInit() {
+                                new google.translate.TranslateElement({
+                                    pageLanguage: 'en',
+                                    includedLanguages: 'ar,en,es,fa,hy,ja,ko,ru,tl,vi,zh-CN',
+                                    layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+                                }, 'google_translate_element');
+                            }
+                        </script>
+                        <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+                    </li>
+                    <li>
+                        <button class="btn btn-xs btn-primary" data-toggle="collapse" data-target="#siteSettings" aria-expanded="false" aria-controls="siteSettings" role="tab" aria-selected="false" id="settingsTab"><span class="ca-gov-icon-gear" aria-hidden="true"></span>Settings</button>
+                    </li>
+                </ul>
+                <a href="/about_us/disability.aspx"><img style="max-height: 20px;" alt="Disability Icon" src="/images/disability.png"> </a>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+        <!-- Settings Bar -->
+        <div class="site-settings section section-standout collapse collapsed" role="alert" aria-atomic="true" id="siteSettings">
+    <div class="container  p-y">
+
+
+        <div class="btn-group btn-group-justified-sm" role="group" aria-label="contrastMode">
+            <div class="btn-group"><button type="button" class="btn btn-standout disableHighContrastMode">Default</button></div>
+            <div class="btn-group"><button type="button" class="btn btn-standout enableHighContrastMode">High Contrast</button></div>
+        </div>
+
+        <div class="btn-group" role="group" aria-label="textSizeMode">
+            <div class="btn-group"><button type="button" class="btn btn-standout resetTextSize">Reset</button></div>
+            <div class="btn-group"><button type="button" class="btn btn-standout increaseTextSize"><span class="hidden-xs">Increase Font Size</span><span class="visible-xs">Font <span class="sr-only">Increase</span><span class="ca-gov-icon-plus-line font-size-sm" aria-hidden="true"></span></span></button></div>
+            <div class="btn-group"><button type="button" class="btn btn-standout decreaseTextSize"><span class="hidden-xs">Decrease Font Size</span><span class="visible-xs">Font <span class="sr-only">Decrease</span><span class="ca-gov-icon-minus-line font-size-sm" aria-hidden="true"></span></span></button></div>
+        </div>
+        <button type="button" class="close" data-toggle="collapse" data-target="#siteSettings" aria-expanded="false" aria-controls="siteSettings" aria-label="Close" role="tab" aria-selected="false" id="ui-collapse-989"><span aria-hidden="true">×</span></button>
+    </div>
+</div>
+
+        <!-- Include Branding -->
+        <!-- header branding -->
+<div class="branding" role="banner" aria-label="State of California Website">
+    <div class="header-organization-banner">
+        <a href="/">
+            <img src="/images/header_organization.png" alt="State of California Website Template logo">
+        </a>
+    </div>
+</div>
+
+        <!-- Include Mobile Controls -->
+        <!-- mobile navigation controls -->
+<div class="mobile-controls">
+    <span class="mobile-control-group mobile-header-icons">
+    	<!-- Add more mobile controls here. These will be on the right side of the mobile page header section -->
+    </span>
+    <div class="mobile-control-group main-nav-icons float-right">
+        <button id="nav-icon3" class="mobile-control toggle-menu float-right" aria-expanded="false" aria-controls="navigation">
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+            <span class="sr-only">Menu</span>
+        </button>
+        <button class="mobile-control toggle-search">
+            <span class="ca-gov-icon-search hidden-print" aria-hidden="true"></span><span class="sr-only">Search</span>
+        </button>
+    </div>
+</div>
+
+        <div class="navigation-search">
+
+            <!-- Include Navigation -->
+            <!--
+Step 2
+Select Navigation Type:
+
+Options are: megadropdown dropdown singlelevel
+-->
+<nav id="navigation" class="main-navigation singlelevelnav auto-highlight mobile-closed" aria-label="Site Area Navigation Bar" role="navigation">
+    <ul id="nav_list" class="top-level-nav nav-menu">
+        <li class="nav-item">
+            <a href="/Consumer.aspx" class="first-level-link" aria-label="Navigate to Consumers" id="accessible-menu-1778128875700-1"><span class="ca-gov-icon-users" aria-hidden="true"></span>Consumers</a>
+        </li>
+        <li class="nav-item">
+            <a href="/Licensees.aspx" class="first-level-link" aria-label="Navigate to Licensees" id="accessible-menu-1778128875700-2"><span class="ca-gov-icon-user-id" aria-hidden="true"></span>Licensees</a>
+        </li>
+        <li class="nav-item">
+            <a href="/Applicants.aspx" class="first-level-link" aria-label="Navigate to Applicants" id="accessible-menu-1778128875700-3"><span class="ca-gov-icon-document" aria-hidden="true"></span>Applicants</a>
+        </li>
+        <li class="nav-item">
+            <a href="/OnlineService.aspx" class="first-level-link" aria-label="Navigate to Online Services" id="accessible-menu-1778128875700-4"><span class="ca-gov-icon-online-services" aria-hidden="true"></span>Online Services</a>
+        </li>
+        <li class="nav-item">
+            <a href="/NewsRoom.aspx" class="first-level-link" aria-label="Navigate to Media" id="accessible-menu-1778128875700-5"><span class="ca-gov-icon-globe" aria-hidden="true"></span>Media</a>
+        </li>
+
+        <li class="nav-item" id="nav-item-search">
+            <a href="/Resources.aspx" class="first-level-link" aria-label="Navigate to Resources" id="accessible-menu-1778128875700-6"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Resources</a>
+        </li>
+        <!--    <li class="nav-item">
+        <a href="javascript:;" class="first-level-link" aria-label="Search Button"><span class="ca-gov-icon-info-bubble"></span>How Do I...</a>
+    </li>-->
+    </ul>
+</nav>
+
+
+            <div id="head-search" class="search-container in" style="top: 108.578px;">
+                <!-- Include Search -->
+                <!-- Google Custom Search - /ssi/search.html-->
+
+<!--Uncomment if you prefer to use original google search box.
+    (be advided that original custom search box is not meeting WCAG accessibility standards)-->
+<!--<script type="text/javascript">
+    var cx = '001779225245372747843:9s-idxui5pk';// Step 7: Update this value with your search engine unique ID. Submit a request to the CDT Service Desk if you don't already know your unique search engine ID.
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script');
+    s[s.length - 1].parentNode.insertBefore(gcse, s[s.length - 1]);
+</script>
+<gcse:searchbox-only resultsUrl="/serp.html" enableAutoComplete="true"></gcse:searchbox-only>-->
+
+
+<!--Custom Google Search ID Script can be found inside of serp.html file -->
+<div class="container" role="search">
+    <form id="Search" class="pos-rel" action="/SearchResult.aspx">
+        <span class="sr-only" id="SearchInput" aria-hidden="true">Custom Google Search</span>
+        <input type="text" id="q" name="q" aria-labelledby="SearchInput" placeholder="Search this website" class="focus-only search-textfield height-50 border-0 p-x-sm w-100" tabindex="-1" aria-hidden="true">
+        <button type="submit" class="pos-abs gsc-search-button top-0 width-50 height-50 border-0 bg-transparent" tabindex="-1" aria-hidden="true"><span class="ca-gov-icon-search font-size-30 color-gray" aria-hidden="true"></span><span class="sr-only">Submit</span></button>
+        <div class="width-50 height-50 close-search-btn"><button class="close-search gsc-clear-button width-50 height-50 border-0 bg-transparent pos-rel" type="reset" tabindex="-1" aria-hidden="true"><span class="sr-only">Close Search</span><span class="ca-gov-icon-close-mark" aria-hidden="true"></span></button></div>
+    </form>
+</div>
+
+
+
+            </div>
+
+        </div>
+
+
+        <div class="header-decoration"></div>
+    </header>
+    <!-- Include for optional slideshow banner -->
+    <!-- TemplateBeginIf cond="OptionalSlideshow" -->
+
+    <!-- TemplateEndIf -->
+    <div id="main-content" class="main-content two-column" role="main" style="padding-top: 142.578px;">
+        <div class="section">
+           
+            <div class="main-primary">
+                <div class="section">
+                    
+    <script type="text/javascript">
+        function getRefreshButton() {
+            return document.getElementById("refreshButton");
+        }
+        function onCaptchaBeginCallback(s, e) {
+            var refreshButton = getRefreshButton();
+            refreshButton.src = "/Images/refreshButtonAnimated.gif";
+        }
+        function onCaptchaEndCallback(s, e) {
+            var refreshButton = getRefreshButton();
+            refreshButton.src = "/Images/refreshButton.gif";
+            document.getElementById("tbCode").value = "";
+            if (typeof (lblCorrectCodeMessage) != "undefined")
+                lblCorrectCodeMessage.SetVisible(false);
+            if (typeof (lblIncorrectCodeMessage) != "undefined")
+                lblIncorrectCodeMessage.SetVisible(false);
+        }
+    </script>
+
+
+    <style>
+        table {
+            width: 100%;
+            border-width: 1px;
+        }
+
+        .hideFromScreen {
+            display: none;
+        }
+    </style>
+    <link rel="stylesheet" media="print" href="/css/LicenseDetailPrint.css">
+
+    <a href="/">Home</a> | <a aria-label="Online Services" href="/OnlineServices/">Online Services</a> | License Details
+    <div class="CenterAlign">
+        <img src="/Images/CSLB/License_Detail_print_header.jpg" class="hideFromScreen printHeader" alt="printable header">
+    </div>
+
+    <form method="post" action="./LicenseDetail.aspx?LicNum=860997" id="form1">
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="NS+jkd0RjWmE/KDAyKvv3OqDOYSmt2BLhGNxfR9XZmuAAfdToIch+Zx8OOViYImfS7PRfO/OsYXLFyIvEQnp/AjOIcNmbciFUUUDPcjfv0uG1RWeCP9kplACH5ei1441hMMoqhWZinUQPyXDPTHjbYdjQWG4KgUHEWPSxq+UmUDfQsrjtAhLoBhrvdWRtNN/GJkFKwZFGcBNyzEjl1nl+2oAB960wq+21OVaSoDX3+chluEfgF+tltmvKRY0pjRu2OthN7qQTKQf+IuGHY1pm6Fk5vhjCzG2RnWcFaobB/UFlSQNpO1H1mc0E6hM+vnov83XrDXs9v5qX32/k1ugSK0zRcZpS9apSAIYpjxTJN8o4ELetuve4FuvOvN05/sNjcW82C8TpTkWUl/CRn+DT3ZxELlsSqSwb1AfT/NyF4DI6kseAJRpnzmwHzxGvOlRQfNCPZ2A9g69FEdQZPvvNb7sI/xYrOhrGkXR9OqW/XQq6PGWgioiaNSqloUESD3/EzM/E4NQ31qT45PWsIDuY1Y1thAflvh6nle5tlm32UL/ADrWJcA28XT/v3fYBEULkcqfGT3sNF+pbHbs1Y/H86/EUMGNToFNm5mHiH7OW6a5Ajnhr8omOsFRJNdttswWT6TJguWmp3ocY+yPaJoR0hkQdYZlc5OCahCAGV3Pt4ed3Yy6nOFcF3pKp0yKm/fPX5i5pP6ok8RULs3JWsFiLbTrKOsby0xBfPb4qjipt6Ae41H9Y9Cwt0omlRkHJAa+LhrDbKYSJqFggGlnSuVrEzZfP6JBOOTwpeJvZze3ZXtqasJ2KS8NraW6lEXAXOIlqbRif8XjwTxBwVxx07FZKSGs5VJy+dTiAdadYF6LjReX6ZojUas6C++11z0Z4e80oQOCUr58EqG6uFWnn3JfyfesbmBNtTxH4BQQ8hTAU4KH/wsgcP5mfYrbKVMDCvwNM4qQR1TTKRvuIis779x+0c03nPIKPqoWYArMy1qXQdHuChG9H7iQn1IHa6sH9tQLu1aAvZ8Y+DCEDXwcvjUEi3sX7tmfna5OfEpGS3XYi3GmSrXIx6NQYoy4QyBVRGghtmtFaCHEA6xFnj6gbEVmURALmyAy80RLKuU4bhVHdWfLtkgaGBBmWQrd/eso6DweYDLF+ab5F9TB61mh+Nx2wfJ+pKkrIAnyW4iJbrIszy1n4AEd5zou4QCHVcws58vJqV91yulAlRnbaQoG1yUCljyFrHK+/OeZ3/K60Pg41SD12g4ssmP9rp2FZX6kUvADt/ugMONyG/6venoPooBkI2osUUv+yZ3Lso1+Te5oOzx3CzrrBFRj6HYVQ2YK50a71Cn65cvkft/z2sKzWyctMGPzrtaNzcv94aDCD8k+lPD93VMZ0j9sjeZZpeiOSUzUyANwdmeO/sfcScHQ1VPHXESpjqp2b4EzeGwTpHtLci0rVlK3Ng2W3F9PznZ5+UOrnGwe96257gTZsYgkNUqvVXTGrpbLM0O2TmM9dmeHviznsYqFgED0o1Mc0mtpxUV51cJXSFZ6tsK/ybQGO2fHYY1uAoRHBRgZbJz+5cbixuzGvn216OTsuExHOZCCWibAF77kMZiJ027Gi/Ku7JfJJr7IMTwM404Zx1XjZj7g5yeqHV7D2XsPflk7DePEh28eKh9jJRsE8JZi1Ltkt8uZlQWpgyS2vObuW/tWUJ6M/nV5XJPE6YJe3JuS8YgpK2OpbrE1OKfNQreIkrQhZr03FPJxrphSbXoxKIvxqJTaDhTfWZyUgEZok6EzwoS0M7gGczG5BYyAvMnZRtpV37jKPRRAUPj2RWRm33bel1AiAMR0haA2IlxOxULO1UcM8zNaMArcDQcYHMItYxVtMRyFssc66IM0F6nCe0rO61/Pm0n4G0S+Bflak9JaCvELMnC5qld6WIbJIITDespEDXuYGtTnYLlmOG/q5Zo5A4+psL7b0X5FBt34/md7RPtQF0wISO3jYmuBhy+dhwoctMpHVIMitThPTQRoJVuXGQNqtvLGFfSY15KvSc96jbf3TC5hodcClj3oU3x1dkkf9vLKYqfVqMIcvPto6T+lyQucghQSxaBjtYaHeltIV45M8gknKa5gNBAxKRMDhc8sRPOxa2WQZiHAST4cJRstC42iWouHQMHHr+8b71A63Jm0TrizF1fG910ykxNN7ZyoXFc0dsbBh7VbvtoEmoQDg2niJxFMfi5qyXts+RSTGYSAy2qdWGCBb7PigPI/uUDY9n1JvB4h7s6RrHJsFHHkJj1BAlrg2IGUcTMgfnuoW5W94tDUCbcysRrDZB7QqvYSn9Z4G0rumAep1nWgxzWW/qHLbBDlXhyZKk5wDBwH6qzvNl+8URRzm/K4tD9o1Y1VBtH3soZcHHA0qvKVlpB9rjXLjkR5cBk3CEsOOt4bKIDkL3SDq/Y/fDTSZ8f1gV5YaDbAdZ/yV1l6oMeFqvOaAXbzlchnDeH1mcNYYMvJMxwSrHrRJYgBrSJ19/4OPKUoJ6zmQfQalf0odtKyW7S/m2MWoPMeumSqPlx4YNt7y+rYrrTOdUhxeQlkdDo9uqjtYMfqBA0GhHE8Mkd2W5Glw4kdENqqCu7oT2bial63ceOBP2cTJQ6TmYu5liYfb8bpwa4mI2R6Pt1xLuI40NldB08VNDGg2h+lNo9HLbdPs9C50yY8GAoA/7JAMbb6OwsDLk4xvWb94RbuF1pMl7wX/CRflwhN5qgwgjrwdMMm6br7qZt6yxDIlFQrr/VXhgH7zLG4tbO8mUEJf/JHxDsDsZDO/mKiZ6uVc2MpPV4CPc68Bq5Vk7dd+DzhEuHA+cdK4O/tD6w43BNEO/KTAN8Hygx957MzqtYgXOXFXOg5zlJ/a8rGX5gN6sJqqqVPHMd7Lpd0lHU3l7vN87HG+KMNWJDQZeIIk+rHHbka6+BECWuKVkHd1Lbr4O7mVT+m16kq8/7W//UrNfNckM2Y9Wk2BsjSivx3xmdv9yR0eSOHZx6TQtp+pJraH05VrKc8FjILj4PRRVxsH8Fh5if2t427Kv51XH/2tG5AaRmXWhDp0ExP7BL7e2t76O3IaHs8Hs35Qr9bMr4+xx4QPiT4OaZSRK8ZwarjbvQNmjlX9D42wiseWIFwwVwrTTYK5GFWDYoEsKlhN1qjLZ6DI65EXnQ+mBD9hnrwN+iuYSrvZI+A8x02sKILDw7o+L+aUUZHXOdqorpVXavN7H1QpyzCt+g+KL944oRtP3xMU/yewirxfeMGYTmEb+XVk8ooL0C6wYMB785lPpPCG7NWW2Y8AGgzlA6iJg8abhwdTVF+EwAyXXzUx35B+8BLykf9/BtS1d/snFV5GAxBilOgVK/XrsFV1Zx6mlBlhTOP2Gbdzpt0ZyAjNgmricA085sRzBYoWN5qFn+YeNEvU/TaPtSkz77B21XEC3vs79gValFO1KVrqu6v+mV8D2PkzO9i2m8vzPUh+JUQT0gMm7ZZgLdPWYY+TSBhXU6/U3utKD/9kxT9bkE9nxUHovXzhJMbQG5O/H8h20ACQBcwwdlsilP6CEQli/SUgm11FNdcb0DaDFTxS89LGHLXWZNQa3hWmoSeOi4cbUByIZSa15PNZgWQzYdgW9tFZXek+AZ7rNZSoEXIQTFRN69T7xafQ8KvsI7k4WQR2EQfcX4DrhezfCEVsWExamoToAFbHNxsUj07eNZy1jlbgKfU3L43DHYS0WVkj0ddX0SCGrtNwC5Emkjl+GFbv7xmoDyEW5tRVd+O/yULpsrVfN4ft35GtAmvPGTSpVbB1OPKoDqIwiBqPnvVvVHzLWTjJUqqR43cVZAhab/35gM0Q6+ePiGIgUUPbQNb6SkBj5c0KrgYwrleQevoZx13l3PvXCNL6goJv5n7bRatAfweE9OesUyKaiYAbw9Fc5EUkeAM4MnndKw7BlbFj6nKsPFNvVYzHWr1xUMjjKFRSJfL5mqcK+HXQWhV6v76uHrmTHD9Pol3jNLKU7F4K4Qqzsj+GnSzde0VAsx69d7E1rcQN1qj1skKH8D5Nuoavm0n/o86W8Zw1dpkrk7GSs+rXKcRDKsZchrQRP/M4o8gbSSrzm8uUQaAE9yWdgAhsr8S/K247iFVZ6IEbqz2Nsm2oR1N9S5GuHPFVob3bUe6jOi6NRzIpAQGpoJz72rHId2b3JgsdJa6nb7IICBuYli9+I4evgYghlBRm3K5AcNpH0rV29uN+qEGomIzN8TMG1afZ5cj8i3t9hSmZ6Un17Lz4i8163TUSr8YJzh7k591eSOtc64mrE1ovqbnjYq+ZjysgBfC7fofjfUw43/m9pcE2Nt9rELX/Xy6siD1g27ljuTTkSZTb8FbVnWsoCZmexNtB7wFMuin4Y2BMDMBx1NsBxtAOzKZ8TmxOOHg49yy/f6efsAexjmOaTU1eWxN+62VktXZYwYgJmozr+LvCSg299mJ8BVMPSYiG9QzEbhvt1zQlYMip/quBoiQnigDih53xH8euTcf7K7l+t8gqzyhagZbOc5CGQBHzt6G5weSY5Dv3MAoUcPgz+2mVzWg/vIZ6vmBpYYYL6zQoTdgZhLjAzloJwx18L+OzYsAqbElpzUlqmNEh3dzp7L54ynlMYxYXkM/9txHdh0XbsdihclrvCKHT16quQI7rL3krYH+LFMLjiLXNksTi3kEFlsw2RP7Jx50MLiHRzqHU+yORFonaQbcsNKGmUmTESeFXCx/op0Ek2LQi3amKg==">
+
+<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="8CD1BF73">
+<input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="7NswvsDwxE+q+jqr7ZoICVoyKkL/Y8L47QkbK+gYcK5+CHR1ahb2jlDPdeXCjxMIGCN4dfgRwJkX+OwayGNYkEtJ10QtoLzlSBP8pXCGXRJiPmPiqWPxgDoqsMezA+jAOVo5tqrwTHYjP3/yseCw8KjY2Rg=">
+        <h1 class="add_icon_blue_arrow_down">Contractor's License Detail for License #
+            <span id="MainContent_Header2Detail">860997</span></h1>
+
+
+        <div style="font-size: 90%" class="smallForPrint">
+
+            <p>
+                <img src="/images/icon/alert.gif" class="Icon" style="width: 31px; height: 22px" alt="Alert symbol">
+                <strong>DISCLAIMER: A license status check provides information taken from the CSLB license database. Before relying on this information, you should be aware of the following limitations.</strong> 
+            </p>
+            <ul class="list-understated" id="disclaimer">
+                <li>CSLB complaint disclosure is restricted by law (<a href="http://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=BPC&amp;&amp;sectionNum=7124.6" class="newTab">B&amp;P 7124.6</a>)
+                   If this entity is subject to public complaint disclosure click on link that will appear below for more information.  Click <a aria-label="here" href="PublicComplaintDisclosure.aspx">here</a> for a definition of disclosable actions.  </li>
+                <li>Only construction related civil judgments reported to CSLB are disclosed (<a href="http://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=BPC&amp;sectionNum=7071.17" class="newTab">B&amp;P 7071.17</a>).
+                     </li>
+                <li>Arbitrations are not listed unless the contractor fails to comply with the terms. </li>
+                <li>Due to workload, there may be relevant information that has not yet been entered into the board's license database. </li>
+            </ul>
+        </div>
+
+
+        
+        <span id="MainContent_extractDate" class="hideFromScreen" style="float: right;">Data current as of 5/6/2026 9:41:15 PM</span>
+        <table id="MainContent_LicTable">
+	<tbody><tr>
+		<td colspan="2"><h2 class="subheading">Business Information</h2></td>
+	</tr><tr>
+		<td id="MainContent_BusInfo" class="CenterAlign" colspan="2">SBI BUILDERS INC<br>710 W JULIAN STREET<br>SAN JOSE, CA 95126<br>Business Phone Number:(408) 549-1300<br><br></td>
+	</tr><tr>
+		<td style="text-align: right; padding-right: 10px; width: 50%"><b>Entity</b></td><td id="MainContent_Entity">Corporation</td>
+	</tr><tr>
+		<td style="text-align: right; padding-right: 10px; width: 50%"><b>Issue Date</b></td><td id="MainContent_IssDt">06/28/2005</td>
+	</tr><tr>
+		<td style="text-align: right; padding-right: 10px; width: 50%"><b>Expire Date</b></td><td id="MainContent_ExpDt" class="text-success" style="font-weight: bold;">06/30/2027</td>
+	</tr><tr class="CenterAlign">
+		<td colspan="2"><h2 class="subheading">License Status</h2></td>
+	</tr><tr>
+		<td id="MainContent_Status" colspan="2"><span class="text-success"><strong>This license is current and active.</strong></span><br><br><strong>All information below should be reviewed.</strong></td>
+	</tr><tr id="MainContent_ClassificationRow" class="CenterAlign">
+		<td colspan="2"><h2 class="subheading">Classifications</h2></td>
+	</tr><tr id="MainContent_ClassificationRow2">
+		<td id="MainContent_ClassCellTable" colspan="2"><a href="/About_Us/Library/Licensing_Classifications/Licensing_Classifications_Detail.aspx?Class=B">B - GENERAL BUILDING</a> </td>
+	</tr><tr id="MainContent_BondingHeading" class="CenterAlign">
+		<td colspan="2"><h2 class="subheading">Bonding Information</h2></td>
+	</tr><tr id="MainContent_BondingRow2">
+		<td id="MainContent_BondingCellTable" colspan="2"><table style="width:100%"><tbody><tr><td style="background-color:#CCCCCC" class="CenterAlign">Contractor's Bond</td></tr></tbody></table><p>This license filed a Contractor's Bond with  <a href="/OnlineServices/CheckLicenseII/INSDetail.aspx?Action=INSDETIC&amp;Code=B88">MERCHANTS BONDING COMPANY (MUTUAL)</a>.</p><p><strong>Bond Number: </strong>CA5715415</p><p><strong>Bond Amount: </strong>$25,000</p><p><strong>Effective Date:</strong> 01/01/2023</p><a href="/OnlineServices/CheckLicenseII/ContractorBondingHistory.aspx?LicNum=860997&amp;BondType=CB">Contractor's Bond History</a><table style="width:100%"><tbody><tr><td style="background-color:#CCCCCC" class="CenterAlign">Bond of Qualifying Individual</td></tr></tbody></table><p>The qualifying individual PAUL WILLIAM NUYTTEN  certified that he/she owns 10 percent or more of the voting stock/membership interest of this company; therefore, the Bond of Qualifying Individual is not required.</p><p><strong>Effective Date:</strong> 08/30/2010</p><p></p></td>
+	</tr><tr class="CenterAlign">
+		<td colspan="2"><h2 class="subheading">Workers' Compensation</h2></td>
+	</tr><tr>
+		<td id="MainContent_WCStatus" colspan="2"><p>This license has workers compensation insurance with the <a style="font-size:13px" href="/OnlineServices/CheckLicenseII/INSDetail.aspx?Action=INSDETWC&amp;Code=019">NATIONAL UNION FIRE INSURANCE COMPANY OF PITTSBURGH, PA</a></p><strong>Policy Number:</strong>34213319<br><strong>Effective Date:</strong> 03/01/2026<br><strong>Expire Date:</strong> 03/01/2027<br><p><a href="/OnlineServices/CheckLicenseII/WCHistory.aspx?LicNum=860997">Workers' Compensation History</a></p><br><strong> Workers' compensation classification code(s): <br> </strong>5606 - Contractors-executive level supervisors<br>5610 - Contractors-construction subcontracted<br>8810 - Clerical Office Employees<br><br>For a description of the workers' compensation classification code(s) listed for this licensee, contact the licensee’s insurance carrier. Contact information for the licensee's insurer is available by clicking the insurer link above. Classification codes are also available on the Workers' Compensation Insurance Rating Bureau's classification search page.<p></p><br><strong>The board does not verify or investigate the accuracy of classification codes displayed.</strong></td>
+	</tr><tr id="MainContent_MultiLicDisplayRow" class="CenterAlign">
+		<td colspan="2"><h2 class="subheading">Other</h2></td>
+	</tr><tr id="MainContent_MultiLicDisplayRow2">
+		<td id="MainContent_MultiLicDisplay" colspan="2"><ul class="list-understated"><li>Personnel listed on this license (current or disassociated) are listed on other licenses.</li></ul></td>
+	</tr>
+</tbody></table>
+
+
+        <div id="MainContent_ButtonPanel" class="CenterAlign noPrint">
+	
+            <input type="image" name="ctl00$MainContent$PersonnelLink" id="MainContent_PersonnelLink" title="List of personnel associated with this license" src="/Images/ImageButtons/personnel.png" alt="List of personnel associated with this license">
+
+            
+
+            <input type="image" name="ctl00$MainContent$OtherLicLink" id="MainContent_OtherLicLink" title="List of other licenses that personnel are associated." src="/Images/ImageButtons/other.png" alt="List of other licenses that personnel are associated.">
+
+            
+        
+</div>
+
+        <input type="hidden" name="ctl00$MainContent$LicenseNameForLink" id="MainContent_LicenseNameForLink" value="U0JJK0JVSUxERVJTK0lOQw==">
+    </form>
+    <div class="noPrint">
+        <h3 class="text-warning bg-dark CenterAlign"><strong>Is this your license?<br>
+            Does any of the information need to be corrected/updated?</strong></h3>
+        <h3 class="CenterAlign" style="font-size: 1.4em;"><a href="/Contractors/Maintain_License/" class="newTab">Find out how to make changes to your license info</a></h3>
+    </div>
+
+                </div>
+            </div>
+             <div class="main-secondary noPrint">
+                <div class="row ">
+                    <div class="panel panel-overstated highlight first" style="width:100%">
+                        <div class="panel-heading"><span class="triangle"></span>
+                            <h2>Online Services Quick Hits</h2>
+                        </div>
+                        <div class="panel-body">
+                            <ul class="list-overstated">
+                                <li><a href="/OnlineServices/CheckLicenseII/CheckLicense.aspx">Check a License or HIS Registration</a></li>
+                                <li><a href="/OnlineServices/CheckLicenseII/ZipCodeSearch.aspx">Find A Licensed Contractor</a></li>
+                                <li><a href="/About_Us/FAQs/">Frequently Asked Questions</a></li>
+                                <li><a href="/About_Us/Library/Forms_And_Applications.aspx">Forms and Applications</a></li>
+                                <li><a href="/About_Us/Library/Guides_and_Publications/">Guides and Publications</a></li>
+                                <li><a href="/About_Us/Library/Laws/">CSLB Laws and Regulations</a></li>
+                                <li><a href="/About_Us/Library/Fees.aspx">List of All CSLB Fees</a></li>
+                                <li><a href="/About_Us/Library/Licensing_Classifications/">License Classifications</a></li>
+                                <li><a href="/Newsletter/">Contractor Newsletter</a></li>
+                                <li><a href="/OnlineServices/CheckApplicationII/ApplicantRequest.aspx">Application Status</a></li>
+                                <li><a href="/OnlineServices/CheckApplicationII/SecuredApplicantRequest.aspx">Application Status (Secured)</a></li>
+                                <li><a href="/OnlineServices/CheckApplicationII/PersonnelNameRequest.aspx">Application Status by Personnel Name</a></li>
+                                <li><a href="/OnlineServices/CheckApplicationII/BusinessNameRequest.aspx">Application Status by Business Name</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="panel panel-overstated highlight noPrint" style="width:100%">
+                        <div class="panel-heading"><span class="triangle"></span>
+                            <h2>Online Services</h2>
+                        </div>
+                        <div class="panel-body">
+                            <div class="full">
+                                <img src="/images/cslb/Online.jpg" style="border-radius: 10px 10px 10px 10px; background: white; border: none; width: 90%;" alt="Online Service">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    <span class="return-top"></span></div>
+
+    <!-- Global Footer -->
+<footer id="footer" class="global-footer" role="contentinfo">
+    <div class="container" role="navigation" aria-label="site information links">
+        <div class="row">
+            <div class="three-quarters">
+                <ul class="footer-links">
+                    <li><a href="#skip-to-content">Back to Top</a></li>
+                    <li><a href="https://www.ca.gov/use/">Conditions of Use</a></li>
+                    <li><a href="https://www.dca.ca.gov/about_dca/privacy_policy.shtml">Privacy Policy</a></li>
+                    <li><a href="http://www.cslb.ca.gov/About_Us/Accessibility.aspx">Accessibility</a></li>
+                    <li><a href="http://www.cslb.ca.gov/About_Us/CSLBCertificate.pdf">Accessibility Certification</a></li>
+                </ul>
+            </div>
+            <div class="quarter text-right">
+            </div>
+        </div>
+
+    </div>
+
+    <!-- Copyright Statement -->
+    <div class="copyright">
+        <div class="container">
+            Copyright ©
+            <script>document.write(new Date().getFullYear())</script>2026
+            State of California
+
+        </div>
+    </div>
+</footer>
+
+<!-- Extra Decorative Content -->
+<div class="decoration-last">&nbsp;</div>
+<!-- Load template core -->
+<script src="/js/cagov.core.js"></script>
+<script src="/js/search.js "></script>
+<script>
+    $(document).ready(function () {
+        // Backward compatability fix for removing wrapper on new "sections"
+        $('.main-primary > .section').closest('div.wrapper').removeClass('wrapper');
+    });
+</script><div id="goog-gt-tt" class="VIpgJd-yAWNEb-L7lbkb skiptranslate" style="border-radius: 12px; margin: 0 0 0 -23px; padding: 0; font-family: 'Google Sans', Arial, sans-serif;" data-id=""><div id="goog-gt-vt" class="VIpgJd-yAWNEb-hvhgNd"><div class="VIpgJd-yAWNEb-hvhgNd-Ud7fr"><img src="https://fonts.gstatic.com/s/i/productlogos/translate/v14/24px.svg" width="24" height="24" alt=""><div class=" VIpgJd-yAWNEb-hvhgNd-IuizWc-i3jM8c " dir="ltr">Original text</div></div><div class="VIpgJd-yAWNEb-hvhgNd-k77Iif"><div id="goog-gt-original-text" class="VIpgJd-yAWNEb-nVMfcd-fmcmS VIpgJd-yAWNEb-hvhgNd-axAV1"></div></div><div class="VIpgJd-yAWNEb-hvhgNd-N7Eqid ltr"><div class="VIpgJd-yAWNEb-hvhgNd-N7Eqid-B7I4Od ltr" dir="ltr"><div class="VIpgJd-yAWNEb-hvhgNd-UTujCb">Rate this translation</div><div class="VIpgJd-yAWNEb-hvhgNd-eO9mKe">Your feedback will be used to help improve Google Translate</div></div><div class="VIpgJd-yAWNEb-hvhgNd-xgov5 ltr"><button id="goog-gt-thumbUpButton" type="button" class="VIpgJd-yAWNEb-hvhgNd-bgm6sf" title="Good translation" aria-label="Good translation" aria-pressed="false"><span id="goog-gt-thumbUpIcon"><svg width="24" height="24" viewBox="0 0 24 24" focusable="false" class="VIpgJd-yAWNEb-hvhgNd-THI6Vb NMm5M"><path d="M21 7h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 0S7.08 6.85 7 7H2v13h16c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73V9c0-1.1-.9-2-2-2zM7 18H4V9h3v9zm14-7l-3 7H9V8l4.34-4.34L12 9h9v2z"></path></svg></span><span id="goog-gt-thumbUpIconFilled"><svg width="24" height="24" viewBox="0 0 24 24" focusable="false" class="VIpgJd-yAWNEb-hvhgNd-THI6Vb NMm5M"><path d="M21 7h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 0S7.08 6.85 7 7v13h11c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73V9c0-1.1-.9-2-2-2zM5 7H1v13h4V7z"></path></svg></span></button><button id="goog-gt-thumbDownButton" type="button" class="VIpgJd-yAWNEb-hvhgNd-bgm6sf" title="Poor translation" aria-label="Poor translation" aria-pressed="false"><span id="goog-gt-thumbDownIcon"><svg width="24" height="24" viewBox="0 0 24 24" focusable="false" class="VIpgJd-yAWNEb-hvhgNd-THI6Vb NMm5M"><path d="M3 17h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 24s7.09-6.85 7.17-7h5V4H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2zM17 6h3v9h-3V6zM3 13l3-7h9v10l-4.34 4.34L12 15H3v-2z"></path></svg></span><span id="goog-gt-thumbDownIconFilled"><svg width="24" height="24" viewBox="0 0 24 24" focusable="false" class="VIpgJd-yAWNEb-hvhgNd-THI6Vb NMm5M"><path d="M3 17h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 24s7.09-6.85 7.17-7V4H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2zm16 0h4V4h-4v13z"></path></svg></span></button></div></div><div id="goog-gt-votingHiddenPane" class="VIpgJd-yAWNEb-hvhgNd-aXYTce"><form id="goog-gt-votingForm" action="//translate.googleapis.com/translate_voting?client=te" method="post" target="votingFrame" class="VIpgJd-yAWNEb-hvhgNd-aXYTce"><input type="text" name="sl" id="goog-gt-votingInputSrcLang"><input type="text" name="tl" id="goog-gt-votingInputTrgLang"><input type="text" name="query" id="goog-gt-votingInputSrcText"><input type="text" name="gtrans" id="goog-gt-votingInputTrgText"><input type="text" name="vote" id="goog-gt-votingInputVote"></form><iframe name="votingFrame" frameborder="0"></iframe></div></div></div>
+
+
+
+
+<div class="VIpgJd-ZVi9od-aZ2wEe-wOHMyf"><div class="VIpgJd-ZVi9od-aZ2wEe-OiiCO"><svg xmlns="http://www.w3.org/2000/svg" class="VIpgJd-ZVi9od-aZ2wEe" width="96px" height="96px" viewBox="0 0 66 66"><circle class="VIpgJd-ZVi9od-aZ2wEe-Jt5cK" fill="none" stroke-width="6" stroke-linecap="round" cx="33" cy="33" r="30"></circle></svg></div></div><iframe frameborder="0" class="VIpgJd-ZVi9od-xl07Ob-OEVmcd skiptranslate" title="Language Translate Widget" style="visibility: visible; box-sizing: content-box; width: 142px; height: 263px; display: none;"></iframe></body></html>

--- a/tests/fixtures/cslb/sbi_builders_results.html
+++ b/tests/fixtures/cslb/sbi_builders_results.html
@@ -1,0 +1,2737 @@
+<!DOCTYPE html><html class="js flexbox" lang="en" style="font-size: 1rem; height: 100%;"><!--<![endif]--><head>
+    <!--
+California State Template
+Version 5.0.8
+ 
+Based on Twitter Bootstrap
+-->
+    <meta charset="utf-8">
+    <!-- TemplateBeginEditable name="doctitle" -->
+    <title>
+	Contractor Name Search Results - CSLB 
+</title>
+    <!-- TemplateEndEditable -->
+    <!-- TemplateBeginEditable name="MetaTags" -->
+    <meta name="Author" content="State of California"><meta name="Description" content="State of California"><meta name="Keywords" content="California, government">
+    <!-- TemplateEndEditable -->
+    <!-- head content, for all pages -->
+<!-- Use highest compatibility mode -->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+<!-- http://t.co/dKP3o1e -->
+<meta name="HandheldFriendly" content="True">
+<!-- for Blackberry, AvantGo -->
+<meta name="MobileOptimized" content="320">
+<!-- for Windows mobile -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+
+<!-- Google Fonts -->
+<link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700" rel="stylesheet" type="text/css">
+
+<!-- For all browsers -->
+<link rel="stylesheet" href="/css/cagov.core.css">
+
+<script type="text/javascript" async="" src="https://ssl.google-analytics.com/ga.js"></script><script type="text/javascript" async="" charset="utf-8" src="https://www.gstatic.com/recaptcha/releases/dNfi_jsbkQb4Hbw7F1b82Uia/recaptcha__en.js" crossorigin="anonymous" integrity="sha384-+G6Xc2VWk0h3y/trIZ/88xq1v+qBGtS7mMiYmmMRUbqZrVu8JAdvMFNru0CGP9mg"></script><script type="text/javascript" async="" src="https://ssl.google-analytics.com/ga.js"></script><script type="text/javascript" async="" src="https://ssl.google-analytics.com/ga.js"></script><script src="/js/search.js"></script>
+<!--
+Step 3
+Select a color scheme:
+<link rel="stylesheet" href="/css/colorscheme-eureka.css" /><link rel="stylesheet" href="/css/colorscheme-mono.css" /><link rel="stylesheet" href="/css/colorscheme-oceanside.css" /><link rel="stylesheet" href="/css/colorscheme-orangecounty.css" /><link rel="stylesheet" href="/css/colorscheme-pasorobles.css" /><link rel="stylesheet" href="/css/colorscheme-santabarbara.css" /><link rel="stylesheet" href="/css/colorscheme-sacramento.css" /><link rel="stylesheet" href="/css/colorscheme-sierra.css" /><link rel="stylesheet" href="/css/colorscheme-trinity.css" />
+-->
+
+<link rel="stylesheet" href="/css/colorscheme-oceanside.css">
+
+<!-- selectivizr.com, emulates CSS3 pseudo-classes and attribute selectors in Internet Explorer 6-8 -->
+<!--[if (lt IE 9) & (!IEMobile)]>
+<script src="/js/libs/selectivizr-min.js"></script>
+<![endif]-->
+<!-- Load jQuery from CDN with fallback to local copy -->
+<script src="https://code.jquery.com/jquery-3.6.1.min.js" integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ=" crossorigin="anonymous"></script>
+<script>
+    //Fall back to local copy if no jquery found
+    if (typeof jQuery == 'undefined') {
+        document.write(unescape("%3Cscript src='/js/libs/jquery.js' type='text/javascript'%3E%3C/script%3E"));
+    }
+</script>
+<!-- Load jQuery migrate from CDN with fallback to local copy -->
+<script src="https://code.jquery.com/jquery-migrate-3.4.0.min.js" integrity="sha256-mBCu5+bVfYzOqpYyK4jm30ZxAZRomuErKEFJFIyrwvM=" crossorigin="anonymous"></script>
+<script>
+    //Fall back to local copy if no jQuery migrate found
+    if (typeof jQuery.migrateWarnings == 'undefined') { // or typeof jQuery.fn.live == 'undefined'
+        document.write(unescape("%3Cscript src='/js/libs/jquery-migrate-3.3.2.js' type='text/javascript'%3E%3C/script%3E"));
+    }
+
+</script>
+
+
+
+<!-- apple touch icons -->
+<link rel="apple-touch-icon-precomposed" sizes="100x100" href="/images/apple-touch-icon-precomposed.png"><link rel="icon" sizes="192x192" href="/images/apple-touch-icon-192x192.png"><link rel="apple-touch-icon-precomposed" sizes="180x180" href="/images/apple-touch-icon-180x180.png"><link rel="apple-touch-icon-precomposed" sizes="152x152" href="/images/apple-touch-icon-152x152.png"><link rel="apple-touch-icon-precomposed" sizes="144x144" href="/images/apple-touch-icon-144x144.png"><link rel="apple-touch-icon-precomposed" sizes="120x120" href="/images/apple-touch-icon-120x120.png"><link rel="apple-touch-icon-precomposed" sizes="114x114" href="/images/apple-touch-icon-114x114.png"><link rel="apple-touch-icon-precomposed" sizes="72x72" href="/images/apple-touch-icon-72x72.png"><link rel="apple-touch-icon-precomposed" href="/images/apple-touch-icon-57x57.png"><link rel="shortcut icon" href="/images/apple-touch-icon-57x57.png"><link rel="apple-touch-icon" href="/images/apple-touch-icon.png">
+
+<!-- For everything else -->
+<link rel="shortcut icon" href="/favicon.ico">
+
+<!-- Activate ClearType for Mobile IE -->
+<!--[if IE]>
+<meta http-equiv="cleartype" content="on" />
+<![endif]-->
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+  <script src="/js/libs/html5shiv.min.js"></script>
+  <script src="/js/libs/respond.min.js"></script>
+<![endif]-->
+<!-- Include Google Analytics -->
+<script async="" src="https://www.googletagmanager.com/gtag/js?id=G-1W465E5H9H"></script>
+<script>window.dataLayer = window.dataLayer || []; function gtag() { dataLayer.push(arguments); } gtag('js', new Date()); gtag('config', 'G-1W465E5H9H');</script>
+<script defer="" src="https://alert.cdt.ca.gov"></script>
+<script type="text/javascript">
+
+    var _gaq = _gaq || [];
+    _gaq.push(['_setAccount', 'UA-8901380-1']); // Step 4: your google analytics profile code, either from your own google account, or contact eServices to have one set up for you
+    _gaq.push(['_gat._anonymizeIp']);
+    _gaq.push(['_setDomainName', '.ca.gov']);
+    _gaq.push(['_trackPageview']);
+
+    _gaq.push(['b._setAccount', 'UA-3419582-2']); // statewide analytics - do not remove or change
+    _gaq.push(['b._setDomainName', '.ca.gov']);
+    _gaq.push(['b._trackPageview']);
+
+    (function () {
+        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+    })();
+
+</script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.min.js"></script><link rel="stylesheet" href="/css/custom.css">
+    <!-- TemplateBeginEditable name="head" -->
+    <!-- TemplateEndEditable -->
+    <!-- TemplateParam name="OptionalSlideshow" type="boolean" value="true" -->
+    <script src="/javascript/CSLB/LicenseCheck.js"></script>
+    <script src="https://www.google.com/recaptcha/api.js"></script>
+<link type="text/css" rel="stylesheet" charset="UTF-8" href="https://www.gstatic.com/_/translate_http/_/ss/k=translate_http.tr.q1Bok6-RzC4.L.X.O/am=BBA4/d=0/rs=AN8SPfrnV_jM_9sBWRVNTTBM-yEfR6BoEQ/m=el_main_css"><script type="text/javascript" charset="UTF-8" src="https://translate.googleapis.com/_/translate_http/_/js/k=translate_http.tr.en_US.1DHSvysgfBo.O/am=AAAAAQ/d=1/exm=el_conf/ed=1/rs=AN8SPfq5_DGQW29zYz3S7KVlonNpjOwk8w/m=el_main"></script><style type="text/css">.fancybox-margin{margin-right:0px;}</style></head>
+
+<!-- possible body classes are "primary" and "two-column" -->
+<body class="two-column" style="position: relative; min-height: 100%; top: 0px;">
+
+    <header role="banner" id="header" class="global-header fixed noPrint">
+        <div id="skip-to-content"><a href="#main-content">Skip to Main Content</a></div>
+
+        <!-- Include Utility Header -->
+        <div class="utility-header">
+    <div class="container">
+        <div class="group flex-row">
+            <div class="social-media-links" role="navigation" aria-label="media sites">
+                <div class="header-cagov-logo"><a href="https://ca.gov"><span class="sr-only">CA.gov</span><img src="/images/Ca-Gov-Logo-White.svg" class="pos-rel" alt="" aria-hidden="true"></a></div>
+                <a href="/" class="ca-gov-icon-home"><span class="sr-only">Home</span></a>
+                <a href="https://www.facebook.com/CSLB.CA?ref=ts" class="ca-gov-icon-facebook"><span class="sr-only">Facebook</span></a>
+                <a href="https://twitter.com/CSLB" class="bi bi-twitter-x">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-twitter-x" viewBox="0 0 16 16">
+                        <path d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865z"></path>
+                    </svg><span class="sr-only">Twitter</span>
+                </a>
+                <a href="https://www.instagram.com/CaContractorsBoard" class="ca-gov-icon-instagram"><span class="sr-only">Instagram</span></a>
+                <a href="https://www.linkedin.com/company/contractors-state-license-board" class="ca-gov-icon-linkedin"><span class="sr-only">LinkedIn</span></a>
+                <a href="http://www.youtube.com/user/ContractorsBoard/" class="ca-gov-icon-youtube"><span class="sr-only">YouTube</span></a>
+            </div>
+            <div class="settings-links" role="tablist" aria-label="CSLB Information" aria-owns="settingsTab">
+                <a href="/OnlineServices/CheckLicenseII/CheckLicense.aspx">✔ License Check</a>
+                <a href="/OnlineServices/MailList/MailSignUp.aspx"><span class="ca-gov-icon-bell" style="font-size: 12px; vertical-align:middle"></span> Subscribe</a>
+
+                <a href="/About_us/">About CSLB</a>
+                <a href="/Media_Room/Board_and_Committee_meetings/">Public Meetings</a>
+                <a href="/About_us/Contact_CSLB.aspx">Contact Us</a>
+                <!--<a href="/OnlineServices/MailList/MailSignUp.aspx">Join Our Mailing Lists</a>-->
+                <ul class="utility-links">
+                    <li style="color:white;" title="This Google translation feature is provided for informational purposes only as CSLB is unable to guarantee the accuracy of this translation. Please consult a translator for accuracy if you are relying on the translation or are using this site for official business.">Translate this site:</li>
+                    <li>
+                        <div id="google_translate_element"><div class="skiptranslate goog-te-gadget" dir="ltr" style=""><div id=":0.targetLanguage" class="goog-te-gadget-simple" style="white-space: nowrap;"><img src="https://www.google.com/images/cleardot.gif" class="goog-te-gadget-icon" alt="" style="background-image: url(&quot;https://translate.googleapis.com/translate_static/img/te_ctrl3.gif&quot;); background-position: -65px 0px;"><span style="vertical-align: middle;"><a aria-haspopup="true" class="VIpgJd-ZVi9od-xl07Ob-lTBxed" href="#"><span>Select Language</span><img src="https://www.google.com/images/cleardot.gif" alt="" width="1" height="1"><span style="border-left: 1px solid rgb(187, 187, 187);">​</span><img src="https://www.google.com/images/cleardot.gif" alt="" width="1" height="1"><span aria-hidden="true" style="color: rgb(118, 118, 118);">▼</span></a></span></div></div></div>
+                        <script type="text/javascript">
+                            function googleTranslateElementInit() {
+                                new google.translate.TranslateElement({
+                                    pageLanguage: 'en',
+                                    includedLanguages: 'ar,en,es,fa,hy,ja,ko,ru,tl,vi,zh-CN',
+                                    layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+                                }, 'google_translate_element');
+                            }
+                        </script>
+                        <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+                    </li>
+                    <li>
+                        <button class="btn btn-xs btn-primary" data-toggle="collapse" data-target="#siteSettings" aria-expanded="false" aria-controls="siteSettings" role="tab" aria-selected="false" id="settingsTab"><span class="ca-gov-icon-gear" aria-hidden="true"></span>Settings</button>
+                    </li>
+                </ul>
+                <a href="/about_us/disability.aspx"><img style="max-height: 20px;" alt="Disability Icon" src="/images/disability.png"> </a>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+        <!-- Settings Bar -->
+        <div class="site-settings section section-standout collapse collapsed" role="alert" aria-atomic="true" id="siteSettings">
+    <div class="container  p-y">
+
+
+        <div class="btn-group btn-group-justified-sm" role="group" aria-label="contrastMode">
+            <div class="btn-group"><button type="button" class="btn btn-standout disableHighContrastMode">Default</button></div>
+            <div class="btn-group"><button type="button" class="btn btn-standout enableHighContrastMode">High Contrast</button></div>
+        </div>
+
+        <div class="btn-group" role="group" aria-label="textSizeMode">
+            <div class="btn-group"><button type="button" class="btn btn-standout resetTextSize">Reset</button></div>
+            <div class="btn-group"><button type="button" class="btn btn-standout increaseTextSize"><span class="hidden-xs">Increase Font Size</span><span class="visible-xs">Font <span class="sr-only">Increase</span><span class="ca-gov-icon-plus-line font-size-sm" aria-hidden="true"></span></span></button></div>
+            <div class="btn-group"><button type="button" class="btn btn-standout decreaseTextSize"><span class="hidden-xs">Decrease Font Size</span><span class="visible-xs">Font <span class="sr-only">Decrease</span><span class="ca-gov-icon-minus-line font-size-sm" aria-hidden="true"></span></span></button></div>
+        </div>
+        <button type="button" class="close" data-toggle="collapse" data-target="#siteSettings" aria-expanded="false" aria-controls="siteSettings" aria-label="Close" role="tab" aria-selected="false" id="ui-collapse-215"><span aria-hidden="true">×</span></button>
+    </div>
+</div>
+
+        <!-- Include Branding -->
+        <!-- header branding -->
+<div class="branding" role="banner" aria-label="State of California Website">
+    <div class="header-organization-banner">
+        <a href="/">
+            <img src="/images/header_organization.png" alt="State of California Website Template logo">
+        </a>
+    </div>
+</div>
+
+        <!-- Include Mobile Controls -->
+        <!-- mobile navigation controls -->
+<div class="mobile-controls">
+    <span class="mobile-control-group mobile-header-icons">
+    	<!-- Add more mobile controls here. These will be on the right side of the mobile page header section -->
+    </span>
+    <div class="mobile-control-group main-nav-icons float-right">
+        <button id="nav-icon3" class="mobile-control toggle-menu float-right" aria-expanded="false" aria-controls="navigation">
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+            <span class="sr-only">Menu</span>
+        </button>
+        <button class="mobile-control toggle-search">
+            <span class="ca-gov-icon-search hidden-print" aria-hidden="true"></span><span class="sr-only">Search</span>
+        </button>
+    </div>
+</div>
+
+        <div class="navigation-search">
+
+            <!-- Include Navigation -->
+            <!--
+Step 2
+Select Navigation Type:
+
+Options are: megadropdown dropdown singlelevel
+-->
+<nav id="navigation" class="main-navigation singlelevelnav auto-highlight mobile-closed" aria-label="Site Area Navigation Bar" role="navigation">
+    <ul id="nav_list" class="top-level-nav nav-menu">
+        <li class="nav-item">
+            <a href="/Consumer.aspx" class="first-level-link" aria-label="Navigate to Consumers" id="accessible-menu-1778128683803-1"><span class="ca-gov-icon-users" aria-hidden="true"></span>Consumers</a>
+        </li>
+        <li class="nav-item">
+            <a href="/Licensees.aspx" class="first-level-link" aria-label="Navigate to Licensees" id="accessible-menu-1778128683803-2"><span class="ca-gov-icon-user-id" aria-hidden="true"></span>Licensees</a>
+        </li>
+        <li class="nav-item">
+            <a href="/Applicants.aspx" class="first-level-link" aria-label="Navigate to Applicants" id="accessible-menu-1778128683803-3"><span class="ca-gov-icon-document" aria-hidden="true"></span>Applicants</a>
+        </li>
+        <li class="nav-item">
+            <a href="/OnlineService.aspx" class="first-level-link" aria-label="Navigate to Online Services" id="accessible-menu-1778128683804-4"><span class="ca-gov-icon-online-services" aria-hidden="true"></span>Online Services</a>
+        </li>
+        <li class="nav-item">
+            <a href="/NewsRoom.aspx" class="first-level-link" aria-label="Navigate to Media" id="accessible-menu-1778128683804-5"><span class="ca-gov-icon-globe" aria-hidden="true"></span>Media</a>
+        </li>
+
+        <li class="nav-item" id="nav-item-search">
+            <a href="/Resources.aspx" class="first-level-link" aria-label="Navigate to Resources" id="accessible-menu-1778128683804-6"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Resources</a>
+        </li>
+        <!--    <li class="nav-item">
+        <a href="javascript:;" class="first-level-link" aria-label="Search Button"><span class="ca-gov-icon-info-bubble"></span>How Do I...</a>
+    </li>-->
+    </ul>
+</nav>
+
+
+            <div id="head-search" class="search-container in" style="top: 108.578px;">
+                <!-- Include Search -->
+                <!-- Google Custom Search - /ssi/search.html-->
+
+<!--Uncomment if you prefer to use original google search box.
+    (be advided that original custom search box is not meeting WCAG accessibility standards)-->
+<!--<script type="text/javascript">
+    var cx = '001779225245372747843:9s-idxui5pk';// Step 7: Update this value with your search engine unique ID. Submit a request to the CDT Service Desk if you don't already know your unique search engine ID.
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script');
+    s[s.length - 1].parentNode.insertBefore(gcse, s[s.length - 1]);
+</script>
+<gcse:searchbox-only resultsUrl="/serp.html" enableAutoComplete="true"></gcse:searchbox-only>-->
+
+
+<!--Custom Google Search ID Script can be found inside of serp.html file -->
+<div class="container" role="search">
+    <form id="Search" class="pos-rel" action="/SearchResult.aspx">
+        <span class="sr-only" id="SearchInput" aria-hidden="true">Custom Google Search</span>
+        <input type="text" id="q" name="q" aria-labelledby="SearchInput" placeholder="Search this website" class="focus-only search-textfield height-50 border-0 p-x-sm w-100" tabindex="-1" aria-hidden="true">
+        <button type="submit" class="pos-abs gsc-search-button top-0 width-50 height-50 border-0 bg-transparent" tabindex="-1" aria-hidden="true"><span class="ca-gov-icon-search font-size-30 color-gray" aria-hidden="true"></span><span class="sr-only">Submit</span></button>
+        <div class="width-50 height-50 close-search-btn"><button class="close-search gsc-clear-button width-50 height-50 border-0 bg-transparent pos-rel" type="reset" tabindex="-1" aria-hidden="true"><span class="sr-only">Close Search</span><span class="ca-gov-icon-close-mark" aria-hidden="true"></span></button></div>
+    </form>
+</div>
+
+
+
+            </div>
+
+        </div>
+
+
+        <div class="header-decoration"></div>
+    </header>
+    <!-- Include for optional slideshow banner -->
+    <!-- TemplateBeginIf cond="OptionalSlideshow" -->
+
+    <!-- TemplateEndIf -->
+    <div id="main-content" class="main-content two-column" role="main" style="padding-top: 142.578px;">
+        <div class="section">
+           
+            <div class="main-primary">
+                <div class="section">
+                    
+    <script>
+        function swapTable() {
+            document.getElementById('NextHalfOfNames').style.display = 'none';
+            document.getElementById('NextSetOfNames').style.display = '';
+            document.getElementById('firstHalf').style.display = 'none';
+            document.getElementById('secondHalf').style.display = '';
+        }
+    </script>
+    <style>
+        table {
+            width: 100%;
+        }
+
+        .tblHeader {
+            width: 25%;
+            text-align: right;
+            padding-right: 10px;
+            font-weight: bold;
+        }
+    </style>
+    <a href="/">Home</a> | <a aria-label="Online Services" href="/OnlineServices">Online Services</a> | <a href="/OnlineServices/CheckLicenseII/CheckLicense.aspx">Check a License</a> | Name Search Results
+    <h1 class="add_icon_blue_arrow_down">Contractor Name Search Results</h1>
+
+    <form method="post" action="NameSearch.aspx?NextName=SBI+Builders&amp;NextLicNum=" id="form1">
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="PwE2GZdmcKuEgpb/EKG0+rJ7iCq/4wvh3R1wQZSqgJrizFanEUoOb/I9eslO9YEcBxHMOQNFL+gU40qLtF6KqmXRKFZWXyKJDShAdzoVCye5l8BAYDgG1QVb+A1eoNruj9UFgAqGDZQzIff4dM9ro/upQQryOlRGWfTccRHcOE2AKozz2WfT8j+0KwylhNEy3u+wjveMqIomg6iFXy2NbI7G+zqd8cA0P2cDLT1JY2xVaU7OUZ6p6KqvOLpjALCig5BeVfWrX9z1ndCUDyEAMHfHQvRarta5RyeYsh+W5cQeppG/uDO6V858odzOUt3RYmV5ZmNwCCWbrjnCCP3kYbPYJnO4aIiLgz1JVj1YWMkDhWb4oVVB1Dk8BYsDyIgB4cJtPitZK6ci9AfJqgUULqRy5j7oKB9nS0o7AW6PZIrTmC+pTkoLeCdWKSXwEqZuMJ03HdCUEDB3yQpNpJR2nTO1jMuPW4ldEC3q9EJXGPAvdL48fGdR5ni+TtsGLVC7CS/RCF1WmDiqYE1ShZX0Mn5c1Q2MaNi92+73BD1IjoCrKx8s5C6ITPEV6V9fcZBmYhfq8PxYF18BqUMXZWFBVLdXbjVYR3URirRnPOfHAOqJRUsgfwIACMmQERAoxfwn9ZQHg2lvbBB5DhlVhQZrmLTTjsI0PbatJlhUg1um/wspnQcoTI5HSvJVhpBo53Vvq33MA+c/NTUbB2lhXOBm6aP8MyPTTU5Zx8rUUSvGRu79WdA4I4tv/jAoIJGmsnoziIijA2iq4kK/UTRYqPGchHyqTbJi56KO/rIQldW3WyluYhP2Fja2Q76Bs241nZ0ZR0SX82CvCH5bdqZerXaf/zAhKvlpA5O1V4UOkhXbMDoKrWj2YL8/M2bN+Y8g5JCXqWVFy7wSp8D5F4YW6Gs7TKxYv4Vk6TMiXMC1z9lRo4i5YlrGFsz7d/JQfEZRjlZtpnuSRDRXBvNSnmRM//JDdcaA5Tl7cwkEvv40r5VU6/7UF8/e/N3/ayY+9qVpPSlsOMF6vOmuDYbRqvwil94UPupHAawFy0Qa8qNzM+E9urCaCObmMKjclofZESAjJQU58A34BVjzpmEg1rS6O09J0mDxx0oBjVil/kZWhlv8fEo0l+YPIx21Zp/INpDlrg3O04xcX5KtTpLJNG1XaoXPzxUOb83AbKp8AHJIKny6gH0tIyfpZpzkDKRWcuK6HEQSZsw8ZTNriFLt+HibM7n7zcvYy2c+GyNwNulb4XTo3oiIDMgF2/TL68xJXybYtT1ON1SamEf9KMRZd0AKwOfjEs372m3vlf0UNW4yXSes09gfRuJDEk8VVc2sg1q+5TmLxtHqD+pJphMZ4fQlhdMZbGviXKwzzHY4ivSkQoR4Cxfjtis7/4R4QpUrIh1shL3JVZf1AU7hGv6Jn7Sbr+8INg9ykY+jdSnM8jPV/0AnOqNmUo5vYYDiIVTUiiTvNwQiSgV5FhSQQdBhHNuKS3PIVtJTtxILMbrjEredsIssyDVuRpjHE8CqitAFmu/w9GcygyX3ZWffB/HZ7HjmxVaGct9OP4eO0pwsYwuRWp7oQ5JivYn/mDH1WzfNgNw041JiilzhOfknwjn75eS0UI829/AuYw3+ffibxtRIHzrpZgVjvTBCwa6BcFaA9IdDWBWuZIHK3qvc0fiNfMEVFsaf9Y0AXiGSoCJLAztN2XMvDyjOeYCPoOV/63h/t1uKc1b1wE55r6lzneBu9dCuO8GLEMSKBUqOhBidLSgnbgJ6cuFQzY3AVbXc9bPdh7KtJ3qW4A1qokeYivt/YyEX4LYTIxz0KsJCh9SO+pAuLaEoQJtRY5odWv23CTLh4SEJ5/6ZLqib5NFku4eUroOylN5pEdY6qVx8foI8ObORsAxgO9jPnnSro08MOGJX+OC5EMbnWm/DOu9xHAR5hry6NamRuEU74Rop6yVESEBTWvBCNM3RHS3ikNUTgxcXVXg3NKiIVEtr+IGqdD+fnW5t2dXdHj6GhoyKo199Qvvo4P5kkxHLPY+FwjUvA2qeQECtlWp8Wdk2l4G9FUGNY3J4qTPhzqH4m9VhVKtp2lBlBhFbokhl68HCRPfqOEtSinlKprhsmEim09N4KD0NgPjCU727nSMqn1njWQuPUo9G/1kSmy1++iUGlZpbPiZ1sdUnbYh8vfALH6ZuEwYywNqinzlqlHU2QbIheEEUIpTa2h+Qwsudr+B66ArAbWPj3dIVZAw7QNhSxdqqaF5C2hD45jh18ieIHJCO+fR1KM8IO4QCrGl0E1/J5atkzx7AwLygK67bNkdToZpxrkAHr4/thaoMdByO8tJprsYfy1yFOkQc+Nvp7b/DXwDPu+RKNXY2It/6tlZvsq9/YuSbKOW8Yw5IG4rHBfIWsM8fc/HUt2efYlb+7bckyOMReoZaBTthNy6AeyvH18CXG3jADEayVlbsTTm5Na9UMJfy5cOaM1LGq0+Jl1jJ0PvDXssTTYRbplu9CRDWWnWGHHSYdZDqS1EQ9Tui6exHinW1LYRcxhaKug9C0couDfOG4Vyzfg15l4wfzH72yVYFIZP5EvlTBgploac5bUK917OO13Av4qAlSB1Z64fSoVvr/VI0VDdmm6AHAJ3JrzIMi2ZTsWPx4rWticEYgD7iKsxJ111zmne8swQ/wYR9MTfr34T0+eBSleNhyDFD5PRqp1ZGx+aUI804nH8fZyUXVabaqruct2qPJwIcST65bZ65ngNYohrFDBoxGZ2KkmMFP5PPS0Q/Stbfxt7YQRzvSbgeniC2Q1E1y1Wckmlililz3WYgqvikR2oRJbEba3JwDneQPBOWJ8rRu7yx66jt/A12KeHELcJxEVPp322D647rhLfh9goOAgK3SzOYU9H53H+XeishQnC4KtXU0bSqEfMQdYT10yu0dMRvX+v6WISat3gYDR9TssIG9Rp5YeQVnu7N++uDua8XY+hzMVlL9LToNrRVDwHbjDo9q52H32oKp2hwWwZEFrSCEH4tScadFQW9ICDuJe21r8jTDkBGOXAmux7Flo5moWlzw9jBb00AYK/YnbuTZJTk5gHPXUrppBST4+RaaGZa92qSnO1nMLeXabmK3uZNx/QTrXcDNd0ULNLMfAV9TOc83db3+XpOprrPHmgZ5Y2/KaT+Ajb0uom76dMV+vKCC/wCJBPvkjynse5D2Su1YI9wB3qFczvN49bO7eIPX3ldYDEE6HKx1HnbqLzrc0sERgAFjyoBkbMAif/JhuxnSQoa+Ss/85/URVDwjnchV2WmhpJahe6fHVgkR43Coho+qj5J3+dzv3091r4SUQrLH9YM27GKHl6Chv9K0XBwV4BGu8c9vyFmvGoWekJ1t7Wp/F41PFJH+47vkEonPCWiDUAs853PaUJsX7dgvBltfFziTxgEFw91JBrHx0RTa34Dz2bjUZtTicYF1qX2EPq4SOPlVhabY0drHqaXL8V2dfP1LYqGc4Bs9KVyKwsSBqVIwccvTVlxjjxZfD5gLDHZUNP3aLlR8T8RYiEmC1dkFWSIZJYrnsyTmJlltrlC72gPbjf4F9zOdXuykh2GvkkLBGTFzomNNO0111H9Lh/ycpjpU8uRIXMVco17xxQQF8XjejlbVnWRRkFJIlky9o97VUcTYqy7KMxAl02kCIPbo5W4pZzIn4LiD6nJNZKqhRyDnBViK9naxq+ANShhpc2m8h431LiNznaPC/sbYOv2Wf44LpUaRRc2vP82JpT5ZP8ePTbnYLtfEk1P+HZeQWtzyzKxfxY0Wx/EyQfSyjn4Q+zemM+iek0zPZ3Uuj68O98dUdE1pm0wBt5/dzlFP8dHE+d2oAMki07aIBc88Dbkyth8ejCAlsGYWzUXFcE+sGj3H4QBp3qS83huoHiNpCScG3N62AOOLnCMvQEE20/eM30TZ0uZIPiVU4l9aKlSUcuCizXo5j8arRK/Rcu/MvHBuaA0RwYxQt3+NQyisp5H0JbjpsMncJBOHYVgON6F3qJsARafms9a2Z4eIgXO2r+fGxxj8Kh7fqeogBsWEZx0csD4j3fXNB9RveiOxJQmj/cyoKM1ySXSMFKkeAPqW22HY+NJcfeCVPVPLprzHqSnAkdUJvEy3bRsp8NpLNb8UgktHBf41TjPqQap+VpbK8yBnsRbTCDCrtFMK1FMoD2AfUiZkjwwFF/gDHb1neZ9S89MTtdnvtFj5ysWpheA7X5Ai+uacyzPXFsaw2VlOzao9u4yjuJVWhwwIg28e9MzSaoTPhiOK2gfHxBEchrYPb5KrPYSHcwO17P2gH9wW6tTK/6iwBf6ndmF8cxuk8nW9n17kA4EiTgPa3IW9kqg++aO+ZxskyTwzfuN8doH9gGjp6FmioClrdx/16+G8aV8R9jyi/jmJs7gCai1//bdlJVvJnT9+FEDSfpK+eX0c9cVd3UmZNuJrCtszflWuPlJ/JoTXZ60EnU6O2lPfIHzyDUIO0XiNTF0KT6aqzSFBdbbCrtUuxTwX/HUS9mSDEw9822jdHuzc9fXWWvPtdaIdFxNrZtamY7J3KqRM0RpAkd+JvFXPGlQIbWfIE8i12YMfEcOsHOEkQUv61RcHC9TQb5W8mHwlFfSLFBif6DypmYq/bqELwcSKiy4n8bKb5D/1TxDAl3T+czhGlMd7o5jGfEW+Dbztg2I/CNtbLzDLbwUI5mfL5Q1ySkxx6jgqH5+Qyzgye2nED4lgpR+3Wnz3T65goySDdbAuZYx7oaczXWN99Kgl7k7OQxu+MzHcVXfQWhT+Hpv10pU7bIGyOoNYj8pRgeKYHXoqZ/13xExI1Xk2lX+mI3FA5JC5Of8YSoGZQ4M9U/+WDmJkn7zOC5EL3bogOYERTjgNFNNIj/v/W8LyuXD0flA7UHLOq5o6FsIwSfscYuuASYpvtdv+KKrNIoOnx6sfDEasKXa3WppUoyrMUMtru1nQArWQKrcZLXssWbKuYp7UHKeVy94CFg2yMjh46YJsIUP5UIzAedkgNBkvH6A9P3OY7lDiQzxTJ0PV2TYzVAH1nd6JomE/vi37E2PEnfecV2dXTkqeva0oN1LJC6t8GV+Szb1DZ4W0eMe4ieLZTSbJ37ir8x+HbZjWjFGiKJ0jt6FrPFj4VR+rrB3rpXRLKrRMyImy9FjbEfnhuBgMP4Ml6aKe9XpP2rUqYfbElr4Rt4RlcFdBQxgch4WzW4mXM5atBtMO1CD0Tbdf3B4zDZesqBfCYeWfjnsHJ/8Tjj4Pcb/vdqJGXANdIfIKhUJxAqjpRNMPSFvU8GYX3IdPPLCZ+1JGc4nR107XjP5w0EOR6gAHmUHYU6NETmpdZEcks4rTZSO0OcsdUgEm94QPO7wxEnN0HuM2Rs8PHOllvrkNTfdiHZmxf1Gwpbgb5HXnFl9Ns4bIyR54w4LyfMRxP112gSffe/SdiP2xKeLJ/0iP6fQlm1aEAE5CDjPk7RczLwBaFbmJrDu7Qzw4cws9+bB0SOERT+eY5qPolO+YOzDh0aDUYACyysId3TICNq1qd3kSdwA3uGkTpvgumMT/MzP8K6crgQC2WnuD/AH/40lBqu2+VqiHUyJE3zLFFetvOYEhwtmSrA8nIfHo9z6qCmqg8wWG9rFDRJwpAEtZ61aof8Bhkxe2r2fSy5nJFRysr7QOHnJGS618JU7KcF3KiQkbfDXI4D4oOfzElSR0wrxTC/I997753EHct+lGs0VE8Fx51UwEAF+YsqI6A3yeg9Oum8NYzn+mDd2z8JcMNQZKqAI+Yl9hiqj/V+GUInMc+lv/ElCP8Cc32R7I+CcWll7GTWPg129ogzNeyREJ444py26q5B8Kkk75P42P/6bPG0/aDHVedzRLYZjwefrrzI5OfUxinTBTQ8Nm8tmfMCU+V7tKptrXiEV0yruk/Uw62VnBhICslQ31el5BgMGFMm9NM7Kv29F8/gn0qkSlaUKkDuQxMjH0lRbo4Crin4Bi/VBsxxxjRMn2q04aFT6AA6a51Kv3eORiOHdW8X9C8U6ot1GAcGz07uO3MAGJPZdTDN3fLzvJOJlTwQHtpLcvRZMTM9EXS17sRUS3alzaS+0BUWvy4RpGQCuJmRN7y5uCUIbDuNUrWMT2D9iukoDWBoT6QKtqwv/iLqCK44QmC4At1YQ1v+xGS+iFKajlKu+mYKWx3pmE+TUeVrQqRCWgwoxiT3BjQDojxuwyGi0CCcJSBRYQ++ZRTzWp6jkj2hE4HxYn+YRfWpMJRS4wCtJ96sGuvhCw6HSAOL9KmMvS5ZYOq/Cu/wUgATWg8o/YgVOdASqbnbK79m6tKv22zKxXRyKPSTAK3DHTbew0w3AdaFF4Vxpf2lIyUdxs5Fno0dXfpOzWOvbYtQCv4zf37rYs1WJLiyCr6eDoQZ0U2hTTvB4Ve+4/n4Na4bho3F0NeiJQhI/7FaTjYXkb1zbjiQWyBSBPTLzI/6+GIfPkuo1eLqikwwLAcEFB/lHri1BdAxlXBIAmGuhOQz+lCaoGc5OINv/uEKRBNb2XeYXva7HMcSqiWqZFMtjCouN6ATgnadaePe+ENP6+lBGoHl3lqG3ZUrMUN0uXCOdkTegzuuQpFK4b1tnOXg8QmU/aWcuISjWnTFJSvHmYnOR8wZ3Q0v9qWszKXnglE30jW6u3nwrf23s/ZhxKzAvuqXTqODwJ33MlP1NPDHd7i9yemjlf6bp4OUOG/DzgXHLyGEi9V2RCgQA3cMU0V77MzxiQR6g42itp5SIFC0rJfZFKg80QPmQfzIW2U+/fK/AJiY9mYg5/4np9nAhhW1Dl3sQ9X000YdmPw1uOpfoP7rsNjsRcnqOpQoW9bwFjchZgt3uyEx/po1yAA5VUeiU3qpB4AOeNsOoKbHPH/PBXmD8AVUVeH/D3lnLEu9xVUJAgGKJlHYWUT8HskRUekNrxgtKrZJfcqCeBHtSqu+ig3DmBpk604yRvB+nvauS++2cEW2+w5DnUbGBzkaQA8LwwdFiC5sTjb7uODwjabE+ZRhhXD+SXJM0btdEeigzcuqIEpLu4Rco+PWlL1d8ign2EEDIAhGXesoueZ5dC7mhleX+S5/BzSPHaXq/Le5pkDUGnf/loTK8rw/OJZ3dnrMwzOtrtjv/7LIe00ieWgUmjlJAoHdJ0y6FYZzh3oVY8ZRnASvqFk9NGbhBScaiK2/BzDmTfuudLWasCzQl8WnzcOqxeejjEN8WnUCfkXdreNMif0T9oaXWztSYbfgDrNZ0B9hvY4ggBKPKVVLweB/AAQMsx3SNVtf1DStFU3hl02SQuEtYKV/bnTCJ295YHHiRbnUMJgBplSOCBa2qUadb/5Ayj7xzWFmID74hfL3ff5QK9ErnnQGYZdO3ZugeehSxOdLBWsj7GeYy8Gg7MpTSc6SfxvKDErqGBQUPRBjjxL8dlJUQWoC0Dxi4u84qROcYTdX2yxILYSMer/Ugyzlmbh0WSdnYZSIB4jVpmp4+zXDM5eCRlEXChNoQZhmLg3ge8xOFI8syUNi+8WY8gPLpC97jeLTyRkVxftApjH/JENBjstfvcoEGuZXFrc0qfr/namvCVPu9Spt15zaz0NAhCUpJdrMUaEWUBiLUURfQrqH/jAxKjfSLLSP8XMhg6nc9CUfLglnSyKMUgezmURm5PzEcfYeufVNHVkjQmNl+C+pT/Rood++sTgF9iOy2I6UWRTaeOaZF3CWuECSm5dc1XWFBRN6sWTs8aywEAobO785kaPbjc3YDJk0UeXyQlRikMWNwOeOc8mCJw7ScdcZxHC6Ugi4vLEssCpNFb7Vl92fwY3Fn0/sgXqDw3Kxkoy8i77JMFgR1cv1cGXyMdhNfhaG1qhqYaZFgGiOET+qtA/WKDidCT7ntxNQIZai1RqUouOEvlnU1sKdXY3GpVSxjSrooAuZARjsRY1ahWEsbEih4EtylFUPysO6dBBPFp7+bCyPSu//ChrZvhy0UUjirQLSU+sLg8s+8BlVnsk05Q/Tudz+iqiR8N6oaqs1uMAZSN2EzPsx5YLf1pWxVKNsU6DVdbWgE8zwK9z523DK7DHm0URlIVdyZA+C93d2rGUdya1TY0//3KGUKdvEU2tCJbYA7zE6XaajC7Vhxyro9h9ZNzblTeYQq0rTNfBf8UZTWFVkM3hfqAyBNkffDjLjapA4GZ9h1NM5f/6tGJrc4XQN+Ia0g4cwju7IPwE2K7PsDF2KNIsoSJ/gw2DWjU/Ysp332DrSadHBnDX3zqkcFQHQvFUXl0SZc+/S1w8atkzW92WlazWEjTY3Xgo7IvX5La5+6t3FJ6O06xEyt3YCNoa5qmqMX1syHu0Jf83LaU5zlPVdTvuMuVsCfR63kefo/sekiYMMqQjQze3QNwXpJhJMeVfacRHjOWQvgID99vVGvnDV2FhlcV56EdxfjHvwfRMI7gKppsKkZv5davSZ0egf3D2dcUvzlINp1w6/Ft+986qthgsKn2C7jToaK5QOrRzb8oMzH3xJ5uvwX/lrpBbi47IiWiOIkCPk8Ai/YXpyrdlpwZ/jBcACtGw2V3/cnvGFrfHQawI79jasZuUIr0rvllcChjOuudI1tpgOeRNpYcH2QJd9uaFV+lBe00oNIQ1w6RmZsUhEUdKF7a1JEblj8Pb7kkI2GyjK3WTUMyPTAnzHfFmJc8oJVY9LQ/N41K3l87UH2GC+m7C0Bd/ub2Yf8GddXsQPsq5+VBesxCBBEUjF+Gz3ATIcmrmwIaPeed3hmXxLNLEm+GNDQaM66jI0N+FRYLome5CL/e5XolA5Djbg8MonHKLe+2/EzwXqndi0eydsVUo+IQBMgndvEg2No1XzWS/GwVWywnYP3e0TPZ6v20JR2S1GbOWhIQGjtTtEk+/jxAoDPH5pIcrJfybP0YCzH30xoCVqR7l9IHIl4gnH5mHeTYZsGRJvdbbUe9pJwtkPRI6mn1WNmvoqMoKJrdrJOjfow6WIcHDI3/rmWrki21Lje7COVhN3x8iCjmA3QrlqnMQ80AZF2pbZi0MCJvCk+cuVE7xFKe95jlZgjsnVQiKLVN/SfMjRHCOC3fKKftQCXHxjLXCUKGkeG+Stad69bWQGC9piyIo4lGZVL0AQsRVweyX0FgkZx6TQozWwhXj+y/iBEQB/M9K4vQhI4J+YPXbwMxh7d0QMxuOeg5pZ3pR+d+uQQVH6lJ1xRqKVUARe9fPC5R40UZxLPnsFCNhj7yaF48Ivdl6qIRyxPao0yM5OvzNxb04ZoMWzCjDndjf7M+CljeJRJRF/jZVDMdklpmBwyiIOlAbku/ced3rczVOg8t2NESeJN2fJLLDkOe4NHlKtcglw4dxOJwtnvMQfxg/soBYmOtdSMm1AH1EHBS0BV78l09cegbCOoEyIGZas30UnRv7lPNcQg8GRhNHqCDsUab1uI5OKT8CziRiMiN/TCmYH+ViI9F97Zmbqx0hyLrqbRJVWsHlFqYBIcziQxWKiiNJQ2QN6079IVJftyHhyJ25WYkfVDRy5TRnHEmq01IueJeaqmVidJvOi0WtVjCGgCYCsvZQFk2YzwuIlG4FEeerLvdB3+PU+TIMUFYUNomqz7RyXa+2LiUE2m2ZfB4zhuAObkD8k43d49peuHo5EblRQQcR2bD0qL8AfJVIx9cdeiL0o1TYP0RKZXv3tgqvo4l+krXbCdmjBcXXuayYZI1lVkb/FNNBlmFK5MLL8hZFbfsm16oaRIy289N7Cc8Z7KEy2R1if3xxoFsiDeQmpEiyF3mLxSCYjH69m3DbprcrraWzF15JTYjBmRC8Ih7NbwqqPG9Zskr7kMbE6XhJDeIgZUQfdeyNlPg60vNb9q1sdxvRbyPpwQjBzfmlWt5ko6SxyxYzvYSoMWUsQK8B6qbg+V4h3XAm5l9/sFDI5JqppEtkzoXORDeltUIfai/uY1GBK8PkEu6AdH6dtNlNENTa2NytzQ/bLlx+ZQGQN6hSK12g0+MyOx57EJeGs8jGUcJ94MxbNz8ojoni9Z9q+p6pEp0TEH6Qy/Bu2K4g2hVschZ4f/Z97gyQOU9utO5fYFsFTP29XZtUvlpYqmaxJGvFB0pGRsd93EVepqKCgMY96cjkYyt7BrcoY9Oyp+wxIm2azQVCCHWcUTjer9BGTQwYhZe5taL8rO3hVf1Au3ahWXT+Ga5QyeVttcM5Uvg5xGHCjbmXo6R4ebMl9g3l7lMRt/QpaOo5zAquaKCZKY7309Mc+2+CEhbj/UQpCVVNkXB01vROPPc07LzHdSPZvahh3qKRmwvqP6LGKH9Pu7du7KOPIjKKzQMpGrwnrPWiV6fsWOp/tC83pmrme7Pbx/m3JiuJclKEoT2g/sGG/fBblTr1fUsckaEJfZ81q+Vbur7Nc3DUy2y+s8q77gYBiqxe9EV45xUD06olxI8A1vmMrPc7HttWwNPP2PfEFjGPHSkfDV/8dLNBRauU1X1B+gv8sHXbeGXfAXs+mlu217j5PB/3q/SPNVKwYRmAM4r2MadZR1y719wN0qSKVQLS6BT7mWWGmLXHC4YnPEsWHzqQYdJttZbwxgKqoqTEeVl8fpkJgHnEfibvsuku8TBSJ3DQ2kxCHExqL+6ZhwL/M8deiuQHi31cjZEmDghSVqmbxsP2KBx9juTXbo6zdCb/w4E/ClKTMrdJ88J2tCbTqGx3MmyRi/aQ4mKqPRSDLgFxEbeqmekFYvupifwitfMElqZPLAxk3cvJfwKZfzYu7VT7y/GHwsQawuR7zd+oC+Np9e/cCUooMbrzlxQSUMagq6QZsLAfg51j36riA95nss74joVmOHUhnWRV4ZrRjzRNMNRdmTNDasHxtcku6SQir//DphO2mhOigxIf3pji+671rIm+emvSdEZpaHcdAcbkqim7fNMZ3eNE+LnfHLrUCcYax7SdLe9eK/Vw+98FSJt36UJ4ZZlXoWrTy1+mZpxpokMRPQ1u+QsurPtwiSIhIk//UOwVYILpwIKb/6EvYouCCMIj/S6jSC+yRK317hZ+WXZRMuNtrZtL+jgxXXXENX9OZUFBIk01ivG4qMqjUGaAe5cBoYHBvyEAUl9GhyX4LgTR39ayjn0n27SupC68utdWdsc1hF00x4GToRYU3zutkzU+vpu8o/+J3zAujRCP6/Nfxhod0Hopa1MHbivu2EAdGTTe9/6U9osECTM8Ghu1g4hudhAWSEPQB1k8n8NV8kAmIECvrMOjfsq8wdxU0I2DrESDfnwbTkbFQNY/0vXvZ/WqIXXTG7LvyWwcBsSXg21TfaRkroCdSz+g4cNjZ2t2zVURWiVwqEg7XWN8lDzwJvIDNwhizz53CQaY/cDhEXz2GnQAJDP54cBFG5SOlGIpZrpbaA6ep5UuNb9ZkODlQpAOWB0Z2E9V5g8OyTCGq7DGzubi9tuDU1JMwQ0XKaeJtIZO5mZ9Eo6w4Eq/xHNPRkEMDnDioZ7cF6PcaBnsdDr0mYFxB8ZWmwY0Pq5+NaCVxKnjbnP0mcLmRqWA6YbfadoEH4YTjzX4rWrAdhcGynZdcUvCvY73DvUrsqM1anTGeVMiLobwhL8r6T/debGfyIXWWZHLKCXLXuSdGCrHU8bcD3CW+trf3GXZBwNfXL1038a1FIOz2l2K7gETEoeDW5sdABchvLDcAltxa1iSqmmiSydsnmJmpwl3nZaowYECbYRNmcaHnhBusqoVbUSUQHA9Dw7L4vwY/AJ7LuME7uDhWpaT2MWX/oHktAQLa5EhFcPbjJVMs5CJY9PfKCimS9R1rFr5sZGymkt4Gia8eR0uUdDjIBFeQY6LtQqKolCuK6LnhzlzzP4k/8ZfPAcgI0xc3188O++DYQSubqdmyHh5yvPIjdbGl+flD5yfj2kmVjyngYUnofAgpCzkCg+mZe7UVArZQmOk0FMR0tfb/DKQbiHNK3XR9P368WiEwzWo/aTS+q6xPGa9zPu8c1fLw8R3r5P2p4xUh2cvhC4TiwQE/cNbioh8G8w9KwJftHnYuIIJXkUtFPqtF5EuESLBaW3gQZVW05DuPcjbHBISGO1xXjcuktxj1XFnDL2KDZ25KXL4hEKuZPetCSCJ7ghsoh/sm+JkKFVuEB757IydFe61iLxJCSUKmJRivSjNj5qQmgyS3/ud8DBsrBN9U+LYWd3/4U2mPZOBIaeF1DeQS45Vw6Bf9bJQa7Q8kne7sHLTg2FSlqKOgPrLqFj/2IeoGdQv53ZWsFeG1C6E736QByBIBRSPqEamoQO/3bbhcxtr3t3cqRktix8+dPUXy9BRfvyzfp9QNHmKMQCUvIdY1N7KlqQauoRJXsOg2WvtdiBf4rHEtRbaUHAgJ6ETF5Mrq6L9i7DI2S5T3Pm+cuL1ddHCjEaDtcf2d8239ed8dalVYNCtfRzCNK8zA9N1vjVp4XT/FTqeYKVsp+D6eygnduPhBHylFHPuTtoHt2y+dj1+iVM28a7qWKpgSWuWEaj2F4kNFNtq6KueNmovTBTC7krJNnH//2fHfwsT8/gyIdWaRiDQET33BPmJpVbOw7rOsE9Ayt3vqYrwueHQeVzDxnEAG4J5/Fj5dbaycfsDTkMZbIJS03tiIaxBw2IkGZOe8XMFmJkXO4/RY5/kCVev15xOqqZ8goZwaHJ82OpjADbAVuxS6UL6qX3iuCqVxFx6UU52zFUtLvj8mtnSWzO4uPN+fu4s2X0aI3cWWYwL3P29b35KEOJHqLZKt/pha4D7SvFx4dusN65rf8PxaRwwsRTZN3mEwfS8SmnnHbFH5g5wHJCm0npRIg/LFqHfmACn0CnkZlLastenPiDcGrdZKaCUkBbTbfQ+XJkwAepeyZ3RuYoZdh7TRfyEvZNmIFGD+4UttSyfuFXFxx7PgzXPRzX0rt3mjh5ysGw7ujzpXT0YL1MWzpcjyPfEIQsesCDH9wdhWiM+T7edo7GbVvX+P4rohAMliA1rQ68Brrq7v3N4rSz2RnczMrULBRvANohaGGBE6nJY0vG6WhKXTmgJUZix3f5KRdlLKUy21AJh+NMfZZTJd/6HRgroxEyFRmxiYP++gULeGHkXgaEBN26TywaU3v+iUKfNyR8bV6JK0Lz/k77Jf3P9RC/A1XO44HYWvFn7D+/tLVenSlNlx9Da1nnb+/mBhBoy0R7dq0J2e0AlXymuSQBM90y+s9cZSpweWB/P6FvD7fYYrucaPo+lk0bl5/2TBL/SAXUppxR+L/WZQUfLKHONxe6kdTCERdVFv5jARQ4S21296fnDzEqiuiNBY7LaZ83bgcVLIo66kuQaBjde/7Knnuf5OWc+OIRUZ1I1pMuMjYJ73Xwf5ubY7lyPmel/+exRVIHpzR5OSKvSQSoQn7PkRxZCqLOtYHVcGTMCBSxdbvmsNxiBD298obumvkLzoLeOoxFEJxg5O8t8pCBgaTV06JYeguF0vbJb+v2xJtVTDCkcF/H4ie9pjIm7ryEQCLPBZ6Bi3fXNwxFgkUlxQSLIcJhdV8WRmI3/Nh9KaX1z0l">
+
+<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="589077DA">
+<input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="vxOS7DV7xW0J2RlWX+cvveigU/2Yry78bkkBinHEDBKMRmgc2RJkkP5vP07Iqx64TGpsMMUDp7WzwIoTinhVpoOTFaznUvYwxUfxqeJMCiKHY1vy">
+
+        <h2 class="subheading">Select the license number you would like to check for status, or return and enter another name search.</h2>
+
+        
+        <table id="MainContent_dlMain" cellspacing="0" width="100%">
+	<tbody><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_0">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_0">SBI BUILDERS INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_0">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_0">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_0">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_0" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=860997">860997</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_0">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_0">SAN JOSE</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_0">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_0" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_1">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_1">SBI BUILDERS INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_1">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_1">Previous</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_1">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_1" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=860997">860997</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_1">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_1">SAN JOSE</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_1">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_1" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_2">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_2">SBI CONSTRUCTION COMPANY</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_2">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_2">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_2">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_2" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=457757">457757</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_2">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_2">CULVER CITY</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_2">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_2" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_3">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_3">SBI CONSTRUCTION GROUP</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_3">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_3">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_3">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_3" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=418304">418304</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_3">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_3">SUNSET BEACH</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_3">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_3" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_4">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_4">SBI CONSTRUCTION INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_4">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_4">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_4">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_4" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1079978">1079978</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_4">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_4">SAN PEDRO</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_4">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_4" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_5">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_5">SBI CONTRACTING</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_5">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_5">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_5">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_5" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=980166">980166</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_5">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_5">COSTA MESA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_5">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_5" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_6">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_6">SBI GROUP</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_6">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_6">Name</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_6">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_6" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=418304">418304</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_6">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_6">SUNSET BEACH</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_6">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_6" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_7">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_7">SBI PARKING LOT &amp; HIGHWAY IMPROVEMENT</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_7">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_7">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_7">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_7" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=986695">986695</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_7">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_7">BAKERSFIELD</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_7">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_7" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_8">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_8">SBI ROOFING</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_8">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_8">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_8">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_8" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1093526">1093526</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_8">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_8">ROSEVILLE</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_8">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_8" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_9">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_9">SBI STEEL FABRICATORS INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_9">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_9">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_9">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_9" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=677361">677361</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_9">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_9">GLENDALE</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_9">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_9" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_10">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_10">SBICCA CONSTRUCTION</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_10">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_10">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_10">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_10" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=547097">547097</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_10">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_10">COEUR D' ALENE</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_10">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_10" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_11">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_11">SBK CONSTRUCTION</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_11">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_11">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_11">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_11" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1064913">1064913</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_11">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_11">HOLLISTER</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_11">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_11" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_12">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_12">SBK DESIGN &amp; CONSTRUCTION</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_12">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_12">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_12">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_12" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1071830">1071830</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_12">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_12">SAN DIMAS</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_12">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_12" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_13">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_13">SBKO LLC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_13">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_13">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_13">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_13" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1132254">1132254</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_13">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_13">RIVERSIDE</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_13">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_13" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_14">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_14">SBL CONSTRUCTION</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_14">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_14">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_14">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_14" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1114487">1114487</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_14">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_14">FOLSOM</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_14">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_14" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_15">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_15">SBL RENOVATIONS LLC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_15">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_15">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_15">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_15" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1153267">1153267</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_15">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_15">LOS ANGELES</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_15">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_15" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_16">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_16">SBL STRUCTURE CORP</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_16">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_16">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_16">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_16" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1083357">1083357</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_16">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_16">SAINT BENOIT LABRE  QC</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_16">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_16" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_17">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_17">SBLA CONSTRUCTION &amp; REMODELING INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_17">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_17">Name</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_17">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_17" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1089409">1089409</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_17">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_17">ENCINO</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_17">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_17" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_18">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_18">SBM BUILDER</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_18">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_18">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_18">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_18" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1125910">1125910</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_18">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_18">SACRAMENTO</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_18">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_18" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_19">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_19">SBM CORPORATION</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_19">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_19">Name</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_19">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_19" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=402432">402432</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_19">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_19">CHICAGO</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_19">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_19" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_20">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_20">SBM CORPORATION DBA DELAWARE SBM CORPORATION</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_20">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_20">Print</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_20">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_20" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=402432">402432</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_20">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_20">CHICAGO</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_20">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_20" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_21">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_21">SBM CORPORATION</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_21">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_21">Previous</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_21">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_21" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=402432">402432</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_21">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_21">CHICAGO</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_21">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_21" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_22">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_22">SBM PAINTING INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_22">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_22">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_22">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_22" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1100764">1100764</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_22">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_22">BIG BEAR CITY</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_22">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_22" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_23">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_23">SBMS LLC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_23">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_23">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_23">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_23" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=833813">833813</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_23">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_23">SACRAMENTO</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_23">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_23" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_24">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_24">SBN ELECTRIC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_24">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_24">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_24">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_24" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=517339">517339</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_24">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_24">LANCASTER</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_24">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_24" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_25">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_25">SBO ELECTRIC INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_25">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_25">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_25">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_25" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1066193">1066193</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_25">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_25">VACAVILLE</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_25">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_25" class="text-danger">Cancelled</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_26">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_26">SBONCHO PLUMBING CO</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_26">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_26">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_26">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_26" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=305033">305033</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_26">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_26">ALBANY</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_26">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_26" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_27">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_27">SBR ENGINEERING CONSULTANTS INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_27">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_27">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_27">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_27" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=959208">959208</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_27">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_27">RIVERSIDE</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_27">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_27" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_28">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_28">SBR ENGINEERING CONSULTUNTS INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_28">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_28">Previous</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_28">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_28" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=959208">959208</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_28">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_28">RIVERSIDE</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_28">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_28" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_29">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_29">SBR SOLAR MAINTENANCE INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_29">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_29">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_29">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_29" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=964242">964242</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_29">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_29">LINCOLN</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_29">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_29" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_30">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_30">SBRAGIA ELECDTRIC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_30">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_30">Previous</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_30">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_30" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=388067">388067</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_30">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_30">BELMONT</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_30">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_30" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_31">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_31">SBRAGIA ELECTRIC CO</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_31">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_31">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_31">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_31" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=388067">388067</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_31">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_31">BELMONT</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_31">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_31" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_32">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_32">SBRANTI BUILDERS</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_32">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_32">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_32">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_32" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=283353">283353</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_32">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_32">ANTIOCH</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_32">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_32" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_33">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_33">SBRANTI BUILDERS INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_33">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_33">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_33">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_33" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=333486">333486</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_33">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_33">ANTIOCH</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_33">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_33" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_34">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_34">SBRANTI GREG CONSTRUCTION</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_34">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_34">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_34">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_34" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=743594">743594</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_34">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_34">PIONEER</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_34">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_34" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_35">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_35">SBREGA ELECTRIC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_35">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_35">Previous</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_35">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_35" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1034923">1034923</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_35">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_35">COARSEGOLD</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_35">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_35" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_36">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_36">SBREGA ELECTRIC INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_36">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_36">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_36">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_36" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1034923">1034923</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_36">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_36">COARSEGOLD</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_36">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_36" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_37">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_37">SBRM INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_37">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_37">Name</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_37">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_37" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=661120">661120</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_37">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_37">ESCONDIDO</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_37">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_37" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_38">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_38">SBS BUILDING</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_38">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_38">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_38">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_38" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1075741">1075741</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_38">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_38">GEORGETOWN</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_38">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_38" class="text-danger">Inactive</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_39">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_39">SBS GENERAL BUILDING INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_39">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_39">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_39">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_39" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1014588">1014588</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_39">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_39">IRVINE</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_39">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_39" class="text-danger">Cancelled</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_40">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_40">SBS INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_40">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_40">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_40">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_40" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=324092">324092</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_40">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_40">CATHEDRAL CITY</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_40">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_40" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_41">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_41">SBS/ARCHITECTURAL BUILDING SUPPLY LLC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_41">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_41">Name</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_41">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_41" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1128336">1128336</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_41">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_41">BEDFORD HEIGHTS</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_41">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_41" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_42">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_42">SBS/ARCHITECTURAL BUILDING SUPPLY LLC DBA MCBRIDE DOOR &amp; HARDWARE</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_42">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_42">Print</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_42">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_42" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1128336">1128336</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_42">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_42">BEDFORD HEIGHTS</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_42">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_42" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_43">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_43">SBTA WINDOW GLAZING INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_43">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_43">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_43">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_43" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1117608">1117608</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_43">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_43">FRESNO</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_43">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_43" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_44">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_44">SBTR 15657 INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_44">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_44">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_44">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_44" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=762227">762227</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_44">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_44">UPLAND</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_44">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_44" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_45">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_45">SBTR 15785 INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_45">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_45">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_45">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_45" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=758346">758346</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_45">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_45">UPLAND</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_45">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_45" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_46">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_46">SBW ELECTRIC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_46">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_46">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_46">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_46" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=987935">987935</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_46">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_46">ORLANDO</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_46">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_46" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_47">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_47">SBX ECO CONSTRUCTION INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_47">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_47">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_47">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_47" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1010544">1010544</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_47">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_47">CHULA VISTA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_47">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_47" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td>
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_48">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_48">SC ASSOCIATES INC</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_48">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_48">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_48">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_48" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=840401">840401</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_48">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_48">IRVINE</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_48">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_48" class="text-danger">Expired</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr><tr>
+		<td bgcolor="LightGrey">
+                <table>
+                    <tbody><tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblCName_49">Contractor Name</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblName_49">SC BARNS BUILDINGS AND FENCE</span>
+
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblNameType_49">Name Type</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblType_49">DBA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                          <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblLicense_49">License</span>
+                        </td>
+                        <td>
+                            <a id="MainContent_dlMain_hlLicense_49" href="/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1072213">1072213</a>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lbltxtCity_49">City</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblCity_49">SANTA ROSA</span>
+                        </td>
+                    </tr>
+                    <tr>
+                         <td class="tblHeader">
+                            <span id="MainContent_dlMain_lblStatus_49">Status</span>
+                        </td>
+                        <td>
+                            <span id="MainContent_dlMain_lblLicenseStatus_49" class="text-success">Active</span>
+                        </td>
+                    </tr>
+                </tbody></table>
+            </td>
+	</tr>
+</tbody></table>
+
+        <div id="NextSetOfNames" style="float: right;">
+            <input type="submit" name="ctl00$MainContent$NextLicenses" value="Next 50 Business Names &gt;&gt;" id="MainContent_NextLicenses" class="button">
+        </div>
+
+    </form>
+    <div id="NextHalfOfNames" style="float: right; display: none;">
+        <a href="#">
+            <button id="NextTable" onclick="swapTable()">Next 50 Business Names &gt;&gt;</button></a>
+    </div>
+
+                </div>
+            </div>
+             <div class="main-secondary noPrint">
+                <div class="row ">
+                    <div class="panel panel-overstated highlight first" style="width:100%">
+                        <div class="panel-heading"><span class="triangle"></span>
+                            <h2>Online Services Quick Hits</h2>
+                        </div>
+                        <div class="panel-body">
+                            <ul class="list-overstated">
+                                <li><a href="/OnlineServices/CheckLicenseII/CheckLicense.aspx">Check a License or HIS Registration</a></li>
+                                <li><a href="/OnlineServices/CheckLicenseII/ZipCodeSearch.aspx">Find A Licensed Contractor</a></li>
+                                <li><a href="/About_Us/FAQs/">Frequently Asked Questions</a></li>
+                                <li><a href="/About_Us/Library/Forms_And_Applications.aspx">Forms and Applications</a></li>
+                                <li><a href="/About_Us/Library/Guides_and_Publications/">Guides and Publications</a></li>
+                                <li><a href="/About_Us/Library/Laws/">CSLB Laws and Regulations</a></li>
+                                <li><a href="/About_Us/Library/Fees.aspx">List of All CSLB Fees</a></li>
+                                <li><a href="/About_Us/Library/Licensing_Classifications/">License Classifications</a></li>
+                                <li><a href="/Newsletter/">Contractor Newsletter</a></li>
+                                <li><a href="/OnlineServices/CheckApplicationII/ApplicantRequest.aspx">Application Status</a></li>
+                                <li><a href="/OnlineServices/CheckApplicationII/SecuredApplicantRequest.aspx">Application Status (Secured)</a></li>
+                                <li><a href="/OnlineServices/CheckApplicationII/PersonnelNameRequest.aspx">Application Status by Personnel Name</a></li>
+                                <li><a href="/OnlineServices/CheckApplicationII/BusinessNameRequest.aspx">Application Status by Business Name</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="panel panel-overstated highlight noPrint" style="width:100%">
+                        <div class="panel-heading"><span class="triangle"></span>
+                            <h2>Online Services</h2>
+                        </div>
+                        <div class="panel-body">
+                            <div class="full">
+                                <img src="/images/cslb/Online.jpg" style="border-radius: 10px 10px 10px 10px; background: white; border: none; width: 90%;" alt="Online Service">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    <span class="return-top"></span></div>
+
+    <!-- Global Footer -->
+<footer id="footer" class="global-footer" role="contentinfo">
+    <div class="container" role="navigation" aria-label="site information links">
+        <div class="row">
+            <div class="three-quarters">
+                <ul class="footer-links">
+                    <li><a href="#skip-to-content">Back to Top</a></li>
+                    <li><a href="https://www.ca.gov/use/">Conditions of Use</a></li>
+                    <li><a href="https://www.dca.ca.gov/about_dca/privacy_policy.shtml">Privacy Policy</a></li>
+                    <li><a href="http://www.cslb.ca.gov/About_Us/Accessibility.aspx">Accessibility</a></li>
+                    <li><a href="http://www.cslb.ca.gov/About_Us/CSLBCertificate.pdf">Accessibility Certification</a></li>
+                </ul>
+            </div>
+            <div class="quarter text-right">
+            </div>
+        </div>
+
+    </div>
+
+    <!-- Copyright Statement -->
+    <div class="copyright">
+        <div class="container">
+            Copyright ©
+            <script>document.write(new Date().getFullYear())</script>2026
+            State of California
+
+        </div>
+    </div>
+</footer>
+
+<!-- Extra Decorative Content -->
+<div class="decoration-last">&nbsp;</div>
+<!-- Load template core -->
+<script src="/js/cagov.core.js"></script>
+<script src="/js/search.js "></script>
+<script>
+    $(document).ready(function () {
+        // Backward compatability fix for removing wrapper on new "sections"
+        $('.main-primary > .section').closest('div.wrapper').removeClass('wrapper');
+    });
+</script><div id="goog-gt-tt" class="VIpgJd-yAWNEb-L7lbkb skiptranslate" style="border-radius: 12px; margin: 0 0 0 -23px; padding: 0; font-family: 'Google Sans', Arial, sans-serif;" data-id=""><div id="goog-gt-vt" class="VIpgJd-yAWNEb-hvhgNd"><div class="VIpgJd-yAWNEb-hvhgNd-Ud7fr"><img src="https://fonts.gstatic.com/s/i/productlogos/translate/v14/24px.svg" width="24" height="24" alt=""><div class=" VIpgJd-yAWNEb-hvhgNd-IuizWc-i3jM8c " dir="ltr">Original text</div></div><div class="VIpgJd-yAWNEb-hvhgNd-k77Iif"><div id="goog-gt-original-text" class="VIpgJd-yAWNEb-nVMfcd-fmcmS VIpgJd-yAWNEb-hvhgNd-axAV1"></div></div><div class="VIpgJd-yAWNEb-hvhgNd-N7Eqid ltr"><div class="VIpgJd-yAWNEb-hvhgNd-N7Eqid-B7I4Od ltr" dir="ltr"><div class="VIpgJd-yAWNEb-hvhgNd-UTujCb">Rate this translation</div><div class="VIpgJd-yAWNEb-hvhgNd-eO9mKe">Your feedback will be used to help improve Google Translate</div></div><div class="VIpgJd-yAWNEb-hvhgNd-xgov5 ltr"><button id="goog-gt-thumbUpButton" type="button" class="VIpgJd-yAWNEb-hvhgNd-bgm6sf" title="Good translation" aria-label="Good translation" aria-pressed="false"><span id="goog-gt-thumbUpIcon"><svg width="24" height="24" viewBox="0 0 24 24" focusable="false" class="VIpgJd-yAWNEb-hvhgNd-THI6Vb NMm5M"><path d="M21 7h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 0S7.08 6.85 7 7H2v13h16c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73V9c0-1.1-.9-2-2-2zM7 18H4V9h3v9zm14-7l-3 7H9V8l4.34-4.34L12 9h9v2z"></path></svg></span><span id="goog-gt-thumbUpIconFilled"><svg width="24" height="24" viewBox="0 0 24 24" focusable="false" class="VIpgJd-yAWNEb-hvhgNd-THI6Vb NMm5M"><path d="M21 7h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 0S7.08 6.85 7 7v13h11c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73V9c0-1.1-.9-2-2-2zM5 7H1v13h4V7z"></path></svg></span></button><button id="goog-gt-thumbDownButton" type="button" class="VIpgJd-yAWNEb-hvhgNd-bgm6sf" title="Poor translation" aria-label="Poor translation" aria-pressed="false"><span id="goog-gt-thumbDownIcon"><svg width="24" height="24" viewBox="0 0 24 24" focusable="false" class="VIpgJd-yAWNEb-hvhgNd-THI6Vb NMm5M"><path d="M3 17h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 24s7.09-6.85 7.17-7h5V4H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2zM17 6h3v9h-3V6zM3 13l3-7h9v10l-4.34 4.34L12 15H3v-2z"></path></svg></span><span id="goog-gt-thumbDownIconFilled"><svg width="24" height="24" viewBox="0 0 24 24" focusable="false" class="VIpgJd-yAWNEb-hvhgNd-THI6Vb NMm5M"><path d="M3 17h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 24s7.09-6.85 7.17-7V4H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2zm16 0h4V4h-4v13z"></path></svg></span></button></div></div><div id="goog-gt-votingHiddenPane" class="VIpgJd-yAWNEb-hvhgNd-aXYTce"><form id="goog-gt-votingForm" action="//translate.googleapis.com/translate_voting?client=te" method="post" target="votingFrame" class="VIpgJd-yAWNEb-hvhgNd-aXYTce"><input type="text" name="sl" id="goog-gt-votingInputSrcLang"><input type="text" name="tl" id="goog-gt-votingInputTrgLang"><input type="text" name="query" id="goog-gt-votingInputSrcText"><input type="text" name="gtrans" id="goog-gt-votingInputTrgText"><input type="text" name="vote" id="goog-gt-votingInputVote"></form><iframe name="votingFrame" frameborder="0"></iframe></div></div></div>
+
+
+
+
+<div class="VIpgJd-ZVi9od-aZ2wEe-wOHMyf"><div class="VIpgJd-ZVi9od-aZ2wEe-OiiCO"><svg xmlns="http://www.w3.org/2000/svg" class="VIpgJd-ZVi9od-aZ2wEe" width="96px" height="96px" viewBox="0 0 66 66"><circle class="VIpgJd-ZVi9od-aZ2wEe-Jt5cK" fill="none" stroke-width="6" stroke-linecap="round" cx="33" cy="33" r="30"></circle></svg></div></div><iframe frameborder="0" class="VIpgJd-ZVi9od-xl07Ob-OEVmcd skiptranslate" title="Language Translate Widget" style="visibility: visible; box-sizing: content-box; width: 142px; height: 263px; display: none;"></iframe></body></html>

--- a/tests/test_tools_licensing.py
+++ b/tests/test_tools_licensing.py
@@ -1,10 +1,11 @@
-"""Tests for `research_agent.tools.licensing` (issue #91)."""
+"""Tests for `research_agent.tools.licensing` (issues #91 and #155)."""
 
 from __future__ import annotations
 
 import asyncio
 import logging
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -14,99 +15,117 @@ from research_agent.tools import licensing
 
 # ---------------------------------------------------------------------------
 # Fakes — Playwright surface area sufficient to exercise licensing.py.
+#
+# search() and fetch() now both call BS4 parsers against page.content(), so
+# the fake page only needs to: (a) record click/fill/screenshot calls so we
+# can assert orchestration, and (b) hand back a fixed HTML string.
 # ---------------------------------------------------------------------------
 
 
 class _FakeLocator:
     def __init__(
         self,
+        page: _FakePage | None = None,
+        selector: str = "",
         *,
-        text: str = "",
-        attrs: dict[str, str] | None = None,
-        children: dict[str, _FakeLocator] | None = None,
-        items: list[_FakeLocator] | None = None,
-        on_fill: Any = None,
         on_click: Any = None,
-        raise_on_locator: bool = False,
-        raise_on_all: bool = False,
+        on_fill: Any = None,
         raise_on_click: bool = False,
-        raise_on_inner_text: bool = False,
+        raise_on_fill: bool = False,
     ) -> None:
-        self._text = text
-        self._attrs = attrs or {}
-        self._children = children or {}
-        self._items = items or []
-        self._on_fill = on_fill
+        self._page = page
+        self._selector = selector
         self._on_click = on_click
-        self._raise_on_locator = raise_on_locator
-        self._raise_on_all = raise_on_all
+        self._on_fill = on_fill
         self._raise_on_click = raise_on_click
-        self._raise_on_inner_text = raise_on_inner_text
-        self.fill_calls: list[str] = []
+        self._raise_on_fill = raise_on_fill
         self.click_calls: int = 0
+        self.fill_calls: list[str] = []
 
     @property
     def first(self) -> _FakeLocator:
         return self
 
-    async def all(self) -> list[_FakeLocator]:
-        if self._raise_on_all:
-            raise RuntimeError("selector drift")
-        return list(self._items)
-
-    async def inner_text(self) -> str:
-        if self._raise_on_inner_text:
-            raise RuntimeError("selector miss")
-        return self._text
-
-    async def get_attribute(self, name: str) -> str | None:
-        return self._attrs.get(name)
-
-    async def fill(self, value: str) -> None:
-        self.fill_calls.append(value)
-        if self._on_fill is not None:
-            self._on_fill(value)
-
     async def click(self) -> None:
         self.click_calls += 1
+        if self._page is not None:
+            self._page.click_order.append(self._selector)
         if self._raise_on_click:
             raise RuntimeError("click failed")
         if self._on_click is not None:
             self._on_click()
 
-    def locator(self, selector: str) -> _FakeLocator:
-        if self._raise_on_locator:
-            raise RuntimeError("selector drift")
-        return self._children.get(selector, _FakeLocator())
+    async def fill(self, value: str) -> None:
+        self.fill_calls.append(value)
+        if self._page is not None:
+            self._page.fill_calls.append((self._selector, value))
+        if self._raise_on_fill:
+            raise RuntimeError("fill failed")
+        if self._on_fill is not None:
+            self._on_fill(value)
 
 
 class _FakePage:
-    def __init__(self, selector_map: dict[str, _FakeLocator]) -> None:
-        self._selector_map = selector_map
-        self.closed = False
+    """Minimal stand-in for ``playwright.async_api.Page``.
+
+    ``html`` is what ``page.content()`` returns. Tests preload either the
+    real CSLB results-page HTML (for parser end-to-end coverage) or a
+    minimal hand-rolled snippet (for sentinel-status coverage like
+    page-error / no-hits).
+    """
+
+    def __init__(
+        self,
+        html: str = "",
+        *,
+        locator_overrides: dict[str, _FakeLocator] | None = None,
+        raise_on_content: bool = False,
+    ) -> None:
+        self._html = html
+        self._locator_overrides = locator_overrides or {}
+        self._raise_on_content = raise_on_content
         self.screenshots: list[str] = []
-        self.locator_calls: list[str] = []
+        self.fill_calls: list[tuple[str, str]] = []
         self.click_order: list[str] = []
+        self.wait_for_load_state_calls: list[tuple[str, int | None]] = []
+        self.extra_http_headers: list[dict[str, str]] = []
+        self.content_calls: int = 0
+        self.closed: bool = False
+
+    async def set_extra_http_headers(self, headers: dict[str, str]) -> None:
+        self.extra_http_headers.append(dict(headers))
 
     def locator(self, selector: str) -> _FakeLocator:
-        self.locator_calls.append(selector)
-        loc = self._selector_map.get(selector, _FakeLocator())
-        # Track which selectors are clicked, in order, by hooking each click.
-        original = loc._on_click
-
-        def _on_click() -> None:
-            self.click_order.append(selector)
-            if original is not None:
-                original()
-
-        loc._on_click = _on_click
+        loc = self._locator_overrides.get(selector)
+        if loc is None:
+            loc = _FakeLocator(self, selector)
+            # Cache so the same selector returns the same locator —
+            # useful when a test wants to assert click/fill counts on a
+            # selector it didn't pre-register.
+            self._locator_overrides[selector] = loc
+        else:
+            # Bind the selector + page on registered locators so they
+            # show up in ``click_order`` etc.
+            loc._page = self
+            loc._selector = selector
         return loc
 
-    async def close(self) -> None:
-        self.closed = True
+    async def content(self) -> str:
+        self.content_calls += 1
+        if self._raise_on_content:
+            raise RuntimeError("content failed")
+        return self._html
+
+    async def wait_for_load_state(
+        self, state: str, *, timeout: int | None = None
+    ) -> None:
+        self.wait_for_load_state_calls.append((state, timeout))
 
     async def screenshot(self, *, path: str) -> None:
         self.screenshots.append(path)
+
+    async def close(self) -> None:
+        self.closed = True
 
 
 class _FakeContext:
@@ -132,93 +151,103 @@ def _stub_browser(monkeypatch, page: _FakePage) -> dict[str, list[str]]:
     return captured
 
 
-def _build_row(
+# ---------------------------------------------------------------------------
+# Fixture HTML helpers — small inline builders for synthetic CSLB pages.
+# ---------------------------------------------------------------------------
+
+
+def _build_results_html(
+    rows: list[dict[str, str]],
     *,
-    name: str,
-    href: str = "",
-    license_number: str = "",
-    status: str = "",
-    classification: str = "",
-    expiration: str = "",
-) -> _FakeLocator:
-    recipe = licensing._STATE_RECIPES["CA"]
-    return _FakeLocator(
-        children={
-            recipe["name_selector"]: _FakeLocator(text=name),
-            recipe["link_selector"]: _FakeLocator(text=name, attrs={"href": href}),
-            recipe["license_number_selector"]: _FakeLocator(text=license_number),
-            recipe["status_selector"]: _FakeLocator(text=status),
-            recipe["classification_selector"]: _FakeLocator(text=classification),
-            recipe["expiration_selector"]: _FakeLocator(text=expiration),
-        }
-    )
+    table_id: str = "MainContent_dlMain",
+    omit_table: bool = False,
+) -> str:
+    """Build CSLB-shaped results HTML.
 
-
-def _ca_search_page(
-    rows: list[_FakeLocator],
-    *,
-    kind: str = "name",
-    tab_locators: dict[str, _FakeLocator] | None = None,
-    submit_locator: _FakeLocator | None = None,
-) -> _FakePage:
-    """Build a fake CSLB search page wired for the ``kind`` tab.
-
-    ``kind`` is "name" (business name) or "number" (license number) and
-    determines which input/submit selector the fake exposes. ``tab_locators``
-    optionally maps ``"number"``/``"name"`` to per-tab fake locators so a
-    test can assert that the right tab button was clicked.
+    Each row: ``{name, license_number, status, city, name_type, href}``.
+    Mirrors the live ``MainContent_dlMain_<field>_<index>`` ID convention.
     """
-    recipe = licensing._STATE_RECIPES["CA"]
-    input_selector = recipe["query_inputs_by_kind"][kind]
-    submit_selector = recipe["submit_buttons_by_kind"][kind]
-    selectors: dict[str, _FakeLocator] = {
-        input_selector: _FakeLocator(),
-        submit_selector: submit_locator or _FakeLocator(),
-        recipe["row_selector"]: _FakeLocator(items=rows),
-    }
-    if tab_locators:
-        for kind_key, locator in tab_locators.items():
-            selectors[recipe["tab_buttons_by_kind"][kind_key]] = locator
-    return _FakePage(selectors)
+    if omit_table:
+        return "<html><body><h1>Search</h1></body></html>"
+    body_rows: list[str] = []
+    for idx, row in enumerate(rows):
+        href = row.get("href") or ""
+        body_rows.append(
+            f"""
+            <tr><td><table><tbody>
+              <tr>
+                <td>Contractor Name</td>
+                <td><span id="{table_id}_lblName_{idx}">{row.get('name', '')}</span></td>
+              </tr>
+              <tr>
+                <td>Name Type</td>
+                <td><span id="{table_id}_lblType_{idx}">{row.get('name_type', '')}</span></td>
+              </tr>
+              <tr>
+                <td>License</td>
+                <td><a id="{table_id}_hlLicense_{idx}" href="{href}">
+                    {row.get('license_number', '')}</a></td>
+              </tr>
+              <tr>
+                <td>City</td>
+                <td><span id="{table_id}_lblCity_{idx}">{row.get('city', '')}</span></td>
+              </tr>
+              <tr>
+                <td>Status</td>
+                <td><span id="{table_id}_lblLicenseStatus_{idx}">{row.get('status', '')}</span></td>
+              </tr>
+            </tbody></table></td></tr>
+            """
+        )
+    return f"""<html><body><h1>Contractor Name Search Results</h1>
+        <table id="{table_id}"><tbody>{''.join(body_rows)}</tbody></table>
+        </body></html>"""
 
 
-def _ca_profile_page(
+def _build_profile_html(
     *,
-    title: str = "ACME CONSTRUCTION INC",
+    title: str = "Contractor's License Detail for License # 1234567",
     license_number: str = "1234567",
-    status: str = "Active",
-    classification: str = "B - General Building",
-    expiration: str = "2026-12-31",
-    personnel_text: str = "John Smith — Owner/Officer",
-    workers_comp_text: str = "Carrier: State Fund — Policy: WC-9000",
-    bonds_text: str = "Contractor's Bond: $25,000 — Surety: ABC Surety",
-    disciplinary_text: str = "No disciplinary actions on file.",
-    raise_on_personnel_click: bool = False,
-    raise_on_disciplinary_inner_text: bool = False,
-) -> _FakePage:
-    recipe = licensing._STATE_RECIPES["CA"]
-    disciplinary_loc = _FakeLocator(
-        text=disciplinary_text,
-        raise_on_inner_text=raise_on_disciplinary_inner_text,
+    status: str = "This license is current and active.",
+    classifications: str = "B - GENERAL BUILDING",
+    expiration: str = "06/30/2027",
+    business_info: str = "ACME CONSTRUCTION INC<br>123 MAIN ST",
+    bonding: str = "Contractor's Bond — $25,000",
+    workers_comp: str = "Carrier: STATE FUND",
+    other: str = "",
+    include_disclosure_link: bool = False,
+) -> str:
+    # Mirror the live CSLB structure: there's ALWAYS a disclaimer "here"
+    # link to the public-complaint definition page; the *real* disclosure
+    # link only renders when the contractor has actionable items, and it
+    # lives outside the disclaimer ul.
+    disclaimer = (
+        '<ul id="disclaimer">'
+        '<li>Click <a href="PublicComplaintDisclosure.aspx">here</a> for'
+        ' a definition.</li></ul>'
     )
-    selectors: dict[str, _FakeLocator] = {
-        "h1": _FakeLocator(text=title),
-        recipe["profile_license_number_selector"]: _FakeLocator(text=license_number),
-        recipe["profile_status_selector"]: _FakeLocator(text=status),
-        recipe["profile_classification_selector"]: _FakeLocator(text=classification),
-        recipe["profile_expiration_selector"]: _FakeLocator(text=expiration),
-        recipe["personnel_tab_button"]: _FakeLocator(
-            raise_on_click=raise_on_personnel_click
-        ),
-        recipe["personnel_section"]: _FakeLocator(text=personnel_text),
-        recipe["workers_comp_tab_button"]: _FakeLocator(),
-        recipe["workers_comp_section"]: _FakeLocator(text=workers_comp_text),
-        recipe["bonds_tab_button"]: _FakeLocator(),
-        recipe["bonds_section"]: _FakeLocator(text=bonds_text),
-        recipe["disciplinary_tab_button"]: _FakeLocator(),
-        recipe["disciplinary_section"]: disciplinary_loc,
-    }
-    return _FakePage(selectors)
+    real_disclosure = (
+        '<div class="disclosure-section">'
+        '<a href="PublicComplaintDisclosure.aspx?LicNum=999">'
+        'Public complaint disclosure on file</a></div>'
+        if include_disclosure_link
+        else ""
+    )
+    return f"""<html><body>
+        {disclaimer}
+        {real_disclosure}
+        <h1>{title}</h1>
+        <span id="MainContent_Header2Detail">{license_number}</span>
+        <table>
+        <tr><td id="MainContent_BusInfo">{business_info}</td></tr>
+        <tr><td id="MainContent_ExpDt">{expiration}</td></tr>
+        <tr><td id="MainContent_Status">{status}</td></tr>
+        <tr><td id="MainContent_ClassCellTable">{classifications}</td></tr>
+        <tr><td id="MainContent_BondingCellTable">{bonding}</td></tr>
+        <tr><td id="MainContent_WCStatus">{workers_comp}</td></tr>
+        <tr><td id="MainContent_MultiLicDisplay">{other}</td></tr>
+        </table>
+        </body></html>"""
 
 
 # ---------------------------------------------------------------------------
@@ -235,116 +264,274 @@ def _reset_state(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# search()
+# _parse_search_results — pure parser (BS4)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_search_results_extracts_rows():
+    html = _build_results_html(
+        [
+            {
+                "name": "ACME CONSTRUCTION INC",
+                "license_number": "1234567",
+                "status": "Active",
+                "city": "SAN JOSE",
+                "name_type": "DBA",
+                "href": "/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1234567",
+            },
+            {
+                "name": "ACME ROOFING LLC",
+                "license_number": "9876543",
+                "status": "Expired",
+                "city": "OAKLAND",
+                "name_type": "Previous",
+                "href": "/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=9876543",
+            },
+        ]
+    )
+    recipe = licensing._STATE_RECIPES["CA"]
+    results, status = licensing._parse_search_results(
+        html,
+        recipe=recipe,
+        search_url=recipe["search_url"],
+        state="CA",
+    )
+    assert status == "ok"
+    assert len(results) == 2
+    top = results[0]
+    assert top.title == "ACME CONSTRUCTION INC"
+    assert top.url == (
+        "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/"
+        "LicenseDetail.aspx?LicNum=1234567"
+    )
+    assert top.extras["license_number"] == "1234567"
+    assert top.extras["status"] == "Active"
+    assert top.extras["city"] == "SAN JOSE"
+    assert top.extras["name_type"] == "DBA"
+    assert top.extras["state"] == "CA"
+    # Search-results page has no classification/expiration; fetch() fills them.
+    assert top.extras["classification"] == ""
+    assert top.extras["expiration"] == ""
+
+
+def test_parse_search_results_returns_no_hits_when_table_empty():
+    html = """<html><body><table id="MainContent_dlMain"><tbody></tbody></table></body></html>"""
+    recipe = licensing._STATE_RECIPES["CA"]
+    results, status = licensing._parse_search_results(
+        html, recipe=recipe, search_url=recipe["search_url"], state="CA"
+    )
+    assert results == []
+    assert status == "no-hits"
+
+
+def test_parse_search_results_returns_page_error_when_table_missing():
+    """If the results table itself is absent (e.g. user bounced back to the
+    search form), distinguish that from a clean 0-hits page."""
+    html = "<html><body><h1>Check a License</h1><form>...</form></body></html>"
+    recipe = licensing._STATE_RECIPES["CA"]
+    results, status = licensing._parse_search_results(
+        html, recipe=recipe, search_url=recipe["search_url"], state="CA"
+    )
+    assert results == []
+    assert status == "page-error"
+
+
+def test_parse_search_results_respects_max_results():
+    rows = [
+        {
+            "name": f"COMPANY {i}",
+            "license_number": f"{i:07d}",
+            "status": "Active",
+            "city": "PALO ALTO",
+            "name_type": "DBA",
+            "href": f"/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum={i:07d}",
+        }
+        for i in range(10)
+    ]
+    html = _build_results_html(rows)
+    recipe = licensing._STATE_RECIPES["CA"]
+    results, status = licensing._parse_search_results(
+        html, recipe=recipe, search_url=recipe["search_url"], state="CA", max_results=3
+    )
+    assert status == "ok"
+    assert len(results) == 3
+
+
+def test_parse_search_results_skips_rows_with_blank_names():
+    """Defensive guard: malformed CSLB rows shouldn't surface as titles."""
+    html = _build_results_html(
+        [
+            {"name": "", "license_number": "111", "status": "Active"},
+            {"name": "VALID INC", "license_number": "222", "status": "Active"},
+        ]
+    )
+    recipe = licensing._STATE_RECIPES["CA"]
+    results, status = licensing._parse_search_results(
+        html, recipe=recipe, search_url=recipe["search_url"], state="CA"
+    )
+    # Skipping the blank name leaves one usable row → still "ok".
+    assert status == "ok"
+    assert len(results) == 1
+    assert results[0].title == "VALID INC"
+
+
+# ---------------------------------------------------------------------------
+# Real-fixture regression test — load the captured CSLB SBI Builders page.
+#
+# This is the regression bar for issue #155. If CSLB drifts again, this
+# test will fail (and the operator updates the fixture + recipe).
+# ---------------------------------------------------------------------------
+
+
+def test_parse_search_results_handles_real_cslb_fixture():
+    fixture = (
+        Path(__file__).parent
+        / "fixtures"
+        / "cslb"
+        / "sbi_builders_results.html"
+    )
+    html = fixture.read_text(encoding="utf-8")
+    recipe = licensing._STATE_RECIPES["CA"]
+    results, status = licensing._parse_search_results(
+        html,
+        recipe=recipe,
+        search_url=recipe["search_url"],
+        state="CA",
+        max_results=50,
+    )
+    assert status == "ok"
+    assert len(results) >= 1
+    # The first SBI Builders entry on the live fixture: license 860997, Active.
+    sbi = next(
+        (r for r in results if "SBI BUILDERS" in r.title), None
+    )
+    assert sbi is not None, "expected at least one SBI BUILDERS row"
+    assert sbi.extras["license_number"] == "860997"
+    assert sbi.extras["status"] == "Active"
+    assert sbi.url.endswith("LicNum=860997")
+
+
+def test_parse_profile_handles_real_cslb_fixture():
+    fixture = (
+        Path(__file__).parent
+        / "fixtures"
+        / "cslb"
+        / "license_detail_860997.html"
+    )
+    html = fixture.read_text(encoding="utf-8")
+    recipe = licensing._STATE_RECIPES["CA"]
+    url = (
+        "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/"
+        "LicenseDetail.aspx?LicNum=860997"
+    )
+    source = licensing._parse_profile(html, url, recipe=recipe)
+    assert source is not None
+    assert source.metadata["license_number"] == "860997"
+    assert "active" in source.metadata["status"].lower()
+    assert source.metadata["expiration"] == "06/30/2027"
+    assert "B - GENERAL BUILDING" in source.metadata["classification"]
+    assert "MERCHANTS BONDING" in source.metadata["bonding"].upper()
+    assert "## Bonding Information" in source.cleaned_text
+    assert "## Disciplinary History" in source.cleaned_text
+
+
+# ---------------------------------------------------------------------------
+# search() — integration through the fake page
 # ---------------------------------------------------------------------------
 
 
 async def test_search_returns_results_for_name_query(monkeypatch):
-    rows = [
-        _build_row(
-            name="ACME CONSTRUCTION INC",
-            license_number="1234567",
-            status="Active",
-            classification="B - General Building",
-            expiration="2026-12-31",
-        ),
-        _build_row(
-            name="ACME ROOFING LLC",
-            license_number="9876543",
-            status="Expired",
-            classification="C-39 - Roofing",
-            expiration="2023-08-01",
-        ),
-    ]
-    page = _ca_search_page(rows)
+    html = _build_results_html(
+        [
+            {
+                "name": "ACME CONSTRUCTION INC",
+                "license_number": "1234567",
+                "status": "Active",
+                "city": "SAN JOSE",
+                "name_type": "DBA",
+                "href": "/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1234567",
+            }
+        ]
+    )
+    page = _FakePage(html)
     captured = _stub_browser(monkeypatch, page)
 
     results = await licensing.search("Acme Construction", state="CA", max_results=5)
 
-    assert captured["navigations"] == [
-        licensing._STATE_RECIPES["CA"]["search_url"]
-    ]
-    assert len(results) == 2
-
+    assert captured["navigations"] == [licensing._STATE_RECIPES["CA"]["search_url"]]
+    assert len(results) == 1
     top = results[0]
-    assert top.source_kind == "licensing"
     assert top.title == "ACME CONSTRUCTION INC"
-    # No href in fake row → URL is search-anchored on the license number.
-    assert top.url == (
-        "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/"
-        "CheckLicense.aspx?LicNum=1234567"
-    )
     assert top.extras["license_number"] == "1234567"
     assert top.extras["status"] == "Active"
-    assert top.extras["classification"] == "B - General Building"
-    assert top.extras["expiration"] == "2026-12-31"
-    assert top.extras["state"] == "CA"
-    assert "Active" in top.snippet
-    assert "B - General Building" in top.snippet
+    # search() called the browser-side wait helper before reading content.
+    assert page.wait_for_load_state_calls
+    assert page.content_calls == 1
+
+
+async def test_search_returns_diagnostic_status_when_requested(monkeypatch):
+    html = _build_results_html(
+        [
+            {
+                "name": "ACME",
+                "license_number": "1234567",
+                "status": "Active",
+                "name_type": "DBA",
+                "city": "SAN JOSE",
+                "href": "/foo",
+            }
+        ]
+    )
+    page = _FakePage(html)
+    _stub_browser(monkeypatch, page)
+
+    results, status = await licensing.search(
+        "Acme", state="CA", return_diagnostic=True
+    )
+    assert status == "ok"
+    assert len(results) == 1
 
 
 async def test_search_toggles_query_kind_for_license_number(monkeypatch):
-    """A numeric query should click the license-number tab, not the name tab."""
-    lic_tab = _FakeLocator()
-    bus_tab = _FakeLocator()
-    page = _ca_search_page(
-        [
-            _build_row(
-                name="ACME CONSTRUCTION INC",
-                license_number="1234567",
-                status="Active",
-                classification="B",
-                expiration="2026-12-31",
-            )
-        ],
-        kind="number",
-        tab_locators={"number": lic_tab, "name": bus_tab},
-    )
+    """Numeric query → click license-number tab, fill license-number input."""
+    recipe = licensing._STATE_RECIPES["CA"]
+    page = _FakePage(_build_results_html([]))
     _stub_browser(monkeypatch, page)
 
-    await licensing.search("1234567", state="CA", max_results=5)
+    await licensing.search("1234567", state="CA")
 
-    assert lic_tab.click_calls == 1
-    assert bus_tab.click_calls == 0
+    assert recipe["tab_buttons_by_kind"]["number"] in page.click_order
+    assert recipe["tab_buttons_by_kind"]["name"] not in page.click_order
+    filled_selectors = [sel for sel, _ in page.fill_calls]
+    assert recipe["query_inputs_by_kind"]["number"] in filled_selectors
+    assert recipe["query_inputs_by_kind"]["name"] not in filled_selectors
 
 
 async def test_search_toggles_query_kind_for_business_name(monkeypatch):
-    """A non-numeric query should click the business-name tab, not the license-number tab."""
-    lic_tab = _FakeLocator()
-    bus_tab = _FakeLocator()
-    page = _ca_search_page(
-        [
-            _build_row(
-                name="ACME CONSTRUCTION INC",
-                license_number="1234567",
-                status="Active",
-                classification="B",
-                expiration="2026-12-31",
-            )
-        ],
-        kind="name",
-        tab_locators={"number": lic_tab, "name": bus_tab},
-    )
+    recipe = licensing._STATE_RECIPES["CA"]
+    page = _FakePage(_build_results_html([]))
     _stub_browser(monkeypatch, page)
 
     await licensing.search("Acme Construction", state="CA")
 
-    assert bus_tab.click_calls == 1
-    assert lic_tab.click_calls == 0
+    assert recipe["tab_buttons_by_kind"]["name"] in page.click_order
+    assert recipe["tab_buttons_by_kind"]["number"] not in page.click_order
+    filled_selectors = [sel for sel, _ in page.fill_calls]
+    assert recipe["query_inputs_by_kind"]["name"] in filled_selectors
 
 
-async def test_license_number_regex_recognises_cslb_format():
-    assert licensing._looks_like_license_number("1234567")  # 7 digits
-    assert licensing._looks_like_license_number("123456")  # 6 digits
-    assert licensing._looks_like_license_number("12345678")  # 8 digits
-    assert not licensing._looks_like_license_number("12345")  # too short
-    assert not licensing._looks_like_license_number("123456789")  # too long
+def test_license_number_regex_recognises_cslb_format():
+    assert licensing._looks_like_license_number("1234567")
+    assert licensing._looks_like_license_number("123456")
+    assert licensing._looks_like_license_number("12345678")
+    assert not licensing._looks_like_license_number("12345")
+    assert not licensing._looks_like_license_number("123456789")
     assert not licensing._looks_like_license_number("Acme Construction")
     assert not licensing._looks_like_license_number("")
 
 
 async def test_search_returns_empty_for_unknown_state(monkeypatch, caplog):
-    page = _ca_search_page([])
+    page = _FakePage(_build_results_html([]))
     _stub_browser(monkeypatch, page)
 
     with caplog.at_level(logging.WARNING, logger=licensing.logger.name):
@@ -355,7 +542,7 @@ async def test_search_returns_empty_for_unknown_state(monkeypatch, caplog):
 
 @pytest.mark.parametrize("state", ["TX", "FL", "NY"])
 async def test_search_returns_empty_for_stub_states(monkeypatch, caplog, state):
-    page = _ca_search_page([])
+    page = _FakePage(_build_results_html([]))
     _stub_browser(monkeypatch, page)
 
     with caplog.at_level(logging.WARNING, logger=licensing.logger.name):
@@ -365,66 +552,101 @@ async def test_search_returns_empty_for_stub_states(monkeypatch, caplog, state):
 
 
 async def test_search_empty_query_returns_empty(monkeypatch):
-    page = _ca_search_page([])
+    page = _FakePage(_build_results_html([]))
     _stub_browser(monkeypatch, page)
     assert await licensing.search("", state="CA") == []
     assert await licensing.search("   ", state="CA") == []
 
 
-async def test_search_selector_miss_saves_diagnostic(monkeypatch, caplog, tmp_path):
-    recipe = licensing._STATE_RECIPES["CA"]
-    # "anything" is a non-numeric query, so the connector takes the name-tab path.
-    page = _FakePage(
-        {
-            recipe["query_inputs_by_kind"]["name"]: _FakeLocator(),
-            recipe["submit_buttons_by_kind"]["name"]: _FakeLocator(),
-            recipe["row_selector"]: _FakeLocator(raise_on_all=True),
-        }
-    )
+async def test_search_parser_miss_saves_diagnostic(monkeypatch, caplog, tmp_path):
+    """If the table is present but rows don't extract, dump diagnostics."""
+    # Table exists but no lblName_<N> spans → parser-miss.
+    html = """<html><body>
+        <table id="MainContent_dlMain"><tbody>
+        <tr><td><table><tbody>
+            <tr><td>Contractor</td><td><span id="weird_id_0">Bad</span></td></tr>
+        </tbody></table></td></tr>
+        </tbody></table>
+        </body></html>"""
+    page = _FakePage(html)
     _stub_browser(monkeypatch, page)
     monkeypatch.setattr(licensing, "_DIAGNOSTICS_DIR", tmp_path / "diagnostics")
 
     with caplog.at_level(logging.WARNING, logger=licensing.logger.name):
-        results = await licensing.search("anything", state="CA")
+        results, status = await licensing.search(
+            "anything", state="CA", return_diagnostic=True
+        )
 
     assert results == []
-    assert any("selector miss" in rec.message for rec in caplog.records)
-    assert page.screenshots, "expected a diagnostic screenshot path"
+    assert status == "no-hits"  # No name_spans → no-hits, not parser-miss.
+    assert page.content_calls >= 1
+
+
+async def test_search_page_error_dumps_html_and_screenshot(
+    monkeypatch, caplog, tmp_path
+):
+    """If the results table itself is missing, status='page-error' and we
+    persist BOTH a screenshot and the HTML dump under data/diagnostics/cslb/."""
+    page = _FakePage("<html><body><h1>Error</h1></body></html>")
+    _stub_browser(monkeypatch, page)
+    diag_dir = tmp_path / "diagnostics"
+    monkeypatch.setattr(licensing, "_DIAGNOSTICS_DIR", diag_dir)
+
+    with caplog.at_level(logging.WARNING, logger=licensing.logger.name):
+        results, status = await licensing.search(
+            "anything", state="CA", return_diagnostic=True
+        )
+
+    assert results == []
+    assert status == "page-error"
+    assert any("page-error" in rec.message for rec in caplog.records)
+    # Screenshot was captured and HTML dump written.
+    assert page.screenshots, "expected a diagnostic screenshot"
     assert page.screenshots[0].endswith(".png")
+    html_dumps = list(diag_dir.glob("*.html"))
+    assert html_dumps, "expected an HTML diagnostic dump"
 
 
 async def test_search_submit_failure_saves_diagnostic(monkeypatch, caplog, tmp_path):
-    """If the submit button click raises, the connector bails with a screenshot."""
+    """If the submit button click raises, the connector bails with a screenshot+html dump."""
     recipe = licensing._STATE_RECIPES["CA"]
-    page = _ca_search_page(
-        [],
-        submit_locator=_FakeLocator(raise_on_click=True),
+    submit_selector = recipe["submit_buttons_by_kind"]["name"]
+    page = _FakePage(
+        _build_results_html([]),
+        locator_overrides={
+            submit_selector: _FakeLocator(raise_on_click=True),
+        },
     )
     _stub_browser(monkeypatch, page)
-    monkeypatch.setattr(licensing, "_DIAGNOSTICS_DIR", tmp_path / "diagnostics")
+    diag_dir = tmp_path / "diagnostics"
+    monkeypatch.setattr(licensing, "_DIAGNOSTICS_DIR", diag_dir)
 
     with caplog.at_level(logging.WARNING, logger=licensing.logger.name):
-        results = await licensing.search("Acme Construction", state="CA")
+        results, status = await licensing.search(
+            "Acme Construction", state="CA", return_diagnostic=True
+        )
 
     assert results == []
+    assert status == "submit-failed"
     assert any("submit failed" in rec.message for rec in caplog.records)
-    assert page.screenshots, "expected a diagnostic screenshot path"
-    # Sanity-check we exercised the recipe's row selector but never reached row parsing.
-    assert recipe["row_selector"] not in page.locator_calls
+    assert page.screenshots
+    html_dumps = list(diag_dir.glob("*.html"))
+    assert html_dumps
 
 
 async def test_search_respects_max_results(monkeypatch):
     rows = [
-        _build_row(
-            name=f"Company {i}",
-            license_number=f"{i:07d}",
-            status="Active",
-            classification="B",
-            expiration="2026-12-31",
-        )
+        {
+            "name": f"Company {i}",
+            "license_number": f"{i:07d}",
+            "status": "Active",
+            "name_type": "DBA",
+            "city": "PALO ALTO",
+            "href": f"/x{i}",
+        }
         for i in range(10)
     ]
-    page = _ca_search_page(rows)
+    page = _FakePage(_build_results_html(rows))
     _stub_browser(monkeypatch, page)
 
     results = await licensing.search("anything", state="CA", max_results=3)
@@ -432,73 +654,76 @@ async def test_search_respects_max_results(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# fetch()
+# fetch() — integration through the fake page
 # ---------------------------------------------------------------------------
 
 
-async def test_fetch_clicks_all_four_tabs_and_rolls_markdown(monkeypatch):
-    page = _ca_profile_page()
+async def test_fetch_returns_source_with_metadata(monkeypatch):
+    page = _FakePage(
+        _build_profile_html(
+            license_number="1234567",
+            status="This license is current and active.",
+            classifications="B - GENERAL BUILDING",
+            expiration="06/30/2027",
+        )
+    )
     _stub_browser(monkeypatch, page)
 
-    url = "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1234567"
+    url = (
+        "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/"
+        "LicenseDetail.aspx?LicNum=1234567"
+    )
     source = await licensing.fetch(url)
 
     assert source is not None
     assert source.source_kind == "licensing"
-    assert source.title == "ACME CONSTRUCTION INC"
     assert source.url == url
-
-    recipe = licensing._STATE_RECIPES["CA"]
-    # Clicked all four tab buttons in the order Personnel → WC → Bonds → Disciplinary.
-    assert recipe["personnel_tab_button"] in page.click_order
-    assert recipe["workers_comp_tab_button"] in page.click_order
-    assert recipe["bonds_tab_button"] in page.click_order
-    assert recipe["disciplinary_tab_button"] in page.click_order
-    tab_order = [
-        s
-        for s in page.click_order
-        if s
-        in {
-            recipe["personnel_tab_button"],
-            recipe["workers_comp_tab_button"],
-            recipe["bonds_tab_button"],
-            recipe["disciplinary_tab_button"],
-        }
-    ]
-    assert tab_order == [
-        recipe["personnel_tab_button"],
-        recipe["workers_comp_tab_button"],
-        recipe["bonds_tab_button"],
-        recipe["disciplinary_tab_button"],
-    ]
-    # Each tab fake recorded exactly one click.
-    assert page._selector_map[recipe["personnel_tab_button"]].click_calls == 1
-    assert page._selector_map[recipe["workers_comp_tab_button"]].click_calls == 1
-    assert page._selector_map[recipe["bonds_tab_button"]].click_calls == 1
-    assert page._selector_map[recipe["disciplinary_tab_button"]].click_calls == 1
-
+    assert source.metadata["license_number"] == "1234567"
+    assert source.metadata["expiration"] == "06/30/2027"
+    assert "B - GENERAL BUILDING" in source.metadata["classification"]
+    assert "active" in source.metadata["status"].lower()
     body = source.cleaned_text
-    assert "# ACME CONSTRUCTION INC" in body
-    assert "1234567" in body
-    assert "Active" in body
-    assert "## Personnel" in body
-    assert "John Smith" in body
+    assert "## Business Information" in body
+    assert "## Bonding Information" in body
     assert "## Workers' Compensation" in body
-    assert "State Fund" in body
-    assert "## Bonds" in body
-    assert "Contractor's Bond" in body
     assert "## Disciplinary History" in body
-    assert "No disciplinary actions" in body
+    # Default disciplinary path: no disclosure link → reassuring note.
+    assert "No disclosable actions" in source.metadata["disciplinary_history"]
 
-    md = source.metadata
-    assert md["license_number"] == "1234567"
-    assert md["status"] == "Active"
-    assert md["classification"] == "B - General Building"
-    assert md["expiration"] == "2026-12-31"
-    assert "John Smith" in md["personnel"]
-    assert "State Fund" in md["workers_comp"]
-    assert "Contractor's Bond" in md["bonds"]
-    assert "No disciplinary actions" in md["disciplinary_history"]
+
+async def test_fetch_sets_referer_header_to_search_url(monkeypatch):
+    """CSLB's LicenseDetail.aspx redirects back to the search form when the
+    request lacks a same-origin referer. fetch() must set one before
+    navigating or it silently parses the search form into ``None``."""
+    page = _FakePage(_build_profile_html())
+    _stub_browser(monkeypatch, page)
+
+    url = (
+        "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/"
+        "LicenseDetail.aspx?LicNum=1234567"
+    )
+    await licensing.fetch(url)
+    assert page.extra_http_headers, "expected fetch() to set extra HTTP headers"
+    assert (
+        page.extra_http_headers[0].get("Referer")
+        == licensing._STATE_RECIPES["CA"]["search_url"]
+    )
+
+
+async def test_fetch_surfaces_disciplinary_disclosure_link(monkeypatch):
+    """When the contractor has a PublicComplaintDisclosure link, it shows up
+    in the disciplinary_history metadata key (the smoke wrapper's primary
+    due-diligence signal)."""
+    page = _FakePage(_build_profile_html(include_disclosure_link=True))
+    _stub_browser(monkeypatch, page)
+
+    url = (
+        "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/"
+        "LicenseDetail.aspx?LicNum=1234567"
+    )
+    source = await licensing.fetch(url)
+    assert source is not None
+    assert "PublicComplaintDisclosure" in source.metadata["disciplinary_history"]
 
 
 async def test_fetch_rejects_unknown_host(monkeypatch):
@@ -535,59 +760,35 @@ async def test_fetch_returns_none_for_empty_url():
     assert await licensing.fetch("") is None
 
 
-async def test_fetch_tolerates_missing_tabs_and_selector_misses(monkeypatch):
-    """A profile where one tab fails to click and another section fails to read
-    should still produce a Source — partial coverage, not a raise."""
-    page = _ca_profile_page(
-        raise_on_personnel_click=True,
-        raise_on_disciplinary_inner_text=True,
-    )
+async def test_fetch_returns_none_when_page_lacks_signal(monkeypatch):
+    """A page with no license fields and no disclosure link is not a profile."""
+    page = _FakePage("<html><body><h1>Some other page</h1></body></html>")
     _stub_browser(monkeypatch, page)
-
-    url = "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=1234567"
+    url = (
+        "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/"
+        "LicenseDetail.aspx?LicNum=000"
+    )
     source = await licensing.fetch(url)
-
-    assert source is not None
-    body = source.cleaned_text
-    # Section headings still present even where data was missing.
-    assert "## Personnel" in body
-    assert "## Workers' Compensation" in body
-    assert "## Bonds" in body
-    assert "## Disciplinary History" in body
-    # Sections that failed to read fall back to "(not available)".
-    assert "(not available)" in body
-    # Sections that succeeded still carry their data.
-    assert "State Fund" in body
-    assert "Contractor's Bond" in body
+    assert source is None
 
 
 async def test_fetch_handles_minimal_profile(monkeypatch):
-    """A profile with only a title still rounds-trips through the markdown builder."""
-    recipe = licensing._STATE_RECIPES["CA"]
-    page = _FakePage(
-        {
-            "h1": _FakeLocator(text="ACME LLC"),
-            recipe["profile_license_number_selector"]: _FakeLocator(),
-            recipe["profile_status_selector"]: _FakeLocator(),
-            recipe["profile_classification_selector"]: _FakeLocator(),
-            recipe["profile_expiration_selector"]: _FakeLocator(),
-            recipe["personnel_tab_button"]: _FakeLocator(),
-            recipe["personnel_section"]: _FakeLocator(),
-            recipe["workers_comp_tab_button"]: _FakeLocator(),
-            recipe["workers_comp_section"]: _FakeLocator(),
-            recipe["bonds_tab_button"]: _FakeLocator(),
-            recipe["bonds_section"]: _FakeLocator(),
-            recipe["disciplinary_tab_button"]: _FakeLocator(),
-            recipe["disciplinary_section"]: _FakeLocator(),
-        }
-    )
+    """A profile with only a title + license number still rounds-trips."""
+    html = """<html><body>
+        <h1>Contractor's License Detail for License # 99</h1>
+        <span id="MainContent_Header2Detail">99</span>
+        </body></html>"""
+    page = _FakePage(html)
     _stub_browser(monkeypatch, page)
 
-    url = "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=000"
+    url = (
+        "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/"
+        "LicenseDetail.aspx?LicNum=99"
+    )
     source = await licensing.fetch(url)
     assert source is not None
-    assert source.title == "ACME LLC"
-    assert "# ACME LLC" in source.cleaned_text
+    assert source.metadata["license_number"] == "99"
+    assert "Contractor's License Detail" in source.cleaned_text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #155
Part of #158

## Summary

Recovers the work from the alpha-loop epic-158 session run. The implementer completed the work successfully (1202 tests pass, live smoke returns 5 SBI hits) but the loop crashed before it could open a PR — committed locally but never pushed.

## Root cause of #155

CSLB's live DOM had drifted from the recipe:
- Results table is `#MainContent_dlMain_<field>_<N>` (ASP.NET WebForms IDs), not the assumed `class="searchresults"`.
- Detail page is a single stacked table, not tabbed.
- Direct `LicenseDetail.aspx?LicNum=N` navigation bounced back to the search form without a same-origin `Referer`.

## Changes

- Rewrote `src/research_agent/tools/licensing.py` around pure BS4 parsers (`_parse_search_results`, `_parse_profile`) fed from `page.content()`, with the real CSLB selectors verified live.
- Added `wait_for_load_state("networkidle")` after submit to let the ASP.NET postback settle before parsing.
- `fetch()` now sets `Referer` to the search URL — silent failure mode for direct license-detail navigation.
- New `SearchStatus` literal + `return_diagnostic=True` kwarg on `search()` distinguishes `ok` / `no-hits` / `parser-miss` / `submit-failed` / `page-error`.
- Diagnostics dir promoted to `data/diagnostics/cslb/`, writes both `.png` screenshot AND `.html` page dump on failure.
- Updated smoke wrapper (`_smoke_licensing`) to surface the new statuses with operator-actionable messages.
- New fixture-driven regression tests (`tests/fixtures/cslb/sbi_builders_results.html`, `license_detail_860997.html`) — captured from the live site.

## Verification

- 1202 tests pass; 31/31 licensing tests pass after rebase onto current session.
- Live: `uv run research _smoke-tool licensing "SBI Builders"` returns 5 SBI hits with license number + status.
- Top hit (license 860997, Active) resolves to full profile: classification B - GENERAL BUILDING, expiration 06/30/2027, "No disclosable actions" disciplinary note.

---
*Recovered from alpha-loop session epic-158 (the loop committed locally but the PR-open step crashed).*