### PR TITLE
feat: fix: planner.md teaches one site: example, not the connector roster — most connectors sit idle (closes #174)

### DIFF
--- a/src/research_agent/prompts/planner.md
+++ b/src/research_agent/prompts/planner.md
@@ -101,6 +101,36 @@ classification, and disciplinary history — before generic web hits.
 The `licensing` connector takes over from there once the URL is in
 hand; the planner only needs to seed the discovery query.
 
+### Connector routing — use `site:` operators to reach authoritative APIs
+
+`web_fetch` host-dispatches the domains below to dedicated connector
+modules — a `site:<domain>` query is the path to the API. Plain
+`web_search` queries hit Brave's general index and miss these
+authoritative sources entirely; many of them are not even crawlable
+without the right URL shape. **Mix `site:`-scoped queries into broad /
+comprehensive plans whenever a subgoal asks about federal records,
+lobbying, campaign finance, court filings, nonprofits, sanctions, or
+licensing** — those signals only show up when the planner names the
+domain.
+
+| Domain | What's there | Example query |
+|---|---|---|
+| `site:sec.gov` | SEC EDGAR filings (10-K, 10-Q, 8-K, Form 4 insider trades) | `site:sec.gov "Cisco" 8-K cybersecurity` |
+| `site:courtlistener.com` | Federal & state court opinions, dockets (RECAP), oral arguments | `site:courtlistener.com "Schedule F" appellate` |
+| `site:federalregister.gov` | Federal Register rules, proposed rules, agency notices since 1994 | `site:federalregister.gov "Schedule F"` |
+| `site:projects.propublica.org/nonprofits` | ProPublica Nonprofit Explorer (Form 990 filings) | `site:projects.propublica.org/nonprofits "Heritage Foundation"` |
+| `site:fec.gov` | FEC candidate / committee filings, contributions, expenditures | `site:fec.gov "Trump 2024" committee` |
+| `site:congress.gov` | Bills, members, committees, hearings, congressional record | `site:congress.gov "Project 2025"` |
+| `site:lda.senate.gov` | Senate Lobbying Disclosure Act filings (legacy host; `lda.gov` also routes) | `site:lda.senate.gov "Heritage Foundation"` |
+| `site:usaspending.gov` | Federal contracts, grants, loans (award-level detail) | `site:usaspending.gov "Heritage Foundation" contract` |
+| GDELT | Global news event aggregator — **no `site:` operator**; emit a plain `web_search` query and the GDELT connector indexes from there | `Project 2025 mainstream coverage` |
+| `site:littlesis.org` | Power-mapping database — entities, donations, board seats, family ties (lead, not evidence) | `site:littlesis.org "Peter Thiel"` |
+| `site:treasury.gov sanctions` | OFAC sanctions list (SDN, sectoral, country programs) | `site:treasury.gov sanctions "Wagner Group"` |
+| `site:powersearch.sos.ca.gov` | California Cal-Access campaign finance (donors, committees, IEs) | `site:powersearch.sos.ca.gov "Newsom"` |
+| `site:cslb.ca.gov` | California Contractors State License Board profiles, disciplinary history | `site:cslb.ca.gov "SBI Builders"` |
+| `site:bizfileonline.sos.ca.gov` | California Secretary of State business entity filings | `site:bizfileonline.sos.ca.gov "Acme Corp"` |
+| `site:bbb.org` | Better Business Bureau profiles, ratings, complaint counts | `site:bbb.org "SBI Builders"` |
+
 ### Payload shapes
 
 - `web_search`: `{ query: "…", sub_question: "…", max_results: 10, engine: "auto" }` (optional `expand_top_k` to override the scope-aware default)
@@ -165,8 +195,14 @@ task_template:
     depends_on: []
   - kind: web_search
     payload:
-      query: "Acme Corp WARN notice 2024 SEC filing"
-      sub_question: "Are there formal SEC or WARN notices documenting the layoffs?"
+      query: "site:sec.gov \"Acme Corp\" 8-K layoffs"
+      sub_question: "Are there SEC filings (8-K material event, 10-Q risk-factor amendment) referencing the layoffs?"
+    priority: 0
+    depends_on: []
+  - kind: web_search
+    payload:
+      query: "Acme Corp WARN notice 2024"
+      sub_question: "Are there state WARN-Act notices documenting the layoffs?"
     priority: 0
     depends_on: []
 ```
@@ -233,7 +269,14 @@ or by sub-policy is `broad` or `comprehensive`.
   `Project 2025 HUD`, `Project 2025 VA`, `Project 2025 Transportation`,
   plus cross-cutting queries `Project 2025 executive orders`, `Project
   2025 schedule F`, `Project 2025 Heritage Foundation`, `Project 2025
-  staffing tracker` (~20–30 searches).
+  staffing tracker`, plus authoritative-source queries
+  `site:congress.gov "Project 2025"`,
+  `site:federalregister.gov "Schedule F"`,
+  `site:lda.senate.gov "Heritage Foundation"`,
+  `site:projects.propublica.org/nonprofits "Heritage Foundation"`
+  (~20–30 searches). Always include a handful of `site:`-scoped
+  queries in broad/comprehensive plans so the connector routing in
+  the worked YAML below has somewhere to land.
 - **comprehensive** — Goal: *"Complete public record of Anthropic's
   safety governance 2023–present"*. Queries span: each public policy
   document, each leadership statement, each external commitment,

--- a/src/research_agent/tools/bbb.py
+++ b/src/research_agent/tools/bbb.py
@@ -44,6 +44,10 @@ logger = logging.getLogger(__name__)
 _DIAGNOSTICS_DIR = Path("data/diagnostics/bbb")
 _PER_HOST_RPS = 0.5
 _HOST = "www.bbb.org"
+# Accept both ``www.bbb.org`` and the bare ``bbb.org`` host so URLs that
+# arrive from search results without the ``www.`` prefix still navigate;
+# bbb.org 301s to www.bbb.org so Playwright will follow the redirect.
+_ACCEPTED_HOSTS = frozenset({_HOST, "bbb.org"})
 _SEARCH_URL = "https://www.bbb.org/search"
 
 # Short per-call timeout for selector reads. Playwright's default 30s
@@ -327,7 +331,7 @@ async def fetch(url: str) -> Source | None:
         return None
     parsed = urlparse(url)
     host = (parsed.netloc or "").lower().split(":", 1)[0]
-    if host != _HOST:
+    if host not in _ACCEPTED_HOSTS:
         return None
 
     try:

--- a/src/research_agent/tools/congress.py
+++ b/src/research_agent/tools/congress.py
@@ -613,13 +613,16 @@ def _bill_type_from_slug(slug: str) -> str | None:
 def _classify_url(url: str) -> tuple[str | None, dict[str, Any]]:
     """Return ``(resource, ids)`` for supported www.congress.gov URLs.
 
-    Strict host check — anything outside ``www.congress.gov`` (look-alikes
-    like ``www.congress.gov.attacker.example`` must not pass) returns
-    ``(None, {})``.
+    Strict host check — anything outside ``www.congress.gov`` /
+    ``congress.gov`` (look-alikes like ``www.congress.gov.attacker.example``
+    must not pass) returns ``(None, {})``. The bare-host form is accepted
+    so URLs that arrive without the ``www.`` prefix from search results
+    still classify; the API calls themselves are issued internally to the
+    canonical host.
     """
     parsed = urlparse(url)
     host = (parsed.netloc or "").lower().split(":", 1)[0]
-    if host != "www.congress.gov":
+    if host not in {"www.congress.gov", "congress.gov"}:
         return None, {}
     path = parsed.path or ""
 

--- a/src/research_agent/tools/fec.py
+++ b/src/research_agent/tools/fec.py
@@ -453,12 +453,15 @@ async def search(
 def _classify_url(url: str) -> tuple[str | None, str | None]:
     """Return ``(resource, id)`` where resource ∈ {"candidate","committee"}.
 
-    Anything outside ``www.fec.gov`` (strict host match — look-alikes like
-    ``www.fec.gov.attacker.example`` must not pass) returns ``(None, None)``.
+    Anything outside ``www.fec.gov`` / ``fec.gov`` (strict host match —
+    look-alikes like ``www.fec.gov.attacker.example`` must not pass)
+    returns ``(None, None)``. The bare-host form is accepted so URLs
+    that arrive without the ``www.`` prefix from search results still
+    classify; API calls are issued internally to the canonical host.
     """
     parsed = urlparse(url)
     host = (parsed.netloc or "").lower().split(":", 1)[0]
-    if host != "www.fec.gov":
+    if host not in {"www.fec.gov", "fec.gov"}:
         return None, None
     path = parsed.path or ""
     m = _CANDIDATE_URL_RE.match(path)

--- a/src/research_agent/tools/lda.py
+++ b/src/research_agent/tools/lda.py
@@ -45,7 +45,7 @@ _BASE_URL = "https://lda.senate.gov/api/v1/"
 _SITE_BASE = "https://lda.senate.gov"
 # Accept the new ``lda.gov`` cutover host once the migration lands; keeping
 # both in the set means we don't have to flip a flag the moment it happens.
-_ACCEPTED_HOSTS = frozenset({"lda.senate.gov", "lda.gov"})
+_ACCEPTED_HOSTS = frozenset({"lda.senate.gov", "lda.gov", "www.lda.gov"})
 # AC: per-host rate of 1 RPS.
 _RATE_LIMIT_INTERVAL = 1.0
 

--- a/src/research_agent/tools/web_fetch.py
+++ b/src/research_agent/tools/web_fetch.py
@@ -297,6 +297,71 @@ _YOUTUBE_HOSTS = frozenset(
     {"youtube.com", "www.youtube.com", "m.youtube.com", "youtu.be", "www.youtu.be"}
 )
 
+# Connector host-dispatch (issue #174). Each set covers the public netlocs
+# its module's ``fetch(url)`` recognises — see the connector's own host-gate
+# for the authoritative list. The planner emits ``site:<domain>`` queries to
+# steer hits onto these hosts; without dispatch, the generic httpx +
+# trafilatura path eats the page and the connector never runs.
+#
+# Search-only connectors (no URL-fetch contract — they expose only API search):
+#   - arxiv_tool: ArXiv abstract fetch lives behind arxiv_fetch tasks, not URL
+#   - news: RSS aggregator, not a per-URL fetcher
+#   - web_search: itself
+# These do not appear here; the planner emits search tasks for them.
+
+_CONGRESS_HOSTS = frozenset({"www.congress.gov", "congress.gov"})
+_FEC_HOSTS = frozenset({"www.fec.gov", "fec.gov"})
+_EDGAR_HOSTS = frozenset({"www.sec.gov", "sec.gov"})
+_FEDREGISTER_HOSTS = frozenset(
+    {"www.federalregister.gov", "federalregister.gov"}
+)
+_COURTLISTENER_HOSTS = frozenset({"courtlistener.com", "www.courtlistener.com"})
+_LDA_HOSTS = frozenset({"lda.senate.gov", "lda.gov", "www.lda.gov"})
+_USASPENDING_HOSTS = frozenset(
+    {"api.usaspending.gov", "usaspending.gov", "www.usaspending.gov"}
+)
+_LITTLESIS_HOSTS = frozenset({"littlesis.org", "www.littlesis.org"})
+_NONPROFITS_HOSTS = frozenset({"projects.propublica.org"})
+_SANCTIONS_HOSTS = frozenset(
+    {
+        "sanctionssearch.ofac.treas.gov",
+        "home.treasury.gov",
+        "www.treasury.gov",
+        "webgate.ec.europa.eu",
+        "ofsistorage.blob.core.windows.net",
+        "www.gov.uk",
+    }
+)
+_CALACCESS_HOSTS = frozenset({"powersearch.sos.ca.gov"})
+# licensing module: CA (CSLB) wired; TX/FL/NY ship as stubs that return None.
+# Including the stubs in dispatch costs nothing (the module already host-gates
+# them) and makes future state wires routing-only.
+_LICENSING_HOSTS = frozenset(
+    {
+        "www.cslb.ca.gov",
+        "cslb.ca.gov",
+        "www.tdlr.texas.gov",
+        "www.myfloridalicense.com",
+        "www.dos.ny.gov",
+    }
+)
+# sos module: CA wired; DE/NV/WY/FL/NY stubs return None. Same dispatch
+# rationale as _LICENSING_HOSTS.
+_SOS_HOSTS = frozenset(
+    {
+        "bizfileonline.sos.ca.gov",
+        "icis.corp.delaware.gov",
+        "esos.nv.gov",
+        "wyobiz.wyo.gov",
+        "search.sunbiz.org",
+        "apps.dos.ny.gov",
+    }
+)
+_BBB_HOSTS = frozenset({"www.bbb.org", "bbb.org"})
+_OPENCORPORATES_HOSTS = frozenset(
+    {"opencorporates.com", "www.opencorporates.com"}
+)
+
 _PDF_CONTENT_TYPE = "application/pdf"
 
 _IMAGE_CONTENT_TYPES: frozenset[str] = frozenset(
@@ -486,11 +551,42 @@ async def fetch(
     Playwright + trafilatura path strips reddit pages to empty content
     (their SPA shell defeats readability extractors), so without this
     dispatch every reddit follow-up would task_failed.
+
+    The connector roster (issue #174) extends the same pattern to the
+    free-tier authoritative-source modules (Congress, FEC, EDGAR,
+    Federal Register, CourtListener, LDA, USAspending, LittleSis,
+    ProPublica nonprofits, OFAC sanctions, Cal-Access, CSLB, CA SoS,
+    BBB, OpenCorporates) so a planner-emitted ``site:<domain>`` query
+    that yields one of those URLs is handled by the connector that
+    knows the page shape rather than being eaten by the generic HTML
+    extractor.
     """
     if not url or not urlparse(url).netloc:
         return None
 
-    netloc = urlparse(url).netloc.lower()
+    # Binary URL shortcuts run BEFORE connector dispatch: a `.pdf` on
+    # ``sec.gov`` (EDGAR exhibits, 10-K appendices, …) must go through the
+    # PDF extractor, not edgar.fetch which expects an HTML index page.
+    # Same logic for `.mp3` / image suffixes on connector-owned hosts.
+    if _is_pdf_url(url):
+        source = await _build_pdf_source(url, status_code=None, content=None)
+        if source is not None:
+            _spawn_archive_task(source)
+        return source
+
+    if _is_audio_url(url):
+        source = await _build_audio_source(url, status_code=None, content=None)
+        if source is not None:
+            _spawn_archive_task(source)
+        return source
+
+    if _is_image_url(url):
+        source = await _build_image_source(url, status_code=None, content=None)
+        if source is not None:
+            _spawn_archive_task(source)
+        return source
+
+    netloc = urlparse(url).netloc.lower().split(":", 1)[0]
     if netloc in _REDDIT_HOSTS:
         from research_agent.tools import reddit
 
@@ -501,39 +597,91 @@ async def fetch(
 
         return await youtube.fetch(url)
 
+    if netloc in _CONGRESS_HOSTS:
+        from research_agent.tools import congress
+
+        return await congress.fetch(url)
+
+    if netloc in _FEC_HOSTS:
+        from research_agent.tools import fec
+
+        return await fec.fetch(url)
+
+    if netloc in _EDGAR_HOSTS:
+        from research_agent.tools import edgar
+
+        return await edgar.fetch(url)
+
+    if netloc in _FEDREGISTER_HOSTS:
+        from research_agent.tools import fedregister
+
+        return await fedregister.fetch(url)
+
+    if netloc in _COURTLISTENER_HOSTS:
+        from research_agent.tools import courtlistener
+
+        return await courtlistener.fetch(url)
+
+    if netloc in _LDA_HOSTS:
+        from research_agent.tools import lda
+
+        return await lda.fetch(url)
+
+    if netloc in _USASPENDING_HOSTS:
+        from research_agent.tools import usaspending
+
+        return await usaspending.fetch(url)
+
+    if netloc in _LITTLESIS_HOSTS:
+        from research_agent.tools import littlesis
+
+        return await littlesis.fetch(url)
+
+    # ``projects.propublica.org`` is a multi-tenant subdomain (Nonprofit
+    # Explorer, Electionland, Dollars for Docs, …). Only the
+    # ``/nonprofits/`` path is owned by this connector — leave other
+    # ProPublica pages on the generic httpx + trafilatura path.
+    if netloc in _NONPROFITS_HOSTS and urlparse(url).path.startswith("/nonprofits/"):
+        from research_agent.tools import nonprofits
+
+        return await nonprofits.fetch(url)
+
+    if netloc in _SANCTIONS_HOSTS:
+        from research_agent.tools import sanctions
+
+        return await sanctions.fetch(url)
+
+    if netloc in _CALACCESS_HOSTS:
+        from research_agent.tools import calaccess
+
+        return await calaccess.fetch(url)
+
+    if netloc in _LICENSING_HOSTS:
+        from research_agent.tools import licensing
+
+        return await licensing.fetch(url)
+
+    if netloc in _SOS_HOSTS:
+        from research_agent.tools import sos
+
+        return await sos.fetch(url)
+
+    if netloc in _BBB_HOSTS:
+        from research_agent.tools import bbb
+
+        return await bbb.fetch(url)
+
+    if netloc in _OPENCORPORATES_HOSTS:
+        from research_agent.tools import opencorporates
+
+        return await opencorporates.fetch(url)
+
     user_agent = _resolve_user_agent()
 
     if not _ignore_robots():
         if not await _robots_allows(url, user_agent):
             logger.info("web_fetch skipped %s — disallowed by robots.txt", url)
             return None
-
-    # Cheap path: a ``.pdf`` URL means we can skip httpx + trafilatura entirely
-    # and let pdf.extract handle the download. Saves a wasted HTML decode and
-    # a 500-page render through readability.
-    if _is_pdf_url(url):
-        source = await _build_pdf_source(url, status_code=None, content=None)
-        if source is not None:
-            _spawn_archive_task(source)
-        return source
-
-    # Same shortcut for ``.mp3`` / ``.m4a`` / ``.wav`` / ``.ogg`` / ``.flac``
-    # URLs — trafilatura would just see binary data, and httpx download +
-    # transcribe gets handled inside the audio module.
-    if _is_audio_url(url):
-        source = await _build_audio_source(url, status_code=None, content=None)
-        if source is not None:
-            _spawn_archive_task(source)
-        return source
-
-    # Same again for ``.png`` / ``.jpg`` / ``.jpeg`` / ``.webp`` / ``.gif``
-    # URLs — screenshots and scanned documents are binary; route through
-    # the OCR pipeline rather than letting trafilatura eat the bytes.
-    if _is_image_url(url):
-        source = await _build_image_source(url, status_code=None, content=None)
-        if source is not None:
-            _spawn_archive_task(source)
-        return source
 
     html: str | None = None
     status_code: int | None = None

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -742,3 +742,55 @@ def test_persisted_plan_round_trips_via_db(
     assert rebuilt == returned
     expected = stub.model_copy(update={"version": 1})
     assert rebuilt == expected
+
+
+# ---------------------------------------------------------------------------
+# planner.md connector-routing guardrail (issue #174)
+# ---------------------------------------------------------------------------
+
+
+def test_planner_md_documents_connector_site_operators() -> None:
+    """`prompts/planner.md` must teach the full connector roster (issue #174).
+
+    Without this section, the planner emits plain `web_search` queries and
+    bypasses every site:-routed connector — see the 2026-05-07 Project 2025
+    overnight run that fired 8× plain web_search and 0× site:-scoped queries.
+    """
+    body = prompts_loader.load_prompt(
+        "planner",
+        goal="dummy goal — this test only inspects static prompt content",
+    )
+
+    assert "Connector routing" in body, (
+        "planner.md is missing the 'Connector routing' section that teaches "
+        "the model when to use site: operators"
+    )
+
+    # One concrete site:-prefixed example per shipped connector. The
+    # web_fetch host-dispatch is keyed on these domains; if the planner
+    # never names them, the connectors never run.
+    required_site_patterns = [
+        "site:sec.gov",
+        "site:courtlistener.com",
+        "site:federalregister.gov",
+        "site:projects.propublica.org/nonprofits",
+        "site:fec.gov",
+        "site:congress.gov",
+        "site:lda.senate.gov",
+        "site:usaspending.gov",
+        "site:littlesis.org",
+        "site:treasury.gov",
+        "site:powersearch.sos.ca.gov",
+        "site:cslb.ca.gov",
+        "site:bizfileonline.sos.ca.gov",
+        "site:bbb.org",
+    ]
+    missing = [pat for pat in required_site_patterns if pat not in body]
+    assert not missing, (
+        f"planner.md must include one example per connector domain — missing: {missing}"
+    )
+
+    # GDELT is the lone aggregator: no site: operator. The doc should
+    # explicitly say so or the planner will assume site:gdelt-something
+    # is the right move.
+    assert "GDELT" in body, "planner.md should call out GDELT as the no-site: aggregator"

--- a/tests/test_tools_web_fetch.py
+++ b/tests/test_tools_web_fetch.py
@@ -515,3 +515,121 @@ def test_browser_module_imported_lazily(monkeypatch):
     """
     assert hasattr(web_fetch, "browser")
     assert web_fetch.browser is browser
+
+
+# ---------------------------------------------------------------------------
+# Connector host-dispatch (issue #174)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("url", "module_name"),
+    [
+        ("https://www.congress.gov/bill/118th-congress/h-r/1", "congress"),
+        ("https://www.fec.gov/data/candidate/P00000001/", "fec"),
+        ("https://www.sec.gov/Archives/edgar/data/123/000012345.htm", "edgar"),
+        ("https://www.federalregister.gov/documents/2024/01/01/x", "fedregister"),
+        ("https://www.courtlistener.com/opinion/12345/foo/", "courtlistener"),
+        ("https://lda.senate.gov/filings/public/filing/abcd/", "lda"),
+        ("https://www.usaspending.gov/award/CONT_AWD_X/", "usaspending"),
+        ("https://littlesis.org/entity/123-Peter-Thiel", "littlesis"),
+        (
+            "https://projects.propublica.org/nonprofits/organizations/123456789",
+            "nonprofits",
+        ),
+        (
+            "https://sanctionssearch.ofac.treas.gov/Details.aspx?id=42",
+            "sanctions",
+        ),
+        ("https://powersearch.sos.ca.gov/results.aspx?id=42", "calaccess"),
+        (
+            "https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/LicenseDetail.aspx?LicNum=42",
+            "licensing",
+        ),
+        (
+            "https://bizfileonline.sos.ca.gov/search/business/2741233",
+            "sos",
+        ),
+        ("https://www.bbb.org/us/ca/santa-clara/profile/general-contractor/sbi", "bbb"),
+    ],
+)
+async def test_fetch_dispatches_to_connector_by_host(monkeypatch, url, module_name):
+    """A `site:`-scoped query that lands on a connector domain must reach
+    that connector — not be eaten by the generic httpx + trafilatura path.
+
+    Issue #174: planner-emitted ``site:congress.gov`` etc. only routes to
+    the right connector if the host-dispatch table covers it.
+    """
+    _disable_robots(monkeypatch)
+    _stub_archive(monkeypatch)
+
+    # Make the generic paths blow up — if dispatch is missing, the test fails.
+    async def _no_httpx(*args, **kwargs):
+        raise AssertionError(
+            f"web_fetch fell through to httpx for {url}; expected dispatch to {module_name}"
+        )
+
+    async def _no_browser(*args, **kwargs):
+        raise AssertionError(
+            f"web_fetch fell through to playwright for {url}; expected dispatch to {module_name}"
+        )
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _no_httpx)
+    monkeypatch.setattr(web_fetch, "_fetch_via_playwright", _no_browser)
+
+    captured: list[str] = []
+
+    async def _fake_connector_fetch(target_url, *args, **kwargs):
+        captured.append(target_url)
+        return None  # contract: connector decides; None is a valid answer
+
+    # Patch the connector module's fetch so we don't actually hit the network.
+    # The dispatch imports lazily (`from research_agent.tools import <name>`),
+    # so we patch at the package level.
+    import importlib
+
+    module = importlib.import_module(f"research_agent.tools.{module_name}")
+    monkeypatch.setattr(module, "fetch", _fake_connector_fetch)
+
+    result = await web_fetch.fetch(url)
+    assert captured == [url], (
+        f"expected {module_name}.fetch to receive {url}, got {captured}"
+    )
+    assert result is None  # connector returned None; dispatch must not fall back
+
+
+async def test_fetch_falls_through_to_generic_for_propublica_non_nonprofits(
+    monkeypatch,
+):
+    """`projects.propublica.org` hosts multiple ProPublica projects.
+
+    Only the ``/nonprofits/`` path is owned by the nonprofits connector —
+    ``/electionland/``, ``/dollars-for-docs/``, etc. should fall through to
+    the generic httpx path so we don't break those URLs.
+    """
+    _disable_robots(monkeypatch)
+    _stub_archive(monkeypatch)
+
+    from research_agent.tools import nonprofits
+
+    async def _should_not_dispatch(*args, **kwargs):
+        raise AssertionError(
+            "nonprofits.fetch was called for a non-/nonprofits/ ProPublica URL"
+        )
+
+    monkeypatch.setattr(nonprofits, "fetch", _should_not_dispatch)
+
+    httpx_calls: list[str] = []
+
+    async def _fake_httpx(url, timeout, user_agent):
+        httpx_calls.append(url)
+        return 200, ARTICLE_HTML, ARTICLE_HTML.encode("utf-8"), "text/html"
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _fake_httpx)
+
+    source = await web_fetch.fetch(
+        "https://projects.propublica.org/electionland/"
+    )
+    assert httpx_calls == ["https://projects.propublica.org/electionland/"]
+    assert source is not None
+    assert source.metadata["fetched_via"] == "httpx"

--- a/tests/test_tools_web_fetch.py
+++ b/tests/test_tools_web_fetch.py
@@ -598,6 +598,65 @@ async def test_fetch_dispatches_to_connector_by_host(monkeypatch, url, module_na
     assert result is None  # connector returned None; dispatch must not fall back
 
 
+@pytest.mark.parametrize(
+    ("url", "module_name"),
+    [
+        # Bare-domain forms — search engines occasionally return URLs without
+        # the canonical ``www.`` prefix. Before the connector host-gates were
+        # widened to accept bare hosts, dispatch routed these to the connector
+        # which silently returned None, dropping the page entirely (regression
+        # vs. the pre-dispatch generic httpx fallback).
+        ("https://congress.gov/bill/118th-congress/h-r/1", "congress"),
+        ("https://fec.gov/data/candidate/P00000001/", "fec"),
+        ("https://bbb.org/us/ca/santa-clara/profile/general-contractor/sbi", "bbb"),
+        ("https://www.lda.gov/filings/public/filing/abcd/", "lda"),
+    ],
+)
+async def test_fetch_dispatches_to_connector_for_bare_domain(
+    monkeypatch, url, module_name
+):
+    """Bare-domain URLs must reach the connector, not be silently dropped.
+
+    The four connectors with stricter internal host-gates than the dispatch
+    table (issue #174 follow-up): congress, fec, bbb, lda. If the connector
+    rejects the bare host, web_fetch returns None and the page is lost — a
+    regression vs. the pre-dispatch generic httpx fallback. Each connector
+    now accepts both ``www.<domain>`` and the bare form.
+    """
+    _disable_robots(monkeypatch)
+    _stub_archive(monkeypatch)
+
+    async def _no_httpx(*args, **kwargs):
+        raise AssertionError(
+            f"web_fetch fell through to httpx for {url}; expected dispatch to {module_name}"
+        )
+
+    async def _no_browser(*args, **kwargs):
+        raise AssertionError(
+            f"web_fetch fell through to playwright for {url}; expected dispatch to {module_name}"
+        )
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _no_httpx)
+    monkeypatch.setattr(web_fetch, "_fetch_via_playwright", _no_browser)
+
+    captured: list[str] = []
+
+    async def _fake_connector_fetch(target_url, *args, **kwargs):
+        captured.append(target_url)
+        return None
+
+    import importlib
+
+    module = importlib.import_module(f"research_agent.tools.{module_name}")
+    monkeypatch.setattr(module, "fetch", _fake_connector_fetch)
+
+    result = await web_fetch.fetch(url)
+    assert captured == [url], (
+        f"expected {module_name}.fetch to receive {url}, got {captured}"
+    )
+    assert result is None
+
+
 async def test_fetch_falls_through_to_generic_for_propublica_non_nonprofits(
     monkeypatch,
 ):


### PR DESCRIPTION
Closes #174
Part of #180

## Summary

Automated implementation of **fix: planner.md teaches one site: example, not the connector roster — most connectors sit idle**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

All 15 connector site: examples present in planner.md, dispatch table covers each connector, and 4 host-gate mismatches found and fixed (congress/fec/bbb bare-domain rejection + lda missing www.lda.gov).

- **CRITICAL** [FIXED] `src/research_agent/tools/congress.py`: web_fetch dispatch routes bare 'congress.gov' to congress.fetch, but congress._classify_bill_url only accepts 'www.congress.gov' — silently returned None and dropped the page (regression vs. pre-dispatch generic httpx fallback). Widened classifier to accept both www and bare host; lookalike rejection preserved by strict-set membership.
- **CRITICAL** [FIXED] `src/research_agent/tools/fec.py`: Same bare-domain mismatch for FEC: dispatch sends 'fec.gov' but classifier rejected anything not 'www.fec.gov'. Widened to accept both.
- **CRITICAL** [FIXED] `src/research_agent/tools/bbb.py`: Same bare-domain mismatch for BBB: dispatch sends 'bbb.org' but fetch rejected anything not 'www.bbb.org'. Introduced _ACCEPTED_HOSTS covering both forms; bbb.org 301s to www so Playwright follows the redirect.
- **WARNING** [FIXED] `src/research_agent/tools/lda.py`: LDA dispatch includes 'www.lda.gov' but the connector's _ACCEPTED_HOSTS only had 'lda.senate.gov' and 'lda.gov'. Added 'www.lda.gov' to match the dispatch table.
- **INFO** [FIXED] `tests/test_tools_web_fetch.py`: Added parametrized regression test asserting bare-domain URLs (congress.gov, fec.gov, bbb.org, www.lda.gov) reach their connector via dispatch rather than being silently dropped.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*