### PR TITLE
feat: feat: extend TaskKind with connector-specific kinds (congress_search, fec_search, etc.) (closes #175)

### DIFF
--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -99,8 +99,11 @@ async def _not_implemented_handler(job: Job, task: dict[str, Any]) -> dict[str, 
 # API. Search payloads pass ``query`` plus any of these well-known kwargs
 # through to the underlying ``search()`` call — most connectors take a
 # ``kind`` switch (e.g. congress: bill/member/hearing) and a few take
-# ``state``/``since``/``form_type``. Unknown payload keys are ignored so
-# planner drift doesn't break the call.
+# ``state``/``since``/``form_type``. The set is the *union* across all
+# connectors; ``_filter_kwargs_for`` then narrows to what each connector
+# actually accepts, so planner drift (e.g. emitting ``kind`` for
+# ``edgar_search``, which takes ``form_type`` instead) doesn't surface as
+# a TypeError that bypasses the documented FatalError path.
 _CONNECTOR_SEARCH_PASSTHROUGH: frozenset[str] = frozenset(
     {
         "kind",
@@ -114,6 +117,40 @@ _CONNECTOR_SEARCH_PASSTHROUGH: frozenset[str] = frozenset(
         "language",
     }
 )
+
+
+def _filter_kwargs_for(fn: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Drop kwargs the callable doesn't accept.
+
+    Connectors have heterogeneous signatures — congress takes ``kind``,
+    edgar takes ``form_type``, fedregister takes ``since``/``agencies``.
+    The handler's passthrough whitelist is the union; this narrows it to
+    what ``fn`` actually accepts so a planner-drift kwarg like ``kind``
+    on ``edgar_search`` is silently dropped instead of crashing the call.
+    Falls back to the unfiltered dict when introspection fails (e.g.
+    C-implemented or wrapped callables).
+    """
+    import inspect
+
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return kwargs
+    accepts_var_kw = any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+    )
+    if accepts_var_kw:
+        return kwargs
+    accepted = {
+        name
+        for name, p in sig.parameters.items()
+        if p.kind
+        in (
+            inspect.Parameter.KEYWORD_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    }
+    return {k: v for k, v in kwargs.items() if k in accepted}
 
 
 def _make_connector_search_handler(module_name: str) -> Handler:
@@ -135,6 +172,7 @@ def _make_connector_search_handler(module_name: str) -> Handler:
         kwargs = {
             k: v for k, v in payload.items() if k in _CONNECTOR_SEARCH_PASSTHROUGH
         }
+        kwargs = _filter_kwargs_for(mod.search, kwargs)
         try:
             results = await mod.search(payload.get("query", ""), **kwargs)
         except RuntimeError as exc:

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -95,6 +95,99 @@ async def _not_implemented_handler(job: Job, task: dict[str, Any]) -> dict[str, 
     raise FatalError(f"handler not implemented for kind={task['kind']!r}")
 
 
+# Issue #175: connector kinds dispatch directly to each tool's structured
+# API. Search payloads pass ``query`` plus any of these well-known kwargs
+# through to the underlying ``search()`` call — most connectors take a
+# ``kind`` switch (e.g. congress: bill/member/hearing) and a few take
+# ``state``/``since``/``form_type``. Unknown payload keys are ignored so
+# planner drift doesn't break the call.
+_CONNECTOR_SEARCH_PASSTHROUGH: frozenset[str] = frozenset(
+    {
+        "kind",
+        "max_results",
+        "state",
+        "form_type",
+        "since",
+        "agencies",
+        "jurisdiction",
+        "award_type",
+        "language",
+    }
+)
+
+
+def _make_connector_search_handler(module_name: str) -> Handler:
+    """Build a thin search-handler that dispatches to ``tools.<module_name>.search``.
+
+    Converts the connector's missing-credential ``RuntimeError`` (raised by
+    edgar/courtlistener/scholar/linkedin when their API key/UA isn't
+    configured) into :class:`FatalError` so the loop marks the task failed
+    cleanly down the documented path. Returns the standard search-result
+    + ``follow_up_tasks`` shape so each top hit becomes a connector-aware
+    ``web_fetch`` follow-up.
+    """
+
+    async def _handler(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        from importlib import import_module
+
+        mod = import_module(f"research_agent.tools.{module_name}")
+        payload = task["payload"]
+        kwargs = {
+            k: v for k, v in payload.items() if k in _CONNECTOR_SEARCH_PASSTHROUGH
+        }
+        try:
+            results = await mod.search(payload.get("query", ""), **kwargs)
+        except RuntimeError as exc:
+            raise FatalError(f"{module_name}_search: {exc}") from exc
+        return _expand_search_to_fetches(job, payload, results)
+
+    return _handler
+
+
+def _make_connector_fetch_handler(module_name: str) -> Handler:
+    """Build a thin fetch-handler that dispatches to ``tools.<module_name>.fetch``.
+
+    Mirrors :func:`_make_connector_search_handler` but for the single-URL
+    fetch path: persists the returned ``Source`` and converts the
+    connector's missing-credential ``RuntimeError`` to :class:`FatalError`.
+    """
+
+    async def _handler(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        from importlib import import_module
+
+        mod = import_module(f"research_agent.tools.{module_name}")
+        payload = task["payload"]
+        try:
+            source = await mod.fetch(payload["url"])
+        except RuntimeError as exc:
+            raise FatalError(f"{module_name}_fetch: {exc}") from exc
+        return _persist_fetched_source(job, source)
+
+    return _handler
+
+
+_CONNECTOR_KINDS: tuple[str, ...] = (
+    "congress",
+    "fec",
+    "edgar",
+    "courtlistener",
+    "fedregister",
+    "lda",
+    "usaspending",
+    "gdelt",
+    "littlesis",
+    "nonprofits",
+    "opencorporates",
+    "sanctions",
+    "bbb",
+    "licensing",
+    "sos",
+    "calaccess",
+    "scholar",
+    "linkedin",
+)
+
+
 def default_handlers(router: Any) -> dict[str, Handler]:
     """Build the standard ``kind → handler`` registry.
 
@@ -240,7 +333,7 @@ def default_handlers(router: Any) -> dict[str, Handler]:
             )
         return result.model_dump()
 
-    return {
+    registry: dict[str, Handler] = {
         "web_search": _web_search,
         "web_fetch": _web_fetch,
         "arxiv_search": _arxiv_search,
@@ -255,6 +348,10 @@ def default_handlers(router: Any) -> dict[str, Handler]:
         "synthesize": _synthesize,
         "critique": _critique,
     }
+    for name in _CONNECTOR_KINDS:
+        registry[f"{name}_search"] = _make_connector_search_handler(name)
+        registry[f"{name}_fetch"] = _make_connector_fetch_handler(name)
+    return registry
 
 
 # ---------------------------------------------------------------------------

--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -58,6 +58,47 @@ TaskKind = Literal[
     "summarize_source",
     "synthesize",
     "critique",
+    # Issue #175: connector-specific kinds dispatch directly to each
+    # tool's structured-API call (one round trip, JSON in / claims out)
+    # instead of routing through Brave + trafilatura. Each *_search emits
+    # ``web_fetch`` follow-ups via ``_expand_search_to_fetches``; each
+    # *_fetch persists a single source like ``arxiv_fetch``.
+    "congress_search",
+    "congress_fetch",
+    "fec_search",
+    "fec_fetch",
+    "edgar_search",
+    "edgar_fetch",
+    "courtlistener_search",
+    "courtlistener_fetch",
+    "fedregister_search",
+    "fedregister_fetch",
+    "lda_search",
+    "lda_fetch",
+    "usaspending_search",
+    "usaspending_fetch",
+    "gdelt_search",
+    "gdelt_fetch",
+    "littlesis_search",
+    "littlesis_fetch",
+    "nonprofits_search",
+    "nonprofits_fetch",
+    "opencorporates_search",
+    "opencorporates_fetch",
+    "sanctions_search",
+    "sanctions_fetch",
+    "bbb_search",
+    "bbb_fetch",
+    "licensing_search",
+    "licensing_fetch",
+    "sos_search",
+    "sos_fetch",
+    "calaccess_search",
+    "calaccess_fetch",
+    "scholar_search",
+    "scholar_fetch",
+    "linkedin_search",
+    "linkedin_fetch",
 ]
 
 ScopeClass = Literal["narrow", "medium", "broad", "comprehensive"]

--- a/src/research_agent/prompts/planner.md
+++ b/src/research_agent/prompts/planner.md
@@ -34,10 +34,16 @@ the schema below.
 - `task_template`: ordered list of tasks the loop will run. Each task:
   - `kind`: one of these EXACT strings (no others allowed):
     `web_search`, `news_search`, `reddit_search`, `arxiv_search`,
-    `local_corpus_query`. **One narrow exception: `web_fetch` is allowed
-    only as the cornerstone-document fetch — see the "Cornerstone-document
-    pattern" section below.**
-    Do **not** emit any other kind. `extract_findings`,
+    `local_corpus_query`, plus the **direct connector kinds**:
+    `congress_search`, `fec_search`, `edgar_search`,
+    `courtlistener_search`, `fedregister_search`, `lda_search`,
+    `usaspending_search`, `gdelt_search`, `littlesis_search`,
+    `nonprofits_search`, `opencorporates_search`, `sanctions_search`,
+    `bbb_search`, `licensing_search`, `sos_search`, `calaccess_search`,
+    `scholar_search`, `linkedin_search`. **One narrow exception:
+    `web_fetch` is allowed only as the cornerstone-document fetch — see
+    the "Cornerstone-document pattern" section below.**
+    Do **not** emit any other kind. `*_fetch`, `extract_findings`,
     `summarize_source`, `synthesize`, and `critique` are valid in the
     schema but MUST NOT appear in your plan — the loop creates them
     automatically.
@@ -58,8 +64,9 @@ the schema below.
 
 You only plan the **search** layer. For each sub-question, emit one or
 more search tasks (`web_search`, `news_search`, `reddit_search`,
-`arxiv_search`, or `local_corpus_query`) with a `sub_question` field in
-the payload. The loop will then:
+`arxiv_search`, `local_corpus_query`, or one of the **direct connector
+kinds** below) with a `sub_question` field in the payload. The loop will
+then:
 
 1. Run your search → get real URLs
 2. Automatically enqueue `web_fetch` for the top hits
@@ -67,8 +74,8 @@ the payload. The loop will then:
    real source rowid + your `sub_question`
 4. Synthesis and critique fire on their own cadence
 
-You do NOT enqueue `web_fetch`, `extract_findings`, `summarize_source`,
-`synthesize`, or `critique`. Trust the loop.
+You do NOT enqueue `web_fetch`, `*_fetch`, `extract_findings`,
+`summarize_source`, `synthesize`, or `critique`. Trust the loop.
 
 ### Query-writing rules — critical
 
@@ -108,35 +115,78 @@ classification, and disciplinary history — before generic web hits.
 The `licensing` connector takes over from there once the URL is in
 hand; the planner only needs to seed the discovery query.
 
-### Connector routing — use `site:` operators to reach authoritative APIs
+### Connector routing — prefer direct connector kinds over `site:`-scoped web search
 
-`web_fetch` host-dispatches the domains below to dedicated connector
-modules — a `site:<domain>` query is the path to the API. Plain
-`web_search` queries hit Brave's general index and miss these
-authoritative sources entirely; many of them are not even crawlable
-without the right URL shape. **Mix `site:`-scoped queries into broad /
-comprehensive plans whenever a subgoal asks about federal records,
-lobbying, campaign finance, court filings, nonprofits, sanctions, or
-licensing** — those signals only show up when the planner names the
-domain.
+For every authoritative source below there are now **two ways** to reach
+it: a direct connector kind that calls the source's structured API, and
+a `site:`-scoped `web_search` fallback that goes through Brave +
+trafilatura. **Prefer the direct connector kind whenever the subject
+matches its domain** — one round trip, structured JSON in (sponsor,
+latest action, vote results, filing metadata, …), no HTML extraction
+loss. `web_search` with a `site:` operator is the documented fallback
+when no direct kind covers the case (or the connector's API key isn't
+configured in this environment).
 
-| Domain | What's there | Example query |
+> Example: prefer `congress_search` with `query: "Inflation Reduction
+> Act"` over `web_search` with `query: "site:congress.gov Inflation
+> Reduction Act"`. The Congress.gov API returns structured sponsor /
+> action / vote JSON in a single round trip; the `site:`-scoped path
+> needs Brave → fetch → trafilatura, drops fields, and may miss recent
+> records that aren't in Brave's index yet.
+
+#### Direct connector kinds
+
+Each kind dispatches to a dedicated `tools/<name>.py` module. Payload
+shape is `{ query: "…", sub_question: "…" }`; a few connectors take
+optional `kind`, `state`, `since`, or `max_results` knobs (noted
+below). The loop turns top hits into `web_fetch` follow-ups exactly as
+it does for `web_search`.
+
+| Kind | What it covers | Optional payload knobs | Example query |
+|---|---|---|---|
+| `congress_search` | Bills, members, committees, hearings, congressional record (Congress.gov v3 API) | `kind: bill\|member\|committee\|hearing\|congressional-record` | `"Inflation Reduction Act"` |
+| `fec_search` | Candidates, committees, schedule A/E filings (OpenFEC) | `kind: candidates\|committees\|schedules/schedule_a\|schedules/schedule_e` | `"Trump 2024" committee` |
+| `edgar_search` | SEC filings (10-K, 10-Q, 8-K, Form 4) — requires `RESEARCH_USER_AGENT` w/ contact email | `form_type: 10-K\|8-K\|...` | `"Cisco" cybersecurity` |
+| `courtlistener_search` | Federal & state court opinions, dockets (RECAP), oral arguments — requires `COURTLISTENER_API_TOKEN` | `kind: opinions\|dockets\|oral_arguments` | `"Schedule F" appellate` |
+| `fedregister_search` | Federal Register rules, proposed rules, agency notices since 1994 (no auth) | `since: YYYY-MM-DD`, `agencies: [...]` | `"Schedule F"` |
+| `lda_search` | Senate Lobbying Disclosure Act filings (registrants, contributions) | `kind: filings\|registrants\|contributions` | `"Heritage Foundation"` |
+| `usaspending_search` | Federal contracts, grants, loans (award-level detail, no auth) | `award_type: contracts\|grants\|loans` | `"Heritage Foundation" contract` |
+| `gdelt_search` | GDELT — Global news event aggregator, no `site:` operator (no auth) | `since: YYYY-MM-DD`, `language: english` | `Project 2025 mainstream coverage` |
+| `littlesis_search` | Power-mapping database — entities, donations, board seats, family ties (lead, not evidence) | `kind: entities\|relationships` | `"Peter Thiel"` |
+| `nonprofits_search` | ProPublica Nonprofit Explorer (Form 990 filings, no auth) | — | `"Heritage Foundation"` |
+| `opencorporates_search` | Global company registry — requires `OPENCORPORATES_API_KEY` | `jurisdiction: us_ca\|gb\|...` | `"Acme Holdings"` |
+| `sanctions_search` | OFAC SDN + UK sanctions lists (local index, no auth) | — | `"Wagner Group"` |
+| `bbb_search` | Better Business Bureau profiles + ratings (Playwright, no auth) | — | `"SBI Builders"` |
+| `licensing_search` | State contractor / licensing-board lookups (Playwright; CA wired, others stubs) | `state: CA\|TX\|FL\|NY` | `"SBI Builders"` |
+| `sos_search` | State Secretary-of-State business entity filings (Playwright; CA wired, others stubs) | `state: CA\|DE\|NV\|...` | `"Acme Corp"` |
+| `calaccess_search` | California Cal-Access campaign finance (Playwright) | `kind: contributions\|independent_expenditures` | `"Newsom"` |
+| `scholar_search` | Google Scholar via SerpAPI — requires `SERPAPI_KEY` | `kind: case_law\|articles` | `"Section 230" appellate` |
+| `linkedin_search` | LinkedIn person/company lookup via Proxycurl or Lix — requires broker key | `kind: person\|company` | `"Sundar Pichai"` |
+
+#### `site:`-scoped fallback (when a direct kind doesn't apply)
+
+If no direct kind matches the subject, or you know the connector's API
+key isn't configured in this environment, fall back to `web_search`
+with a `site:` operator targeting the authoritative domain. The
+`web_fetch` host-dispatcher will still route those URLs to the right
+connector module on the fetch side.
+
+| Domain | Direct kind | Example fallback query |
 |---|---|---|
-| `site:sec.gov` | SEC EDGAR filings (10-K, 10-Q, 8-K, Form 4 insider trades) | `site:sec.gov "Cisco" 8-K cybersecurity` |
-| `site:courtlistener.com` | Federal & state court opinions, dockets (RECAP), oral arguments | `site:courtlistener.com "Schedule F" appellate` |
-| `site:federalregister.gov` | Federal Register rules, proposed rules, agency notices since 1994 | `site:federalregister.gov "Schedule F"` |
-| `site:projects.propublica.org/nonprofits` | ProPublica Nonprofit Explorer (Form 990 filings) | `site:projects.propublica.org/nonprofits "Heritage Foundation"` |
-| `site:fec.gov` | FEC candidate / committee filings, contributions, expenditures | `site:fec.gov "Trump 2024" committee` |
-| `site:congress.gov` | Bills, members, committees, hearings, congressional record | `site:congress.gov "Project 2025"` |
-| `site:lda.senate.gov` | Senate Lobbying Disclosure Act filings (legacy host; `lda.gov` also routes) | `site:lda.senate.gov "Heritage Foundation"` |
-| `site:usaspending.gov` | Federal contracts, grants, loans (award-level detail) | `site:usaspending.gov "Heritage Foundation" contract` |
-| GDELT | Global news event aggregator — **no `site:` operator**; emit a plain `web_search` query and the GDELT connector indexes from there | `Project 2025 mainstream coverage` |
-| `site:littlesis.org` | Power-mapping database — entities, donations, board seats, family ties (lead, not evidence) | `site:littlesis.org "Peter Thiel"` |
-| `site:treasury.gov sanctions` | OFAC sanctions list (SDN, sectoral, country programs) | `site:treasury.gov sanctions "Wagner Group"` |
-| `site:powersearch.sos.ca.gov` | California Cal-Access campaign finance (donors, committees, IEs) | `site:powersearch.sos.ca.gov "Newsom"` |
-| `site:cslb.ca.gov` | California Contractors State License Board profiles, disciplinary history | `site:cslb.ca.gov "SBI Builders"` |
-| `site:bizfileonline.sos.ca.gov` | California Secretary of State business entity filings | `site:bizfileonline.sos.ca.gov "Acme Corp"` |
-| `site:bbb.org` | Better Business Bureau profiles, ratings, complaint counts | `site:bbb.org "SBI Builders"` |
+| `site:sec.gov` | `edgar_search` | `site:sec.gov "Cisco" 8-K cybersecurity` |
+| `site:courtlistener.com` | `courtlistener_search` | `site:courtlistener.com "Schedule F" appellate` |
+| `site:federalregister.gov` | `fedregister_search` | `site:federalregister.gov "Schedule F"` |
+| `site:projects.propublica.org/nonprofits` | `nonprofits_search` | `site:projects.propublica.org/nonprofits "Heritage Foundation"` |
+| `site:fec.gov` | `fec_search` | `site:fec.gov "Trump 2024" committee` |
+| `site:congress.gov` | `congress_search` | `site:congress.gov "Project 2025"` |
+| `site:lda.senate.gov` | `lda_search` | `site:lda.senate.gov "Heritage Foundation"` |
+| `site:usaspending.gov` | `usaspending_search` | `site:usaspending.gov "Heritage Foundation" contract` |
+| `site:littlesis.org` | `littlesis_search` | `site:littlesis.org "Peter Thiel"` |
+| `site:treasury.gov sanctions` | `sanctions_search` | `site:treasury.gov sanctions "Wagner Group"` |
+| `site:powersearch.sos.ca.gov` | `calaccess_search` | `site:powersearch.sos.ca.gov "Newsom"` |
+| `site:cslb.ca.gov` | `licensing_search` (state: CA) | `site:cslb.ca.gov "SBI Builders"` |
+| `site:bizfileonline.sos.ca.gov` | `sos_search` (state: CA) | `site:bizfileonline.sos.ca.gov "Acme Corp"` |
+| `site:bbb.org` | `bbb_search` | `site:bbb.org "SBI Builders"` |
 
 ### Payload shapes
 
@@ -145,6 +195,7 @@ domain.
 - `reddit_search`: `{ query: "…", sub_question: "…" }`
 - `arxiv_search`: `{ query: "…", sub_question: "…", max_results: 10 }`
 - `local_corpus_query`: `{ query: "…", sub_question: "…", top_k: 10 }`
+- direct connector kinds (`congress_search`, `fec_search`, `edgar_search`, `courtlistener_search`, `fedregister_search`, `lda_search`, `usaspending_search`, `gdelt_search`, `littlesis_search`, `nonprofits_search`, `opencorporates_search`, `sanctions_search`, `bbb_search`, `licensing_search`, `sos_search`, `calaccess_search`, `scholar_search`, `linkedin_search`): `{ query: "…", sub_question: "…" }` plus the optional knobs noted in the **Direct connector kinds** table above (e.g. `kind`, `state`, `since`, `max_results`).
 
 ### When to use each search
 
@@ -280,13 +331,13 @@ so you can convert high-confidence claims into per-proposal follow-ups.
 2. **For each named subject, emit one or more focused search tasks.** The
    `sub_question` MUST mention the specific name verbatim (e.g.
    `"What is the comment-period status of the WOTUS rulemaking?"`, not
-   `"What EPA rules are pending?"`). Prefer `site:`-scoped queries against
-   the connector roster from the **Connector routing** section above:
-   `site:federalregister.gov`, `site:courtlistener.com`,
-   `site:congress.gov`, `site:sec.gov`,
-   `site:projects.propublica.org/nonprofits`, `site:fec.gov`,
-   `site:lda.senate.gov`, `site:usaspending.gov` — when the subject's
-   shape matches the connector.
+   `"What EPA rules are pending?"`). Prefer the **direct connector kind**
+   when one matches the subject's shape (e.g. `fedregister_search`,
+   `courtlistener_search`, `congress_search`, `edgar_search`,
+   `nonprofits_search`, `fec_search`, `lda_search`, `usaspending_search`,
+   `littlesis_search`, `sanctions_search`) — one round trip, structured
+   JSON. Fall back to `site:`-scoped `web_search` only when no direct
+   kind covers the case.
 3. **Forbidden in replans:** generic umbrella queries that retread v1's
    territory. If the findings already name `WOTUS rulemaking` and
    `Schedule F`, do **NOT** emit `Project 2025 EPA` or `Project 2025
@@ -491,7 +542,13 @@ or by sub-policy is `broad` or `comprehensive`.
 
 - Output ONLY the fenced YAML block. No prose, no preamble, no postscript.
 - Every `kind` MUST be one of: `web_search`, `news_search`, `reddit_search`,
-  `arxiv_search`, `local_corpus_query`. The single exception is
+  `arxiv_search`, `local_corpus_query`, or one of the direct connector
+  kinds (`congress_search`, `fec_search`, `edgar_search`,
+  `courtlistener_search`, `fedregister_search`, `lda_search`,
+  `usaspending_search`, `gdelt_search`, `littlesis_search`,
+  `nonprofits_search`, `opencorporates_search`, `sanctions_search`,
+  `bbb_search`, `licensing_search`, `sos_search`, `calaccess_search`,
+  `scholar_search`, `linkedin_search`). The single exception is
   `web_fetch`, allowed only as the cornerstone-document fetch when
   `cornerstone_url` is also set — see the **Cornerstone-document
   pattern** section.

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -592,6 +592,56 @@ async def test_connector_fetch_handler_wraps_runtime_error_as_fatal(
 
 
 @pytest.mark.asyncio
+async def test_connector_search_handler_drops_kwargs_connector_does_not_accept(
+    job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Planner drift: a passthrough kwarg the target connector doesn't accept
+    must be dropped, not raised as a TypeError that bypasses the documented
+    FatalError path. ``edgar.search`` takes ``form_type`` (not ``kind``); a
+    plan that emits ``kind`` for ``edgar_search`` must still produce a clean
+    call rather than crashing.
+    """
+    from research_agent.tools import edgar
+
+    captured: dict[str, Any] = {}
+
+    async def fake_search(
+        query: str,
+        *,
+        form_type: Any = None,
+        max_results: int = 20,
+        timeout: float = 15.0,
+    ) -> list[SearchResult]:
+        captured["query"] = query
+        captured["form_type"] = form_type
+        captured["max_results"] = max_results
+        return []
+
+    monkeypatch.setattr(edgar, "search", fake_search)
+
+    handler = default_handlers(router=None)["edgar_search"]
+    out = await handler(
+        job,
+        {
+            "kind": "edgar_search",
+            "payload": {
+                "query": "cybersecurity",
+                "kind": "should-be-dropped",  # edgar takes form_type, not kind
+                "form_type": "8-K",
+                "max_results": 5,
+            },
+        },
+    )
+    assert captured == {
+        "query": "cybersecurity",
+        "form_type": "8-K",
+        "max_results": 5,
+    }
+    assert isinstance(out, dict)
+    assert out["results"] == []
+
+
+@pytest.mark.asyncio
 async def test_run_loop_loads_plan_from_db_when_not_provided(
     job: Job, db_path: Path, plan: Plan
 ) -> None:

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -368,6 +368,33 @@ def test_module_constants_match_spec() -> None:
     assert RETRY_MAX_ATTEMPTS == 5
 
 
+CONNECTOR_KIND_PREFIXES: tuple[str, ...] = (
+    "congress",
+    "fec",
+    "edgar",
+    "courtlistener",
+    "fedregister",
+    "lda",
+    "usaspending",
+    "gdelt",
+    "littlesis",
+    "nonprofits",
+    "opencorporates",
+    "sanctions",
+    "bbb",
+    "licensing",
+    "sos",
+    "calaccess",
+    "scholar",
+    "linkedin",
+)
+
+# Connector module name → ``source_kind`` Literal value. Most connectors
+# match by name; ``edgar`` is the SEC connector so its source_kind is "sec".
+_CONNECTOR_SOURCE_KIND: dict[str, str] = {p: p for p in CONNECTOR_KIND_PREFIXES}
+_CONNECTOR_SOURCE_KIND["edgar"] = "sec"
+
+
 def test_default_handlers_covers_every_task_kind() -> None:
     handlers = default_handlers(router=None)
     expected = {
@@ -385,6 +412,9 @@ def test_default_handlers_covers_every_task_kind() -> None:
         "synthesize",
         "critique",
     }
+    for prefix in CONNECTOR_KIND_PREFIXES:
+        expected.add(f"{prefix}_search")
+        expected.add(f"{prefix}_fetch")
     assert set(handlers.keys()) == expected
 
 
@@ -407,6 +437,158 @@ async def test_default_not_implemented_handler_raises_fatal(
     rows = _read_task_rows(db_path, job.id)
     assert rows[0]["status"] == STATUS_FAILED
     assert "not implemented" in (rows[0]["error"] or "")
+
+
+# ---------------------------------------------------------------------------
+# Issue #175: connector-specific kinds dispatch to tools.<name>.search()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", CONNECTOR_KIND_PREFIXES)
+async def test_connector_search_handler_dispatches_to_module(
+    job: Job, monkeypatch: pytest.MonkeyPatch, prefix: str
+) -> None:
+    """Each ``<prefix>_search`` handler must call ``tools.<prefix>.search`` and
+    expand top hits into ``web_fetch`` follow-ups via the standard helper.
+    """
+    import importlib
+
+    mod = importlib.import_module(f"research_agent.tools.{prefix}")
+    captured: dict[str, Any] = {}
+
+    sk = _CONNECTOR_SOURCE_KIND[prefix]
+
+    async def fake_search(query: str, **kwargs: Any) -> list[SearchResult]:
+        captured["query"] = query
+        captured["kwargs"] = kwargs
+        return [
+            SearchResult(
+                url=f"https://{prefix}.example/1",
+                title="Hit 1",
+                snippet="…",
+                source_kind=sk,  # type: ignore[arg-type]
+            ),
+            SearchResult(
+                url=f"https://{prefix}.example/2",
+                title="Hit 2",
+                snippet="…",
+                source_kind=sk,  # type: ignore[arg-type]
+            ),
+        ]
+
+    monkeypatch.setattr(mod, "search", fake_search)
+
+    handlers = default_handlers(router=None)
+    handler = handlers[f"{prefix}_search"]
+    out = await handler(
+        job,
+        {"kind": f"{prefix}_search", "payload": {"query": "needle", "kind": "x"}},
+    )
+
+    assert captured["query"] == "needle"
+    # ``kind`` is in the passthrough allowlist so it reaches the connector.
+    assert captured["kwargs"].get("kind") == "x"
+    assert isinstance(out, dict)
+    assert "results" in out
+    assert "follow_up_tasks" in out
+    assert len(out["results"]) == 2
+    follow_kinds = {f["kind"] for f in out["follow_up_tasks"]}
+    assert follow_kinds == {"web_fetch"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", CONNECTOR_KIND_PREFIXES)
+async def test_connector_fetch_handler_dispatches_to_module(
+    job: Job, monkeypatch: pytest.MonkeyPatch, prefix: str
+) -> None:
+    """Each ``<prefix>_fetch`` handler must call ``tools.<prefix>.fetch`` and
+    persist the returned :class:`Source` via the shared helper.
+    """
+    import importlib
+    from datetime import datetime, timezone
+
+    from research_agent.tools.models import Source
+
+    mod = importlib.import_module(f"research_agent.tools.{prefix}")
+    captured: dict[str, Any] = {}
+
+    sk = _CONNECTOR_SOURCE_KIND[prefix]
+
+    async def fake_fetch(url: str) -> Source:
+        captured["url"] = url
+        return Source(
+            url=url,
+            title="t",
+            cleaned_text="hello world",
+            fetched_at=datetime.now(tz=timezone.utc),
+            source_kind=sk,  # type: ignore[arg-type]
+        )
+
+    monkeypatch.setattr(mod, "fetch", fake_fetch)
+
+    handlers = default_handlers(router=None)
+    handler = handlers[f"{prefix}_fetch"]
+    out = await handler(
+        job,
+        {
+            "kind": f"{prefix}_fetch",
+            "payload": {"url": f"https://{prefix}.example/abc"},
+        },
+    )
+
+    assert captured["url"] == f"https://{prefix}.example/abc"
+    assert isinstance(out, dict)
+    assert "source_id" in out
+    assert isinstance(out["source_id"], int)
+
+
+@pytest.mark.asyncio
+async def test_connector_search_handler_wraps_runtime_error_as_fatal(
+    job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When a connector raises ``RuntimeError`` (its missing-credential path),
+    the handler must convert it to :class:`FatalError` so the loop marks the
+    task failed cleanly down the documented path rather than relying on the
+    daemon's catch-all guard.
+    """
+    from research_agent.tools import linkedin
+
+    async def fake_search(query: str, **kwargs: Any) -> list[SearchResult]:
+        raise RuntimeError(
+            "linkedin requires LINKEDIN_DATA_API_KEY (or LIX_API_KEY for lix broker)"
+        )
+
+    monkeypatch.setattr(linkedin, "search", fake_search)
+
+    handler = default_handlers(router=None)["linkedin_search"]
+    with pytest.raises(FatalError, match="LINKEDIN_DATA_API_KEY"):
+        await handler(
+            job, {"kind": "linkedin_search", "payload": {"query": "Sundar Pichai"}}
+        )
+
+
+@pytest.mark.asyncio
+async def test_connector_fetch_handler_wraps_runtime_error_as_fatal(
+    job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``<prefix>_fetch`` mirrors the search-side FatalError wrapping."""
+    from research_agent.tools import courtlistener
+
+    async def fake_fetch(url: str) -> Any:
+        raise RuntimeError("courtlistener requires COURTLISTENER_API_TOKEN")
+
+    monkeypatch.setattr(courtlistener, "fetch", fake_fetch)
+
+    handler = default_handlers(router=None)["courtlistener_fetch"]
+    with pytest.raises(FatalError, match="COURTLISTENER_API_TOKEN"):
+        await handler(
+            job,
+            {
+                "kind": "courtlistener_fetch",
+                "payload": {"url": "https://www.courtlistener.com/opinion/123/"},
+            },
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -42,6 +42,28 @@ ALL_SCOPE_CLASSES: tuple[str, ...] = get_args(ScopeClass)
 # ---------------------------------------------------------------------------
 
 
+CONNECTOR_KIND_PREFIXES: tuple[str, ...] = (
+    "congress",
+    "fec",
+    "edgar",
+    "courtlistener",
+    "fedregister",
+    "lda",
+    "usaspending",
+    "gdelt",
+    "littlesis",
+    "nonprofits",
+    "opencorporates",
+    "sanctions",
+    "bbb",
+    "licensing",
+    "sos",
+    "calaccess",
+    "scholar",
+    "linkedin",
+)
+
+
 def test_task_kind_covers_expected_set() -> None:
     expected = {
         "web_search",
@@ -58,7 +80,22 @@ def test_task_kind_covers_expected_set() -> None:
         "synthesize",
         "critique",
     }
+    for prefix in CONNECTOR_KIND_PREFIXES:
+        expected.add(f"{prefix}_search")
+        expected.add(f"{prefix}_fetch")
     assert set(ALL_TASK_KINDS) == expected
+
+
+@pytest.mark.parametrize("prefix", CONNECTOR_KIND_PREFIXES)
+def test_task_spec_accepts_connector_search_kind(prefix: str) -> None:
+    spec = TaskSpec(kind=f"{prefix}_search")  # type: ignore[arg-type]
+    assert spec.kind == f"{prefix}_search"
+
+
+@pytest.mark.parametrize("prefix", CONNECTOR_KIND_PREFIXES)
+def test_task_spec_accepts_connector_fetch_kind(prefix: str) -> None:
+    spec = TaskSpec(kind=f"{prefix}_fetch")  # type: ignore[arg-type]
+    assert spec.kind == f"{prefix}_fetch"
 
 
 @pytest.mark.parametrize("kind", ALL_TASK_KINDS)


### PR DESCRIPTION
Closes #175
Part of #180

## Summary

Automated implementation of **feat: extend TaskKind with connector-specific kinds (congress_search, fec_search, etc.)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Issue #175 implementation meets all acceptance criteria; fixed one robustness gap where planner-drift kwargs caused TypeError instead of going down the FatalError path.

- **WARNING** [FIXED] `src/research_agent/orchestrator/loop.py`: Connector search handler's passthrough whitelist is the union across all 18 connectors, but it was passed verbatim to each connector's search() — so a planner emitting a known passthrough key for the wrong connector (e.g. `kind` for `edgar_search`, which takes `form_type`) raised TypeError that bypassed the documented FatalError path. The loop's catch-all guard caught it but the implementation's own comment promise (`planner drift doesn't break the call`) wasn't honored. Fixed by adding `_filter_kwargs_for` that introspects each connector's signature with `inspect.signature` and drops kwargs the function doesn't accept. Added a regression test (`test_connector_search_handler_drops_kwargs_connector_does_not_accept`) using edgar_search with a stray `kind` kwarg.
- **INFO** [FIXED] `tests/test_orchestrator_loop.py`: Test gap (now closed by the fix above): the parametrized `test_connector_search_handler_dispatches_to_module` test passes `kind: "x"` to all 18 connectors with a fake_search that accepts `**kwargs`, so it didn't surface the type-mismatch issue for connectors that don't actually accept `kind` (edgar, fedregister, usaspending, gdelt, nonprofits, opencorporates, sanctions, bbb, licensing, sos). The new regression test for edgar covers this category.
- **INFO** [OPEN] `src/research_agent/orchestrator/loop.py`: `sanctions.search` takes `kinds` (plural list) for filtering by list_kind, but the passthrough whitelist contains `kind` (singular). Planner.md documents no optional knobs for sanctions_search, so this is currently a non-issue — flagging only because future planner.md guidance to filter by SDN/EU/UK lists would need either `kinds` added to the whitelist or a separate sanctions-specific knob.
- **INFO** [OPEN] `src/research_agent/tools/opencorporates.py`: `opencorporates.search` returns `[]` silently when `OPENCORPORATES_API_KEY` is unset rather than raising RuntimeError, so the handler's RuntimeError → FatalError conversion does not apply. Acceptance criteria are still met (the connector that needs a key handles its own missing-credential path) but the failure mode is `0 results` rather than `task failed`. This is a connector-level design choice and out of scope for #175.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*