### PR TITLE
feat: fix: tactical_replan emits generic searches; should drill into named claims from prior findings (closes #179)

### DIFF
--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -47,6 +47,7 @@ EventKind = Literal[
     "drain_replan",
     "replan_triggered",
     "replan_truncated",
+    "findings_truncated",
     "llm_call",
     "lmstudio_degraded",
     "lmstudio_recovered",

--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -129,6 +129,15 @@ local-tier planner. Each entry is also compressed to a small summary dict so a
 long-running goal can't push the prompt past the model's context window —
 issue #176 saw a 524k-token payload at task 96."""
 
+MAX_FINDINGS_FOR_REPLAN = 60
+"""Cap on ``findings`` shipped into the ``tactical_replan`` payload (issue #179).
+
+Drilling down into named claims (Schedule F, WOTUS, mifepristone) requires the
+planner to *see* those claims — but a long broad-scope run can accumulate
+hundreds of findings, so we keep the most recent N (highest ids) and re-order
+them ascending before injection. Each entry is also compressed by
+:func:`_summarize_finding` so the per-entry footprint stays small."""
+
 _SUMMARY_REPR_MAX_CHARS = 500
 
 
@@ -210,6 +219,30 @@ def _summarize_recent_result(r: dict[str, Any]) -> dict[str, Any]:
         "status": status,
         "summary": summary,
     }
+
+
+def _summarize_finding(f: dict[str, Any]) -> dict[str, Any]:
+    """Compress one finding row into a planner-sized dict (issue #179).
+
+    The planner needs the *claim text* (so it can drill into the named
+    entity/proposal/rule), plus minimal evidence weight (``confidence``,
+    ``tags``, one source pointer). The full ``source_ids`` list is dropped
+    in favor of a single ``source_id`` — chasing every source URL is the
+    fetcher's job, not the planner's.
+    """
+    src_ids = f.get("source_ids")
+    first_source: Any = None
+    if isinstance(src_ids, list) and src_ids:
+        first_source = src_ids[0]
+
+    summarized: dict[str, Any] = {
+        "id": f.get("id"),
+        "claim": f.get("claim"),
+        "confidence": f.get("confidence"),
+        "tags": f.get("tags"),
+        "source_id": first_source,
+    }
+    return summarized
 
 
 class PlanVersionCapExceeded(RuntimeError):
@@ -449,8 +482,29 @@ async def tactical_replan(
         "prior_plan": plan.model_dump(),
         "recent_results": summarized,
     }
+
+    # issue #179: include a bounded view of the running ``findings`` so the
+    # planner can drill into named claims (Schedule F, WOTUS, mifepristone)
+    # rather than re-emitting the same per-department generic queries. Cap to
+    # the most recent MAX_FINDINGS_FOR_REPLAN entries (highest ids first, then
+    # re-ordered ascending) and compress each via ``_summarize_finding``.
+    findings_truncation: tuple[int, int] | None = None
     if findings is not None:
-        payload["findings"] = findings
+        findings_before = len(findings)
+        if findings_before > MAX_FINDINGS_FOR_REPLAN:
+            top_recent = sorted(
+                findings,
+                key=lambda f: f.get("id") if isinstance(f.get("id"), int) else -1,
+                reverse=True,
+            )[:MAX_FINDINGS_FOR_REPLAN]
+            tail_findings = sorted(
+                top_recent,
+                key=lambda f: f.get("id") if isinstance(f.get("id"), int) else -1,
+            )
+            findings_truncation = (findings_before, len(tail_findings))
+        else:
+            tail_findings = list(findings)
+        payload["findings"] = [_summarize_finding(f) for f in tail_findings]
     if synthesis_md is not None:
         payload["synthesis_md"] = synthesis_md
     context = json.dumps(payload, sort_keys=True, default=str)
@@ -466,6 +520,19 @@ async def tactical_replan(
                 "after": len(summarized),
                 "compressed": True,
                 "max": MAX_RECENT_RESULTS_FOR_REPLAN,
+            },
+        )
+    if findings_truncation is not None:
+        emit(
+            job,
+            "WARN",
+            "planner",
+            "findings_truncated",
+            {
+                "before": findings_truncation[0],
+                "after": findings_truncation[1],
+                "compressed": True,
+                "max": MAX_FINDINGS_FOR_REPLAN,
             },
         )
     raw = await _run_planner_for_yaml(
@@ -630,6 +697,7 @@ async def cloud_replan(
 
 
 __all__ = [
+    "MAX_FINDINGS_FOR_REPLAN",
     "MAX_PLAN_VERSIONS",
     "MAX_RECENT_RESULTS_FOR_REPLAN",
     "Plan",

--- a/src/research_agent/prompts/planner.md
+++ b/src/research_agent/prompts/planner.md
@@ -261,6 +261,101 @@ let the search tasks fan out in parallel. On `tactical_replan`, the
 planner can convert each high-confidence cornerstone finding into a
 `sub_question` for a per-proposal follow-up search.
 
+## Drill-down rule for replans — fires whenever the user message contains `findings`
+
+When the orchestrator runs you as a **tactical_replan** (the user-message
+JSON payload contains `findings` and/or `recent_results`, NOT just a bare
+goal), the rules above are **inverted**. v1 plans use short broad
+queries; replans must go *narrower*, not broader. The cornerstone-document
+section foreshadows this: the loop now hands you the running findings list
+so you can convert high-confidence claims into per-proposal follow-ups.
+
+**Mandatory drill-down procedure on every replan:**
+
+1. **Scan `findings` for 3–7 specific named subjects** — people, agencies,
+   rule numbers (e.g. *WOTUS*, *Schedule F*), bill numbers, named programs,
+   court cases, named proposals, named documents. Pick claims that are
+   inconclusive, partially supported, or sit in clusters where multiple
+   findings reference the same name.
+2. **For each named subject, emit one or more focused search tasks.** The
+   `sub_question` MUST mention the specific name verbatim (e.g.
+   `"What is the comment-period status of the WOTUS rulemaking?"`, not
+   `"What EPA rules are pending?"`). Prefer `site:`-scoped queries against
+   the connector roster from the **Connector routing** section above:
+   `site:federalregister.gov`, `site:courtlistener.com`,
+   `site:congress.gov`, `site:sec.gov`,
+   `site:projects.propublica.org/nonprofits`, `site:fec.gov`,
+   `site:lda.senate.gov`, `site:usaspending.gov` — when the subject's
+   shape matches the connector.
+3. **Forbidden in replans:** generic umbrella queries that retread v1's
+   territory. If the findings already name `WOTUS rulemaking` and
+   `Schedule F`, do **NOT** emit `Project 2025 EPA` or `Project 2025
+   federal civil service` — those are v1 queries. They re-skim ground
+   the prior searches already covered and waste fetches. Replans must
+   make the plan *narrower*, not just *deeper*.
+4. **Generic broadeners are still allowed sparingly** when the findings
+   surface a *new* angle the prior plan missed (e.g. a finding that names
+   an outside funder the v1 plan didn't query for). But every generic
+   query must be justified by a finding the prior plan didn't already
+   cover.
+
+#### Worked side-by-side: v1 plan vs v2 tactical_replan
+
+A v1 plan for *"Project 2025 implementation tracker"* runs department-level
+breadth queries:
+
+```yaml
+# v1 — broad, per-department coverage
+task_template:
+  - kind: web_search
+    payload:
+      query: "Project 2025 EPA"
+      sub_question: "What EPA-related Project 2025 proposals are surfacing?"
+  - kind: web_search
+    payload:
+      query: "Project 2025 HHS"
+      sub_question: "What HHS-related Project 2025 proposals are surfacing?"
+  - kind: web_search
+    payload:
+      query: "Project 2025 OPM"
+      sub_question: "What OPM-related Project 2025 proposals are surfacing?"
+```
+
+After v1 runs, `findings` carries claims like *"WOTUS rulemaking is in
+active comment period"*, *"Schedule F implementation pending OPM
+guidance"*, *"FDA mifepristone reversal challenged in 5th Circuit"*. The
+v2 **tactical_replan must NOT re-emit** `Project 2025 EPA`. Instead it
+drills into each named claim:
+
+```yaml
+# v2 tactical_replan — drilled into named findings
+task_template:
+  - kind: web_search
+    payload:
+      query: "site:federalregister.gov WOTUS rule comment period 2026"
+      sub_question: "Status and sponsors of the WOTUS rulemaking comment period."
+  - kind: web_search
+    payload:
+      query: "WOTUS rule industry comments NRDC"
+      sub_question: "Industry vs. environmental-group positions on the WOTUS rulemaking."
+  - kind: web_search
+    payload:
+      query: "Schedule F implementation timeline OPM guidance"
+      sub_question: "OPM implementation timeline for Schedule F civil-service reform."
+  - kind: web_search
+    payload:
+      query: "site:courtlistener.com mifepristone reversal 5th Circuit"
+      sub_question: "Court filings and docket movement on the FDA mifepristone reversal."
+  - kind: news_search
+    payload:
+      query: "mifepristone court ruling"
+      sub_question: "Recent news on the mifepristone reversal court challenges."
+```
+
+Notice: every `sub_question` in v2 names a specific subject from the
+findings (`WOTUS`, `Schedule F`, `mifepristone`). None of them retread the
+v1 per-department queries. This is what *narrower, not deeper* looks like.
+
 ## Concrete example
 
 For the goal "What does the public record show about Acme Corp's 2024 layoffs?":

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -16,6 +16,7 @@ from research_agent.llm.budgets import BudgetTracker
 from research_agent.llm.router import Router, load_models_config
 from research_agent.orchestrator import plan as plan_module
 from research_agent.orchestrator.plan import (
+    MAX_FINDINGS_FOR_REPLAN,
     MAX_PLAN_VERSIONS,
     MAX_RECENT_RESULTS_FOR_REPLAN,
     Plan,
@@ -716,6 +717,282 @@ def test_tactical_replan_does_not_emit_truncated_when_recent_empty(
         row = conn.execute(
             "SELECT COUNT(*) AS c FROM events"
             " WHERE job_id = ? AND kind = 'replan_truncated'",
+            (job.id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row["c"] == 0
+
+
+# ---------------------------------------------------------------------------
+# tactical_replan findings drill-down — issue #179
+# ---------------------------------------------------------------------------
+
+
+def _make_findings(
+    n: int,
+    *,
+    claim_template: str = "Finding {i} body text",
+    starting_id: int = 1,
+    source_ids_per_finding: int = 1,
+) -> list[dict[str, Any]]:
+    """Build ``n`` synthetic finding rows shaped like ``_load_all_findings``."""
+    out: list[dict[str, Any]] = []
+    for offset in range(n):
+        i = starting_id + offset
+        out.append(
+            {
+                "id": i,
+                "claim": claim_template.format(i=i),
+                "confidence": 0.7,
+                "source_ids": [
+                    f"src-{i}-{j}" for j in range(source_ids_per_finding)
+                ],
+                "tags": ["topic-a"],
+            }
+        )
+    return out
+
+
+def test_tactical_replan_includes_findings_in_payload(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """Issue #179: ``tactical_replan`` must ship ``findings`` in the planner payload.
+
+    Without findings in the payload, the planner has no way to drill into
+    named claims and just re-emits umbrella queries.
+    """
+    router, calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    findings = _make_findings(
+        5,
+        claim_template="Schedule F implementation note {i}",
+    )
+    _StubAgent.next_plan = _sample_plan(version=2)
+    asyncio.run(
+        tactical_replan(job, v1, [], router=router, findings=findings),
+    )
+
+    args = calls[1][2]
+    payload = json.loads(args[0])
+    assert "findings" in payload
+    sent = payload["findings"]
+    assert len(sent) == 5
+    for entry in sent:
+        assert "id" in entry
+        assert "claim" in entry
+        assert "tags" in entry
+        assert "source_id" in entry
+    assert sent[0]["claim"] == "Schedule F implementation note 1"
+
+
+def test_tactical_replan_drills_into_named_findings(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """End-to-end wiring: a stub planner drilling into 5 named subjects must surface
+    at least 3 of those names verbatim in the resulting plan's task queries.
+
+    This exercises the orchestrator wiring (findings reach the planner; the
+    planner's tasks land in the persisted plan). The actual prompt-driven
+    drill-down behavior is exercised at runtime where a real LLM reads the
+    drill-down rule in ``planner.md``.
+    """
+    router, _calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    named_subjects = [
+        "Schedule F",
+        "WOTUS rule",
+        "mifepristone reversal",
+        "IRS workforce",
+        "FDA Title X",
+    ]
+    findings: list[dict[str, Any]] = []
+    fid = 1
+    for subject in named_subjects:
+        for variant_idx in range(3):
+            findings.append(
+                {
+                    "id": fid,
+                    "claim": (
+                        f"{subject} update {variant_idx}: implementation status "
+                        "is partially supported by recent reporting."
+                    ),
+                    "confidence": 0.6,
+                    "source_ids": [f"src-{fid}"],
+                    "tags": [subject],
+                }
+            )
+            fid += 1
+    assert len(findings) == 15
+
+    drilled_plan = Plan(
+        version=2,
+        objective="Drill into named findings.",
+        scope_class="broad",
+        subgoals=[
+            Subgoal(id=1, description="Drill into named claims from prior findings."),
+        ],
+        task_template=[
+            TaskSpec(
+                kind="web_search",
+                payload={
+                    "query": "Schedule F implementation timeline OPM guidance",
+                    "sub_question": "What is the Schedule F rollout timeline?",
+                },
+            ),
+            TaskSpec(
+                kind="web_search",
+                payload={
+                    "query": "site:federalregister.gov WOTUS rule comment period",
+                    "sub_question": "Comment-period status of the WOTUS rule.",
+                },
+            ),
+            TaskSpec(
+                kind="news_search",
+                payload={
+                    "query": "mifepristone reversal court ruling",
+                    "sub_question": "Recent court filings on the mifepristone reversal.",
+                },
+            ),
+            TaskSpec(
+                kind="web_search",
+                payload={
+                    "query": "IRS workforce downsizing 2026",
+                    "sub_question": "IRS staffing cuts and downsizing actions.",
+                },
+            ),
+        ],
+        expected_iterations=2,
+    )
+    _StubAgent.next_plan = drilled_plan
+
+    v2 = asyncio.run(
+        tactical_replan(job, v1, [], router=router, findings=findings),
+    )
+
+    queries = [
+        str(t.payload.get("query", "")) for t in v2.task_template
+    ]
+    sub_questions = [
+        str(t.payload.get("sub_question", "")) for t in v2.task_template
+    ]
+    haystack = " || ".join(queries + sub_questions).lower()
+
+    matched = [s for s in named_subjects if s.lower() in haystack]
+    assert len(matched) >= 3, (
+        f"expected at least 3 named subjects to appear verbatim in v2 task "
+        f"queries/sub_questions; got {matched} from {named_subjects}"
+    )
+
+
+def test_tactical_replan_truncates_findings_to_max(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """200 findings → payload caps at MAX_FINDINGS_FOR_REPLAN, event emitted."""
+    router, calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    findings = _make_findings(200)
+    _StubAgent.next_plan = _sample_plan(version=2)
+    asyncio.run(
+        tactical_replan(job, v1, [], router=router, findings=findings),
+    )
+
+    args = calls[1][2]
+    payload = json.loads(args[0])
+    sent = payload["findings"]
+    assert len(sent) == MAX_FINDINGS_FOR_REPLAN == 60
+    # Highest-ID findings (most recent) survive, re-ordered ascending.
+    sent_ids = [e["id"] for e in sent]
+    assert sent_ids == sorted(sent_ids)
+    assert sent_ids[0] == 200 - MAX_FINDINGS_FOR_REPLAN + 1  # 141
+    assert sent_ids[-1] == 200
+
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT level, payload_json FROM events"
+            " WHERE job_id = ? AND kind = 'findings_truncated'"
+            " ORDER BY id ASC",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    assert rows[0]["level"] == "WARN"
+    event_payload = json.loads(rows[0]["payload_json"])
+    assert event_payload["before"] == 200
+    assert event_payload["after"] == MAX_FINDINGS_FOR_REPLAN
+    assert event_payload["compressed"] is True
+
+
+def test_tactical_replan_compresses_finding_source_ids(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """A finding with 50 source_ids ships as a single ``source_id``, not a list."""
+    router, calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    findings = [
+        {
+            "id": 7,
+            "claim": "Schedule F restructures civil service.",
+            "confidence": 0.9,
+            "source_ids": [f"src-{j}" for j in range(50)],
+            "tags": ["civil-service"],
+        }
+    ]
+    _StubAgent.next_plan = _sample_plan(version=2)
+    asyncio.run(
+        tactical_replan(job, v1, [], router=router, findings=findings),
+    )
+
+    args = calls[1][2]
+    payload = json.loads(args[0])
+    sent = payload["findings"]
+    assert len(sent) == 1
+    entry = sent[0]
+    assert "source_ids" not in entry
+    assert "source_id" in entry
+    assert entry["source_id"] == "src-0"
+    assert isinstance(entry["source_id"], str)
+
+
+def test_tactical_replan_does_not_emit_findings_truncated_when_under_cap(
+    job: Job,
+    db_path: Path,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    """Under-cap findings: no truncation event, payload carries them all."""
+    router, _calls = router_with_spy
+    _StubAgent.next_plan = _sample_plan()
+    v1 = asyncio.run(initial_plan(job, router=router))
+
+    findings = _make_findings(MAX_FINDINGS_FOR_REPLAN)  # exactly at the cap
+    _StubAgent.next_plan = _sample_plan(version=2)
+    asyncio.run(
+        tactical_replan(job, v1, [], router=router, findings=findings),
+    )
+
+    conn = db.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) AS c FROM events"
+            " WHERE job_id = ? AND kind = 'findings_truncated'",
             (job.id,),
         ).fetchone()
     finally:


### PR DESCRIPTION
Closes #179
Part of #180

## Summary

Automated implementation of **fix: tactical_replan emits generic searches; should drill into named claims from prior findings**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

All acceptance criteria met: drill-down rule + v1/v2 example in planner.md, findings shipped to tactical_replan with bounded compression, 4 new tests cover wiring/cap/compression. 82 plan+loop tests pass.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*