### PR TITLE
feat: fix: expand_top_k=3 default starves broad-scope runs of fetch surface-area (closes #178)

### DIFF
--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -65,6 +65,18 @@ RETRY_WAITS: tuple[int, ...] = (1, 2, 4, 8, 16, 30, 60)
 RETRY_MAX_ATTEMPTS = 5
 MAX_DRAIN_REPLANS = 10
 
+# Scope-aware default for how many top hits per search become web_fetch
+# follow-ups. Issue #178: a global default of 3 starves broad/comprehensive
+# investigations of fetch surface area. The planner can still override per
+# task via ``payload["expand_top_k"]``.
+_DEFAULT_TOP_K_BY_SCOPE: dict[str, int] = {
+    "narrow": 3,
+    "medium": 5,
+    "broad": 7,
+    "comprehensive": 10,
+}
+_DEFAULT_TOP_K_FALLBACK = 3
+
 Handler = Callable[[Job, dict[str, Any]], Awaitable[dict[str, Any] | None]]
 
 
@@ -530,15 +542,23 @@ def _expand_search_to_fetches(
     ``extract_findings`` follow-up inherits context.
 
     ``payload`` knobs:
-      * ``expand_top_k`` (default 3) — cap follow-ups per search to keep
-        the queue from exploding.
+      * ``expand_top_k`` — cap follow-ups per search to keep the queue
+        from exploding. If the planner sets it explicitly, that wins.
+        Otherwise the default scales with the plan's ``scope_class``
+        (narrow→3, medium→5, broad→7, comprehensive→10), falling back
+        to 3 when no plan / no scope is available.
       * ``sub_question`` — overrides the auto-derived question.
       * ``query`` — used as the sub_question fallback if neither
         ``sub_question`` nor ``job.goal`` are set.
     """
     from research_agent.orchestrator.plan import TaskSpec
 
-    top_k = int(payload.get("expand_top_k", 3))
+    if "expand_top_k" in payload:
+        top_k = int(payload["expand_top_k"])
+    else:
+        plan = _load_latest_plan(job)
+        scope = plan.scope_class if plan is not None else None
+        top_k = _DEFAULT_TOP_K_BY_SCOPE.get(scope or "", _DEFAULT_TOP_K_FALLBACK)
     sub_question = payload.get("sub_question") or payload.get("query") or job.goal
 
     follow_ups: list[TaskSpec] = [

--- a/src/research_agent/prompts/planner.md
+++ b/src/research_agent/prompts/planner.md
@@ -103,7 +103,7 @@ hand; the planner only needs to seed the discovery query.
 
 ### Payload shapes
 
-- `web_search`: `{ query: "…", sub_question: "…", max_results: 10, engine: "auto", expand_top_k: 3 }`
+- `web_search`: `{ query: "…", sub_question: "…", max_results: 10, engine: "auto" }` (optional `expand_top_k` to override the scope-aware default)
 - `news_search`: `{ query: "…", sub_question: "…" }`
 - `reddit_search`: `{ query: "…", sub_question: "…" }`
 - `arxiv_search`: `{ query: "…", sub_question: "…", max_results: 10 }`
@@ -171,9 +171,23 @@ task_template:
     depends_on: []
 ```
 
-Each search above will be automatically expanded into 3 fetches and 3
-extracts by the loop (configurable via `expand_top_k`). You do not need
-to write those fetch/extract tasks yourself.
+Each search above will be automatically expanded into N fetches (and N
+extracts) by the loop, where N defaults to the plan's `scope_class`:
+narrow→3, medium→5, broad→7, comprehensive→10. You do not need to write
+those fetch/extract tasks yourself.
+
+You can override per task by setting `expand_top_k` in the search
+payload. Use this when a single search has a different role from the
+rest of the plan:
+
+- **Broad-net mainstream-news scan** (e.g. `Project 2025 mainstream
+  coverage`) → set `expand_top_k: 10` so you fan out across many
+  outlets.
+- **Targeted "find the canonical source"** (e.g. a query whose only
+  good answer is one specific PDF or one official-record URL) → set
+  `expand_top_k: 1` so you don't waste fetches on near-duplicate hits.
+
+If you don't set it, the scope-aware default applies.
 
 ## Scope-aware planning
 
@@ -239,6 +253,8 @@ or by sub-policy is `broad` or `comprehensive`.
 - Always include a top-level `scope_class` field. Size `task_template`
   to match it (narrow 3–8, medium 8–20, broad 20–50, comprehensive
   50+). The orchestrator's `MAX_TASKS_PER_JOB` cap is 10000, and each
-  search expands to roughly 6 follow-up tasks — even 50 searches
-  (~300 tasks) fits comfortably; do not undersize a broad goal out of
-  caution.
+  search expands to a scope-dependent number of follow-up tasks
+  (~3× for narrow, ~5× for medium, ~7× for broad, ~10× for
+  comprehensive, plus one extract per fetch — so multiply by ~2 for
+  total fan-out). Even 50 broad-scope searches (~700 tasks) fits
+  comfortably; do not undersize a broad goal out of caution.

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -15,10 +15,12 @@ from research_agent.orchestrator.loop import (
     MAX_TASKS_PER_JOB,
     RETRY_MAX_ATTEMPTS,
     Handler,
+    _expand_search_to_fetches,
     default_handlers,
     run_loop,
 )
-from research_agent.orchestrator.plan import Plan, Subgoal, TaskSpec
+from research_agent.orchestrator.plan import Plan, ScopeClass, Subgoal, TaskSpec
+from research_agent.tools.models import SearchResult
 from research_agent.storage import db
 from research_agent.storage.jobs import Job
 from research_agent.storage.markdown import write_plan
@@ -660,3 +662,89 @@ async def test_drain_replan_break_on_empty_template(
 
 def test_max_drain_replans_default_is_ten() -> None:
     assert MAX_DRAIN_REPLANS == 10
+
+
+# ---------------------------------------------------------------------------
+# _expand_search_to_fetches scope-aware top_K (issue #178)
+# ---------------------------------------------------------------------------
+
+
+def _make_results(n: int) -> list[SearchResult]:
+    return [
+        SearchResult(
+            url=f"https://example.com/{i}",
+            title=f"Hit {i}",
+            snippet="…",
+            source_kind="web",
+        )
+        for i in range(n)
+    ]
+
+
+def _persist_plan_with_scope(job: Job, scope: ScopeClass | None) -> None:
+    p = Plan(
+        version=1,
+        objective="Investigate the target",
+        subgoals=[Subgoal(id=1, description="Gather", done=False)],
+        task_template=[TaskSpec(kind="web_search")],
+        expected_iterations=3,
+        scope_class=scope,
+    )
+    write_plan(job, p.model_dump())
+
+
+def test_expand_search_to_fetches_broad_scope_emits_seven(job: Job) -> None:
+    _persist_plan_with_scope(job, "broad")
+    results = _make_results(10)
+
+    out = _expand_search_to_fetches(job, {"query": "q"}, results)
+
+    assert len(out["follow_up_tasks"]) == 7
+    assert len(out["results"]) == 10
+
+
+@pytest.mark.parametrize(
+    "scope,expected",
+    [
+        ("narrow", 3),
+        ("medium", 5),
+        ("broad", 7),
+        ("comprehensive", 10),
+    ],
+)
+def test_expand_search_to_fetches_scope_mapping(
+    job: Job, scope: ScopeClass, expected: int
+) -> None:
+    _persist_plan_with_scope(job, scope)
+    results = _make_results(10)
+
+    out = _expand_search_to_fetches(job, {"query": "q"}, results)
+
+    assert len(out["follow_up_tasks"]) == expected
+
+
+def test_expand_search_to_fetches_payload_override_still_wins(job: Job) -> None:
+    _persist_plan_with_scope(job, "broad")
+    results = _make_results(10)
+
+    out = _expand_search_to_fetches(job, {"query": "q", "expand_top_k": 2}, results)
+
+    assert len(out["follow_up_tasks"]) == 2
+
+
+def test_expand_search_to_fetches_unknown_scope_falls_back_to_three(job: Job) -> None:
+    _persist_plan_with_scope(job, None)
+    results = _make_results(10)
+
+    out = _expand_search_to_fetches(job, {"query": "q"}, results)
+
+    assert len(out["follow_up_tasks"]) == 3
+
+
+def test_expand_search_to_fetches_no_plan_falls_back_to_three(job: Job) -> None:
+    # No plan persisted at all — handler should still default to 3.
+    results = _make_results(10)
+
+    out = _expand_search_to_fetches(job, {"query": "q"}, results)
+
+    assert len(out["follow_up_tasks"]) == 3


### PR DESCRIPTION
Closes #178
Part of #180

## Summary

Automated implementation of **fix: expand_top_k=3 default starves broad-scope runs of fetch surface-area**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Issue #178 fully implemented: scope-aware expand_top_k mapping (narrow=3, medium=5, broad=7, comprehensive=10), planner override preserved, planner.md updated, 8 new tests passing, 1223 total tests green.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*