### PR TITLE
fix: register 5 unregistered env vars (closes #171)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,3 +88,30 @@ LINKEDIN_BROKER=
 # Optional: Lix data-broker key (https://lix-it.com/) — only consulted
 # when LINKEDIN_BROKER=lix. Similar per-lookup pricing to Proxycurl.
 LIX_API_KEY=
+
+# Optional: override the User-Agent sent by `tools/reddit.py`. Reddit's
+# anonymous JSON endpoint 403s the project's descriptive UA, so the
+# connector defaults to a Chrome UA. Set this if you have a registered
+# Reddit OAuth app or want a different override than RESEARCH_USER_AGENT
+# (which is consulted next in the fallback chain).
+RESEARCH_REDDIT_USER_AGENT=
+
+# Optional: path to the models routing YAML the daemon loads. Defaults to
+# `config/models.yaml` relative to cwd. Set when running out-of-tree or
+# pointing at a packaged config.
+RESEARCH_MODELS_CONFIG=
+
+# Optional: override the SQLite index path the daemon uses. Unset uses the
+# repo default (`data/index.sqlite`). Useful for isolating runs under test
+# or pointing at a writable disk.
+RESEARCH_DB_PATH=
+
+# Optional: override the directory that holds per-job folders. Unset uses
+# the repo default (`jobs/`). Useful for redirecting big runs onto a
+# larger disk.
+RESEARCH_JOBS_ROOT=
+
+# Optional: override where `tools/sanctions.py` writes its SDN/EU index
+# sqlite. Unset uses the module default under `data/sanctions/`. Useful
+# when refreshing into a staging path before atomic swap.
+SANCTIONS_DB_PATH=

--- a/README.md
+++ b/README.md
@@ -195,6 +195,11 @@ that list, so there is no drift.
 | `LINKEDIN_DATA_API_KEY` | no | LinkedIn data-broker key (default broker: Proxycurl) — required by `tools/linkedin.py`. Per-lookup ≈ $0.01–$0.05; gate fetches behind explicit planner tasks. Sign up at <https://nubela.co/proxycurl/>. |
 | `LINKEDIN_BROKER` | no | Broker recipe used by `tools/linkedin.py`. `proxycurl` (default) or `lix`; switching to `lix` consults `LIX_API_KEY` instead of `LINKEDIN_DATA_API_KEY`. |
 | `LIX_API_KEY` | no | Lix data-broker key (<https://lix-it.com/>) — only consulted when `LINKEDIN_BROKER=lix`. Similar per-lookup pricing to Proxycurl. |
+| `RESEARCH_REDDIT_USER_AGENT` | no | Override the User-Agent `tools/reddit.py` sends. Reddit's anonymous JSON endpoint 403s the project's descriptive UA; the connector defaults to a Chrome UA. Set this when you have a registered OAuth app or want a different override than `RESEARCH_USER_AGENT` (consulted next in the fallback chain). |
+| `RESEARCH_MODELS_CONFIG` | no | Path to the models routing YAML the daemon loads. Defaults to `config/models.yaml` relative to cwd. Set when running out-of-tree or pointing at a packaged config. |
+| `RESEARCH_DB_PATH` | no | Override the SQLite index path the daemon uses. Unset uses `data/index.sqlite`. Useful for isolating runs under test or pointing at a writable disk. |
+| `RESEARCH_JOBS_ROOT` | no | Override the directory that holds per-job folders. Unset uses `jobs/`. Useful for redirecting big runs onto a larger disk. |
+| `SANCTIONS_DB_PATH` | no | Override where `tools/sanctions.py` writes its SDN/EU index sqlite. Unset uses the module default under `data/sanctions/`. Useful when refreshing into a staging path before atomic swap. |
 
 </details>
 

--- a/src/research_agent/config.py
+++ b/src/research_agent/config.py
@@ -170,6 +170,54 @@ EXPECTED_ENV_KEYS: tuple[EnvKey, ...] = (
             " LINKEDIN_BROKER=lix. Similar per-lookup pricing to Proxycurl."
         ),
     ),
+    EnvKey(
+        name="RESEARCH_REDDIT_USER_AGENT",
+        required=False,
+        description=(
+            "Override the User-Agent that tools/reddit.py sends. Reddit's"
+            " anonymous JSON endpoint 403s the project's descriptive UA, so"
+            " the connector defaults to a Chrome UA. Set this when you have"
+            " a registered Reddit OAuth app or want a different override"
+            " than RESEARCH_USER_AGENT (which is consulted next)."
+        ),
+    ),
+    EnvKey(
+        name="RESEARCH_MODELS_CONFIG",
+        required=False,
+        description=(
+            "Path to the models routing YAML the daemon loads. Defaults to"
+            " 'config/models.yaml' relative to cwd. Set this when running"
+            " out-of-tree or pointing at a packaged config."
+        ),
+        default="config/models.yaml",
+    ),
+    EnvKey(
+        name="RESEARCH_DB_PATH",
+        required=False,
+        description=(
+            "Override the SQLite index path the daemon uses. Unset uses the"
+            " repo default ('data/index.sqlite'). Useful for isolating runs"
+            " under test or pointing at a writable disk."
+        ),
+    ),
+    EnvKey(
+        name="RESEARCH_JOBS_ROOT",
+        required=False,
+        description=(
+            "Override the directory that holds per-job folders. Unset uses"
+            " the repo default ('jobs/'). Useful for redirecting big runs"
+            " onto a larger disk."
+        ),
+    ),
+    EnvKey(
+        name="SANCTIONS_DB_PATH",
+        required=False,
+        description=(
+            "Override where tools/sanctions.py writes its SDN/EU index"
+            " sqlite. Unset uses the module default under 'data/sanctions/'."
+            " Useful when refreshing into a staging path before atomic swap."
+        ),
+    ),
 )
 
 


### PR DESCRIPTION
Closes #171

## Summary

Five env vars were read by code but never declared in \`EXPECTED_ENV_KEYS\`, \`.env.example\`, or the README env table — \`research doctor\` couldn't surface them, operators couldn't discover them, and \`.env\` parsing wouldn't validate them.

## Registered

| Env var | Used in | Default |
|---|---|---|
| \`RESEARCH_REDDIT_USER_AGENT\` | \`tools/reddit.py\` | falls back to \`RESEARCH_USER_AGENT\` then a Chrome UA |
| \`RESEARCH_MODELS_CONFIG\` | \`daemon.py\` | \`config/models.yaml\` |
| \`RESEARCH_DB_PATH\` | \`daemon.py\` | repo default (\`data/index.sqlite\`) |
| \`RESEARCH_JOBS_ROOT\` | \`daemon.py\` | repo default (\`jobs/\`) |
| \`SANCTIONS_DB_PATH\` | \`tools/sanctions.py\` | module default under \`data/sanctions/\` |

\`RESEARCH_DAEMON_SKIP_HEALTH_CHECKS\` is intentionally left unregistered — it's set by \`cli.py\` programmatically before spawning the daemon, not an operator-facing override.

## Out of scope

This is pre-existing drift, not from epic #158. Surfaced while reviewing the README env table.

## Verification

- 1211 tests pass, 1 skipped.
- \`research doctor\` lists all five new keys with \`optional\` / \`missing\` rows (verified locally).
- Diff is strictly scoped per \`scope-discipline\`: only the three docs/config files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)