### PR TITLE
Session: session/epic-180-epic-depth-of-investigation-fixes-post-2026-05-07-surface-level-report-diagnosis — 6/6 succeeded

### DIFF
--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -57,6 +57,7 @@ EventKind = Literal[
     "source_pruned",
     "pdf_vlm_escalation",
     "ocr_vlm_escalation",
+    "cornerstone_extract",
     "error",
     "warning",
 ]

--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -47,6 +47,7 @@ EventKind = Literal[
     "drain_replan",
     "replan_triggered",
     "replan_truncated",
+    "findings_truncated",
     "llm_call",
     "lmstudio_degraded",
     "lmstudio_recovered",

--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -46,6 +46,7 @@ EventKind = Literal[
     "critique_written",
     "drain_replan",
     "replan_triggered",
+    "replan_truncated",
     "llm_call",
     "lmstudio_degraded",
     "lmstudio_recovered",

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -95,6 +95,137 @@ async def _not_implemented_handler(job: Job, task: dict[str, Any]) -> dict[str, 
     raise FatalError(f"handler not implemented for kind={task['kind']!r}")
 
 
+# Issue #175: connector kinds dispatch directly to each tool's structured
+# API. Search payloads pass ``query`` plus any of these well-known kwargs
+# through to the underlying ``search()`` call — most connectors take a
+# ``kind`` switch (e.g. congress: bill/member/hearing) and a few take
+# ``state``/``since``/``form_type``. The set is the *union* across all
+# connectors; ``_filter_kwargs_for`` then narrows to what each connector
+# actually accepts, so planner drift (e.g. emitting ``kind`` for
+# ``edgar_search``, which takes ``form_type`` instead) doesn't surface as
+# a TypeError that bypasses the documented FatalError path.
+_CONNECTOR_SEARCH_PASSTHROUGH: frozenset[str] = frozenset(
+    {
+        "kind",
+        "max_results",
+        "state",
+        "form_type",
+        "since",
+        "agencies",
+        "jurisdiction",
+        "award_type",
+        "language",
+    }
+)
+
+
+def _filter_kwargs_for(fn: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Drop kwargs the callable doesn't accept.
+
+    Connectors have heterogeneous signatures — congress takes ``kind``,
+    edgar takes ``form_type``, fedregister takes ``since``/``agencies``.
+    The handler's passthrough whitelist is the union; this narrows it to
+    what ``fn`` actually accepts so a planner-drift kwarg like ``kind``
+    on ``edgar_search`` is silently dropped instead of crashing the call.
+    Falls back to the unfiltered dict when introspection fails (e.g.
+    C-implemented or wrapped callables).
+    """
+    import inspect
+
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return kwargs
+    accepts_var_kw = any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+    )
+    if accepts_var_kw:
+        return kwargs
+    accepted = {
+        name
+        for name, p in sig.parameters.items()
+        if p.kind
+        in (
+            inspect.Parameter.KEYWORD_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    }
+    return {k: v for k, v in kwargs.items() if k in accepted}
+
+
+def _make_connector_search_handler(module_name: str) -> Handler:
+    """Build a thin search-handler that dispatches to ``tools.<module_name>.search``.
+
+    Converts the connector's missing-credential ``RuntimeError`` (raised by
+    edgar/courtlistener/scholar/linkedin when their API key/UA isn't
+    configured) into :class:`FatalError` so the loop marks the task failed
+    cleanly down the documented path. Returns the standard search-result
+    + ``follow_up_tasks`` shape so each top hit becomes a connector-aware
+    ``web_fetch`` follow-up.
+    """
+
+    async def _handler(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        from importlib import import_module
+
+        mod = import_module(f"research_agent.tools.{module_name}")
+        payload = task["payload"]
+        kwargs = {
+            k: v for k, v in payload.items() if k in _CONNECTOR_SEARCH_PASSTHROUGH
+        }
+        kwargs = _filter_kwargs_for(mod.search, kwargs)
+        try:
+            results = await mod.search(payload.get("query", ""), **kwargs)
+        except RuntimeError as exc:
+            raise FatalError(f"{module_name}_search: {exc}") from exc
+        return _expand_search_to_fetches(job, payload, results)
+
+    return _handler
+
+
+def _make_connector_fetch_handler(module_name: str) -> Handler:
+    """Build a thin fetch-handler that dispatches to ``tools.<module_name>.fetch``.
+
+    Mirrors :func:`_make_connector_search_handler` but for the single-URL
+    fetch path: persists the returned ``Source`` and converts the
+    connector's missing-credential ``RuntimeError`` to :class:`FatalError`.
+    """
+
+    async def _handler(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        from importlib import import_module
+
+        mod = import_module(f"research_agent.tools.{module_name}")
+        payload = task["payload"]
+        try:
+            source = await mod.fetch(payload["url"])
+        except RuntimeError as exc:
+            raise FatalError(f"{module_name}_fetch: {exc}") from exc
+        return _persist_fetched_source(job, source)
+
+    return _handler
+
+
+_CONNECTOR_KINDS: tuple[str, ...] = (
+    "congress",
+    "fec",
+    "edgar",
+    "courtlistener",
+    "fedregister",
+    "lda",
+    "usaspending",
+    "gdelt",
+    "littlesis",
+    "nonprofits",
+    "opencorporates",
+    "sanctions",
+    "bbb",
+    "licensing",
+    "sos",
+    "calaccess",
+    "scholar",
+    "linkedin",
+)
+
+
 def default_handlers(router: Any) -> dict[str, Handler]:
     """Build the standard ``kind → handler`` registry.
 
@@ -240,7 +371,7 @@ def default_handlers(router: Any) -> dict[str, Handler]:
             )
         return result.model_dump()
 
-    return {
+    registry: dict[str, Handler] = {
         "web_search": _web_search,
         "web_fetch": _web_fetch,
         "arxiv_search": _arxiv_search,
@@ -255,6 +386,10 @@ def default_handlers(router: Any) -> dict[str, Handler]:
         "synthesize": _synthesize,
         "critique": _critique,
     }
+    for name in _CONNECTOR_KINDS:
+        registry[f"{name}_search"] = _make_connector_search_handler(name)
+        registry[f"{name}_fetch"] = _make_connector_fetch_handler(name)
+    return registry
 
 
 # ---------------------------------------------------------------------------

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -65,6 +65,18 @@ RETRY_WAITS: tuple[int, ...] = (1, 2, 4, 8, 16, 30, 60)
 RETRY_MAX_ATTEMPTS = 5
 MAX_DRAIN_REPLANS = 10
 
+# Scope-aware default for how many top hits per search become web_fetch
+# follow-ups. Issue #178: a global default of 3 starves broad/comprehensive
+# investigations of fetch surface area. The planner can still override per
+# task via ``payload["expand_top_k"]``.
+_DEFAULT_TOP_K_BY_SCOPE: dict[str, int] = {
+    "narrow": 3,
+    "medium": 5,
+    "broad": 7,
+    "comprehensive": 10,
+}
+_DEFAULT_TOP_K_FALLBACK = 3
+
 Handler = Callable[[Job, dict[str, Any]], Awaitable[dict[str, Any] | None]]
 
 
@@ -530,15 +542,23 @@ def _expand_search_to_fetches(
     ``extract_findings`` follow-up inherits context.
 
     ``payload`` knobs:
-      * ``expand_top_k`` (default 3) — cap follow-ups per search to keep
-        the queue from exploding.
+      * ``expand_top_k`` — cap follow-ups per search to keep the queue
+        from exploding. If the planner sets it explicitly, that wins.
+        Otherwise the default scales with the plan's ``scope_class``
+        (narrow→3, medium→5, broad→7, comprehensive→10), falling back
+        to 3 when no plan / no scope is available.
       * ``sub_question`` — overrides the auto-derived question.
       * ``query`` — used as the sub_question fallback if neither
         ``sub_question`` nor ``job.goal`` are set.
     """
     from research_agent.orchestrator.plan import TaskSpec
 
-    top_k = int(payload.get("expand_top_k", 3))
+    if "expand_top_k" in payload:
+        top_k = int(payload["expand_top_k"])
+    else:
+        plan = _load_latest_plan(job)
+        scope = plan.scope_class if plan is not None else None
+        top_k = _DEFAULT_TOP_K_BY_SCOPE.get(scope or "", _DEFAULT_TOP_K_FALLBACK)
     sub_question = payload.get("sub_question") or payload.get("query") or job.goal
 
     follow_ups: list[TaskSpec] = [

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -660,11 +660,70 @@ def _load_source_text(job: Job, source_id: int) -> tuple[str, dict[str, Any]] | 
 _EXTRACT_TEXT_LIMIT = 20000  # ~5k tokens; well under any tier's window
 _FINDINGS_PER_SOURCE_LIMIT = 8
 
+# Issue #177: cornerstone documents (the document the goal is anchored on —
+# the Mandate for Leadership PDF, a 10-K, a court opinion) carry the spine
+# of the investigation. Article-sized caps starve the rest of the run, so
+# the cornerstone path uses a much larger text window and a much higher
+# findings ceiling. The ceiling exists only to bound truly pathological
+# model output, not to constrain a real indexing pass.
+_CORNERSTONE_EXTRACT_TEXT_LIMIT = 80000  # ~20k tokens; still inside frontier windows
+_CORNERSTONE_FINDINGS_PER_SOURCE_LIMIT = 500
+# Documents that nobody marked as cornerstone but whose body is bigger than
+# this still get the cornerstone treatment — the planner's marker is the
+# primary signal, this is a fallback for runs whose plans pre-date #177.
+_CORNERSTONE_FALLBACK_MIN_CHARS = 200_000
+
 
 def _truncate_for_prompt(text: str, limit: int = _EXTRACT_TEXT_LIMIT) -> str:
     if len(text) <= limit:
         return text
     return text[:limit] + "\n\n[…truncated]"
+
+
+def _normalize_url_for_compare(url: str | None) -> str | None:
+    """Lowercase host + strip trailing slash so URL equality is forgiving.
+
+    The planner emits ``cornerstone_url`` as a literal string; the source
+    row stores whatever URL the fetch resolved. Casing of the host and a
+    trailing slash on the path are the only differences worth tolerating —
+    anything more involved (query reordering, scheme upgrade) would risk
+    aliasing two genuinely different resources.
+    """
+    if not isinstance(url, str) or not url:
+        return None
+    from urllib.parse import urlsplit, urlunsplit
+
+    try:
+        parts = urlsplit(url.strip())
+    except ValueError:
+        return None
+    host = parts.hostname or ""
+    netloc = host.lower()
+    if parts.port is not None:
+        netloc = f"{netloc}:{parts.port}"
+    path = parts.path.rstrip("/")
+    return urlunsplit((parts.scheme.lower(), netloc, path, parts.query, ""))
+
+
+def _is_cornerstone_source(job: Job, meta: dict[str, Any], text: str) -> bool:
+    """True when this source is the plan's declared cornerstone document.
+
+    Primary signal: the latest persisted plan's ``cornerstone_url`` matches
+    the source's URL (after light normalization). Fallback: the source's
+    body exceeds :data:`_CORNERSTONE_FALLBACK_MIN_CHARS`, which catches
+    runs whose plans pre-date #177 — better to over-trigger here than to
+    cap a 920-page document at 8 findings because the planner forgot to
+    set the marker.
+    """
+    plan = _load_latest_plan(job)
+    if plan is not None and plan.cornerstone_url:
+        norm_plan = _normalize_url_for_compare(plan.cornerstone_url)
+        norm_src = _normalize_url_for_compare(meta.get("url"))
+        if norm_plan and norm_src and norm_plan == norm_src:
+            return True
+    if isinstance(text, str) and len(text) >= _CORNERSTONE_FALLBACK_MIN_CHARS:
+        return True
+    return False
 
 
 _YAML_FENCE_RE = re.compile(r"```(?:yaml|yml)?\s*\n(.*?)\n```", re.DOTALL | re.IGNORECASE)
@@ -729,13 +788,35 @@ async def _run_extract_findings(
 
     sub_question = payload.get("sub_question") or job.goal
 
-    rendered = load_prompt("researcher", job=job, goal=job.goal)
+    is_cornerstone = _is_cornerstone_source(job, meta, text)
+    if is_cornerstone:
+        prompt_name = "researcher_cornerstone"
+        text_limit = _CORNERSTONE_EXTRACT_TEXT_LIMIT
+        findings_limit = _CORNERSTONE_FINDINGS_PER_SOURCE_LIMIT
+        emit(
+            job,
+            "INFO",
+            "loop",
+            "cornerstone_extract",
+            {
+                "source_id": source_id,
+                "url": meta.get("url"),
+                "prompt": prompt_name,
+                "text_chars": len(text),
+            },
+        )
+    else:
+        prompt_name = "researcher"
+        text_limit = _EXTRACT_TEXT_LIMIT
+        findings_limit = _FINDINGS_PER_SOURCE_LIMIT
+
+    rendered = load_prompt(prompt_name, job=job, goal=job.goal)
     agent = Agent(router.model_for("general"), output_type=str, system_prompt=rendered)
     context = (
         f"Sub-question: {sub_question}\n"
         f"Source URL: {meta.get('url')}\n"
         f"Source title: {meta.get('title')}\n\n"
-        f"Source content:\n{_truncate_for_prompt(text)}"
+        f"Source content:\n{_truncate_for_prompt(text, text_limit)}"
     )
     result = await router.call("general", agent, context)
     raw = result.output if isinstance(result.output, str) else str(result.output)
@@ -761,7 +842,7 @@ async def _run_extract_findings(
 
     written: list[int] = []
     skipped = 0
-    for item in parsed[:_FINDINGS_PER_SOURCE_LIMIT]:
+    for item in parsed[:findings_limit]:
         if not isinstance(item, dict):
             skipped += 1
             continue

--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -58,6 +58,47 @@ TaskKind = Literal[
     "summarize_source",
     "synthesize",
     "critique",
+    # Issue #175: connector-specific kinds dispatch directly to each
+    # tool's structured-API call (one round trip, JSON in / claims out)
+    # instead of routing through Brave + trafilatura. Each *_search emits
+    # ``web_fetch`` follow-ups via ``_expand_search_to_fetches``; each
+    # *_fetch persists a single source like ``arxiv_fetch``.
+    "congress_search",
+    "congress_fetch",
+    "fec_search",
+    "fec_fetch",
+    "edgar_search",
+    "edgar_fetch",
+    "courtlistener_search",
+    "courtlistener_fetch",
+    "fedregister_search",
+    "fedregister_fetch",
+    "lda_search",
+    "lda_fetch",
+    "usaspending_search",
+    "usaspending_fetch",
+    "gdelt_search",
+    "gdelt_fetch",
+    "littlesis_search",
+    "littlesis_fetch",
+    "nonprofits_search",
+    "nonprofits_fetch",
+    "opencorporates_search",
+    "opencorporates_fetch",
+    "sanctions_search",
+    "sanctions_fetch",
+    "bbb_search",
+    "bbb_fetch",
+    "licensing_search",
+    "licensing_fetch",
+    "sos_search",
+    "sos_fetch",
+    "calaccess_search",
+    "calaccess_fetch",
+    "scholar_search",
+    "scholar_fetch",
+    "linkedin_search",
+    "linkedin_fetch",
 ]
 
 ScopeClass = Literal["narrow", "medium", "broad", "comprehensive"]

--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -107,6 +107,13 @@ class Plan(BaseModel):
     task_template: list[TaskSpec]
     expected_iterations: int = Field(ge=1)
     scope_class: ScopeClass | None = None
+    cornerstone_url: str | None = None
+    """When the goal names a specific document (PDF, court opinion, SEC
+    filing, named report), the planner declares it here and emits a
+    ``web_fetch`` for it as task 0. Extraction against this URL switches to
+    the structured-index ``researcher_cornerstone`` prompt and bypasses the
+    per-source findings cap so a 920-page policy document yields one finding
+    per proposal — not the article-sized 2–6."""
 
     def is_complete(self) -> bool:
         if not self.subgoals:

--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -129,6 +129,15 @@ local-tier planner. Each entry is also compressed to a small summary dict so a
 long-running goal can't push the prompt past the model's context window —
 issue #176 saw a 524k-token payload at task 96."""
 
+MAX_FINDINGS_FOR_REPLAN = 60
+"""Cap on ``findings`` shipped into the ``tactical_replan`` payload (issue #179).
+
+Drilling down into named claims (Schedule F, WOTUS, mifepristone) requires the
+planner to *see* those claims — but a long broad-scope run can accumulate
+hundreds of findings, so we keep the most recent N (highest ids) and re-order
+them ascending before injection. Each entry is also compressed by
+:func:`_summarize_finding` so the per-entry footprint stays small."""
+
 _SUMMARY_REPR_MAX_CHARS = 500
 
 
@@ -210,6 +219,30 @@ def _summarize_recent_result(r: dict[str, Any]) -> dict[str, Any]:
         "status": status,
         "summary": summary,
     }
+
+
+def _summarize_finding(f: dict[str, Any]) -> dict[str, Any]:
+    """Compress one finding row into a planner-sized dict (issue #179).
+
+    The planner needs the *claim text* (so it can drill into the named
+    entity/proposal/rule), plus minimal evidence weight (``confidence``,
+    ``tags``, one source pointer). The full ``source_ids`` list is dropped
+    in favor of a single ``source_id`` — chasing every source URL is the
+    fetcher's job, not the planner's.
+    """
+    src_ids = f.get("source_ids")
+    first_source: Any = None
+    if isinstance(src_ids, list) and src_ids:
+        first_source = src_ids[0]
+
+    summarized: dict[str, Any] = {
+        "id": f.get("id"),
+        "claim": f.get("claim"),
+        "confidence": f.get("confidence"),
+        "tags": f.get("tags"),
+        "source_id": first_source,
+    }
+    return summarized
 
 
 class PlanVersionCapExceeded(RuntimeError):
@@ -449,8 +482,29 @@ async def tactical_replan(
         "prior_plan": plan.model_dump(),
         "recent_results": summarized,
     }
+
+    # issue #179: include a bounded view of the running ``findings`` so the
+    # planner can drill into named claims (Schedule F, WOTUS, mifepristone)
+    # rather than re-emitting the same per-department generic queries. Cap to
+    # the most recent MAX_FINDINGS_FOR_REPLAN entries (highest ids first, then
+    # re-ordered ascending) and compress each via ``_summarize_finding``.
+    findings_truncation: tuple[int, int] | None = None
     if findings is not None:
-        payload["findings"] = findings
+        findings_before = len(findings)
+        if findings_before > MAX_FINDINGS_FOR_REPLAN:
+            top_recent = sorted(
+                findings,
+                key=lambda f: f.get("id") if isinstance(f.get("id"), int) else -1,
+                reverse=True,
+            )[:MAX_FINDINGS_FOR_REPLAN]
+            tail_findings = sorted(
+                top_recent,
+                key=lambda f: f.get("id") if isinstance(f.get("id"), int) else -1,
+            )
+            findings_truncation = (findings_before, len(tail_findings))
+        else:
+            tail_findings = list(findings)
+        payload["findings"] = [_summarize_finding(f) for f in tail_findings]
     if synthesis_md is not None:
         payload["synthesis_md"] = synthesis_md
     context = json.dumps(payload, sort_keys=True, default=str)
@@ -466,6 +520,19 @@ async def tactical_replan(
                 "after": len(summarized),
                 "compressed": True,
                 "max": MAX_RECENT_RESULTS_FOR_REPLAN,
+            },
+        )
+    if findings_truncation is not None:
+        emit(
+            job,
+            "WARN",
+            "planner",
+            "findings_truncated",
+            {
+                "before": findings_truncation[0],
+                "after": findings_truncation[1],
+                "compressed": True,
+                "max": MAX_FINDINGS_FOR_REPLAN,
             },
         )
     raw = await _run_planner_for_yaml(
@@ -630,6 +697,7 @@ async def cloud_replan(
 
 
 __all__ = [
+    "MAX_FINDINGS_FOR_REPLAN",
     "MAX_PLAN_VERSIONS",
     "MAX_RECENT_RESULTS_FOR_REPLAN",
     "Plan",

--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -116,6 +116,94 @@ class Plan(BaseModel):
 
 MAX_PLAN_VERSIONS = 200
 
+MAX_RECENT_RESULTS_FOR_REPLAN = 25
+"""Cap on entries from ``recent_results`` that ``tactical_replan`` ships to the
+local-tier planner. Each entry is also compressed to a small summary dict so a
+long-running goal can't push the prompt past the model's context window —
+issue #176 saw a 524k-token payload at task 96."""
+
+_SUMMARY_REPR_MAX_CHARS = 500
+
+
+def _summarize_recent_result(r: dict[str, Any]) -> dict[str, Any]:
+    """Compress one ``recent_results`` entry into a planner-sized dict.
+
+    The full ``result_json`` per task carries every URL of every search hit,
+    every fetched source's body shape, every emitted claim. Stacking 25 of
+    those at full fidelity already overflows local-tier context windows on
+    long runs; the planner only needs to know *what kind of work ran, what
+    came back at what scale, and the top hits* to decide what to do next.
+    """
+    result = r.get("result")
+    summary: Any
+    status = "ok" if result is not None else "no_result"
+
+    if isinstance(result, dict):
+        hits = result.get("results")
+        if not isinstance(hits, list):
+            hits = result.get("hits") if isinstance(result.get("hits"), list) else None
+        if isinstance(hits, list):
+            top: list[dict[str, Any]] = []
+            for h in hits[:3]:
+                if isinstance(h, dict):
+                    top.append(
+                        {
+                            k: h[k]
+                            for k in ("url", "title")
+                            if k in h and isinstance(h[k], str)
+                        }
+                    )
+            summary = {"count": len(hits), "top": top}
+            if "follow_up_tasks" in result:
+                fu = result.get("follow_up_tasks")
+                summary["follow_up_tasks"] = len(fu) if isinstance(fu, list) else 0
+        elif "source" in result and isinstance(result["source"], dict):
+            src = result["source"]
+            summary = {
+                k: src[k]
+                for k in ("url", "title", "source_kind")
+                if k in src and isinstance(src[k], str)
+            }
+            text = src.get("cleaned_text") or src.get("raw_content") or ""
+            if isinstance(text, str):
+                summary["content_chars"] = len(text)
+            if "source_id" in result:
+                summary["source_id"] = result["source_id"]
+        elif "findings_written" in result or "finding_ids" in result:
+            ids = result.get("finding_ids") or []
+            summary = {
+                "findings_written": result.get(
+                    "findings_written",
+                    len(ids) if isinstance(ids, list) else 0,
+                ),
+                "source_id": result.get("source_id"),
+            }
+        elif "summary" in result and isinstance(result["summary"], str):
+            text = result["summary"]
+            summary = {
+                "summary_chars": len(text),
+                "source_id": result.get("source_id"),
+            }
+        else:
+            text = repr(result)
+            if len(text) > _SUMMARY_REPR_MAX_CHARS:
+                text = text[:_SUMMARY_REPR_MAX_CHARS] + "…"
+            summary = text
+    elif result is None:
+        summary = None
+    else:
+        text = repr(result)
+        if len(text) > _SUMMARY_REPR_MAX_CHARS:
+            text = text[:_SUMMARY_REPR_MAX_CHARS] + "…"
+        summary = text
+
+    return {
+        "task_id": r.get("task_id"),
+        "kind": r.get("kind"),
+        "status": status,
+        "summary": summary,
+    }
+
 
 class PlanVersionCapExceeded(RuntimeError):
     """Raised when a job has hit the §6.3 hard cap of plan versions.
@@ -341,15 +429,38 @@ async def tactical_replan(
     """
     _assert_under_cap(job)
     next_version = plan.version + 1
+
+    # issue #176: bound the payload regardless of caller. recent_results is
+    # truncated to the last MAX_RECENT_RESULTS_FOR_REPLAN entries and each is
+    # replaced by a compact summary; older results are already reflected in
+    # the running plan + findings so dropping them is safe.
+    original_len = len(recent_results)
+    tail = recent_results[-MAX_RECENT_RESULTS_FOR_REPLAN:]
+    summarized = [_summarize_recent_result(r) for r in tail]
+
     payload: dict[str, Any] = {
         "prior_plan": plan.model_dump(),
-        "recent_results": recent_results,
+        "recent_results": summarized,
     }
     if findings is not None:
         payload["findings"] = findings
     if synthesis_md is not None:
         payload["synthesis_md"] = synthesis_md
     context = json.dumps(payload, sort_keys=True, default=str)
+
+    if original_len > 0:
+        emit(
+            job,
+            "WARN" if original_len > MAX_RECENT_RESULTS_FOR_REPLAN else "INFO",
+            "planner",
+            "replan_truncated",
+            {
+                "before": original_len,
+                "after": len(summarized),
+                "compressed": True,
+                "max": MAX_RECENT_RESULTS_FOR_REPLAN,
+            },
+        )
     raw = await _run_planner_for_yaml(
         job, tier="general", router=router, user_message=context
     )
@@ -513,6 +624,7 @@ async def cloud_replan(
 
 __all__ = [
     "MAX_PLAN_VERSIONS",
+    "MAX_RECENT_RESULTS_FOR_REPLAN",
     "Plan",
     "PlanParseError",
     "PlanVersionCapExceeded",

--- a/src/research_agent/prompts/planner.md
+++ b/src/research_agent/prompts/planner.md
@@ -261,6 +261,101 @@ let the search tasks fan out in parallel. On `tactical_replan`, the
 planner can convert each high-confidence cornerstone finding into a
 `sub_question` for a per-proposal follow-up search.
 
+## Drill-down rule for replans — fires whenever the user message contains `findings`
+
+When the orchestrator runs you as a **tactical_replan** (the user-message
+JSON payload contains `findings` and/or `recent_results`, NOT just a bare
+goal), the rules above are **inverted**. v1 plans use short broad
+queries; replans must go *narrower*, not broader. The cornerstone-document
+section foreshadows this: the loop now hands you the running findings list
+so you can convert high-confidence claims into per-proposal follow-ups.
+
+**Mandatory drill-down procedure on every replan:**
+
+1. **Scan `findings` for 3–7 specific named subjects** — people, agencies,
+   rule numbers (e.g. *WOTUS*, *Schedule F*), bill numbers, named programs,
+   court cases, named proposals, named documents. Pick claims that are
+   inconclusive, partially supported, or sit in clusters where multiple
+   findings reference the same name.
+2. **For each named subject, emit one or more focused search tasks.** The
+   `sub_question` MUST mention the specific name verbatim (e.g.
+   `"What is the comment-period status of the WOTUS rulemaking?"`, not
+   `"What EPA rules are pending?"`). Prefer `site:`-scoped queries against
+   the connector roster from the **Connector routing** section above:
+   `site:federalregister.gov`, `site:courtlistener.com`,
+   `site:congress.gov`, `site:sec.gov`,
+   `site:projects.propublica.org/nonprofits`, `site:fec.gov`,
+   `site:lda.senate.gov`, `site:usaspending.gov` — when the subject's
+   shape matches the connector.
+3. **Forbidden in replans:** generic umbrella queries that retread v1's
+   territory. If the findings already name `WOTUS rulemaking` and
+   `Schedule F`, do **NOT** emit `Project 2025 EPA` or `Project 2025
+   federal civil service` — those are v1 queries. They re-skim ground
+   the prior searches already covered and waste fetches. Replans must
+   make the plan *narrower*, not just *deeper*.
+4. **Generic broadeners are still allowed sparingly** when the findings
+   surface a *new* angle the prior plan missed (e.g. a finding that names
+   an outside funder the v1 plan didn't query for). But every generic
+   query must be justified by a finding the prior plan didn't already
+   cover.
+
+#### Worked side-by-side: v1 plan vs v2 tactical_replan
+
+A v1 plan for *"Project 2025 implementation tracker"* runs department-level
+breadth queries:
+
+```yaml
+# v1 — broad, per-department coverage
+task_template:
+  - kind: web_search
+    payload:
+      query: "Project 2025 EPA"
+      sub_question: "What EPA-related Project 2025 proposals are surfacing?"
+  - kind: web_search
+    payload:
+      query: "Project 2025 HHS"
+      sub_question: "What HHS-related Project 2025 proposals are surfacing?"
+  - kind: web_search
+    payload:
+      query: "Project 2025 OPM"
+      sub_question: "What OPM-related Project 2025 proposals are surfacing?"
+```
+
+After v1 runs, `findings` carries claims like *"WOTUS rulemaking is in
+active comment period"*, *"Schedule F implementation pending OPM
+guidance"*, *"FDA mifepristone reversal challenged in 5th Circuit"*. The
+v2 **tactical_replan must NOT re-emit** `Project 2025 EPA`. Instead it
+drills into each named claim:
+
+```yaml
+# v2 tactical_replan — drilled into named findings
+task_template:
+  - kind: web_search
+    payload:
+      query: "site:federalregister.gov WOTUS rule comment period 2026"
+      sub_question: "Status and sponsors of the WOTUS rulemaking comment period."
+  - kind: web_search
+    payload:
+      query: "WOTUS rule industry comments NRDC"
+      sub_question: "Industry vs. environmental-group positions on the WOTUS rulemaking."
+  - kind: web_search
+    payload:
+      query: "Schedule F implementation timeline OPM guidance"
+      sub_question: "OPM implementation timeline for Schedule F civil-service reform."
+  - kind: web_search
+    payload:
+      query: "site:courtlistener.com mifepristone reversal 5th Circuit"
+      sub_question: "Court filings and docket movement on the FDA mifepristone reversal."
+  - kind: news_search
+    payload:
+      query: "mifepristone court ruling"
+      sub_question: "Recent news on the mifepristone reversal court challenges."
+```
+
+Notice: every `sub_question` in v2 names a specific subject from the
+findings (`WOTUS`, `Schedule F`, `mifepristone`). None of them retread the
+v1 per-department queries. This is what *narrower, not deeper* looks like.
+
 ## Concrete example
 
 For the goal "What does the public record show about Acme Corp's 2024 layoffs?":

--- a/src/research_agent/prompts/planner.md
+++ b/src/research_agent/prompts/planner.md
@@ -103,7 +103,7 @@ hand; the planner only needs to seed the discovery query.
 
 ### Payload shapes
 
-- `web_search`: `{ query: "…", sub_question: "…", max_results: 10, engine: "auto", expand_top_k: 3 }`
+- `web_search`: `{ query: "…", sub_question: "…", max_results: 10, engine: "auto" }` (optional `expand_top_k` to override the scope-aware default)
 - `news_search`: `{ query: "…", sub_question: "…" }`
 - `reddit_search`: `{ query: "…", sub_question: "…" }`
 - `arxiv_search`: `{ query: "…", sub_question: "…", max_results: 10 }`
@@ -171,9 +171,23 @@ task_template:
     depends_on: []
 ```
 
-Each search above will be automatically expanded into 3 fetches and 3
-extracts by the loop (configurable via `expand_top_k`). You do not need
-to write those fetch/extract tasks yourself.
+Each search above will be automatically expanded into N fetches (and N
+extracts) by the loop, where N defaults to the plan's `scope_class`:
+narrow→3, medium→5, broad→7, comprehensive→10. You do not need to write
+those fetch/extract tasks yourself.
+
+You can override per task by setting `expand_top_k` in the search
+payload. Use this when a single search has a different role from the
+rest of the plan:
+
+- **Broad-net mainstream-news scan** (e.g. `Project 2025 mainstream
+  coverage`) → set `expand_top_k: 10` so you fan out across many
+  outlets.
+- **Targeted "find the canonical source"** (e.g. a query whose only
+  good answer is one specific PDF or one official-record URL) → set
+  `expand_top_k: 1` so you don't waste fetches on near-duplicate hits.
+
+If you don't set it, the scope-aware default applies.
 
 ## Scope-aware planning
 
@@ -239,6 +253,8 @@ or by sub-policy is `broad` or `comprehensive`.
 - Always include a top-level `scope_class` field. Size `task_template`
   to match it (narrow 3–8, medium 8–20, broad 20–50, comprehensive
   50+). The orchestrator's `MAX_TASKS_PER_JOB` cap is 10000, and each
-  search expands to roughly 6 follow-up tasks — even 50 searches
-  (~300 tasks) fits comfortably; do not undersize a broad goal out of
-  caution.
+  search expands to a scope-dependent number of follow-up tasks
+  (~3× for narrow, ~5× for medium, ~7× for broad, ~10× for
+  comprehensive, plus one extract per fetch — so multiply by ~2 for
+  total fan-out). Even 50 broad-scope searches (~700 tasks) fits
+  comfortably; do not undersize a broad goal out of caution.

--- a/src/research_agent/prompts/planner.md
+++ b/src/research_agent/prompts/planner.md
@@ -101,6 +101,36 @@ classification, and disciplinary history — before generic web hits.
 The `licensing` connector takes over from there once the URL is in
 hand; the planner only needs to seed the discovery query.
 
+### Connector routing — use `site:` operators to reach authoritative APIs
+
+`web_fetch` host-dispatches the domains below to dedicated connector
+modules — a `site:<domain>` query is the path to the API. Plain
+`web_search` queries hit Brave's general index and miss these
+authoritative sources entirely; many of them are not even crawlable
+without the right URL shape. **Mix `site:`-scoped queries into broad /
+comprehensive plans whenever a subgoal asks about federal records,
+lobbying, campaign finance, court filings, nonprofits, sanctions, or
+licensing** — those signals only show up when the planner names the
+domain.
+
+| Domain | What's there | Example query |
+|---|---|---|
+| `site:sec.gov` | SEC EDGAR filings (10-K, 10-Q, 8-K, Form 4 insider trades) | `site:sec.gov "Cisco" 8-K cybersecurity` |
+| `site:courtlistener.com` | Federal & state court opinions, dockets (RECAP), oral arguments | `site:courtlistener.com "Schedule F" appellate` |
+| `site:federalregister.gov` | Federal Register rules, proposed rules, agency notices since 1994 | `site:federalregister.gov "Schedule F"` |
+| `site:projects.propublica.org/nonprofits` | ProPublica Nonprofit Explorer (Form 990 filings) | `site:projects.propublica.org/nonprofits "Heritage Foundation"` |
+| `site:fec.gov` | FEC candidate / committee filings, contributions, expenditures | `site:fec.gov "Trump 2024" committee` |
+| `site:congress.gov` | Bills, members, committees, hearings, congressional record | `site:congress.gov "Project 2025"` |
+| `site:lda.senate.gov` | Senate Lobbying Disclosure Act filings (legacy host; `lda.gov` also routes) | `site:lda.senate.gov "Heritage Foundation"` |
+| `site:usaspending.gov` | Federal contracts, grants, loans (award-level detail) | `site:usaspending.gov "Heritage Foundation" contract` |
+| GDELT | Global news event aggregator — **no `site:` operator**; emit a plain `web_search` query and the GDELT connector indexes from there | `Project 2025 mainstream coverage` |
+| `site:littlesis.org` | Power-mapping database — entities, donations, board seats, family ties (lead, not evidence) | `site:littlesis.org "Peter Thiel"` |
+| `site:treasury.gov sanctions` | OFAC sanctions list (SDN, sectoral, country programs) | `site:treasury.gov sanctions "Wagner Group"` |
+| `site:powersearch.sos.ca.gov` | California Cal-Access campaign finance (donors, committees, IEs) | `site:powersearch.sos.ca.gov "Newsom"` |
+| `site:cslb.ca.gov` | California Contractors State License Board profiles, disciplinary history | `site:cslb.ca.gov "SBI Builders"` |
+| `site:bizfileonline.sos.ca.gov` | California Secretary of State business entity filings | `site:bizfileonline.sos.ca.gov "Acme Corp"` |
+| `site:bbb.org` | Better Business Bureau profiles, ratings, complaint counts | `site:bbb.org "SBI Builders"` |
+
 ### Payload shapes
 
 - `web_search`: `{ query: "…", sub_question: "…", max_results: 10, engine: "auto" }` (optional `expand_top_k` to override the scope-aware default)
@@ -165,8 +195,14 @@ task_template:
     depends_on: []
   - kind: web_search
     payload:
-      query: "Acme Corp WARN notice 2024 SEC filing"
-      sub_question: "Are there formal SEC or WARN notices documenting the layoffs?"
+      query: "site:sec.gov \"Acme Corp\" 8-K layoffs"
+      sub_question: "Are there SEC filings (8-K material event, 10-Q risk-factor amendment) referencing the layoffs?"
+    priority: 0
+    depends_on: []
+  - kind: web_search
+    payload:
+      query: "Acme Corp WARN notice 2024"
+      sub_question: "Are there state WARN-Act notices documenting the layoffs?"
     priority: 0
     depends_on: []
 ```
@@ -233,7 +269,14 @@ or by sub-policy is `broad` or `comprehensive`.
   `Project 2025 HUD`, `Project 2025 VA`, `Project 2025 Transportation`,
   plus cross-cutting queries `Project 2025 executive orders`, `Project
   2025 schedule F`, `Project 2025 Heritage Foundation`, `Project 2025
-  staffing tracker` (~20–30 searches).
+  staffing tracker`, plus authoritative-source queries
+  `site:congress.gov "Project 2025"`,
+  `site:federalregister.gov "Schedule F"`,
+  `site:lda.senate.gov "Heritage Foundation"`,
+  `site:projects.propublica.org/nonprofits "Heritage Foundation"`
+  (~20–30 searches). Always include a handful of `site:`-scoped
+  queries in broad/comprehensive plans so the connector routing in
+  the worked YAML below has somewhere to land.
 - **comprehensive** — Goal: *"Complete public record of Anthropic's
   safety governance 2023–present"*. Queries span: each public policy
   document, each leadership statement, each external commitment,

--- a/src/research_agent/prompts/planner.md
+++ b/src/research_agent/prompts/planner.md
@@ -34,8 +34,10 @@ the schema below.
 - `task_template`: ordered list of tasks the loop will run. Each task:
   - `kind`: one of these EXACT strings (no others allowed):
     `web_search`, `news_search`, `reddit_search`, `arxiv_search`,
-    `local_corpus_query`.
-    Do **not** emit any other kind. `web_fetch`, `extract_findings`,
+    `local_corpus_query`. **One narrow exception: `web_fetch` is allowed
+    only as the cornerstone-document fetch — see the "Cornerstone-document
+    pattern" section below.**
+    Do **not** emit any other kind. `extract_findings`,
     `summarize_source`, `synthesize`, and `critique` are valid in the
     schema but MUST NOT appear in your plan — the loop creates them
     automatically.
@@ -46,6 +48,11 @@ the schema below.
   - `depends_on`: list of zero-based indices into `task_template` that must
     finish first. Empty list `[]` for tasks with no dependencies.
 - `expected_iterations`: integer estimate (e.g. `1`, `2`).
+- `cornerstone_url` (optional): the canonical URL of the primary document
+  the investigation is anchored on, when the goal names one. Set this
+  whenever you also emit a cornerstone `web_fetch` task — see the
+  **Cornerstone-document pattern** section below. Omit for normal
+  search-driven plans.
 
 ### Task pipeline guidance — important
 
@@ -154,6 +161,105 @@ domain.
   bio).
 - `local_corpus_query` is for searching the operator's own pre-indexed
   documents. Only emit it when the goal mentions a corpus.
+
+### Cornerstone-document pattern — when the goal names a specific document
+
+Some goals are anchored to **a specific document, report, filing, or
+opinion** — e.g. *"Project 2025 implementation tracker"* (the 920-page
+*Mandate for Leadership* PDF), *"track Apple's 2024 cybersecurity
+disclosures"* (a specific 10-K), *"Sotomayor's dissent in <Case>"* (a
+specific court opinion), *"summarize Senate Bill 1047"* (a named bill),
+*"map every recommendation in the Mueller Report"* (a named report).
+
+Common cornerstone sources include: SEC 10-K / 10-Q / 8-K filings,
+court opinions and dockets, congressional bills, FOIA-released document
+dumps, leaked archive sets, and any **named** policy report or playbook.
+
+When you recognize this shape, do all three:
+
+1. **Emit a `web_fetch` task as task index 0** (`priority: 1`,
+   `depends_on: []`) whose payload is
+   `{ url: "<canonical URL>", sub_question: "<what to extract>" }`. This
+   is the **only** circumstance under which the planner emits
+   `web_fetch` — every other plan delegates fetch creation to the loop.
+   The cornerstone fetch bypasses the search-expansion pipeline, so
+   `expand_top_k` does not apply to it.
+2. **Set top-level `cornerstone_url`** to the same URL. The orchestrator
+   uses it to (a) route the cornerstone source's `extract_findings`
+   through a structured-index prompt that emits one finding per
+   proposal/section/heading rather than 2–6 high-level claims, and
+   (b) lift the per-source findings cap so a long document doesn't get
+   truncated to a chapter's worth of output.
+3. **Drive the rest of the plan outward from the document.** Emit a
+   broad set of follow-on `web_search` tasks (and `site:`-scoped
+   queries) that map the document's sections — agencies, departments,
+   chapters, named proposals — onto the wider public record. The
+   loop's `tactical_replan` will then convert high-confidence cornerstone
+   findings into per-proposal sub-questions on the next replan.
+
+If the goal does **not** name a specific document, do not invent a
+cornerstone — leave `cornerstone_url` unset and emit only search tasks.
+
+#### Worked cornerstone example
+
+Goal: *"Project 2025 implementation tracker — what's actually being
+implemented?"* The cornerstone is Heritage's published PDF; the rest of
+the plan fans out by department.
+
+```yaml
+version: 1
+objective: "Index every proposal in Project 2025's Mandate for Leadership and track implementation status."
+scope_class: broad
+cornerstone_url: "https://static.heritage.org/project2025/2025_MandateForLeadership_FULL.pdf"
+subgoals:
+  - id: 1
+    description: "Index every concrete proposal in the Mandate by department/section."
+    done: false
+  - id: 2
+    description: "Track which Mandate proposals have surfaced in actual federal action since January 2025."
+    done: false
+  - id: 3
+    description: "Identify cross-cutting themes (Schedule F, agency restructures) and capture primary-source coverage."
+    done: false
+expected_iterations: 3
+task_template:
+  - kind: web_fetch
+    payload:
+      url: "https://static.heritage.org/project2025/2025_MandateForLeadership_FULL.pdf"
+      sub_question: "What concrete proposals does the Mandate make, organized by department/section?"
+    priority: 1
+    depends_on: []
+  - kind: web_search
+    payload:
+      query: "Project 2025 DOJ implementation"
+      sub_question: "What DOJ-related Project 2025 proposals are being implemented?"
+    priority: 0
+    depends_on: []
+  - kind: web_search
+    payload:
+      query: "Project 2025 State Department implementation"
+      sub_question: "What State Department Project 2025 proposals are surfacing in policy?"
+    priority: 0
+    depends_on: []
+  - kind: web_search
+    payload:
+      query: "site:federalregister.gov \"Schedule F\""
+      sub_question: "Federal Register actions matching the Mandate's Schedule F proposal."
+    priority: 0
+    depends_on: []
+  - kind: web_search
+    payload:
+      query: "site:congress.gov \"Project 2025\""
+      sub_question: "Bills, hearings, or member statements referencing Project 2025."
+    priority: 0
+    depends_on: []
+```
+
+The loop will fetch the PDF, route the resulting `extract_findings`
+through `researcher_cornerstone.md` (uncapped, structured-index), and
+let the search tasks fan out in parallel. On `tactical_replan`, the
+planner can convert each high-confidence cornerstone finding into a
+`sub_question` for a per-proposal follow-up search.
 
 ## Concrete example
 
@@ -290,7 +396,10 @@ or by sub-policy is `broad` or `comprehensive`.
 
 - Output ONLY the fenced YAML block. No prose, no preamble, no postscript.
 - Every `kind` MUST be one of: `web_search`, `news_search`, `reddit_search`,
-  `arxiv_search`, `local_corpus_query`. NO others.
+  `arxiv_search`, `local_corpus_query`. The single exception is
+  `web_fetch`, allowed only as the cornerstone-document fetch when
+  `cornerstone_url` is also set — see the **Cornerstone-document
+  pattern** section.
 - Every payload MUST include a `sub_question` describing what the
   downstream extract should look for.
 - Always include a top-level `scope_class` field. Size `task_template`

--- a/src/research_agent/prompts/planner.md
+++ b/src/research_agent/prompts/planner.md
@@ -34,10 +34,16 @@ the schema below.
 - `task_template`: ordered list of tasks the loop will run. Each task:
   - `kind`: one of these EXACT strings (no others allowed):
     `web_search`, `news_search`, `reddit_search`, `arxiv_search`,
-    `local_corpus_query`. **One narrow exception: `web_fetch` is allowed
-    only as the cornerstone-document fetch — see the "Cornerstone-document
-    pattern" section below.**
-    Do **not** emit any other kind. `extract_findings`,
+    `local_corpus_query`, plus the **direct connector kinds**:
+    `congress_search`, `fec_search`, `edgar_search`,
+    `courtlistener_search`, `fedregister_search`, `lda_search`,
+    `usaspending_search`, `gdelt_search`, `littlesis_search`,
+    `nonprofits_search`, `opencorporates_search`, `sanctions_search`,
+    `bbb_search`, `licensing_search`, `sos_search`, `calaccess_search`,
+    `scholar_search`, `linkedin_search`. **One narrow exception:
+    `web_fetch` is allowed only as the cornerstone-document fetch — see
+    the "Cornerstone-document pattern" section below.**
+    Do **not** emit any other kind. `*_fetch`, `extract_findings`,
     `summarize_source`, `synthesize`, and `critique` are valid in the
     schema but MUST NOT appear in your plan — the loop creates them
     automatically.
@@ -58,8 +64,9 @@ the schema below.
 
 You only plan the **search** layer. For each sub-question, emit one or
 more search tasks (`web_search`, `news_search`, `reddit_search`,
-`arxiv_search`, or `local_corpus_query`) with a `sub_question` field in
-the payload. The loop will then:
+`arxiv_search`, `local_corpus_query`, or one of the **direct connector
+kinds** below) with a `sub_question` field in the payload. The loop will
+then:
 
 1. Run your search → get real URLs
 2. Automatically enqueue `web_fetch` for the top hits
@@ -67,8 +74,8 @@ the payload. The loop will then:
    real source rowid + your `sub_question`
 4. Synthesis and critique fire on their own cadence
 
-You do NOT enqueue `web_fetch`, `extract_findings`, `summarize_source`,
-`synthesize`, or `critique`. Trust the loop.
+You do NOT enqueue `web_fetch`, `*_fetch`, `extract_findings`,
+`summarize_source`, `synthesize`, or `critique`. Trust the loop.
 
 ### Query-writing rules — critical
 
@@ -108,35 +115,78 @@ classification, and disciplinary history — before generic web hits.
 The `licensing` connector takes over from there once the URL is in
 hand; the planner only needs to seed the discovery query.
 
-### Connector routing — use `site:` operators to reach authoritative APIs
+### Connector routing — prefer direct connector kinds over `site:`-scoped web search
 
-`web_fetch` host-dispatches the domains below to dedicated connector
-modules — a `site:<domain>` query is the path to the API. Plain
-`web_search` queries hit Brave's general index and miss these
-authoritative sources entirely; many of them are not even crawlable
-without the right URL shape. **Mix `site:`-scoped queries into broad /
-comprehensive plans whenever a subgoal asks about federal records,
-lobbying, campaign finance, court filings, nonprofits, sanctions, or
-licensing** — those signals only show up when the planner names the
-domain.
+For every authoritative source below there are now **two ways** to reach
+it: a direct connector kind that calls the source's structured API, and
+a `site:`-scoped `web_search` fallback that goes through Brave +
+trafilatura. **Prefer the direct connector kind whenever the subject
+matches its domain** — one round trip, structured JSON in (sponsor,
+latest action, vote results, filing metadata, …), no HTML extraction
+loss. `web_search` with a `site:` operator is the documented fallback
+when no direct kind covers the case (or the connector's API key isn't
+configured in this environment).
 
-| Domain | What's there | Example query |
+> Example: prefer `congress_search` with `query: "Inflation Reduction
+> Act"` over `web_search` with `query: "site:congress.gov Inflation
+> Reduction Act"`. The Congress.gov API returns structured sponsor /
+> action / vote JSON in a single round trip; the `site:`-scoped path
+> needs Brave → fetch → trafilatura, drops fields, and may miss recent
+> records that aren't in Brave's index yet.
+
+#### Direct connector kinds
+
+Each kind dispatches to a dedicated `tools/<name>.py` module. Payload
+shape is `{ query: "…", sub_question: "…" }`; a few connectors take
+optional `kind`, `state`, `since`, or `max_results` knobs (noted
+below). The loop turns top hits into `web_fetch` follow-ups exactly as
+it does for `web_search`.
+
+| Kind | What it covers | Optional payload knobs | Example query |
+|---|---|---|---|
+| `congress_search` | Bills, members, committees, hearings, congressional record (Congress.gov v3 API) | `kind: bill\|member\|committee\|hearing\|congressional-record` | `"Inflation Reduction Act"` |
+| `fec_search` | Candidates, committees, schedule A/E filings (OpenFEC) | `kind: candidates\|committees\|schedules/schedule_a\|schedules/schedule_e` | `"Trump 2024" committee` |
+| `edgar_search` | SEC filings (10-K, 10-Q, 8-K, Form 4) — requires `RESEARCH_USER_AGENT` w/ contact email | `form_type: 10-K\|8-K\|...` | `"Cisco" cybersecurity` |
+| `courtlistener_search` | Federal & state court opinions, dockets (RECAP), oral arguments — requires `COURTLISTENER_API_TOKEN` | `kind: opinions\|dockets\|oral_arguments` | `"Schedule F" appellate` |
+| `fedregister_search` | Federal Register rules, proposed rules, agency notices since 1994 (no auth) | `since: YYYY-MM-DD`, `agencies: [...]` | `"Schedule F"` |
+| `lda_search` | Senate Lobbying Disclosure Act filings (registrants, contributions) | `kind: filings\|registrants\|contributions` | `"Heritage Foundation"` |
+| `usaspending_search` | Federal contracts, grants, loans (award-level detail, no auth) | `award_type: contracts\|grants\|loans` | `"Heritage Foundation" contract` |
+| `gdelt_search` | GDELT — Global news event aggregator, no `site:` operator (no auth) | `since: YYYY-MM-DD`, `language: english` | `Project 2025 mainstream coverage` |
+| `littlesis_search` | Power-mapping database — entities, donations, board seats, family ties (lead, not evidence) | `kind: entities\|relationships` | `"Peter Thiel"` |
+| `nonprofits_search` | ProPublica Nonprofit Explorer (Form 990 filings, no auth) | — | `"Heritage Foundation"` |
+| `opencorporates_search` | Global company registry — requires `OPENCORPORATES_API_KEY` | `jurisdiction: us_ca\|gb\|...` | `"Acme Holdings"` |
+| `sanctions_search` | OFAC SDN + UK sanctions lists (local index, no auth) | — | `"Wagner Group"` |
+| `bbb_search` | Better Business Bureau profiles + ratings (Playwright, no auth) | — | `"SBI Builders"` |
+| `licensing_search` | State contractor / licensing-board lookups (Playwright; CA wired, others stubs) | `state: CA\|TX\|FL\|NY` | `"SBI Builders"` |
+| `sos_search` | State Secretary-of-State business entity filings (Playwright; CA wired, others stubs) | `state: CA\|DE\|NV\|...` | `"Acme Corp"` |
+| `calaccess_search` | California Cal-Access campaign finance (Playwright) | `kind: contributions\|independent_expenditures` | `"Newsom"` |
+| `scholar_search` | Google Scholar via SerpAPI — requires `SERPAPI_KEY` | `kind: case_law\|articles` | `"Section 230" appellate` |
+| `linkedin_search` | LinkedIn person/company lookup via Proxycurl or Lix — requires broker key | `kind: person\|company` | `"Sundar Pichai"` |
+
+#### `site:`-scoped fallback (when a direct kind doesn't apply)
+
+If no direct kind matches the subject, or you know the connector's API
+key isn't configured in this environment, fall back to `web_search`
+with a `site:` operator targeting the authoritative domain. The
+`web_fetch` host-dispatcher will still route those URLs to the right
+connector module on the fetch side.
+
+| Domain | Direct kind | Example fallback query |
 |---|---|---|
-| `site:sec.gov` | SEC EDGAR filings (10-K, 10-Q, 8-K, Form 4 insider trades) | `site:sec.gov "Cisco" 8-K cybersecurity` |
-| `site:courtlistener.com` | Federal & state court opinions, dockets (RECAP), oral arguments | `site:courtlistener.com "Schedule F" appellate` |
-| `site:federalregister.gov` | Federal Register rules, proposed rules, agency notices since 1994 | `site:federalregister.gov "Schedule F"` |
-| `site:projects.propublica.org/nonprofits` | ProPublica Nonprofit Explorer (Form 990 filings) | `site:projects.propublica.org/nonprofits "Heritage Foundation"` |
-| `site:fec.gov` | FEC candidate / committee filings, contributions, expenditures | `site:fec.gov "Trump 2024" committee` |
-| `site:congress.gov` | Bills, members, committees, hearings, congressional record | `site:congress.gov "Project 2025"` |
-| `site:lda.senate.gov` | Senate Lobbying Disclosure Act filings (legacy host; `lda.gov` also routes) | `site:lda.senate.gov "Heritage Foundation"` |
-| `site:usaspending.gov` | Federal contracts, grants, loans (award-level detail) | `site:usaspending.gov "Heritage Foundation" contract` |
-| GDELT | Global news event aggregator — **no `site:` operator**; emit a plain `web_search` query and the GDELT connector indexes from there | `Project 2025 mainstream coverage` |
-| `site:littlesis.org` | Power-mapping database — entities, donations, board seats, family ties (lead, not evidence) | `site:littlesis.org "Peter Thiel"` |
-| `site:treasury.gov sanctions` | OFAC sanctions list (SDN, sectoral, country programs) | `site:treasury.gov sanctions "Wagner Group"` |
-| `site:powersearch.sos.ca.gov` | California Cal-Access campaign finance (donors, committees, IEs) | `site:powersearch.sos.ca.gov "Newsom"` |
-| `site:cslb.ca.gov` | California Contractors State License Board profiles, disciplinary history | `site:cslb.ca.gov "SBI Builders"` |
-| `site:bizfileonline.sos.ca.gov` | California Secretary of State business entity filings | `site:bizfileonline.sos.ca.gov "Acme Corp"` |
-| `site:bbb.org` | Better Business Bureau profiles, ratings, complaint counts | `site:bbb.org "SBI Builders"` |
+| `site:sec.gov` | `edgar_search` | `site:sec.gov "Cisco" 8-K cybersecurity` |
+| `site:courtlistener.com` | `courtlistener_search` | `site:courtlistener.com "Schedule F" appellate` |
+| `site:federalregister.gov` | `fedregister_search` | `site:federalregister.gov "Schedule F"` |
+| `site:projects.propublica.org/nonprofits` | `nonprofits_search` | `site:projects.propublica.org/nonprofits "Heritage Foundation"` |
+| `site:fec.gov` | `fec_search` | `site:fec.gov "Trump 2024" committee` |
+| `site:congress.gov` | `congress_search` | `site:congress.gov "Project 2025"` |
+| `site:lda.senate.gov` | `lda_search` | `site:lda.senate.gov "Heritage Foundation"` |
+| `site:usaspending.gov` | `usaspending_search` | `site:usaspending.gov "Heritage Foundation" contract` |
+| `site:littlesis.org` | `littlesis_search` | `site:littlesis.org "Peter Thiel"` |
+| `site:treasury.gov sanctions` | `sanctions_search` | `site:treasury.gov sanctions "Wagner Group"` |
+| `site:powersearch.sos.ca.gov` | `calaccess_search` | `site:powersearch.sos.ca.gov "Newsom"` |
+| `site:cslb.ca.gov` | `licensing_search` (state: CA) | `site:cslb.ca.gov "SBI Builders"` |
+| `site:bizfileonline.sos.ca.gov` | `sos_search` (state: CA) | `site:bizfileonline.sos.ca.gov "Acme Corp"` |
+| `site:bbb.org` | `bbb_search` | `site:bbb.org "SBI Builders"` |
 
 ### Payload shapes
 
@@ -145,6 +195,7 @@ domain.
 - `reddit_search`: `{ query: "…", sub_question: "…" }`
 - `arxiv_search`: `{ query: "…", sub_question: "…", max_results: 10 }`
 - `local_corpus_query`: `{ query: "…", sub_question: "…", top_k: 10 }`
+- direct connector kinds (`congress_search`, `fec_search`, `edgar_search`, `courtlistener_search`, `fedregister_search`, `lda_search`, `usaspending_search`, `gdelt_search`, `littlesis_search`, `nonprofits_search`, `opencorporates_search`, `sanctions_search`, `bbb_search`, `licensing_search`, `sos_search`, `calaccess_search`, `scholar_search`, `linkedin_search`): `{ query: "…", sub_question: "…" }` plus the optional knobs noted in the **Direct connector kinds** table above (e.g. `kind`, `state`, `since`, `max_results`).
 
 ### When to use each search
 
@@ -280,13 +331,13 @@ so you can convert high-confidence claims into per-proposal follow-ups.
 2. **For each named subject, emit one or more focused search tasks.** The
    `sub_question` MUST mention the specific name verbatim (e.g.
    `"What is the comment-period status of the WOTUS rulemaking?"`, not
-   `"What EPA rules are pending?"`). Prefer `site:`-scoped queries against
-   the connector roster from the **Connector routing** section above:
-   `site:federalregister.gov`, `site:courtlistener.com`,
-   `site:congress.gov`, `site:sec.gov`,
-   `site:projects.propublica.org/nonprofits`, `site:fec.gov`,
-   `site:lda.senate.gov`, `site:usaspending.gov` — when the subject's
-   shape matches the connector.
+   `"What EPA rules are pending?"`). Prefer the **direct connector kind**
+   when one matches the subject's shape (e.g. `fedregister_search`,
+   `courtlistener_search`, `congress_search`, `edgar_search`,
+   `nonprofits_search`, `fec_search`, `lda_search`, `usaspending_search`,
+   `littlesis_search`, `sanctions_search`) — one round trip, structured
+   JSON. Fall back to `site:`-scoped `web_search` only when no direct
+   kind covers the case.
 3. **Forbidden in replans:** generic umbrella queries that retread v1's
    territory. If the findings already name `WOTUS rulemaking` and
    `Schedule F`, do **NOT** emit `Project 2025 EPA` or `Project 2025
@@ -491,7 +542,13 @@ or by sub-policy is `broad` or `comprehensive`.
 
 - Output ONLY the fenced YAML block. No prose, no preamble, no postscript.
 - Every `kind` MUST be one of: `web_search`, `news_search`, `reddit_search`,
-  `arxiv_search`, `local_corpus_query`. The single exception is
+  `arxiv_search`, `local_corpus_query`, or one of the direct connector
+  kinds (`congress_search`, `fec_search`, `edgar_search`,
+  `courtlistener_search`, `fedregister_search`, `lda_search`,
+  `usaspending_search`, `gdelt_search`, `littlesis_search`,
+  `nonprofits_search`, `opencorporates_search`, `sanctions_search`,
+  `bbb_search`, `licensing_search`, `sos_search`, `calaccess_search`,
+  `scholar_search`, `linkedin_search`). The single exception is
   `web_fetch`, allowed only as the cornerstone-document fetch when
   `cornerstone_url` is also set — see the **Cornerstone-document
   pattern** section.

--- a/src/research_agent/prompts/researcher_cornerstone.md
+++ b/src/research_agent/prompts/researcher_cornerstone.md
@@ -1,0 +1,106 @@
+---
+version: "1"
+model_tier: general
+description: Structured-index extraction for cornerstone documents — uncapped, organized by section/heading.
+---
+You are the **researcher** for an autonomous research agent, in
+**cornerstone-document mode**.
+
+The source you are reading is the **spine of this investigation** — a
+document the goal is anchored on (e.g. *Mandate for Leadership*, an
+SEC 10-K, a court opinion, a congressional bill, a FOIA-released
+report, a leaked archive). Other research tasks will fan out from
+**your output**, so under-extracting here cripples the rest of the run.
+
+Your job: **index the document exhaustively**. Emit one finding per
+discrete proposal, recommendation, section, ruling, or named claim —
+not a high-level summary. A 920-page policy document should produce
+dozens to hundreds of findings, not 5.
+
+## Output format — YAML in a single fenced code block
+
+Emit ONE fenced YAML block (```yaml … ```). Nothing before, nothing
+after. The block must parse as YAML and conform to the schema below.
+
+### Schema
+
+A YAML list of findings. Each list item is a mapping with these keys:
+
+- `claim`: one sentence stating the proposal/section/claim, factual
+  and specific. Name the agency, department, statute, or actor when
+  the document does.
+- `confidence`: a number between 0.0 and 1.0.
+  - `0.85+` = the document states it directly in an authoritative
+    section
+  - `0.5–0.85` = paraphrased, secondary, or implied
+  - `< 0.5` = weakly supported or inferred
+- `quote`: a short verbatim quote (one sentence) anchoring the claim.
+  Empty string `""` only if no clean quote exists.
+- `tags`: list of 1–4 short tags. **At least one tag MUST identify
+  the section context** — the department, agency, chapter heading,
+  bill section, court-opinion section (e.g. `holding`, `dissent`),
+  or page reference. The orchestrator's tactical replan converts
+  these tags into per-proposal sub-questions, so accuracy here drives
+  the rest of the investigation.
+
+### Rules — cornerstone mode
+
+- **Do not summarize.** List every concrete proposal, recommendation,
+  finding, or named claim the document makes. If it lists 40
+  recommendations across 10 chapters, your output is ~40 findings,
+  not 5 chapter summaries.
+- **Target 30–200 findings** for a long document; there is **no upper
+  cap**. Emit fewer only when the document genuinely contains fewer
+  discrete claims (e.g. a one-page memo).
+- **Cite by quote.** Every claim should be supportable by a quote
+  from the source. Do not invent claims the source does not make.
+- **Tag the section context** for every finding. The downstream
+  planner reads `tags` to decide what to search for next; an untagged
+  cornerstone finding wastes a follow-up slot.
+- **Stay literal.** This is an indexing pass, not analysis. Save
+  interpretation for synthesis.
+- A truncation marker (`[…truncated]`) means the document was longer
+  than the prompt window. Index what you can see; do not speculate
+  about what was cut.
+
+## Concrete example
+
+For sub-question "What concrete proposals does the Mandate for
+Leadership make, organized by department?" reading the document:
+
+```yaml
+- claim: "The Mandate proposes converting career civil-service positions in policy-influencing roles into Schedule F appointments to enable rapid replacement."
+  confidence: 0.95
+  quote: "Schedule F should be reinstated and expanded to cover all confidential and policy-determining positions."
+  tags: [schedule-f, executive-office, ch.1]
+- claim: "The Mandate recommends abolishing the Department of Education and devolving its functions to the states."
+  confidence: 0.95
+  quote: "The Department of Education should be eliminated."
+  tags: [education, abolition, ch.11]
+- claim: "The Mandate calls for moving the FBI's headquarters and reducing its domestic-intelligence footprint."
+  confidence: 0.9
+  quote: "The FBI's domestic-intelligence operations should be wound down and its headquarters relocated."
+  tags: [doj, fbi, ch.17]
+- claim: "The Mandate recommends withdrawing the United States from the Paris climate agreement."
+  confidence: 0.95
+  quote: "The next administration should withdraw the United States from the Paris Agreement."
+  tags: [state, climate, ch.5]
+- claim: "The Mandate proposes that the EPA halt enforcement of greenhouse-gas regulations promulgated under the Clean Air Act."
+  confidence: 0.9
+  quote: "EPA should cease all enforcement actions premised on greenhouse-gas endangerment findings."
+  tags: [epa, climate, ch.13]
+```
+
+If the document is empty or contains no discrete claims (which is
+unusual for a cornerstone source), emit `[]`.
+
+## Hard rules
+
+- Output ONLY the fenced YAML block. No prose, no preamble, no
+  commentary, no chapter summaries outside the YAML.
+- Every `claim` MUST be a non-empty single sentence.
+- Every `confidence` MUST be a number in [0.0, 1.0].
+- Every `tags` list MUST be non-empty and include at least one tag
+  identifying the section/department/chapter/page.
+- Do NOT cap your own output. Long documents legitimately produce
+  long lists; truncating early defeats the purpose of this prompt.

--- a/src/research_agent/tools/bbb.py
+++ b/src/research_agent/tools/bbb.py
@@ -44,6 +44,10 @@ logger = logging.getLogger(__name__)
 _DIAGNOSTICS_DIR = Path("data/diagnostics/bbb")
 _PER_HOST_RPS = 0.5
 _HOST = "www.bbb.org"
+# Accept both ``www.bbb.org`` and the bare ``bbb.org`` host so URLs that
+# arrive from search results without the ``www.`` prefix still navigate;
+# bbb.org 301s to www.bbb.org so Playwright will follow the redirect.
+_ACCEPTED_HOSTS = frozenset({_HOST, "bbb.org"})
 _SEARCH_URL = "https://www.bbb.org/search"
 
 # Short per-call timeout for selector reads. Playwright's default 30s
@@ -327,7 +331,7 @@ async def fetch(url: str) -> Source | None:
         return None
     parsed = urlparse(url)
     host = (parsed.netloc or "").lower().split(":", 1)[0]
-    if host != _HOST:
+    if host not in _ACCEPTED_HOSTS:
         return None
 
     try:

--- a/src/research_agent/tools/congress.py
+++ b/src/research_agent/tools/congress.py
@@ -613,13 +613,16 @@ def _bill_type_from_slug(slug: str) -> str | None:
 def _classify_url(url: str) -> tuple[str | None, dict[str, Any]]:
     """Return ``(resource, ids)`` for supported www.congress.gov URLs.
 
-    Strict host check — anything outside ``www.congress.gov`` (look-alikes
-    like ``www.congress.gov.attacker.example`` must not pass) returns
-    ``(None, {})``.
+    Strict host check — anything outside ``www.congress.gov`` /
+    ``congress.gov`` (look-alikes like ``www.congress.gov.attacker.example``
+    must not pass) returns ``(None, {})``. The bare-host form is accepted
+    so URLs that arrive without the ``www.`` prefix from search results
+    still classify; the API calls themselves are issued internally to the
+    canonical host.
     """
     parsed = urlparse(url)
     host = (parsed.netloc or "").lower().split(":", 1)[0]
-    if host != "www.congress.gov":
+    if host not in {"www.congress.gov", "congress.gov"}:
         return None, {}
     path = parsed.path or ""
 

--- a/src/research_agent/tools/fec.py
+++ b/src/research_agent/tools/fec.py
@@ -453,12 +453,15 @@ async def search(
 def _classify_url(url: str) -> tuple[str | None, str | None]:
     """Return ``(resource, id)`` where resource ∈ {"candidate","committee"}.
 
-    Anything outside ``www.fec.gov`` (strict host match — look-alikes like
-    ``www.fec.gov.attacker.example`` must not pass) returns ``(None, None)``.
+    Anything outside ``www.fec.gov`` / ``fec.gov`` (strict host match —
+    look-alikes like ``www.fec.gov.attacker.example`` must not pass)
+    returns ``(None, None)``. The bare-host form is accepted so URLs
+    that arrive without the ``www.`` prefix from search results still
+    classify; API calls are issued internally to the canonical host.
     """
     parsed = urlparse(url)
     host = (parsed.netloc or "").lower().split(":", 1)[0]
-    if host != "www.fec.gov":
+    if host not in {"www.fec.gov", "fec.gov"}:
         return None, None
     path = parsed.path or ""
     m = _CANDIDATE_URL_RE.match(path)

--- a/src/research_agent/tools/lda.py
+++ b/src/research_agent/tools/lda.py
@@ -45,7 +45,7 @@ _BASE_URL = "https://lda.senate.gov/api/v1/"
 _SITE_BASE = "https://lda.senate.gov"
 # Accept the new ``lda.gov`` cutover host once the migration lands; keeping
 # both in the set means we don't have to flip a flag the moment it happens.
-_ACCEPTED_HOSTS = frozenset({"lda.senate.gov", "lda.gov"})
+_ACCEPTED_HOSTS = frozenset({"lda.senate.gov", "lda.gov", "www.lda.gov"})
 # AC: per-host rate of 1 RPS.
 _RATE_LIMIT_INTERVAL = 1.0
 

--- a/src/research_agent/tools/web_fetch.py
+++ b/src/research_agent/tools/web_fetch.py
@@ -297,6 +297,71 @@ _YOUTUBE_HOSTS = frozenset(
     {"youtube.com", "www.youtube.com", "m.youtube.com", "youtu.be", "www.youtu.be"}
 )
 
+# Connector host-dispatch (issue #174). Each set covers the public netlocs
+# its module's ``fetch(url)`` recognises — see the connector's own host-gate
+# for the authoritative list. The planner emits ``site:<domain>`` queries to
+# steer hits onto these hosts; without dispatch, the generic httpx +
+# trafilatura path eats the page and the connector never runs.
+#
+# Search-only connectors (no URL-fetch contract — they expose only API search):
+#   - arxiv_tool: ArXiv abstract fetch lives behind arxiv_fetch tasks, not URL
+#   - news: RSS aggregator, not a per-URL fetcher
+#   - web_search: itself
+# These do not appear here; the planner emits search tasks for them.
+
+_CONGRESS_HOSTS = frozenset({"www.congress.gov", "congress.gov"})
+_FEC_HOSTS = frozenset({"www.fec.gov", "fec.gov"})
+_EDGAR_HOSTS = frozenset({"www.sec.gov", "sec.gov"})
+_FEDREGISTER_HOSTS = frozenset(
+    {"www.federalregister.gov", "federalregister.gov"}
+)
+_COURTLISTENER_HOSTS = frozenset({"courtlistener.com", "www.courtlistener.com"})
+_LDA_HOSTS = frozenset({"lda.senate.gov", "lda.gov", "www.lda.gov"})
+_USASPENDING_HOSTS = frozenset(
+    {"api.usaspending.gov", "usaspending.gov", "www.usaspending.gov"}
+)
+_LITTLESIS_HOSTS = frozenset({"littlesis.org", "www.littlesis.org"})
+_NONPROFITS_HOSTS = frozenset({"projects.propublica.org"})
+_SANCTIONS_HOSTS = frozenset(
+    {
+        "sanctionssearch.ofac.treas.gov",
+        "home.treasury.gov",
+        "www.treasury.gov",
+        "webgate.ec.europa.eu",
+        "ofsistorage.blob.core.windows.net",
+        "www.gov.uk",
+    }
+)
+_CALACCESS_HOSTS = frozenset({"powersearch.sos.ca.gov"})
+# licensing module: CA (CSLB) wired; TX/FL/NY ship as stubs that return None.
+# Including the stubs in dispatch costs nothing (the module already host-gates
+# them) and makes future state wires routing-only.
+_LICENSING_HOSTS = frozenset(
+    {
+        "www.cslb.ca.gov",
+        "cslb.ca.gov",
+        "www.tdlr.texas.gov",
+        "www.myfloridalicense.com",
+        "www.dos.ny.gov",
+    }
+)
+# sos module: CA wired; DE/NV/WY/FL/NY stubs return None. Same dispatch
+# rationale as _LICENSING_HOSTS.
+_SOS_HOSTS = frozenset(
+    {
+        "bizfileonline.sos.ca.gov",
+        "icis.corp.delaware.gov",
+        "esos.nv.gov",
+        "wyobiz.wyo.gov",
+        "search.sunbiz.org",
+        "apps.dos.ny.gov",
+    }
+)
+_BBB_HOSTS = frozenset({"www.bbb.org", "bbb.org"})
+_OPENCORPORATES_HOSTS = frozenset(
+    {"opencorporates.com", "www.opencorporates.com"}
+)
+
 _PDF_CONTENT_TYPE = "application/pdf"
 
 _IMAGE_CONTENT_TYPES: frozenset[str] = frozenset(
@@ -486,11 +551,42 @@ async def fetch(
     Playwright + trafilatura path strips reddit pages to empty content
     (their SPA shell defeats readability extractors), so without this
     dispatch every reddit follow-up would task_failed.
+
+    The connector roster (issue #174) extends the same pattern to the
+    free-tier authoritative-source modules (Congress, FEC, EDGAR,
+    Federal Register, CourtListener, LDA, USAspending, LittleSis,
+    ProPublica nonprofits, OFAC sanctions, Cal-Access, CSLB, CA SoS,
+    BBB, OpenCorporates) so a planner-emitted ``site:<domain>`` query
+    that yields one of those URLs is handled by the connector that
+    knows the page shape rather than being eaten by the generic HTML
+    extractor.
     """
     if not url or not urlparse(url).netloc:
         return None
 
-    netloc = urlparse(url).netloc.lower()
+    # Binary URL shortcuts run BEFORE connector dispatch: a `.pdf` on
+    # ``sec.gov`` (EDGAR exhibits, 10-K appendices, …) must go through the
+    # PDF extractor, not edgar.fetch which expects an HTML index page.
+    # Same logic for `.mp3` / image suffixes on connector-owned hosts.
+    if _is_pdf_url(url):
+        source = await _build_pdf_source(url, status_code=None, content=None)
+        if source is not None:
+            _spawn_archive_task(source)
+        return source
+
+    if _is_audio_url(url):
+        source = await _build_audio_source(url, status_code=None, content=None)
+        if source is not None:
+            _spawn_archive_task(source)
+        return source
+
+    if _is_image_url(url):
+        source = await _build_image_source(url, status_code=None, content=None)
+        if source is not None:
+            _spawn_archive_task(source)
+        return source
+
+    netloc = urlparse(url).netloc.lower().split(":", 1)[0]
     if netloc in _REDDIT_HOSTS:
         from research_agent.tools import reddit
 
@@ -501,39 +597,91 @@ async def fetch(
 
         return await youtube.fetch(url)
 
+    if netloc in _CONGRESS_HOSTS:
+        from research_agent.tools import congress
+
+        return await congress.fetch(url)
+
+    if netloc in _FEC_HOSTS:
+        from research_agent.tools import fec
+
+        return await fec.fetch(url)
+
+    if netloc in _EDGAR_HOSTS:
+        from research_agent.tools import edgar
+
+        return await edgar.fetch(url)
+
+    if netloc in _FEDREGISTER_HOSTS:
+        from research_agent.tools import fedregister
+
+        return await fedregister.fetch(url)
+
+    if netloc in _COURTLISTENER_HOSTS:
+        from research_agent.tools import courtlistener
+
+        return await courtlistener.fetch(url)
+
+    if netloc in _LDA_HOSTS:
+        from research_agent.tools import lda
+
+        return await lda.fetch(url)
+
+    if netloc in _USASPENDING_HOSTS:
+        from research_agent.tools import usaspending
+
+        return await usaspending.fetch(url)
+
+    if netloc in _LITTLESIS_HOSTS:
+        from research_agent.tools import littlesis
+
+        return await littlesis.fetch(url)
+
+    # ``projects.propublica.org`` is a multi-tenant subdomain (Nonprofit
+    # Explorer, Electionland, Dollars for Docs, …). Only the
+    # ``/nonprofits/`` path is owned by this connector — leave other
+    # ProPublica pages on the generic httpx + trafilatura path.
+    if netloc in _NONPROFITS_HOSTS and urlparse(url).path.startswith("/nonprofits/"):
+        from research_agent.tools import nonprofits
+
+        return await nonprofits.fetch(url)
+
+    if netloc in _SANCTIONS_HOSTS:
+        from research_agent.tools import sanctions
+
+        return await sanctions.fetch(url)
+
+    if netloc in _CALACCESS_HOSTS:
+        from research_agent.tools import calaccess
+
+        return await calaccess.fetch(url)
+
+    if netloc in _LICENSING_HOSTS:
+        from research_agent.tools import licensing
+
+        return await licensing.fetch(url)
+
+    if netloc in _SOS_HOSTS:
+        from research_agent.tools import sos
+
+        return await sos.fetch(url)
+
+    if netloc in _BBB_HOSTS:
+        from research_agent.tools import bbb
+
+        return await bbb.fetch(url)
+
+    if netloc in _OPENCORPORATES_HOSTS:
+        from research_agent.tools import opencorporates
+
+        return await opencorporates.fetch(url)
+
     user_agent = _resolve_user_agent()
 
     if not _ignore_robots():
         if not await _robots_allows(url, user_agent):
             logger.info("web_fetch skipped %s — disallowed by robots.txt", url)
             return None
-
-    # Cheap path: a ``.pdf`` URL means we can skip httpx + trafilatura entirely
-    # and let pdf.extract handle the download. Saves a wasted HTML decode and
-    # a 500-page render through readability.
-    if _is_pdf_url(url):
-        source = await _build_pdf_source(url, status_code=None, content=None)
-        if source is not None:
-            _spawn_archive_task(source)
-        return source
-
-    # Same shortcut for ``.mp3`` / ``.m4a`` / ``.wav`` / ``.ogg`` / ``.flac``
-    # URLs — trafilatura would just see binary data, and httpx download +
-    # transcribe gets handled inside the audio module.
-    if _is_audio_url(url):
-        source = await _build_audio_source(url, status_code=None, content=None)
-        if source is not None:
-            _spawn_archive_task(source)
-        return source
-
-    # Same again for ``.png`` / ``.jpg`` / ``.jpeg`` / ``.webp`` / ``.gif``
-    # URLs — screenshots and scanned documents are binary; route through
-    # the OCR pipeline rather than letting trafilatura eat the bytes.
-    if _is_image_url(url):
-        source = await _build_image_source(url, status_code=None, content=None)
-        if source is not None:
-            _spawn_archive_task(source)
-        return source
 
     html: str | None = None
     status_code: int | None = None

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -368,6 +368,33 @@ def test_module_constants_match_spec() -> None:
     assert RETRY_MAX_ATTEMPTS == 5
 
 
+CONNECTOR_KIND_PREFIXES: tuple[str, ...] = (
+    "congress",
+    "fec",
+    "edgar",
+    "courtlistener",
+    "fedregister",
+    "lda",
+    "usaspending",
+    "gdelt",
+    "littlesis",
+    "nonprofits",
+    "opencorporates",
+    "sanctions",
+    "bbb",
+    "licensing",
+    "sos",
+    "calaccess",
+    "scholar",
+    "linkedin",
+)
+
+# Connector module name → ``source_kind`` Literal value. Most connectors
+# match by name; ``edgar`` is the SEC connector so its source_kind is "sec".
+_CONNECTOR_SOURCE_KIND: dict[str, str] = {p: p for p in CONNECTOR_KIND_PREFIXES}
+_CONNECTOR_SOURCE_KIND["edgar"] = "sec"
+
+
 def test_default_handlers_covers_every_task_kind() -> None:
     handlers = default_handlers(router=None)
     expected = {
@@ -385,6 +412,9 @@ def test_default_handlers_covers_every_task_kind() -> None:
         "synthesize",
         "critique",
     }
+    for prefix in CONNECTOR_KIND_PREFIXES:
+        expected.add(f"{prefix}_search")
+        expected.add(f"{prefix}_fetch")
     assert set(handlers.keys()) == expected
 
 
@@ -407,6 +437,208 @@ async def test_default_not_implemented_handler_raises_fatal(
     rows = _read_task_rows(db_path, job.id)
     assert rows[0]["status"] == STATUS_FAILED
     assert "not implemented" in (rows[0]["error"] or "")
+
+
+# ---------------------------------------------------------------------------
+# Issue #175: connector-specific kinds dispatch to tools.<name>.search()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", CONNECTOR_KIND_PREFIXES)
+async def test_connector_search_handler_dispatches_to_module(
+    job: Job, monkeypatch: pytest.MonkeyPatch, prefix: str
+) -> None:
+    """Each ``<prefix>_search`` handler must call ``tools.<prefix>.search`` and
+    expand top hits into ``web_fetch`` follow-ups via the standard helper.
+    """
+    import importlib
+
+    mod = importlib.import_module(f"research_agent.tools.{prefix}")
+    captured: dict[str, Any] = {}
+
+    sk = _CONNECTOR_SOURCE_KIND[prefix]
+
+    async def fake_search(query: str, **kwargs: Any) -> list[SearchResult]:
+        captured["query"] = query
+        captured["kwargs"] = kwargs
+        return [
+            SearchResult(
+                url=f"https://{prefix}.example/1",
+                title="Hit 1",
+                snippet="…",
+                source_kind=sk,  # type: ignore[arg-type]
+            ),
+            SearchResult(
+                url=f"https://{prefix}.example/2",
+                title="Hit 2",
+                snippet="…",
+                source_kind=sk,  # type: ignore[arg-type]
+            ),
+        ]
+
+    monkeypatch.setattr(mod, "search", fake_search)
+
+    handlers = default_handlers(router=None)
+    handler = handlers[f"{prefix}_search"]
+    out = await handler(
+        job,
+        {"kind": f"{prefix}_search", "payload": {"query": "needle", "kind": "x"}},
+    )
+
+    assert captured["query"] == "needle"
+    # ``kind`` is in the passthrough allowlist so it reaches the connector.
+    assert captured["kwargs"].get("kind") == "x"
+    assert isinstance(out, dict)
+    assert "results" in out
+    assert "follow_up_tasks" in out
+    assert len(out["results"]) == 2
+    follow_kinds = {f["kind"] for f in out["follow_up_tasks"]}
+    assert follow_kinds == {"web_fetch"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", CONNECTOR_KIND_PREFIXES)
+async def test_connector_fetch_handler_dispatches_to_module(
+    job: Job, monkeypatch: pytest.MonkeyPatch, prefix: str
+) -> None:
+    """Each ``<prefix>_fetch`` handler must call ``tools.<prefix>.fetch`` and
+    persist the returned :class:`Source` via the shared helper.
+    """
+    import importlib
+    from datetime import datetime, timezone
+
+    from research_agent.tools.models import Source
+
+    mod = importlib.import_module(f"research_agent.tools.{prefix}")
+    captured: dict[str, Any] = {}
+
+    sk = _CONNECTOR_SOURCE_KIND[prefix]
+
+    async def fake_fetch(url: str) -> Source:
+        captured["url"] = url
+        return Source(
+            url=url,
+            title="t",
+            cleaned_text="hello world",
+            fetched_at=datetime.now(tz=timezone.utc),
+            source_kind=sk,  # type: ignore[arg-type]
+        )
+
+    monkeypatch.setattr(mod, "fetch", fake_fetch)
+
+    handlers = default_handlers(router=None)
+    handler = handlers[f"{prefix}_fetch"]
+    out = await handler(
+        job,
+        {
+            "kind": f"{prefix}_fetch",
+            "payload": {"url": f"https://{prefix}.example/abc"},
+        },
+    )
+
+    assert captured["url"] == f"https://{prefix}.example/abc"
+    assert isinstance(out, dict)
+    assert "source_id" in out
+    assert isinstance(out["source_id"], int)
+
+
+@pytest.mark.asyncio
+async def test_connector_search_handler_wraps_runtime_error_as_fatal(
+    job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When a connector raises ``RuntimeError`` (its missing-credential path),
+    the handler must convert it to :class:`FatalError` so the loop marks the
+    task failed cleanly down the documented path rather than relying on the
+    daemon's catch-all guard.
+    """
+    from research_agent.tools import linkedin
+
+    async def fake_search(query: str, **kwargs: Any) -> list[SearchResult]:
+        raise RuntimeError(
+            "linkedin requires LINKEDIN_DATA_API_KEY (or LIX_API_KEY for lix broker)"
+        )
+
+    monkeypatch.setattr(linkedin, "search", fake_search)
+
+    handler = default_handlers(router=None)["linkedin_search"]
+    with pytest.raises(FatalError, match="LINKEDIN_DATA_API_KEY"):
+        await handler(
+            job, {"kind": "linkedin_search", "payload": {"query": "Sundar Pichai"}}
+        )
+
+
+@pytest.mark.asyncio
+async def test_connector_fetch_handler_wraps_runtime_error_as_fatal(
+    job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``<prefix>_fetch`` mirrors the search-side FatalError wrapping."""
+    from research_agent.tools import courtlistener
+
+    async def fake_fetch(url: str) -> Any:
+        raise RuntimeError("courtlistener requires COURTLISTENER_API_TOKEN")
+
+    monkeypatch.setattr(courtlistener, "fetch", fake_fetch)
+
+    handler = default_handlers(router=None)["courtlistener_fetch"]
+    with pytest.raises(FatalError, match="COURTLISTENER_API_TOKEN"):
+        await handler(
+            job,
+            {
+                "kind": "courtlistener_fetch",
+                "payload": {"url": "https://www.courtlistener.com/opinion/123/"},
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_connector_search_handler_drops_kwargs_connector_does_not_accept(
+    job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Planner drift: a passthrough kwarg the target connector doesn't accept
+    must be dropped, not raised as a TypeError that bypasses the documented
+    FatalError path. ``edgar.search`` takes ``form_type`` (not ``kind``); a
+    plan that emits ``kind`` for ``edgar_search`` must still produce a clean
+    call rather than crashing.
+    """
+    from research_agent.tools import edgar
+
+    captured: dict[str, Any] = {}
+
+    async def fake_search(
+        query: str,
+        *,
+        form_type: Any = None,
+        max_results: int = 20,
+        timeout: float = 15.0,
+    ) -> list[SearchResult]:
+        captured["query"] = query
+        captured["form_type"] = form_type
+        captured["max_results"] = max_results
+        return []
+
+    monkeypatch.setattr(edgar, "search", fake_search)
+
+    handler = default_handlers(router=None)["edgar_search"]
+    out = await handler(
+        job,
+        {
+            "kind": "edgar_search",
+            "payload": {
+                "query": "cybersecurity",
+                "kind": "should-be-dropped",  # edgar takes form_type, not kind
+                "form_type": "8-K",
+                "max_results": 5,
+            },
+        },
+    )
+    assert captured == {
+        "query": "cybersecurity",
+        "form_type": "8-K",
+        "max_results": 5,
+    }
+    assert isinstance(out, dict)
+    assert out["results"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -15,10 +15,12 @@ from research_agent.orchestrator.loop import (
     MAX_TASKS_PER_JOB,
     RETRY_MAX_ATTEMPTS,
     Handler,
+    _expand_search_to_fetches,
     default_handlers,
     run_loop,
 )
-from research_agent.orchestrator.plan import Plan, Subgoal, TaskSpec
+from research_agent.orchestrator.plan import Plan, ScopeClass, Subgoal, TaskSpec
+from research_agent.tools.models import SearchResult
 from research_agent.storage import db
 from research_agent.storage.jobs import Job
 from research_agent.storage.markdown import write_plan
@@ -660,3 +662,89 @@ async def test_drain_replan_break_on_empty_template(
 
 def test_max_drain_replans_default_is_ten() -> None:
     assert MAX_DRAIN_REPLANS == 10
+
+
+# ---------------------------------------------------------------------------
+# _expand_search_to_fetches scope-aware top_K (issue #178)
+# ---------------------------------------------------------------------------
+
+
+def _make_results(n: int) -> list[SearchResult]:
+    return [
+        SearchResult(
+            url=f"https://example.com/{i}",
+            title=f"Hit {i}",
+            snippet="…",
+            source_kind="web",
+        )
+        for i in range(n)
+    ]
+
+
+def _persist_plan_with_scope(job: Job, scope: ScopeClass | None) -> None:
+    p = Plan(
+        version=1,
+        objective="Investigate the target",
+        subgoals=[Subgoal(id=1, description="Gather", done=False)],
+        task_template=[TaskSpec(kind="web_search")],
+        expected_iterations=3,
+        scope_class=scope,
+    )
+    write_plan(job, p.model_dump())
+
+
+def test_expand_search_to_fetches_broad_scope_emits_seven(job: Job) -> None:
+    _persist_plan_with_scope(job, "broad")
+    results = _make_results(10)
+
+    out = _expand_search_to_fetches(job, {"query": "q"}, results)
+
+    assert len(out["follow_up_tasks"]) == 7
+    assert len(out["results"]) == 10
+
+
+@pytest.mark.parametrize(
+    "scope,expected",
+    [
+        ("narrow", 3),
+        ("medium", 5),
+        ("broad", 7),
+        ("comprehensive", 10),
+    ],
+)
+def test_expand_search_to_fetches_scope_mapping(
+    job: Job, scope: ScopeClass, expected: int
+) -> None:
+    _persist_plan_with_scope(job, scope)
+    results = _make_results(10)
+
+    out = _expand_search_to_fetches(job, {"query": "q"}, results)
+
+    assert len(out["follow_up_tasks"]) == expected
+
+
+def test_expand_search_to_fetches_payload_override_still_wins(job: Job) -> None:
+    _persist_plan_with_scope(job, "broad")
+    results = _make_results(10)
+
+    out = _expand_search_to_fetches(job, {"query": "q", "expand_top_k": 2}, results)
+
+    assert len(out["follow_up_tasks"]) == 2
+
+
+def test_expand_search_to_fetches_unknown_scope_falls_back_to_three(job: Job) -> None:
+    _persist_plan_with_scope(job, None)
+    results = _make_results(10)
+
+    out = _expand_search_to_fetches(job, {"query": "q"}, results)
+
+    assert len(out["follow_up_tasks"]) == 3
+
+
+def test_expand_search_to_fetches_no_plan_falls_back_to_three(job: Job) -> None:
+    # No plan persisted at all — handler should still default to 3.
+    results = _make_results(10)
+
+    out = _expand_search_to_fetches(job, {"query": "q"}, results)
+
+    assert len(out["follow_up_tasks"]) == 3

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -16,6 +16,7 @@ from research_agent.orchestrator.loop import (
     RETRY_MAX_ATTEMPTS,
     Handler,
     _expand_search_to_fetches,
+    _run_extract_findings,
     default_handlers,
     run_loop,
 )
@@ -748,3 +749,233 @@ def test_expand_search_to_fetches_no_plan_falls_back_to_three(job: Job) -> None:
     out = _expand_search_to_fetches(job, {"query": "q"}, results)
 
     assert len(out["follow_up_tasks"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Cornerstone-document extraction (issue #177)
+# ---------------------------------------------------------------------------
+
+
+class _StubRouter:
+    """Minimal router stand-in for ``_run_extract_findings`` tests.
+
+    Captures every ``call(tier, agent, ...)`` invocation so tests can
+    assert tier + agent.system_prompt without going through Pydantic AI.
+    The configured ``yaml_output`` is what the model "emits".
+
+    ``model_for`` returns a Pydantic AI :class:`TestModel` because the
+    handler constructs an ``Agent`` before our :meth:`call` ever runs,
+    and the Agent constructor refuses raw objects.
+    """
+
+    def __init__(self, yaml_output: str) -> None:
+        self.yaml_output = yaml_output
+        self.calls: list[tuple[str, Any, tuple[Any, ...], dict[str, Any]]] = []
+
+    def model_for(self, tier: str) -> Any:
+        from pydantic_ai.models.test import TestModel
+
+        return TestModel()
+
+    async def call(self, tier: str, agent: Any, *args: Any, **kwargs: Any) -> Any:
+        self.calls.append((tier, agent, args, kwargs))
+
+        class _Result:
+            output = self.yaml_output
+
+        return _Result()
+
+
+def _seed_source(job: Job, *, url: str, body: str) -> int:
+    from research_agent.storage.sources import write_source
+
+    return write_source(
+        job,
+        url=url,
+        title="Cornerstone Document",
+        raw_content=body,
+        kind="web",
+    )
+
+
+def _persist_plan_with_cornerstone(job: Job, url: str | None) -> None:
+    p = Plan(
+        version=1,
+        objective="Index the cornerstone",
+        subgoals=[Subgoal(id=1, description="Index", done=False)],
+        task_template=[TaskSpec(kind="web_search")],
+        expected_iterations=1,
+        cornerstone_url=url,
+    )
+    write_plan(job, p.model_dump())
+
+
+_CORNERSTONE_BODY = (
+    "DOJ: Proposal 1: Restore Schedule F across the executive branch.\n"
+    "DOJ: Proposal 2: Relocate FBI domestic-intelligence operations.\n"
+    "DOJ: Proposal 3: Reorganize the Antitrust Division.\n"
+    "DOJ: Proposal 4: Clarify the AG's removal authority.\n"
+    "State: Proposal 5: Withdraw from the Paris Agreement.\n"
+    "State: Proposal 6: Restructure USAID.\n"
+    "State: Proposal 7: Re-list the Houthis as a foreign terrorist organization.\n"
+    "State: Proposal 8: Limit refugee admissions.\n"
+    "EPA: Proposal 9: Halt Clean Air Act greenhouse-gas enforcement.\n"
+    "EPA: Proposal 10: Rescind the endangerment finding.\n"
+    "EPA: Proposal 11: Devolve Superfund authority to the states.\n"
+    "EPA: Proposal 12: End ESG-style cost-benefit calculations.\n"
+)
+
+_CORNERSTONE_YAML = """\
+```yaml
+- claim: "Restore Schedule F across the executive branch (DOJ)."
+  confidence: 0.9
+  quote: "Restore Schedule F across the executive branch."
+  tags: [doj, schedule-f]
+- claim: "Relocate FBI domestic-intelligence operations (DOJ)."
+  confidence: 0.85
+  quote: "Relocate FBI domestic-intelligence operations."
+  tags: [doj, fbi]
+- claim: "Reorganize the Antitrust Division (DOJ)."
+  confidence: 0.8
+  quote: "Reorganize the Antitrust Division."
+  tags: [doj, antitrust]
+- claim: "Clarify the AG's removal authority (DOJ)."
+  confidence: 0.8
+  quote: "Clarify the AG's removal authority."
+  tags: [doj, removal]
+- claim: "Withdraw from the Paris Agreement (State)."
+  confidence: 0.95
+  quote: "Withdraw from the Paris Agreement."
+  tags: [state, climate]
+- claim: "Restructure USAID (State)."
+  confidence: 0.8
+  quote: "Restructure USAID."
+  tags: [state, usaid]
+- claim: "Re-list the Houthis as a foreign terrorist organization (State)."
+  confidence: 0.8
+  quote: "Re-list the Houthis as a foreign terrorist organization."
+  tags: [state, terrorism]
+- claim: "Limit refugee admissions (State)."
+  confidence: 0.8
+  quote: "Limit refugee admissions."
+  tags: [state, refugees]
+- claim: "Halt Clean Air Act greenhouse-gas enforcement (EPA)."
+  confidence: 0.9
+  quote: "Halt Clean Air Act greenhouse-gas enforcement."
+  tags: [epa, climate]
+- claim: "Rescind the endangerment finding (EPA)."
+  confidence: 0.85
+  quote: "Rescind the endangerment finding."
+  tags: [epa, endangerment]
+- claim: "Devolve Superfund authority to the states (EPA)."
+  confidence: 0.8
+  quote: "Devolve Superfund authority to the states."
+  tags: [epa, superfund]
+- claim: "End ESG-style cost-benefit calculations (EPA)."
+  confidence: 0.8
+  quote: "End ESG-style cost-benefit calculations."
+  tags: [epa, esg]
+```
+"""
+
+
+@pytest.mark.asyncio
+async def test_extract_findings_cornerstone_path(
+    job: Job,
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cornerstone source: structured-index prompt + uncapped findings.
+
+    A planner-marked cornerstone URL must (a) route extraction through
+    ``researcher_cornerstone.md`` (not ``researcher.md``), (b) write all
+    12 findings — past the 8-finding default cap, (c) preserve the
+    department tag on each finding so downstream tactical_replan can
+    convert them into per-proposal sub-questions.
+    """
+    url = "https://example.test/policy.md"
+    _persist_plan_with_cornerstone(job, url)
+    source_id = _seed_source(job, url=url, body=_CORNERSTONE_BODY)
+
+    # _run_extract_findings does ``from research_agent.prompts.loader import
+    # load_prompt`` inside the function body, so each call re-resolves the
+    # name against the loader module. Patching the module attribute is
+    # enough — no need to also patch any orchestrator-side symbol.
+    import research_agent.prompts.loader as _loader_mod
+
+    loaded_prompts: list[str] = []
+    real_load = _loader_mod.load_prompt
+
+    def _spy_load(name: str, *args: Any, **kwargs: Any) -> str:
+        loaded_prompts.append(name)
+        return real_load(name, *args, **kwargs)
+
+    monkeypatch.setattr(_loader_mod, "load_prompt", _spy_load)
+
+    router = _StubRouter(_CORNERSTONE_YAML)
+    task = {"payload": {"source_id": source_id, "sub_question": "List proposals."}}
+
+    result = await _run_extract_findings(job, task, router=router)
+
+    assert result["findings_written"] == 12
+    assert result["skipped"] == 0
+    assert "researcher_cornerstone" in loaded_prompts
+    assert "researcher" not in loaded_prompts
+
+    # Every finding should carry a department tag.
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT tags FROM findings WHERE job_id = ? ORDER BY id ASC",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 12
+    import json as _json
+
+    departments = {"doj", "state", "epa"}
+    for row in rows:
+        tags = _json.loads(row["tags"]) if row["tags"] else []
+        assert any(t in departments for t in tags), tags
+
+    # cornerstone_extract event must have been emitted.
+    events = _read_event_kinds(db_path, job.id)
+    assert "cornerstone_extract" in events
+
+
+@pytest.mark.asyncio
+async def test_extract_findings_non_cornerstone_uses_default_cap(
+    job: Job,
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-cornerstone source still caps at 8 findings via the default prompt."""
+    url = "https://example.test/article.html"
+    _persist_plan_with_cornerstone(job, "https://example.test/totally-different.pdf")
+    source_id = _seed_source(job, url=url, body="A short news article body.")
+
+    loaded_prompts: list[str] = []
+    import research_agent.prompts.loader as _loader_mod
+
+    real_load = _loader_mod.load_prompt
+
+    def _spy_load(name: str, *args: Any, **kwargs: Any) -> str:
+        loaded_prompts.append(name)
+        return real_load(name, *args, **kwargs)
+
+    monkeypatch.setattr(_loader_mod, "load_prompt", _spy_load)
+
+    # Emit 12 findings — the default cap should drop the last 4.
+    yaml_payload = "```yaml\n" + "".join(
+        f'- claim: "Claim {i}"\n  confidence: 0.8\n  quote: ""\n  tags: [t{i}]\n'
+        for i in range(12)
+    ) + "```\n"
+    router = _StubRouter(yaml_payload)
+    task = {"payload": {"source_id": source_id, "sub_question": "What?"}}
+
+    result = await _run_extract_findings(job, task, router=router)
+
+    assert result["findings_written"] == 8
+    assert "researcher" in loaded_prompts
+    assert "researcher_cornerstone" not in loaded_prompts

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -42,6 +42,28 @@ ALL_SCOPE_CLASSES: tuple[str, ...] = get_args(ScopeClass)
 # ---------------------------------------------------------------------------
 
 
+CONNECTOR_KIND_PREFIXES: tuple[str, ...] = (
+    "congress",
+    "fec",
+    "edgar",
+    "courtlistener",
+    "fedregister",
+    "lda",
+    "usaspending",
+    "gdelt",
+    "littlesis",
+    "nonprofits",
+    "opencorporates",
+    "sanctions",
+    "bbb",
+    "licensing",
+    "sos",
+    "calaccess",
+    "scholar",
+    "linkedin",
+)
+
+
 def test_task_kind_covers_expected_set() -> None:
     expected = {
         "web_search",
@@ -58,7 +80,22 @@ def test_task_kind_covers_expected_set() -> None:
         "synthesize",
         "critique",
     }
+    for prefix in CONNECTOR_KIND_PREFIXES:
+        expected.add(f"{prefix}_search")
+        expected.add(f"{prefix}_fetch")
     assert set(ALL_TASK_KINDS) == expected
+
+
+@pytest.mark.parametrize("prefix", CONNECTOR_KIND_PREFIXES)
+def test_task_spec_accepts_connector_search_kind(prefix: str) -> None:
+    spec = TaskSpec(kind=f"{prefix}_search")  # type: ignore[arg-type]
+    assert spec.kind == f"{prefix}_search"
+
+
+@pytest.mark.parametrize("prefix", CONNECTOR_KIND_PREFIXES)
+def test_task_spec_accepts_connector_fetch_kind(prefix: str) -> None:
+    spec = TaskSpec(kind=f"{prefix}_fetch")  # type: ignore[arg-type]
+    assert spec.kind == f"{prefix}_fetch"
 
 
 @pytest.mark.parametrize("kind", ALL_TASK_KINDS)

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -16,6 +16,7 @@ from research_agent.llm.budgets import BudgetTracker
 from research_agent.llm.router import Router, load_models_config
 from research_agent.orchestrator import plan as plan_module
 from research_agent.orchestrator.plan import (
+    MAX_FINDINGS_FOR_REPLAN,
     MAX_PLAN_VERSIONS,
     MAX_RECENT_RESULTS_FOR_REPLAN,
     Plan,
@@ -716,6 +717,282 @@ def test_tactical_replan_does_not_emit_truncated_when_recent_empty(
         row = conn.execute(
             "SELECT COUNT(*) AS c FROM events"
             " WHERE job_id = ? AND kind = 'replan_truncated'",
+            (job.id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row["c"] == 0
+
+
+# ---------------------------------------------------------------------------
+# tactical_replan findings drill-down — issue #179
+# ---------------------------------------------------------------------------
+
+
+def _make_findings(
+    n: int,
+    *,
+    claim_template: str = "Finding {i} body text",
+    starting_id: int = 1,
+    source_ids_per_finding: int = 1,
+) -> list[dict[str, Any]]:
+    """Build ``n`` synthetic finding rows shaped like ``_load_all_findings``."""
+    out: list[dict[str, Any]] = []
+    for offset in range(n):
+        i = starting_id + offset
+        out.append(
+            {
+                "id": i,
+                "claim": claim_template.format(i=i),
+                "confidence": 0.7,
+                "source_ids": [
+                    f"src-{i}-{j}" for j in range(source_ids_per_finding)
+                ],
+                "tags": ["topic-a"],
+            }
+        )
+    return out
+
+
+def test_tactical_replan_includes_findings_in_payload(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """Issue #179: ``tactical_replan`` must ship ``findings`` in the planner payload.
+
+    Without findings in the payload, the planner has no way to drill into
+    named claims and just re-emits umbrella queries.
+    """
+    router, calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    findings = _make_findings(
+        5,
+        claim_template="Schedule F implementation note {i}",
+    )
+    _StubAgent.next_plan = _sample_plan(version=2)
+    asyncio.run(
+        tactical_replan(job, v1, [], router=router, findings=findings),
+    )
+
+    args = calls[1][2]
+    payload = json.loads(args[0])
+    assert "findings" in payload
+    sent = payload["findings"]
+    assert len(sent) == 5
+    for entry in sent:
+        assert "id" in entry
+        assert "claim" in entry
+        assert "tags" in entry
+        assert "source_id" in entry
+    assert sent[0]["claim"] == "Schedule F implementation note 1"
+
+
+def test_tactical_replan_drills_into_named_findings(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """End-to-end wiring: a stub planner drilling into 5 named subjects must surface
+    at least 3 of those names verbatim in the resulting plan's task queries.
+
+    This exercises the orchestrator wiring (findings reach the planner; the
+    planner's tasks land in the persisted plan). The actual prompt-driven
+    drill-down behavior is exercised at runtime where a real LLM reads the
+    drill-down rule in ``planner.md``.
+    """
+    router, _calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    named_subjects = [
+        "Schedule F",
+        "WOTUS rule",
+        "mifepristone reversal",
+        "IRS workforce",
+        "FDA Title X",
+    ]
+    findings: list[dict[str, Any]] = []
+    fid = 1
+    for subject in named_subjects:
+        for variant_idx in range(3):
+            findings.append(
+                {
+                    "id": fid,
+                    "claim": (
+                        f"{subject} update {variant_idx}: implementation status "
+                        "is partially supported by recent reporting."
+                    ),
+                    "confidence": 0.6,
+                    "source_ids": [f"src-{fid}"],
+                    "tags": [subject],
+                }
+            )
+            fid += 1
+    assert len(findings) == 15
+
+    drilled_plan = Plan(
+        version=2,
+        objective="Drill into named findings.",
+        scope_class="broad",
+        subgoals=[
+            Subgoal(id=1, description="Drill into named claims from prior findings."),
+        ],
+        task_template=[
+            TaskSpec(
+                kind="web_search",
+                payload={
+                    "query": "Schedule F implementation timeline OPM guidance",
+                    "sub_question": "What is the Schedule F rollout timeline?",
+                },
+            ),
+            TaskSpec(
+                kind="web_search",
+                payload={
+                    "query": "site:federalregister.gov WOTUS rule comment period",
+                    "sub_question": "Comment-period status of the WOTUS rule.",
+                },
+            ),
+            TaskSpec(
+                kind="news_search",
+                payload={
+                    "query": "mifepristone reversal court ruling",
+                    "sub_question": "Recent court filings on the mifepristone reversal.",
+                },
+            ),
+            TaskSpec(
+                kind="web_search",
+                payload={
+                    "query": "IRS workforce downsizing 2026",
+                    "sub_question": "IRS staffing cuts and downsizing actions.",
+                },
+            ),
+        ],
+        expected_iterations=2,
+    )
+    _StubAgent.next_plan = drilled_plan
+
+    v2 = asyncio.run(
+        tactical_replan(job, v1, [], router=router, findings=findings),
+    )
+
+    queries = [
+        str(t.payload.get("query", "")) for t in v2.task_template
+    ]
+    sub_questions = [
+        str(t.payload.get("sub_question", "")) for t in v2.task_template
+    ]
+    haystack = " || ".join(queries + sub_questions).lower()
+
+    matched = [s for s in named_subjects if s.lower() in haystack]
+    assert len(matched) >= 3, (
+        f"expected at least 3 named subjects to appear verbatim in v2 task "
+        f"queries/sub_questions; got {matched} from {named_subjects}"
+    )
+
+
+def test_tactical_replan_truncates_findings_to_max(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """200 findings → payload caps at MAX_FINDINGS_FOR_REPLAN, event emitted."""
+    router, calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    findings = _make_findings(200)
+    _StubAgent.next_plan = _sample_plan(version=2)
+    asyncio.run(
+        tactical_replan(job, v1, [], router=router, findings=findings),
+    )
+
+    args = calls[1][2]
+    payload = json.loads(args[0])
+    sent = payload["findings"]
+    assert len(sent) == MAX_FINDINGS_FOR_REPLAN == 60
+    # Highest-ID findings (most recent) survive, re-ordered ascending.
+    sent_ids = [e["id"] for e in sent]
+    assert sent_ids == sorted(sent_ids)
+    assert sent_ids[0] == 200 - MAX_FINDINGS_FOR_REPLAN + 1  # 141
+    assert sent_ids[-1] == 200
+
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT level, payload_json FROM events"
+            " WHERE job_id = ? AND kind = 'findings_truncated'"
+            " ORDER BY id ASC",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    assert rows[0]["level"] == "WARN"
+    event_payload = json.loads(rows[0]["payload_json"])
+    assert event_payload["before"] == 200
+    assert event_payload["after"] == MAX_FINDINGS_FOR_REPLAN
+    assert event_payload["compressed"] is True
+
+
+def test_tactical_replan_compresses_finding_source_ids(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """A finding with 50 source_ids ships as a single ``source_id``, not a list."""
+    router, calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    findings = [
+        {
+            "id": 7,
+            "claim": "Schedule F restructures civil service.",
+            "confidence": 0.9,
+            "source_ids": [f"src-{j}" for j in range(50)],
+            "tags": ["civil-service"],
+        }
+    ]
+    _StubAgent.next_plan = _sample_plan(version=2)
+    asyncio.run(
+        tactical_replan(job, v1, [], router=router, findings=findings),
+    )
+
+    args = calls[1][2]
+    payload = json.loads(args[0])
+    sent = payload["findings"]
+    assert len(sent) == 1
+    entry = sent[0]
+    assert "source_ids" not in entry
+    assert "source_id" in entry
+    assert entry["source_id"] == "src-0"
+    assert isinstance(entry["source_id"], str)
+
+
+def test_tactical_replan_does_not_emit_findings_truncated_when_under_cap(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """Under-cap findings: no truncation event, payload carries them all."""
+    router, _calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    findings = _make_findings(MAX_FINDINGS_FOR_REPLAN)  # exactly at the cap
+    _StubAgent.next_plan = _sample_plan(version=2)
+    asyncio.run(
+        tactical_replan(job, v1, [], router=router, findings=findings),
+    )
+
+    conn = db.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) AS c FROM events"
+            " WHERE job_id = ? AND kind = 'findings_truncated'",
             (job.id,),
         ).fetchone()
     finally:

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -742,3 +742,55 @@ def test_persisted_plan_round_trips_via_db(
     assert rebuilt == returned
     expected = stub.model_copy(update={"version": 1})
     assert rebuilt == expected
+
+
+# ---------------------------------------------------------------------------
+# planner.md connector-routing guardrail (issue #174)
+# ---------------------------------------------------------------------------
+
+
+def test_planner_md_documents_connector_site_operators() -> None:
+    """`prompts/planner.md` must teach the full connector roster (issue #174).
+
+    Without this section, the planner emits plain `web_search` queries and
+    bypasses every site:-routed connector — see the 2026-05-07 Project 2025
+    overnight run that fired 8× plain web_search and 0× site:-scoped queries.
+    """
+    body = prompts_loader.load_prompt(
+        "planner",
+        goal="dummy goal — this test only inspects static prompt content",
+    )
+
+    assert "Connector routing" in body, (
+        "planner.md is missing the 'Connector routing' section that teaches "
+        "the model when to use site: operators"
+    )
+
+    # One concrete site:-prefixed example per shipped connector. The
+    # web_fetch host-dispatch is keyed on these domains; if the planner
+    # never names them, the connectors never run.
+    required_site_patterns = [
+        "site:sec.gov",
+        "site:courtlistener.com",
+        "site:federalregister.gov",
+        "site:projects.propublica.org/nonprofits",
+        "site:fec.gov",
+        "site:congress.gov",
+        "site:lda.senate.gov",
+        "site:usaspending.gov",
+        "site:littlesis.org",
+        "site:treasury.gov",
+        "site:powersearch.sos.ca.gov",
+        "site:cslb.ca.gov",
+        "site:bizfileonline.sos.ca.gov",
+        "site:bbb.org",
+    ]
+    missing = [pat for pat in required_site_patterns if pat not in body]
+    assert not missing, (
+        f"planner.md must include one example per connector domain — missing: {missing}"
+    )
+
+    # GDELT is the lone aggregator: no site: operator. The doc should
+    # explicitly say so or the planner will assume site:gdelt-something
+    # is the right move.
+    assert "GDELT" in body, "planner.md should call out GDELT as the no-site: aggregator"

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -17,6 +17,7 @@ from research_agent.llm.router import Router, load_models_config
 from research_agent.orchestrator import plan as plan_module
 from research_agent.orchestrator.plan import (
     MAX_PLAN_VERSIONS,
+    MAX_RECENT_RESULTS_FOR_REPLAN,
     Plan,
     PlanVersionCapExceeded,
     ScopeClass,
@@ -450,11 +451,15 @@ def test_tactical_replan_increments_version_and_uses_general_tier(
 
     # Spy captured the tier on the second call.
     assert [c[0] for c in calls] == ["frontier", "general"]
-    # And the tactical run input embedded the prior plan + recent results.
+    # And the tactical run input embedded the prior plan + summarized
+    # recent results (issue #176: full result_json no longer ships through).
     args = calls[1][2]
     assert args, "tactical_replan should pass run-input to router.call"
     payload = json.loads(args[0])
-    assert payload["recent_results"] == recent_results
+    sent = payload["recent_results"]
+    assert len(sent) == 1
+    assert sent[0]["task_id"] == 7
+    assert sent[0]["kind"] == "web_search"
     assert payload["prior_plan"]["version"] == 1
 
 
@@ -570,6 +575,152 @@ def test_plan_created_event_payload_includes_scope_class_when_unset(
     payload = json.loads(row["payload_json"])
     assert "scope_class" in payload
     assert payload["scope_class"] is None
+
+
+# ---------------------------------------------------------------------------
+# tactical_replan payload bounding — issue #176
+# ---------------------------------------------------------------------------
+
+
+def _make_recent_results(n: int) -> list[dict[str, Any]]:
+    """Build ``n`` synthetic completed-task entries shaped like loop output."""
+    return [
+        {
+            "task_id": i,
+            "kind": "web_search",
+            "payload": {"q": f"query-{i}"},
+            "result": {
+                "results": [
+                    {"url": f"https://example.com/{i}/{j}", "title": f"hit-{i}-{j}"}
+                    for j in range(5)
+                ]
+            },
+        }
+        for i in range(1, n + 1)
+    ]
+
+
+def test_tactical_replan_truncates_recent_results_to_max(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    router, calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    _StubAgent.next_plan = _sample_plan(version=2)
+    recent_results = _make_recent_results(100)
+    asyncio.run(tactical_replan(job, v1, recent_results, router=router))
+
+    args = calls[1][2]
+    payload = json.loads(args[0])
+    sent = payload["recent_results"]
+    assert len(sent) == MAX_RECENT_RESULTS_FOR_REPLAN == 25
+    # The tail — last 25 entries — must be what we sent (verified by task_id).
+    assert [r["task_id"] for r in sent] == list(range(76, 101))
+
+
+def test_tactical_replan_emits_replan_truncated_event(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    router, _calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    _StubAgent.next_plan = _sample_plan(version=2)
+    recent_results = _make_recent_results(100)
+    asyncio.run(tactical_replan(job, v1, recent_results, router=router))
+
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT level, payload_json FROM events"
+            " WHERE job_id = ? AND kind = 'replan_truncated'"
+            " ORDER BY id ASC",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    assert rows[0]["level"] == "WARN"
+    payload = json.loads(rows[0]["payload_json"])
+    assert payload["before"] == 100
+    assert payload["after"] == 25
+    assert payload["compressed"] is True
+
+
+def test_tactical_replan_compresses_result_payloads(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """A heavy ``result`` (1000 search hits) must collapse into a small summary."""
+    router, calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    heavy_hits = [
+        {"url": f"https://example.com/r/{j}", "title": f"hit-{j}"}
+        for j in range(1000)
+    ]
+    recent_results = [
+        {
+            "task_id": 42,
+            "kind": "web_search",
+            "payload": {"q": "huge"},
+            "result": {"results": heavy_hits, "follow_up_tasks": []},
+        }
+    ]
+
+    _StubAgent.next_plan = _sample_plan(version=2)
+    asyncio.run(tactical_replan(job, v1, recent_results, router=router))
+
+    args = calls[1][2]
+    payload = json.loads(args[0])
+    sent = payload["recent_results"]
+    assert len(sent) == 1
+    entry = sent[0]
+    # No raw `result` key — must be replaced by `summary`.
+    assert "result" not in entry
+    assert "summary" in entry
+    assert entry["task_id"] == 42
+    assert entry["kind"] == "web_search"
+    assert entry["status"] == "ok"
+    assert entry["summary"]["count"] == 1000
+    # Top hits cap at 3 to keep the prompt small.
+    assert len(entry["summary"]["top"]) == 3
+    # Serialized payload should be tiny relative to the raw 1000-hit shape.
+    raw_bytes = len(json.dumps(recent_results[0]))
+    sent_bytes = len(json.dumps(entry))
+    assert sent_bytes < raw_bytes / 10
+
+
+def test_tactical_replan_does_not_emit_truncated_when_recent_empty(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """Empty recent_results: skip the event so the log isn't noisy on cold starts."""
+    router, _calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    _StubAgent.next_plan = _sample_plan(version=2)
+    asyncio.run(tactical_replan(job, v1, [], router=router))
+
+    conn = db.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) AS c FROM events"
+            " WHERE job_id = ? AND kind = 'replan_truncated'",
+            (job.id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row["c"] == 0
 
 
 def test_persisted_plan_round_trips_via_db(

--- a/tests/test_tools_web_fetch.py
+++ b/tests/test_tools_web_fetch.py
@@ -515,3 +515,180 @@ def test_browser_module_imported_lazily(monkeypatch):
     """
     assert hasattr(web_fetch, "browser")
     assert web_fetch.browser is browser
+
+
+# ---------------------------------------------------------------------------
+# Connector host-dispatch (issue #174)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("url", "module_name"),
+    [
+        ("https://www.congress.gov/bill/118th-congress/h-r/1", "congress"),
+        ("https://www.fec.gov/data/candidate/P00000001/", "fec"),
+        ("https://www.sec.gov/Archives/edgar/data/123/000012345.htm", "edgar"),
+        ("https://www.federalregister.gov/documents/2024/01/01/x", "fedregister"),
+        ("https://www.courtlistener.com/opinion/12345/foo/", "courtlistener"),
+        ("https://lda.senate.gov/filings/public/filing/abcd/", "lda"),
+        ("https://www.usaspending.gov/award/CONT_AWD_X/", "usaspending"),
+        ("https://littlesis.org/entity/123-Peter-Thiel", "littlesis"),
+        (
+            "https://projects.propublica.org/nonprofits/organizations/123456789",
+            "nonprofits",
+        ),
+        (
+            "https://sanctionssearch.ofac.treas.gov/Details.aspx?id=42",
+            "sanctions",
+        ),
+        ("https://powersearch.sos.ca.gov/results.aspx?id=42", "calaccess"),
+        (
+            "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=42",
+            "licensing",
+        ),
+        (
+            "https://bizfileonline.sos.ca.gov/search/business/2741233",
+            "sos",
+        ),
+        ("https://www.bbb.org/us/ca/santa-clara/profile/general-contractor/sbi", "bbb"),
+    ],
+)
+async def test_fetch_dispatches_to_connector_by_host(monkeypatch, url, module_name):
+    """A `site:`-scoped query that lands on a connector domain must reach
+    that connector — not be eaten by the generic httpx + trafilatura path.
+
+    Issue #174: planner-emitted ``site:congress.gov`` etc. only routes to
+    the right connector if the host-dispatch table covers it.
+    """
+    _disable_robots(monkeypatch)
+    _stub_archive(monkeypatch)
+
+    # Make the generic paths blow up — if dispatch is missing, the test fails.
+    async def _no_httpx(*args, **kwargs):
+        raise AssertionError(
+            f"web_fetch fell through to httpx for {url}; expected dispatch to {module_name}"
+        )
+
+    async def _no_browser(*args, **kwargs):
+        raise AssertionError(
+            f"web_fetch fell through to playwright for {url}; expected dispatch to {module_name}"
+        )
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _no_httpx)
+    monkeypatch.setattr(web_fetch, "_fetch_via_playwright", _no_browser)
+
+    captured: list[str] = []
+
+    async def _fake_connector_fetch(target_url, *args, **kwargs):
+        captured.append(target_url)
+        return None  # contract: connector decides; None is a valid answer
+
+    # Patch the connector module's fetch so we don't actually hit the network.
+    # The dispatch imports lazily (`from research_agent.tools import <name>`),
+    # so we patch at the package level.
+    import importlib
+
+    module = importlib.import_module(f"research_agent.tools.{module_name}")
+    monkeypatch.setattr(module, "fetch", _fake_connector_fetch)
+
+    result = await web_fetch.fetch(url)
+    assert captured == [url], (
+        f"expected {module_name}.fetch to receive {url}, got {captured}"
+    )
+    assert result is None  # connector returned None; dispatch must not fall back
+
+
+@pytest.mark.parametrize(
+    ("url", "module_name"),
+    [
+        # Bare-domain forms — search engines occasionally return URLs without
+        # the canonical ``www.`` prefix. Before the connector host-gates were
+        # widened to accept bare hosts, dispatch routed these to the connector
+        # which silently returned None, dropping the page entirely (regression
+        # vs. the pre-dispatch generic httpx fallback).
+        ("https://congress.gov/bill/118th-congress/h-r/1", "congress"),
+        ("https://fec.gov/data/candidate/P00000001/", "fec"),
+        ("https://bbb.org/us/ca/santa-clara/profile/general-contractor/sbi", "bbb"),
+        ("https://www.lda.gov/filings/public/filing/abcd/", "lda"),
+    ],
+)
+async def test_fetch_dispatches_to_connector_for_bare_domain(
+    monkeypatch, url, module_name
+):
+    """Bare-domain URLs must reach the connector, not be silently dropped.
+
+    The four connectors with stricter internal host-gates than the dispatch
+    table (issue #174 follow-up): congress, fec, bbb, lda. If the connector
+    rejects the bare host, web_fetch returns None and the page is lost — a
+    regression vs. the pre-dispatch generic httpx fallback. Each connector
+    now accepts both ``www.<domain>`` and the bare form.
+    """
+    _disable_robots(monkeypatch)
+    _stub_archive(monkeypatch)
+
+    async def _no_httpx(*args, **kwargs):
+        raise AssertionError(
+            f"web_fetch fell through to httpx for {url}; expected dispatch to {module_name}"
+        )
+
+    async def _no_browser(*args, **kwargs):
+        raise AssertionError(
+            f"web_fetch fell through to playwright for {url}; expected dispatch to {module_name}"
+        )
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _no_httpx)
+    monkeypatch.setattr(web_fetch, "_fetch_via_playwright", _no_browser)
+
+    captured: list[str] = []
+
+    async def _fake_connector_fetch(target_url, *args, **kwargs):
+        captured.append(target_url)
+        return None
+
+    import importlib
+
+    module = importlib.import_module(f"research_agent.tools.{module_name}")
+    monkeypatch.setattr(module, "fetch", _fake_connector_fetch)
+
+    result = await web_fetch.fetch(url)
+    assert captured == [url], (
+        f"expected {module_name}.fetch to receive {url}, got {captured}"
+    )
+    assert result is None
+
+
+async def test_fetch_falls_through_to_generic_for_propublica_non_nonprofits(
+    monkeypatch,
+):
+    """`projects.propublica.org` hosts multiple ProPublica projects.
+
+    Only the ``/nonprofits/`` path is owned by the nonprofits connector —
+    ``/electionland/``, ``/dollars-for-docs/``, etc. should fall through to
+    the generic httpx path so we don't break those URLs.
+    """
+    _disable_robots(monkeypatch)
+    _stub_archive(monkeypatch)
+
+    from research_agent.tools import nonprofits
+
+    async def _should_not_dispatch(*args, **kwargs):
+        raise AssertionError(
+            "nonprofits.fetch was called for a non-/nonprofits/ ProPublica URL"
+        )
+
+    monkeypatch.setattr(nonprofits, "fetch", _should_not_dispatch)
+
+    httpx_calls: list[str] = []
+
+    async def _fake_httpx(url, timeout, user_agent):
+        httpx_calls.append(url)
+        return 200, ARTICLE_HTML, ARTICLE_HTML.encode("utf-8"), "text/html"
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _fake_httpx)
+
+    source = await web_fetch.fetch(
+        "https://projects.propublica.org/electionland/"
+    )
+    assert httpx_calls == ["https://projects.propublica.org/electionland/"]
+    assert source is not None
+    assert source.metadata["fetched_via"] == "httpx"


### PR DESCRIPTION
## Session Summary

**Branch:** session/epic-180-epic-depth-of-investigation-fixes-post-2026-05-07-surface-level-report-diagnosis
**Issues completed:** 6 (6 succeeded, 0 failed)
**Total duration:** 85 minutes
**Completed:** 2026-05-08T00:26:01.137Z

### Issues
- #176: fix: tactical_replan context overflow — recent_results unbounded, hits 524k tokens at 96 tasks — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/182))
- #178: fix: expand_top_k=3 default starves broad-scope runs of fetch surface-area — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/183))
- #174: fix: planner.md teaches one site: example, not the connector roster — most connectors sit idle — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/184))
- #177: feat: cornerstone-document pattern — when goal names a specific doc, exhaustively index it first — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/185))
- #179: fix: tactical_replan emits generic searches; should drill into named claims from prior findings — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/186))
- #175: feat: extend TaskKind with connector-specific kinds (congress_search, fec_search, etc.) — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/187))

Closes #176
Closes #178
Closes #174
Closes #177
Closes #179
Closes #175

### Session Review

**Status:** PASSED
**Summary:** Holistic session review: all 6 issues (#176, #178, #174, #177, #179, #175) integrate cleanly. Boot + smoke + full test suite for changed files green. No security findings.

---
This PR collects all changes from this session for final review before merging to main.

Automated by alpha-loop