### PR TITLE
feat: fix: tactical_replan context overflow — recent_results unbounded, hits 524k tokens at 96 tasks (closes #176)

### DIFF
--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -46,6 +46,7 @@ EventKind = Literal[
     "critique_written",
     "drain_replan",
     "replan_triggered",
+    "replan_truncated",
     "llm_call",
     "lmstudio_degraded",
     "lmstudio_recovered",

--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -116,6 +116,94 @@ class Plan(BaseModel):
 
 MAX_PLAN_VERSIONS = 200
 
+MAX_RECENT_RESULTS_FOR_REPLAN = 25
+"""Cap on entries from ``recent_results`` that ``tactical_replan`` ships to the
+local-tier planner. Each entry is also compressed to a small summary dict so a
+long-running goal can't push the prompt past the model's context window —
+issue #176 saw a 524k-token payload at task 96."""
+
+_SUMMARY_REPR_MAX_CHARS = 500
+
+
+def _summarize_recent_result(r: dict[str, Any]) -> dict[str, Any]:
+    """Compress one ``recent_results`` entry into a planner-sized dict.
+
+    The full ``result_json`` per task carries every URL of every search hit,
+    every fetched source's body shape, every emitted claim. Stacking 25 of
+    those at full fidelity already overflows local-tier context windows on
+    long runs; the planner only needs to know *what kind of work ran, what
+    came back at what scale, and the top hits* to decide what to do next.
+    """
+    result = r.get("result")
+    summary: Any
+    status = "ok" if result is not None else "no_result"
+
+    if isinstance(result, dict):
+        hits = result.get("results")
+        if not isinstance(hits, list):
+            hits = result.get("hits") if isinstance(result.get("hits"), list) else None
+        if isinstance(hits, list):
+            top: list[dict[str, Any]] = []
+            for h in hits[:3]:
+                if isinstance(h, dict):
+                    top.append(
+                        {
+                            k: h[k]
+                            for k in ("url", "title")
+                            if k in h and isinstance(h[k], str)
+                        }
+                    )
+            summary = {"count": len(hits), "top": top}
+            if "follow_up_tasks" in result:
+                fu = result.get("follow_up_tasks")
+                summary["follow_up_tasks"] = len(fu) if isinstance(fu, list) else 0
+        elif "source" in result and isinstance(result["source"], dict):
+            src = result["source"]
+            summary = {
+                k: src[k]
+                for k in ("url", "title", "source_kind")
+                if k in src and isinstance(src[k], str)
+            }
+            text = src.get("cleaned_text") or src.get("raw_content") or ""
+            if isinstance(text, str):
+                summary["content_chars"] = len(text)
+            if "source_id" in result:
+                summary["source_id"] = result["source_id"]
+        elif "findings_written" in result or "finding_ids" in result:
+            ids = result.get("finding_ids") or []
+            summary = {
+                "findings_written": result.get(
+                    "findings_written",
+                    len(ids) if isinstance(ids, list) else 0,
+                ),
+                "source_id": result.get("source_id"),
+            }
+        elif "summary" in result and isinstance(result["summary"], str):
+            text = result["summary"]
+            summary = {
+                "summary_chars": len(text),
+                "source_id": result.get("source_id"),
+            }
+        else:
+            text = repr(result)
+            if len(text) > _SUMMARY_REPR_MAX_CHARS:
+                text = text[:_SUMMARY_REPR_MAX_CHARS] + "…"
+            summary = text
+    elif result is None:
+        summary = None
+    else:
+        text = repr(result)
+        if len(text) > _SUMMARY_REPR_MAX_CHARS:
+            text = text[:_SUMMARY_REPR_MAX_CHARS] + "…"
+        summary = text
+
+    return {
+        "task_id": r.get("task_id"),
+        "kind": r.get("kind"),
+        "status": status,
+        "summary": summary,
+    }
+
 
 class PlanVersionCapExceeded(RuntimeError):
     """Raised when a job has hit the §6.3 hard cap of plan versions.
@@ -341,15 +429,38 @@ async def tactical_replan(
     """
     _assert_under_cap(job)
     next_version = plan.version + 1
+
+    # issue #176: bound the payload regardless of caller. recent_results is
+    # truncated to the last MAX_RECENT_RESULTS_FOR_REPLAN entries and each is
+    # replaced by a compact summary; older results are already reflected in
+    # the running plan + findings so dropping them is safe.
+    original_len = len(recent_results)
+    tail = recent_results[-MAX_RECENT_RESULTS_FOR_REPLAN:]
+    summarized = [_summarize_recent_result(r) for r in tail]
+
     payload: dict[str, Any] = {
         "prior_plan": plan.model_dump(),
-        "recent_results": recent_results,
+        "recent_results": summarized,
     }
     if findings is not None:
         payload["findings"] = findings
     if synthesis_md is not None:
         payload["synthesis_md"] = synthesis_md
     context = json.dumps(payload, sort_keys=True, default=str)
+
+    if original_len > 0:
+        emit(
+            job,
+            "WARN" if original_len > MAX_RECENT_RESULTS_FOR_REPLAN else "INFO",
+            "planner",
+            "replan_truncated",
+            {
+                "before": original_len,
+                "after": len(summarized),
+                "compressed": True,
+                "max": MAX_RECENT_RESULTS_FOR_REPLAN,
+            },
+        )
     raw = await _run_planner_for_yaml(
         job, tier="general", router=router, user_message=context
     )
@@ -513,6 +624,7 @@ async def cloud_replan(
 
 __all__ = [
     "MAX_PLAN_VERSIONS",
+    "MAX_RECENT_RESULTS_FOR_REPLAN",
     "Plan",
     "PlanParseError",
     "PlanVersionCapExceeded",

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -17,6 +17,7 @@ from research_agent.llm.router import Router, load_models_config
 from research_agent.orchestrator import plan as plan_module
 from research_agent.orchestrator.plan import (
     MAX_PLAN_VERSIONS,
+    MAX_RECENT_RESULTS_FOR_REPLAN,
     Plan,
     PlanVersionCapExceeded,
     ScopeClass,
@@ -450,11 +451,15 @@ def test_tactical_replan_increments_version_and_uses_general_tier(
 
     # Spy captured the tier on the second call.
     assert [c[0] for c in calls] == ["frontier", "general"]
-    # And the tactical run input embedded the prior plan + recent results.
+    # And the tactical run input embedded the prior plan + summarized
+    # recent results (issue #176: full result_json no longer ships through).
     args = calls[1][2]
     assert args, "tactical_replan should pass run-input to router.call"
     payload = json.loads(args[0])
-    assert payload["recent_results"] == recent_results
+    sent = payload["recent_results"]
+    assert len(sent) == 1
+    assert sent[0]["task_id"] == 7
+    assert sent[0]["kind"] == "web_search"
     assert payload["prior_plan"]["version"] == 1
 
 
@@ -570,6 +575,152 @@ def test_plan_created_event_payload_includes_scope_class_when_unset(
     payload = json.loads(row["payload_json"])
     assert "scope_class" in payload
     assert payload["scope_class"] is None
+
+
+# ---------------------------------------------------------------------------
+# tactical_replan payload bounding — issue #176
+# ---------------------------------------------------------------------------
+
+
+def _make_recent_results(n: int) -> list[dict[str, Any]]:
+    """Build ``n`` synthetic completed-task entries shaped like loop output."""
+    return [
+        {
+            "task_id": i,
+            "kind": "web_search",
+            "payload": {"q": f"query-{i}"},
+            "result": {
+                "results": [
+                    {"url": f"https://example.com/{i}/{j}", "title": f"hit-{i}-{j}"}
+                    for j in range(5)
+                ]
+            },
+        }
+        for i in range(1, n + 1)
+    ]
+
+
+def test_tactical_replan_truncates_recent_results_to_max(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    router, calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    _StubAgent.next_plan = _sample_plan(version=2)
+    recent_results = _make_recent_results(100)
+    asyncio.run(tactical_replan(job, v1, recent_results, router=router))
+
+    args = calls[1][2]
+    payload = json.loads(args[0])
+    sent = payload["recent_results"]
+    assert len(sent) == MAX_RECENT_RESULTS_FOR_REPLAN == 25
+    # The tail — last 25 entries — must be what we sent (verified by task_id).
+    assert [r["task_id"] for r in sent] == list(range(76, 101))
+
+
+def test_tactical_replan_emits_replan_truncated_event(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    router, _calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    _StubAgent.next_plan = _sample_plan(version=2)
+    recent_results = _make_recent_results(100)
+    asyncio.run(tactical_replan(job, v1, recent_results, router=router))
+
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT level, payload_json FROM events"
+            " WHERE job_id = ? AND kind = 'replan_truncated'"
+            " ORDER BY id ASC",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    assert rows[0]["level"] == "WARN"
+    payload = json.loads(rows[0]["payload_json"])
+    assert payload["before"] == 100
+    assert payload["after"] == 25
+    assert payload["compressed"] is True
+
+
+def test_tactical_replan_compresses_result_payloads(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """A heavy ``result`` (1000 search hits) must collapse into a small summary."""
+    router, calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    heavy_hits = [
+        {"url": f"https://example.com/r/{j}", "title": f"hit-{j}"}
+        for j in range(1000)
+    ]
+    recent_results = [
+        {
+            "task_id": 42,
+            "kind": "web_search",
+            "payload": {"q": "huge"},
+            "result": {"results": heavy_hits, "follow_up_tasks": []},
+        }
+    ]
+
+    _StubAgent.next_plan = _sample_plan(version=2)
+    asyncio.run(tactical_replan(job, v1, recent_results, router=router))
+
+    args = calls[1][2]
+    payload = json.loads(args[0])
+    sent = payload["recent_results"]
+    assert len(sent) == 1
+    entry = sent[0]
+    # No raw `result` key — must be replaced by `summary`.
+    assert "result" not in entry
+    assert "summary" in entry
+    assert entry["task_id"] == 42
+    assert entry["kind"] == "web_search"
+    assert entry["status"] == "ok"
+    assert entry["summary"]["count"] == 1000
+    # Top hits cap at 3 to keep the prompt small.
+    assert len(entry["summary"]["top"]) == 3
+    # Serialized payload should be tiny relative to the raw 1000-hit shape.
+    raw_bytes = len(json.dumps(recent_results[0]))
+    sent_bytes = len(json.dumps(entry))
+    assert sent_bytes < raw_bytes / 10
+
+
+def test_tactical_replan_does_not_emit_truncated_when_recent_empty(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """Empty recent_results: skip the event so the log isn't noisy on cold starts."""
+    router, _calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    _StubAgent.next_plan = _sample_plan(version=2)
+    asyncio.run(tactical_replan(job, v1, [], router=router))
+
+    conn = db.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) AS c FROM events"
+            " WHERE job_id = ? AND kind = 'replan_truncated'",
+            (job.id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row["c"] == 0
 
 
 def test_persisted_plan_round_trips_via_db(


### PR DESCRIPTION
Closes #176
Part of #180

## Summary

Automated implementation of **fix: tactical_replan context overflow — recent_results unbounded, hits 524k tokens at 96 tasks**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

tactical_replan now bounds recent_results to last 25 entries with per-entry compression, registers replan_truncated event, and ships 4 new tests — all 1215 tests pass.

- **INFO** [OPEN] `src/research_agent/orchestrator/plan.py`: replan_truncated is emitted whenever recent_results is non-empty (INFO when entries <= MAX, WARN when truncated). The issue spec said 'emit when truncated', which could be read as 'only on truncation'. The current behavior gives operators visibility into per-call compression too, which is arguably more useful but is a slight divergence from the literal spec.
- **INFO** [OPEN] `src/research_agent/orchestrator/plan.py`: Option C from the issue (tiktoken / model-specific token-budget check) was not implemented. The static cap of 25 entries plus per-entry compression is sufficient to prevent the 524k-token overflow seen in the reproducer; a true token-counter would be defensive belt-and-suspenders. Not required by acceptance criteria.
- **INFO** [OPEN] `src/research_agent/orchestrator/loop.py`: findings (loaded by _drain_replan via _load_all_findings with no limit) and synthesis_md are still passed unbounded into the same JSON payload. Findings rows are small (claim text + ids), so this is unlikely to drive context overflow at 524k scale, but on a year-long goal it could regress. Out of scope for this issue — worth a follow-up.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*