### PR TITLE
Session: session/epic-195-epic-post-180-cleanup-smoke-regressions-and-depth-extension-follow-ups — 7/7 succeeded

### DIFF
--- a/.alpha-loop.yaml
+++ b/.alpha-loop.yaml
@@ -67,7 +67,7 @@ skip_install: true
 
 # CLI/daemon project, no UI to drive with Playwright. The Playwright UI stage
 # is bypassed; per-issue functional verification happens via `smoke_test` below.
-skip_verify: true
+# skip_verify: true
 
 # Post-pipeline smoke test runs after every issue completes. Three layers:
 #   1. CLI surface still parses (`research --help` returns 0)

--- a/config/url_blocklist.yaml
+++ b/config/url_blocklist.yaml
@@ -1,0 +1,25 @@
+# URL blocklist for second-order fan-out (issue #194).
+#
+# Hosts listed here are excluded from `_run_extract_findings`'s
+# auto-fan-out of `web_fetch` tasks for URLs cited inside extracted
+# findings. The match is a case-insensitive substring check against
+# the URL's hostname — so `twitter.com` blocks `mobile.twitter.com`,
+# `t.co/...` redirects we've already followed, and friends.
+#
+# Scope of this list:
+#   * Social-media surfaces that don't render meaningful content for
+#     the agent (auth wall, JS-heavy SPA, paywalled timelines).
+#   * Archive hosts that have their own connector (`archive`) and
+#     should not be fetched twice.
+#
+# This list is intentionally short. Anything that *should* be skipped
+# globally (login walls, paywalls, etc.) belongs in the per-site
+# fetch-layer handling, not here.
+- twitter.com
+- x.com
+- facebook.com
+- instagram.com
+- tiktok.com
+- linkedin.com
+- web.archive.org
+- archive.org

--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -59,6 +59,7 @@ EventKind = Literal[
     "pdf_vlm_escalation",
     "ocr_vlm_escalation",
     "cornerstone_extract",
+    "cornerstone_fallback_triggered",
     "error",
     "warning",
 ]

--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -60,6 +60,7 @@ EventKind = Literal[
     "ocr_vlm_escalation",
     "cornerstone_extract",
     "cornerstone_fallback_triggered",
+    "second_order_fanout",
     "error",
     "warning",
 ]

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -78,6 +78,37 @@ _DEFAULT_TOP_K_BY_SCOPE: dict[str, int] = {
 }
 _DEFAULT_TOP_K_FALLBACK = 3
 
+# Issue #194: how many ``web_fetch`` follow-ups ``_run_extract_findings``
+# may emit per extraction for URLs cited inside the findings it just wrote.
+# Mirrors the scope-class scaling pattern from #178: narrow runs do not
+# auto-fan-out at all (drill-downs at the planner level only), while
+# comprehensive runs ride citation chains aggressively.
+_SECOND_ORDER_MAX_BY_SCOPE: dict[str, int] = {
+    "narrow": 0,
+    "medium": 1,
+    "broad": 2,
+    "comprehensive": 3,
+}
+_SECOND_ORDER_MAX_FALLBACK = 1
+# Don't fan out from low-confidence findings — the agent's least-reliable
+# signal. ``>= 0.5`` is a starting threshold that the planner can override
+# per task via ``payload['second_order_confidence_threshold']``.
+_SECOND_ORDER_CONFIDENCE_THRESHOLD = 0.5
+# Hard cap per job across all extracts. Prevents pathological cases where
+# every fetched document carries dozens of cited URLs and the queue
+# explodes — the user can still get the planner to drill into specific
+# paths via ``tactical_replan`` once this budget is spent.
+_SECOND_ORDER_JOB_CAP = 200
+# URLs in fan-out candidates: match http/https plus a healthy slug of URL-
+# safe characters. Trailing punctuation (``.``, ``,``, ``)``, ``]``, ``}``,
+# ``>``, quotes) is stripped post-match by ``_normalize_url_for_fanout`` so
+# the regex itself stays readable.
+_URL_REGEX = re.compile(r"https?://[^\s)\]\}<>\"']+")
+# Marker key written into a follow-up task's payload so we can SQL-query
+# how many second-order tasks have already been emitted for the job (and
+# enforce the per-job cap).
+_SECOND_ORDER_PARENT_FINDING_ID_KEY = "second_order_parent_finding_id"
+
 Handler = Callable[[Job, dict[str, Any]], Awaitable[dict[str, Any] | None]]
 
 
@@ -848,6 +879,289 @@ def _build_bill_text_followup(
     )
 
 
+# ---------------------------------------------------------------------------
+# Issue #194: second-order URL fan-out from extracted findings
+# ---------------------------------------------------------------------------
+
+
+_BLOCKLIST_PATH_REL = "config/url_blocklist.yaml"
+_BLOCKLIST_CACHE: set[str] | None = None
+
+
+def _load_url_blocklist() -> set[str]:
+    """Read ``config/url_blocklist.yaml`` once; return host substrings.
+
+    The blocklist filters second-order ``web_fetch`` follow-ups so the
+    fan-out doesn't burn budget on social media surfaces, paywalled hosts,
+    or archive.org (which has its own connector). Match is host-substring,
+    case-insensitive, applied in :func:`_is_url_blocked`. Missing or
+    malformed file → empty set; we'd rather lose blocklist enforcement
+    than crash extraction.
+    """
+    global _BLOCKLIST_CACHE
+    if _BLOCKLIST_CACHE is not None:
+        return _BLOCKLIST_CACHE
+
+    from pathlib import Path
+
+    import yaml
+
+    # Walk upward from this module until we find a directory carrying both
+    # the blocklist and a ``pyproject.toml`` (the worktree root). The package
+    # is installed editable, so ``__file__`` always lives inside the project.
+    blocklist: set[str] = set()
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / _BLOCKLIST_PATH_REL
+        if (parent / "pyproject.toml").exists():
+            if candidate.exists():
+                try:
+                    data = yaml.safe_load(candidate.read_text(encoding="utf-8"))
+                except (OSError, yaml.YAMLError):
+                    data = None
+                if isinstance(data, list):
+                    for entry in data:
+                        if isinstance(entry, str) and entry.strip():
+                            blocklist.add(entry.strip().lower())
+            break
+
+    _BLOCKLIST_CACHE = blocklist
+    return _BLOCKLIST_CACHE
+
+
+def _normalize_url_for_fanout(url: str) -> str | None:
+    """Strip trailing punctuation + fragment, lowercase host. Return canonical or None.
+
+    Returns ``None`` for URLs that don't have an http/https scheme or that
+    parse to nonsense — those should never be treated as fan-out candidates.
+    Path/query are preserved as-is (no aggressive normalization that might
+    alias two genuinely different resources).
+    """
+    if not isinstance(url, str) or not url:
+        return None
+    trimmed = url.strip().rstrip(".,;:!?)\"'>]}")
+    if not trimmed:
+        return None
+    from urllib.parse import urlsplit, urlunsplit
+
+    try:
+        parts = urlsplit(trimmed)
+    except ValueError:
+        return None
+    scheme = (parts.scheme or "").lower()
+    if scheme not in ("http", "https"):
+        return None
+    host = parts.hostname or ""
+    if not host:
+        return None
+    netloc = host.lower()
+    if parts.port is not None:
+        netloc = f"{netloc}:{parts.port}"
+    return urlunsplit((scheme, netloc, parts.path, parts.query, ""))
+
+
+def _is_url_blocked(url: str, blocklist: set[str]) -> bool:
+    """Substring match against ``blocklist`` on the URL's hostname.
+
+    ``blocklist`` entries are lowercase host fragments (``twitter.com``,
+    ``web.archive.org``); we extract the URL's host once and check for
+    substring containment so ``mobile.twitter.com`` and ``t.co`` redirects
+    that resolve to the same host are both caught.
+    """
+    if not blocklist:
+        return False
+    from urllib.parse import urlsplit
+
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return False
+    host = (parts.hostname or "").lower()
+    if not host:
+        return False
+    return any(entry in host for entry in blocklist)
+
+
+def _count_second_order_emitted(job: Job) -> int:
+    """Count tasks for ``job`` whose payload carries the second-order marker.
+
+    Used to enforce the job-wide cap (:data:`_SECOND_ORDER_JOB_CAP`). We
+    count tasks in any status — pending/running/done/failed all count
+    against the budget so a long run that has already burned 200 fetches
+    on dead URLs doesn't get to keep adding more.
+    """
+    json_path = f"$.{_SECOND_ORDER_PARENT_FINDING_ID_KEY}"
+    conn = db.connect(job.db_path)
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM tasks"
+            " WHERE job_id = ?"
+            " AND json_extract(payload_json, ?) IS NOT NULL",
+            (job.id, json_path),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return 0
+    return int(row["n"])
+
+
+def _existing_job_source_urls(job: Job) -> set[str]:
+    """Return the normalized URLs of every source already linked to ``job``.
+
+    Drives same-job dedup: if extraction emits a finding citing a URL that
+    the agent has already fetched in this run, skip it. Cross-job dedup
+    is intentionally out of scope (issue #194 § "Out of scope").
+    """
+    conn = db.connect(job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT s.url AS url FROM sources s"
+            " JOIN job_sources js ON js.source_id = s.id"
+            " WHERE js.job_id = ? AND s.url IS NOT NULL",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    out: set[str] = set()
+    for row in rows:
+        norm = _normalize_url_for_fanout(row["url"])
+        if norm is not None:
+            out.add(norm)
+    return out
+
+
+def _extract_followup_urls(
+    findings: list[dict[str, Any]],
+    *,
+    max_per_extract: int,
+    confidence_threshold: float,
+    exclude_urls: set[str],
+    blocklist: set[str],
+) -> list[tuple[dict[str, Any], str]]:
+    """Pick high-confidence findings' cited URLs; return ``(finding, url)`` pairs.
+
+    Sorted by parent confidence descending so when ``max_per_extract`` clips
+    the list, the strongest signals survive. URLs are deduped within the
+    call, normalized via :func:`_normalize_url_for_fanout`, blocklist-
+    filtered via :func:`_is_url_blocked`, and any URL in ``exclude_urls``
+    (typically the job's already-fetched source URLs) is dropped before
+    the cap fires so we don't waste cap slots on dedups.
+    """
+    seen: set[str] = set()
+    candidates: list[tuple[float, dict[str, Any], str]] = []
+    for f in findings:
+        try:
+            confidence = float(f.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            continue
+        if confidence < confidence_threshold:
+            continue
+        text_parts = [str(f.get("claim") or ""), str(f.get("quote") or "")]
+        text = " ".join(text_parts)
+        for raw_url in _URL_REGEX.findall(text):
+            normalized = _normalize_url_for_fanout(raw_url)
+            if normalized is None:
+                continue
+            if normalized in seen:
+                continue
+            if normalized in exclude_urls:
+                continue
+            if _is_url_blocked(normalized, blocklist):
+                continue
+            seen.add(normalized)
+            candidates.append((confidence, f, normalized))
+    # Stable sort by descending confidence so per-extract cap retains the
+    # strongest parent signals.
+    candidates.sort(key=lambda c: -c[0])
+    return [(f, u) for _, f, u in candidates[:max_per_extract]]
+
+
+def _build_second_order_fanout(
+    job: Job,
+    findings: list[dict[str, Any]],
+    payload: dict[str, Any] | None,
+) -> list[TaskSpec]:
+    """Build ``web_fetch`` follow-ups for URLs cited inside ``findings``.
+
+    Precedence for the per-extract cap (mirrors :func:`_expand_search_to_fetches`):
+    explicit ``payload['second_order_max']`` > plan ``scope_class`` > fallback.
+    Returns an empty list when the cap is 0 (e.g. narrow scope), when the
+    job-wide cap is already exceeded, or when nothing in ``findings`` cites
+    a fan-out-eligible URL. Emits one ``second_order_fanout`` event per
+    surfaced URL so operators can audit the fan-out volume.
+    """
+    payload = payload or {}
+    if "second_order_max" in payload:
+        try:
+            max_per_extract = int(payload["second_order_max"])
+        except (TypeError, ValueError):
+            max_per_extract = _SECOND_ORDER_MAX_FALLBACK
+    else:
+        plan = _load_latest_plan(job)
+        scope = plan.scope_class if plan is not None else None
+        max_per_extract = _SECOND_ORDER_MAX_BY_SCOPE.get(
+            scope or "", _SECOND_ORDER_MAX_FALLBACK
+        )
+    if max_per_extract <= 0 or not findings:
+        return []
+
+    threshold_raw = payload.get(
+        "second_order_confidence_threshold", _SECOND_ORDER_CONFIDENCE_THRESHOLD
+    )
+    try:
+        threshold = float(threshold_raw)
+    except (TypeError, ValueError):
+        threshold = _SECOND_ORDER_CONFIDENCE_THRESHOLD
+
+    already_emitted = _count_second_order_emitted(job)
+    remaining_job_budget = _SECOND_ORDER_JOB_CAP - already_emitted
+    if remaining_job_budget <= 0:
+        return []
+    effective_cap = min(max_per_extract, remaining_job_budget)
+
+    blocklist = _load_url_blocklist()
+    exclude_urls = _existing_job_source_urls(job)
+
+    selected = _extract_followup_urls(
+        findings,
+        max_per_extract=effective_cap,
+        confidence_threshold=threshold,
+        exclude_urls=exclude_urls,
+        blocklist=blocklist,
+    )
+    if not selected:
+        return []
+
+    follow_ups: list[TaskSpec] = []
+    for finding, url in selected:
+        parent_finding_id = finding.get("finding_id")
+        sub_question = (finding.get("claim") or "").strip() or job.goal
+        emit(
+            job,
+            "INFO",
+            "loop",
+            "second_order_fanout",
+            {
+                "parent_finding_id": parent_finding_id,
+                "parent_confidence": float(finding.get("confidence", 0.0)),
+                "url": url,
+                "sub_question": sub_question,
+            },
+        )
+        follow_ups.append(
+            TaskSpec(
+                kind="web_fetch",
+                payload={
+                    "url": url,
+                    "sub_question": sub_question,
+                    _SECOND_ORDER_PARENT_FINDING_ID_KEY: parent_finding_id,
+                },
+            )
+        )
+    return follow_ups
+
+
 def _load_source_text(job: Job, source_id: int) -> tuple[str, dict[str, Any]] | None:
     """Read ``sources/<sha>.md`` for ``source_id``; return ``(text, meta)`` or None.
 
@@ -1094,6 +1408,11 @@ async def _run_extract_findings(
         )
 
     written: list[int] = []
+    # Mirror of ``written`` plus the {claim, confidence, quote} fields the
+    # second-order URL fan-out (#194) needs. We capture them at write time
+    # so the fan-out helper doesn't have to round-trip through the DB to
+    # rebuild what we already parsed.
+    written_findings: list[dict[str, Any]] = []
     skipped = 0
     for item in parsed[:findings_limit]:
         if not isinstance(item, dict):
@@ -1114,6 +1433,8 @@ async def _run_extract_findings(
             continue
         tags_raw = item.get("tags") or []
         tags_list = [str(t) for t in tags_raw if isinstance(t, (str, int))] or None
+        quote_raw = item.get("quote")
+        quote_str = quote_raw.strip() if isinstance(quote_raw, str) else ""
         try:
             fid = write_finding(
                 job,
@@ -1123,17 +1444,31 @@ async def _run_extract_findings(
                 tags=tags_list,
             )
             written.append(fid)
+            written_findings.append(
+                {
+                    "finding_id": fid,
+                    "claim": claim_raw.strip(),
+                    "confidence": conf,
+                    "quote": quote_str,
+                }
+            )
         except (ValueError, TypeError):
             skipped += 1
             continue
 
-    return {
+    result_dict: dict[str, Any] = {
         "source_id": source_id,
         "findings_written": len(written),
         "finding_ids": written,
         "skipped": skipped,
         "raw_path": raw_path,
     }
+
+    follow_ups = _build_second_order_fanout(job, written_findings, payload)
+    if follow_ups:
+        result_dict["follow_up_tasks"] = [t.model_dump() for t in follow_ups]
+
+    return result_dict
 
 
 async def _run_summarize_source(

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -56,6 +56,7 @@ from research_agent.storage.tasks import (
     mark_running,
     next_pending,
 )
+from research_agent.tools._errors import MissingCredentialError
 
 logger = logging.getLogger(__name__)
 
@@ -156,12 +157,15 @@ def _filter_kwargs_for(fn: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
 def _make_connector_search_handler(module_name: str) -> Handler:
     """Build a thin search-handler that dispatches to ``tools.<module_name>.search``.
 
-    Converts the connector's missing-credential ``RuntimeError`` (raised by
+    Converts the connector's :class:`MissingCredentialError` (raised by
     edgar/courtlistener/scholar/linkedin when their API key/UA isn't
     configured) into :class:`FatalError` so the loop marks the task failed
-    cleanly down the documented path. Returns the standard search-result
-    + ``follow_up_tasks`` shape so each top hit becomes a connector-aware
-    ``web_fetch`` follow-up.
+    cleanly down the documented path. Other ``RuntimeError`` subclasses —
+    real connector bugs — propagate to the loop's catch-all so they
+    surface as ``daemon/error`` events with tracebacks instead of getting
+    masked as missing-credential failures. Returns the standard
+    search-result + ``follow_up_tasks`` shape so each top hit becomes a
+    connector-aware ``web_fetch`` follow-up.
     """
 
     async def _handler(job: Job, task: dict[str, Any]) -> dict[str, Any]:
@@ -175,7 +179,7 @@ def _make_connector_search_handler(module_name: str) -> Handler:
         kwargs = _filter_kwargs_for(mod.search, kwargs)
         try:
             results = await mod.search(payload.get("query", ""), **kwargs)
-        except RuntimeError as exc:
+        except MissingCredentialError as exc:
             raise FatalError(f"{module_name}_search: {exc}") from exc
         return _expand_search_to_fetches(job, payload, results)
 
@@ -187,7 +191,9 @@ def _make_connector_fetch_handler(module_name: str) -> Handler:
 
     Mirrors :func:`_make_connector_search_handler` but for the single-URL
     fetch path: persists the returned ``Source`` and converts the
-    connector's missing-credential ``RuntimeError`` to :class:`FatalError`.
+    connector's :class:`MissingCredentialError` to :class:`FatalError`.
+    Plain ``RuntimeError`` from inside the connector propagates to the
+    loop's catch-all so unexpected failures stay diagnosable.
     """
 
     async def _handler(job: Job, task: dict[str, Any]) -> dict[str, Any]:
@@ -195,9 +201,12 @@ def _make_connector_fetch_handler(module_name: str) -> Handler:
 
         mod = import_module(f"research_agent.tools.{module_name}")
         payload = task["payload"]
+        url = payload.get("url")
+        if not url:
+            raise FatalError(f"{module_name}_fetch: missing url field")
         try:
-            source = await mod.fetch(payload["url"])
-        except RuntimeError as exc:
+            source = await mod.fetch(url)
+        except MissingCredentialError as exc:
             raise FatalError(f"{module_name}_fetch: {exc}") from exc
         return _persist_fetched_source(job, source)
 

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -208,7 +208,7 @@ def _make_connector_fetch_handler(module_name: str) -> Handler:
             source = await mod.fetch(url)
         except MissingCredentialError as exc:
             raise FatalError(f"{module_name}_fetch: {exc}") from exc
-        return _persist_fetched_source(job, source)
+        return _persist_fetched_source(job, source, payload=payload)
 
     return _handler
 
@@ -270,7 +270,7 @@ def default_handlers(router: Any) -> dict[str, Handler]:
 
         payload = task["payload"]
         source = await web_fetch.fetch(payload["url"])
-        result = _persist_fetched_source(job, source)
+        result = _persist_fetched_source(job, source, payload=payload)
 
         source_id = result.get("source_id")
         if isinstance(source_id, int):
@@ -279,7 +279,12 @@ def default_handlers(router: Any) -> dict[str, Handler]:
                 kind="extract_findings",
                 payload={"source_id": source_id, "sub_question": sub_question},
             )
-            result["follow_up_tasks"] = [follow_up.model_dump()]
+            # Issue #193: ``_persist_fetched_source`` may have already added
+            # a bill-text fan-out follow-up (when web_fetch host-dispatched
+            # to congress.fetch). Merge rather than overwrite so the bill
+            # body still gets fetched alongside the extract on this index.
+            existing = result.get("follow_up_tasks") or []
+            result["follow_up_tasks"] = [*existing, follow_up.model_dump()]
         return result
 
     async def _arxiv_search(job: Job, task: dict[str, Any]) -> dict[str, Any]:
@@ -720,7 +725,11 @@ def _expand_search_to_fetches(
     }
 
 
-def _persist_fetched_source(job: Job, source: Any) -> dict[str, Any]:
+def _persist_fetched_source(
+    job: Job,
+    source: Any,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Write the fetched ``Source`` to disk + the sources table.
 
     Returns a result dict the loop persists into ``tasks.result_json``:
@@ -733,6 +742,13 @@ def _persist_fetched_source(job: Job, source: Any) -> dict[str, Any]:
     blocked fetch, parse failure) so the loop marks the task ``failed``
     rather than silently storing ``source_id=None`` that downstream
     ``extract_findings`` tasks then trip on.
+
+    Issue #193: when the persisted source's metadata carries a
+    ``bill_text_url`` (set by ``congress._fetch_bill``), fan out a
+    ``web_fetch`` follow-up for the actual bill body so the agent reads
+    the substance of the legislation, not just the metadata index card.
+    The follow-up is suppressed if the bill text URL has already been
+    fetched for this job (deduped via the cross-job ``sources.url`` row).
     """
     if source is None:
         raise FatalError("web_fetch returned None — URL unreachable, blocked, or empty body")
@@ -768,7 +784,68 @@ def _persist_fetched_source(job: Job, source: Any) -> dict[str, Any]:
         archive_url=source_dict.get("archive_url"),
         fetched_at=fetched_epoch,
     )
-    return {"source": source_dict, "source_id": source_id}
+    result: dict[str, Any] = {"source": source_dict, "source_id": source_id}
+
+    bill_text_followup = _build_bill_text_followup(job, source, payload)
+    if bill_text_followup is not None:
+        result["follow_up_tasks"] = [bill_text_followup.model_dump()]
+
+    return result
+
+
+def _build_bill_text_followup(
+    job: Job,
+    source: Any,
+    payload: dict[str, Any] | None,
+) -> TaskSpec | None:
+    """Emit a ``web_fetch`` follow-up for the bill text URL if appropriate.
+
+    Returns ``None`` when the source has no ``bill_text_url`` metadata, when
+    the URL has already been fetched for this job (anti-runaway guard against
+    tactical_replan re-fetching the same bill), or when the metadata is
+    malformed. The follow-up's ``sub_question`` inherits from the originating
+    task payload so downstream ``extract_findings`` keeps research context.
+    """
+    metadata = getattr(source, "metadata", None)
+    if not isinstance(metadata, dict):
+        return None
+    bill_text_url = metadata.get("bill_text_url")
+    if not isinstance(bill_text_url, str) or not bill_text_url.strip():
+        return None
+    bill_text_url = bill_text_url.strip()
+
+    # Dedup against any prior fetch of this same URL within the job. Checking
+    # ``sources`` (not ``job_sources``) is fine because cross-job dedup means
+    # any prior write surfaces the existing row. We still scope by job through
+    # the join so a sibling job's fetch doesn't suppress this one.
+    conn = db.connect(job.db_path)
+    try:
+        row = conn.execute(
+            """
+            SELECT 1
+            FROM sources s
+            JOIN job_sources js ON js.source_id = s.id
+            WHERE s.url = ? AND js.job_id = ?
+            LIMIT 1
+            """,
+            (bill_text_url, job.id),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is not None:
+        return None
+
+    sub_question: str
+    if payload and isinstance(payload.get("sub_question"), str) and payload["sub_question"].strip():
+        sub_question = payload["sub_question"].strip()
+    else:
+        title = getattr(source, "title", None) or metadata.get("bill_text_format") or "this bill"
+        sub_question = f"What does the bill text say about: {title}"
+
+    return TaskSpec(
+        kind="web_fetch",
+        payload={"url": bill_text_url, "sub_question": sub_question},
+    )
 
 
 def _load_source_text(job: Job, source_id: int) -> tuple[str, dict[str, Any]] | None:

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -1206,7 +1206,10 @@ _CORNERSTONE_EXTRACT_TEXT_LIMIT = 80000  # ~20k tokens; still inside frontier wi
 _CORNERSTONE_FINDINGS_PER_SOURCE_LIMIT = 500
 # Documents that nobody marked as cornerstone but whose body is bigger than
 # this still get the cornerstone treatment — the planner's marker is the
-# primary signal, this is a fallback for runs whose plans pre-date #177.
+# primary signal, this is a fallback. Issue #189 gates the fallback to
+# ``source_kind == "pdf"`` so long-form HTML (Wikipedia, archive transcripts)
+# stays on the regular extraction path and the #177 report-padding
+# regression doesn't come back. See ``_is_cornerstone_source``.
 _CORNERSTONE_FALLBACK_MIN_CHARS = 200_000
 
 

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -772,7 +772,7 @@ def _load_source_text(job: Job, source_id: int) -> tuple[str, dict[str, Any]] | 
     conn = db.connect(job.db_path)
     try:
         row = conn.execute(
-            "SELECT id, url, title, md_path, archive_url FROM sources WHERE id = ?",
+            "SELECT id, url, title, md_path, archive_url, kind FROM sources WHERE id = ?",
             (source_id,),
         ).fetchone()
     finally:
@@ -788,6 +788,7 @@ def _load_source_text(job: Job, source_id: int) -> tuple[str, dict[str, Any]] | 
         "url": row["url"],
         "title": row["title"],
         "archive_url": row["archive_url"],
+        "source_kind": row["kind"],
     }
     return text, meta
 
@@ -840,25 +841,43 @@ def _normalize_url_for_compare(url: str | None) -> str | None:
     return urlunsplit((parts.scheme.lower(), netloc, path, parts.query, ""))
 
 
-def _is_cornerstone_source(job: Job, meta: dict[str, Any], text: str) -> bool:
-    """True when this source is the plan's declared cornerstone document.
+def _is_cornerstone_source(
+    job: Job, meta: dict[str, Any], text: str
+) -> tuple[bool, bool]:
+    """Return ``(is_cornerstone, via_size_fallback)`` for this source.
 
     Primary signal: the latest persisted plan's ``cornerstone_url`` matches
-    the source's URL (after light normalization). Fallback: the source's
-    body exceeds :data:`_CORNERSTONE_FALLBACK_MIN_CHARS`, which catches
-    runs whose plans pre-date #177 — better to over-trigger here than to
-    cap a 920-page document at 8 findings because the planner forgot to
-    set the marker.
+    the source's URL (after light normalization).
+
+    Fallback (issue #189): a source whose ``source_kind == "pdf"`` and whose
+    body exceeds :data:`_CORNERSTONE_FALLBACK_MIN_CHARS` is treated as the
+    cornerstone even when no planner marker matches. The PDF gate exists
+    because long-form HTML (Wikipedia full-text articles, archive.org
+    transcripts, scraped book chapters) can also exceed 200k chars without
+    being investigation cornerstones, and routing them through the
+    structured-index prompt with the 500-finding ceiling causes the exact
+    report-padding regression #177 was meant to prevent. PDFs of this size
+    are nearly always the kind of monograph/filing the cornerstone path is
+    calibrated for, so the fallback only fires for them.
+
+    The second return value is ``True`` only when the size-fallback path
+    fires (i.e. the planner did not mark the source); the call site uses
+    this to emit a ``cornerstone_fallback_triggered`` event so operators
+    can see the fallback was responsible for the lifted cap.
     """
     plan = _load_latest_plan(job)
     if plan is not None and plan.cornerstone_url:
         norm_plan = _normalize_url_for_compare(plan.cornerstone_url)
         norm_src = _normalize_url_for_compare(meta.get("url"))
         if norm_plan and norm_src and norm_plan == norm_src:
-            return True
-    if isinstance(text, str) and len(text) >= _CORNERSTONE_FALLBACK_MIN_CHARS:
-        return True
-    return False
+            return True, False
+    if (
+        meta.get("source_kind") == "pdf"
+        and isinstance(text, str)
+        and len(text) >= _CORNERSTONE_FALLBACK_MIN_CHARS
+    ):
+        return True, True
+    return False, False
 
 
 _YAML_FENCE_RE = re.compile(r"```(?:yaml|yml)?\s*\n(.*?)\n```", re.DOTALL | re.IGNORECASE)
@@ -923,11 +942,24 @@ async def _run_extract_findings(
 
     sub_question = payload.get("sub_question") or job.goal
 
-    is_cornerstone = _is_cornerstone_source(job, meta, text)
+    is_cornerstone, via_size_fallback = _is_cornerstone_source(job, meta, text)
     if is_cornerstone:
         prompt_name = "researcher_cornerstone"
         text_limit = _CORNERSTONE_EXTRACT_TEXT_LIMIT
         findings_limit = _CORNERSTONE_FINDINGS_PER_SOURCE_LIMIT
+        if via_size_fallback:
+            emit(
+                job,
+                "WARN",
+                "loop",
+                "cornerstone_fallback_triggered",
+                {
+                    "source_id": source_id,
+                    "url": meta.get("url"),
+                    "source_kind": meta.get("source_kind"),
+                    "cleaned_chars": len(text),
+                },
+            )
         emit(
             job,
             "INFO",

--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -512,11 +512,14 @@ async def tactical_replan(
     next_version = plan.version + 1
 
     # issue #176: bound the payload regardless of caller. recent_results is
-    # truncated to the last MAX_RECENT_RESULTS_FOR_REPLAN entries and each is
+    # truncated to the newest MAX_RECENT_RESULTS_FOR_REPLAN entries and each is
     # replaced by a compact summary; older results are already reflected in
     # the running plan + findings so dropping them is safe.
+    # Contract (issue #188): ``recent_results`` arrives newest-first (DESC) per
+    # ``_load_recent_task_results`` (loop.py ORDER BY id DESC), so a head slice
+    # keeps the newest entries.
     original_len = len(recent_results)
-    tail = recent_results[-MAX_RECENT_RESULTS_FOR_REPLAN:]
+    tail = recent_results[:MAX_RECENT_RESULTS_FOR_REPLAN]
     summarized = [_summarize_recent_result(r) for r in tail]
 
     payload: dict[str, Any] = {

--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -8,18 +8,45 @@ from collections.abc import Callable
 from research_agent.tools.models import SearchResult, Source, SourceKind
 
 
-def _smoke_web_search(query: str) -> list[SearchResult]:
-    """Smoke wrapper: run DDG then Google, return top-5 hits from each combined.
+def _smoke_web_search(query: str) -> str:
+    """Smoke wrapper: exercise the runtime ``engine="auto"`` path.
 
-    The CLI smoke verb calls this synchronously and prints ``repr`` of the
-    return value, so the output shows results from both engines per AC #14.
+    Mirrors what the orchestrator actually does: a single
+    ``web_search.search(query, engine="auto")`` call. With
+    ``BRAVE_SEARCH_API_KEY`` set, ``auto`` resolves to the Brave Search API;
+    without the key, it falls back to DDG-Playwright (which is subject to
+    selector drift and may legitimately return zero hits even when the
+    runtime is healthy). The output line marks which engine actually ran so
+    operators can tell apart a Brave miss from a Playwright fallback miss
+    without re-running.
     """
     from research_agent.tools import web_search
 
-    async def _run() -> list[SearchResult]:
-        ddg = await web_search.search(query, max_results=5, engine="ddg")
-        google = await web_search.search(query, max_results=5, engine="google")
-        return ddg + google
+    async def _run() -> str:
+        results = await web_search.search(query, max_results=10, engine="auto")
+        if results:
+            engine_used = str(results[0].extras.get("source_engine") or "?")
+        else:
+            engine_used = "brave" if web_search._brave_api_key() else "ddg"
+
+        if engine_used == "brave":
+            header = f"engine=brave: returned {len(results)} hits"
+        elif engine_used == "ddg":
+            suffix = " (selector drift?)" if not results else ""
+            header = (
+                f"engine=ddg (Playwright fallback, subject to selector drift):"
+                f" returned {len(results)} hits{suffix}"
+            )
+        else:
+            header = f"engine={engine_used}: returned {len(results)} hits"
+
+        lines: list[str] = [header]
+        for hit in results:
+            snippet = hit.snippet.replace("\n", " ")
+            if len(snippet) > 200:
+                snippet = snippet[:200] + "…"
+            lines.append(f"- {hit.title}\n  {hit.url}\n  {snippet}")
+        return "\n".join(lines)
 
     return asyncio.run(_run())
 

--- a/src/research_agent/tools/_errors.py
+++ b/src/research_agent/tools/_errors.py
@@ -1,0 +1,18 @@
+"""Shared connector exception types.
+
+Connectors raise :class:`MissingCredentialError` when a required env var
+(API token, broker key, contact-bearing User-Agent, etc.) is unset. The
+orchestrator's connector handlers catch *only* this typed sentinel and
+convert it into :class:`~research_agent.orchestrator.errors.FatalError`
+— preserving the documented smoke-skip contract (``exit 0`` with
+"would need ENV_VAR; live test skipped") while letting any other
+``RuntimeError`` from inside a connector propagate to the loop's
+catch-all so real bugs surface as ``daemon/error`` events with
+tracebacks instead of masquerading as missing credentials.
+"""
+
+from __future__ import annotations
+
+
+class MissingCredentialError(RuntimeError):
+    """Raised by a connector when a required credential/config value is unset."""

--- a/src/research_agent/tools/congress.py
+++ b/src/research_agent/tools/congress.py
@@ -895,6 +895,12 @@ async def _fetch_bill(
         "latest_action": latest_action,
         "text_url": text_url,
         "text_format": text_label,
+        # Issue #193: alias the bill-text pointer under stable, loop-friendly
+        # keys so ``_persist_fetched_source`` can fan out a web_fetch for the
+        # actual bill body. ``text_url``/``text_format`` are kept above for
+        # back-compat.
+        "bill_text_url": text_url,
+        "bill_text_format": text_label,
         "actions": actions,
     }
 

--- a/src/research_agent/tools/courtlistener.py
+++ b/src/research_agent/tools/courtlistener.py
@@ -36,6 +36,7 @@ import httpx
 import trafilatura
 
 from research_agent import config
+from research_agent.tools._errors import MissingCredentialError
 from research_agent.tools.models import SearchResult, Source
 
 logger = logging.getLogger(__name__)
@@ -75,7 +76,7 @@ def _resolve_token() -> str:
     """
     token = config.get("COURTLISTENER_API_TOKEN") or ""
     if not token.strip():
-        raise RuntimeError(
+        raise MissingCredentialError(
             "CourtListener requires an API token. Sign up at "
             "https://www.courtlistener.com/help/api/rest/ and set "
             "COURTLISTENER_API_TOKEN in your .env."

--- a/src/research_agent/tools/edgar.py
+++ b/src/research_agent/tools/edgar.py
@@ -35,6 +35,7 @@ import httpx
 import trafilatura
 
 from research_agent import config
+from research_agent.tools._errors import MissingCredentialError
 from research_agent.tools.models import SearchResult, Source
 
 logger = logging.getLogger(__name__)
@@ -78,7 +79,7 @@ def _resolve_user_agent() -> str:
     """
     ua = config.get("RESEARCH_USER_AGENT") or ""
     if "@" not in ua:
-        raise RuntimeError(
+        raise MissingCredentialError(
             "SEC EDGAR requires a contact email in the User-Agent. "
             "Set RESEARCH_USER_AGENT in your .env to e.g. "
             '"research-agent your-name@example.com".'

--- a/src/research_agent/tools/linkedin.py
+++ b/src/research_agent/tools/linkedin.py
@@ -40,6 +40,7 @@ from urllib.parse import urlparse
 import httpx
 
 from research_agent import config
+from research_agent.tools._errors import MissingCredentialError
 from research_agent.tools.models import SearchResult, Source
 
 logger = logging.getLogger(__name__)
@@ -513,7 +514,7 @@ def _resolve_broker() -> tuple[str, dict[str, Any]]:
     name = (config.get("LINKEDIN_BROKER") or "proxycurl").strip().lower()
     recipe = _BROKERS.get(name)
     if recipe is None:
-        raise RuntimeError(
+        raise MissingCredentialError(
             f"Unknown LINKEDIN_BROKER {name!r}; expected one of "
             f"{sorted(_BROKERS)}."
         )
@@ -524,7 +525,7 @@ def _resolve_key(broker: str, recipe: dict[str, Any]) -> str:
     env_name = recipe["key_env"]
     key = config.get(env_name) or ""
     if not key.strip():
-        raise RuntimeError(
+        raise MissingCredentialError(
             f"LinkedIn connector requires a {env_name} (broker={broker}). "
             f"Sign up at {recipe['signup_url']} and set {env_name} in your .env."
         )

--- a/src/research_agent/tools/scholar.py
+++ b/src/research_agent/tools/scholar.py
@@ -34,6 +34,7 @@ import trafilatura
 
 from research_agent import config
 from research_agent.tools import pdf as pdf_tool
+from research_agent.tools._errors import MissingCredentialError
 from research_agent.tools.models import SearchResult, Source
 
 logger = logging.getLogger(__name__)
@@ -70,7 +71,7 @@ def _resolve_key() -> str:
     """
     key = config.get("SERPAPI_KEY") or ""
     if not key.strip():
-        raise RuntimeError(
+        raise MissingCredentialError(
             "Google Scholar connector requires a SERPAPI key. Sign up at "
             "https://serpapi.com/ and set SERPAPI_KEY in your .env."
         )

--- a/src/research_agent/tools/sos.py
+++ b/src/research_agent/tools/sos.py
@@ -66,9 +66,16 @@ _STATE_RECIPES: dict[str, dict[str, Any]] = {
     "CA": {
         "host": "bizfileonline.sos.ca.gov",
         "search_url": "https://bizfileonline.sos.ca.gov/search/business",
-        # Live DOM (verified 2026-05): the search input has placeholder
+        # Live DOM (verified 2026-05-07): the search input has placeholder
         # "Search by name or file number"; the submit control is a button
         # with aria-label="Execute search" and no type attribute.
+        # The page is a React SPA that re-renders the search input shortly
+        # after first paint (a hydration step), so a naive
+        # ``locator(...).fill(...)`` races the re-render and Playwright raises
+        # "element was detached from the DOM". Submission goes through
+        # ``_fill_with_retry`` / ``_click_with_retry`` below, which re-query
+        # the locator on each attempt and fall back to a JS evaluate that
+        # sets ``.value`` and dispatches native ``input`` + ``change`` events.
         "query_input": "input[placeholder*='Search' i]",
         "submit_button": "button[aria-label='Execute search']",
         # Optional: if/when the UI exposes name-vs-number tabs, route here.
@@ -180,6 +187,128 @@ async def _safe_attr(locator: Any, name: str) -> str:
     except Exception:  # noqa: BLE001
         return ""
     return (value or "").strip()
+
+
+# bizfileonline.sos.ca.gov re-renders its React tree shortly after first paint
+# (a hydration step). The locator resolves but Playwright's auto-retry inside
+# ``fill()`` can lose the race and raise "element was detached from the DOM".
+# Detect those errors by message-substring rather than exception type because
+# the surface is shared between Playwright's own ``Error`` and the generic
+# ``RuntimeError`` strings the SDK builds at the call site.
+_DETACHED_ERROR_HINTS = (
+    "detached from the dom",
+    "element is not attached",
+    "not attached to the dom",
+)
+
+# JS injected as the last-ditch fallback when ``fill()`` keeps racing the
+# re-render. React listens for native ``input``/``change`` events on its
+# controlled inputs, so setting ``.value`` directly without dispatching the
+# events leaves the framework state out of sync — the form will appear empty
+# the moment React re-renders. Use the prototype setter so React's
+# ``__valueTracker`` shim sees a real value change.
+_FILL_VIA_EVALUATE_JS = """
+([selector, value]) => {
+    const el = document.querySelector(selector);
+    if (!el) return false;
+    const proto = Object.getPrototypeOf(el);
+    const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+    if (desc && typeof desc.set === 'function') {
+        desc.set.call(el, value);
+    } else {
+        el.value = value;
+    }
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+    return true;
+}
+"""
+
+
+def _is_detached_error(exc: BaseException) -> bool:
+    msg = str(exc).lower()
+    return any(hint in msg for hint in _DETACHED_ERROR_HINTS)
+
+
+async def _fill_with_retry(
+    page: Any, selector: str, value: str, *, attempts: int = 3
+) -> None:
+    """Fill ``selector`` with ``value``, re-resolving the locator on detach.
+
+    Re-queries ``page.locator(selector).first`` on every attempt so a stale
+    handle from a React re-render is replaced. After ``attempts`` tries falls
+    back to ``page.evaluate`` setting ``.value`` and dispatching native
+    ``input``/``change`` events — the documented escape hatch for SPA forms.
+    """
+    last_exc: BaseException | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            await page.locator(selector).first.fill(value)
+            return
+        except Exception as exc:  # noqa: BLE001
+            if not _is_detached_error(exc):
+                raise
+            last_exc = exc
+            logger.debug(
+                "sos fill detached on attempt %d/%d (%s): %s",
+                attempt,
+                attempts,
+                selector,
+                exc,
+            )
+    logger.debug(
+        "sos fill falling back to evaluate after %d detached attempts (%s)",
+        attempts,
+        selector,
+    )
+    try:
+        await page.evaluate(_FILL_VIA_EVALUATE_JS, [selector, value])
+    except Exception as exc:  # noqa: BLE001
+        if last_exc is not None:
+            raise last_exc from exc
+        raise
+
+
+async def _click_with_retry(
+    page: Any, selector: str, *, attempts: int = 3
+) -> None:
+    """Click ``selector``, re-resolving the locator on detach.
+
+    Same retry shape as ``_fill_with_retry``; if every attempt loses the race
+    the JS fallback calls ``el.click()`` directly so React's onClick still
+    fires.
+    """
+    last_exc: BaseException | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            await page.locator(selector).first.click()
+            return
+        except Exception as exc:  # noqa: BLE001
+            if not _is_detached_error(exc):
+                raise
+            last_exc = exc
+            logger.debug(
+                "sos click detached on attempt %d/%d (%s): %s",
+                attempt,
+                attempts,
+                selector,
+                exc,
+            )
+    logger.debug(
+        "sos click falling back to evaluate after %d detached attempts (%s)",
+        attempts,
+        selector,
+    )
+    try:
+        await page.evaluate(
+            "(selector) => { const el = document.querySelector(selector); "
+            "if (el) el.click(); return !!el; }",
+            selector,
+        )
+    except Exception as exc:  # noqa: BLE001
+        if last_exc is not None:
+            raise last_exc from exc
+        raise
 
 
 async def _save_diagnostic_screenshot(page: Any, host: str) -> None:
@@ -333,17 +462,27 @@ async def search(
             try:
                 await browser.navigate(page, search_url)
 
+                # Let the React tree finish hydrating before we acquire any
+                # locators — otherwise the search input handle is detached out
+                # from under us between query and fill (see issue #191).
+                try:
+                    await page.wait_for_load_state(
+                        "networkidle", timeout=10_000
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("sos wait_for_load_state failed: %s", exc)
+
                 if recipe.get("query_kind_selector"):
                     kind = "number" if _looks_like_entity_number(query) else "name"
                     selector = recipe["query_kind_selector"].format(kind=kind)
                     try:
-                        await page.locator(selector).first.click()
+                        await _click_with_retry(page, selector)
                     except Exception as exc:  # noqa: BLE001
                         logger.debug("sos query-kind toggle failed: %s", exc)
 
                 try:
-                    await page.locator(recipe["query_input"]).first.fill(query)
-                    await page.locator(recipe["submit_button"]).first.click()
+                    await _fill_with_retry(page, recipe["query_input"], query)
+                    await _click_with_retry(page, recipe["submit_button"])
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "sos search submit failed for state=%s: %s", code, exc

--- a/src/research_agent/tools/web_fetch.py
+++ b/src/research_agent/tools/web_fetch.py
@@ -310,6 +310,18 @@ _YOUTUBE_HOSTS = frozenset(
 # These do not appear here; the planner emits search tasks for them.
 
 _CONGRESS_HOSTS = frozenset({"www.congress.gov", "congress.gov"})
+# Bill-text content URLs (e.g. ``/117/bills/hr5376/BILLS-117hr5376enr.htm``)
+# are raw HTML/XML/PDF bodies that ``congress.fetch`` does not handle — its
+# URL classifier only matches the canonical bill / member / hearing pages.
+# Without this carve-out, the bill-text fan-out (issue #193) routes these
+# URLs to ``congress.fetch``, which returns ``None``, and the loop FatalErrors
+# instead of reading the legislative text. The PDF variant is already caught
+# by ``_is_pdf_url`` ahead of host-dispatch; this pattern handles the
+# ``Formatted Text`` / ``Formatted XML`` HTML variants that are the preferred
+# format per ``_bill_text_pick``.
+_CONGRESS_BILL_TEXT_PATH_RE = re.compile(
+    r"^/\d+/bills?/[^/]+/BILLS-", re.IGNORECASE
+)
 _FEC_HOSTS = frozenset({"www.fec.gov", "fec.gov"})
 _EDGAR_HOSTS = frozenset({"www.sec.gov", "sec.gov"})
 _FEDREGISTER_HOSTS = frozenset(
@@ -598,9 +610,15 @@ async def fetch(
         return await youtube.fetch(url)
 
     if netloc in _CONGRESS_HOSTS:
-        from research_agent.tools import congress
+        # Bill-text content URLs slip past congress.fetch (which only handles
+        # canonical /bill/, /member/, /hearing/ permalinks) and fall through
+        # to the generic httpx + trafilatura extractor below. Issue #193:
+        # without this carve-out, the bill-text fan-out FatalErrors on the
+        # preferred ``Formatted Text`` (HTML) format.
+        if not _CONGRESS_BILL_TEXT_PATH_RE.match(urlparse(url).path):
+            from research_agent.tools import congress
 
-        return await congress.fetch(url)
+            return await congress.fetch(url)
 
     if netloc in _FEC_HOSTS:
         from research_agent.tools import fec

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -16,6 +16,8 @@ from research_agent.orchestrator.loop import (
     RETRY_MAX_ATTEMPTS,
     Handler,
     _expand_search_to_fetches,
+    _is_cornerstone_source,
+    _load_source_text,
     _run_extract_findings,
     default_handlers,
     run_loop,
@@ -1018,7 +1020,7 @@ class _StubRouter:
         return _Result()
 
 
-def _seed_source(job: Job, *, url: str, body: str) -> int:
+def _seed_source(job: Job, *, url: str, body: str, kind: str = "web") -> int:
     from research_agent.storage.sources import write_source
 
     return write_source(
@@ -1026,7 +1028,7 @@ def _seed_source(job: Job, *, url: str, body: str) -> int:
         url=url,
         title="Cornerstone Document",
         raw_content=body,
-        kind="web",
+        kind=kind,
     )
 
 
@@ -1211,3 +1213,151 @@ async def test_extract_findings_non_cornerstone_uses_default_cap(
     assert result["findings_written"] == 8
     assert "researcher" in loaded_prompts
     assert "researcher_cornerstone" not in loaded_prompts
+
+
+def test_is_cornerstone_source_size_fallback_gated_to_pdf(
+    job: Job,
+) -> None:
+    """Issue #189: size-fallback only fires for ``source_kind == "pdf"``.
+
+    Three cases — all share the same 250k-char body, only ``source_kind``
+    and the planner marker differ:
+
+    * HTML, no planner match → ``(False, False)`` — long-form HTML must
+      not be promoted to cornerstone, or #177's report-padding regression
+      comes back.
+    * PDF, no planner match  → ``(True, True)`` — the second flag tells
+      the call site to emit ``cornerstone_fallback_triggered``.
+    * Planner-marked URL     → ``(True, False)`` — primary signal wins,
+      no fallback event regardless of kind/size.
+    """
+    # Bodies must differ — sources dedupe by content sha256 across kinds.
+    html_id = _seed_source(
+        job,
+        url="https://example.test/long-article.html",
+        body="H" * 250_000,
+        kind="html",
+    )
+    pdf_id = _seed_source(
+        job,
+        url="https://example.test/big-doc.pdf",
+        body="P" * 250_000,
+        kind="pdf",
+    )
+    marked_id = _seed_source(
+        job,
+        url="https://example.test/marked.html",
+        body="short body",
+        kind="html",
+    )
+
+    _persist_plan_with_cornerstone(job, "https://example.test/marked.html")
+
+    html_loaded = _load_source_text(job, html_id)
+    pdf_loaded = _load_source_text(job, pdf_id)
+    marked_loaded = _load_source_text(job, marked_id)
+    assert html_loaded is not None
+    assert pdf_loaded is not None
+    assert marked_loaded is not None
+
+    html_text, html_meta = html_loaded
+    pdf_text, pdf_meta = pdf_loaded
+    marked_text, marked_meta = marked_loaded
+
+    assert _is_cornerstone_source(job, html_meta, html_text) == (False, False)
+    assert _is_cornerstone_source(job, pdf_meta, pdf_text) == (True, True)
+    assert _is_cornerstone_source(job, marked_meta, marked_text) == (True, False)
+
+
+@pytest.mark.asyncio
+async def test_extract_findings_pdf_fallback_emits_event(
+    job: Job,
+    db_path: Path,
+) -> None:
+    """PDF size-fallback path emits ``cornerstone_fallback_triggered`` (WARN).
+
+    The planner did not mark this URL; only the PDF size-fallback path
+    routes the source through the cornerstone prompt, so the operator-
+    visible WARN event must fire alongside the existing INFO
+    ``cornerstone_extract`` event.
+    """
+    url = "https://example.test/forgot-to-mark.pdf"
+    _persist_plan_with_cornerstone(job, "https://example.test/something-else.pdf")
+    source_id = _seed_source(job, url=url, body="P" * 250_000, kind="pdf")
+
+    router = _StubRouter("```yaml\n[]\n```\n")
+    task = {"payload": {"source_id": source_id, "sub_question": "What?"}}
+
+    await _run_extract_findings(job, task, router=router)
+
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT level, kind, payload_json FROM events"
+            " WHERE job_id = ? AND kind = 'cornerstone_fallback_triggered'",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    assert rows[0]["level"] == "WARN"
+    import json as _json
+
+    payload = _json.loads(rows[0]["payload_json"])
+    assert payload["source_id"] == source_id
+    assert payload["url"] == url
+    assert payload["source_kind"] == "pdf"
+    # md_path is written as ``cleaned + "\n"`` so the read-back text adds
+    # one byte to the body length; tolerate that without fixing the value.
+    assert payload["cleaned_chars"] >= 250_000
+
+    # Both the fallback WARN and the standard cornerstone_extract INFO must fire.
+    kinds = _read_event_kinds(db_path, job.id)
+    assert "cornerstone_fallback_triggered" in kinds
+    assert "cornerstone_extract" in kinds
+
+
+@pytest.mark.asyncio
+async def test_extract_findings_html_size_does_not_emit_fallback(
+    job: Job,
+    db_path: Path,
+) -> None:
+    """A 250k-char HTML source must NOT trigger the size fallback.
+
+    Long-form HTML (Wikipedia, archive.org transcripts) frequently
+    crosses the 200k-char threshold without being investigation
+    cornerstones — the gate must keep them on the regular extraction
+    path with the 8-finding cap intact.
+    """
+    url = "https://example.test/very-long.html"
+    _persist_plan_with_cornerstone(job, "https://example.test/something-else.pdf")
+    source_id = _seed_source(job, url=url, body="H" * 250_000, kind="html")
+
+    router = _StubRouter("```yaml\n[]\n```\n")
+    task = {"payload": {"source_id": source_id, "sub_question": "What?"}}
+
+    await _run_extract_findings(job, task, router=router)
+
+    kinds = _read_event_kinds(db_path, job.id)
+    assert "cornerstone_fallback_triggered" not in kinds
+    assert "cornerstone_extract" not in kinds
+
+
+@pytest.mark.asyncio
+async def test_extract_findings_planner_marker_does_not_emit_fallback(
+    job: Job,
+    db_path: Path,
+) -> None:
+    """Planner-marked cornerstone never emits the fallback WARN event."""
+    url = "https://example.test/policy.md"
+    _persist_plan_with_cornerstone(job, url)
+    source_id = _seed_source(job, url=url, body=_CORNERSTONE_BODY)
+
+    router = _StubRouter("```yaml\n[]\n```\n")
+    task = {"payload": {"source_id": source_id, "sub_question": "What?"}}
+
+    await _run_extract_findings(job, task, router=router)
+
+    kinds = _read_event_kinds(db_path, job.id)
+    assert "cornerstone_extract" in kinds
+    assert "cornerstone_fallback_triggered" not in kinds

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -1641,3 +1641,307 @@ async def test_extract_findings_planner_marker_does_not_emit_fallback(
     kinds = _read_event_kinds(db_path, job.id)
     assert "cornerstone_extract" in kinds
     assert "cornerstone_fallback_triggered" not in kinds
+
+
+# ---------------------------------------------------------------------------
+# Issue #194: second-order URL fan-out from extracted findings
+# ---------------------------------------------------------------------------
+
+
+def _persist_plan_with_full_scope(
+    job: Job,
+    scope: ScopeClass | None,
+    *,
+    cornerstone_url: str | None = None,
+) -> None:
+    p = Plan(
+        version=1,
+        objective="Investigate the target",
+        subgoals=[Subgoal(id=1, description="Gather", done=False)],
+        task_template=[TaskSpec(kind="web_search")],
+        expected_iterations=3,
+        scope_class=scope,
+        cornerstone_url=cornerstone_url,
+    )
+    write_plan(job, p.model_dump())
+
+
+def _reset_blocklist_cache() -> None:
+    """Clear the module-level blocklist cache so tests can re-stub it."""
+    import research_agent.orchestrator.loop as _loop_mod
+
+    _loop_mod._BLOCKLIST_CACHE = None
+
+
+@pytest.mark.asyncio
+async def test_second_order_fanout_skips_url_already_in_job_sources(
+    job: Job,
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Citation that points at an already-fetched URL must NOT fan out.
+
+    A finding's claim text contains 2 URLs: one already linked to this
+    job via ``job_sources`` (the agent fetched it during a prior task)
+    and one new. Only the new URL should become a ``web_fetch``
+    follow-up — same-job dedup is the whole point of this guard.
+    """
+    import research_agent.orchestrator.loop as _loop_mod
+
+    _reset_blocklist_cache()
+    monkeypatch.setattr(_loop_mod, "_load_url_blocklist", lambda: set())
+
+    _persist_plan_with_full_scope(job, "broad")
+
+    # Pre-seed: the agent has already fetched ``already.example/doc.pdf`` for
+    # this job, so a finding citing that URL must not re-fan-out.
+    already_url = "https://already.example/doc.pdf"
+    _seed_source(
+        job,
+        url=already_url,
+        body="prior fetch contents",
+        kind="pdf",
+    )
+
+    new_url = "https://new.example/citation.pdf"
+    extract_url = "https://example.test/article.html"
+    source_id = _seed_source(
+        job,
+        url=extract_url,
+        body="An article body that triggers extraction.",
+        kind="web",
+    )
+
+    yaml_payload = (
+        "```yaml\n"
+        f'- claim: "Important point — see {already_url} and also {new_url} for detail."\n'
+        '  confidence: 0.9\n'
+        '  quote: ""\n'
+        '  tags: [policy]\n'
+        "```\n"
+    )
+    router = _StubRouter(yaml_payload)
+    task = {"payload": {"source_id": source_id, "sub_question": "Detail?"}}
+
+    result = await _run_extract_findings(job, task, router=router)
+
+    follow_ups = result.get("follow_up_tasks") or []
+    urls = [f["payload"]["url"] for f in follow_ups]
+    assert urls == [new_url], (
+        f"expected only the new URL to fan out; got {urls}"
+    )
+
+    # The fanned-out follow-up must carry the marker key so the job-cap
+    # query can count it.
+    assert (
+        follow_ups[0]["payload"].get("second_order_parent_finding_id") is not None
+    )
+
+    # And one ``second_order_fanout`` event must have fired.
+    events = _read_event_kinds(db_path, job.id)
+    assert events.count("second_order_fanout") == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scope,expected_count",
+    [("comprehensive", 3), ("broad", 2)],
+)
+async def test_second_order_fanout_per_extract_cap_by_scope(
+    job: Job,
+    monkeypatch: pytest.MonkeyPatch,
+    scope: ScopeClass,
+    expected_count: int,
+) -> None:
+    """Per-extract cap follows scope: comprehensive → 3, broad → 2.
+
+    Three high-confidence findings, each citing one distinct URL. The
+    same input must produce 3 follow-ups under comprehensive and only 2
+    under broad — sorted by parent confidence so the strongest signals
+    survive the clip.
+    """
+    import research_agent.orchestrator.loop as _loop_mod
+
+    _reset_blocklist_cache()
+    monkeypatch.setattr(_loop_mod, "_load_url_blocklist", lambda: set())
+
+    _persist_plan_with_full_scope(job, scope)
+
+    extract_url = "https://example.test/article.html"
+    source_id = _seed_source(
+        job,
+        url=extract_url,
+        body=f"Body for {scope}",
+        kind="web",
+    )
+
+    yaml_payload = (
+        "```yaml\n"
+        '- claim: "Top finding cites https://a.example/one.pdf for evidence."\n'
+        '  confidence: 0.95\n'
+        '  quote: ""\n'
+        '  tags: [a]\n'
+        '- claim: "Second finding cites https://b.example/two.pdf for evidence."\n'
+        '  confidence: 0.85\n'
+        '  quote: ""\n'
+        '  tags: [b]\n'
+        '- claim: "Third finding cites https://c.example/three.pdf for evidence."\n'
+        '  confidence: 0.75\n'
+        '  quote: ""\n'
+        '  tags: [c]\n'
+        "```\n"
+    )
+    router = _StubRouter(yaml_payload)
+    task = {"payload": {"source_id": source_id, "sub_question": "Refs?"}}
+
+    result = await _run_extract_findings(job, task, router=router)
+
+    follow_ups = result.get("follow_up_tasks") or []
+    assert len(follow_ups) == expected_count
+
+    urls = [f["payload"]["url"] for f in follow_ups]
+    # Highest-confidence finding's URL must always be present (sorted-by-conf).
+    assert "https://a.example/one.pdf" in urls
+    if expected_count >= 2:
+        assert "https://b.example/two.pdf" in urls
+
+
+@pytest.mark.asyncio
+async def test_second_order_fanout_skips_low_confidence_findings(
+    job: Job,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A finding below the 0.5 confidence threshold must NOT fan out.
+
+    The agent's least-reliable signals should not trigger more fetching.
+    """
+    import research_agent.orchestrator.loop as _loop_mod
+
+    _reset_blocklist_cache()
+    monkeypatch.setattr(_loop_mod, "_load_url_blocklist", lambda: set())
+
+    _persist_plan_with_full_scope(job, "comprehensive")
+
+    extract_url = "https://example.test/article.html"
+    source_id = _seed_source(
+        job,
+        url=extract_url,
+        body="A weakly-confident article.",
+        kind="web",
+    )
+
+    yaml_payload = (
+        "```yaml\n"
+        '- claim: "Possibly relevant — see https://shaky.example/doc.pdf."\n'
+        '  confidence: 0.3\n'
+        '  quote: ""\n'
+        '  tags: [shaky]\n'
+        "```\n"
+    )
+    router = _StubRouter(yaml_payload)
+    task = {"payload": {"source_id": source_id, "sub_question": "Maybe?"}}
+
+    result = await _run_extract_findings(job, task, router=router)
+
+    follow_ups = result.get("follow_up_tasks") or []
+    assert follow_ups == []
+
+
+@pytest.mark.asyncio
+async def test_second_order_fanout_drops_blocklisted_urls(
+    job: Job,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A high-confidence finding citing a blocklisted host must NOT fan out.
+
+    The blocklist filters social-media + archive hosts (issue #194)
+    even when the parent finding is otherwise eligible.
+    """
+    import research_agent.orchestrator.loop as _loop_mod
+
+    _reset_blocklist_cache()
+    monkeypatch.setattr(
+        _loop_mod, "_load_url_blocklist", lambda: {"twitter.com"}
+    )
+
+    _persist_plan_with_full_scope(job, "comprehensive")
+
+    extract_url = "https://example.test/article.html"
+    source_id = _seed_source(
+        job,
+        url=extract_url,
+        body="An article with a Twitter citation.",
+        kind="web",
+    )
+
+    yaml_payload = (
+        "```yaml\n"
+        '- claim: "Per https://twitter.com/foo/status/123 the source confirms it."\n'
+        '  confidence: 0.9\n'
+        '  quote: ""\n'
+        '  tags: [social]\n'
+        "```\n"
+    )
+    router = _StubRouter(yaml_payload)
+    task = {"payload": {"source_id": source_id, "sub_question": "Confirms?"}}
+
+    result = await _run_extract_findings(job, task, router=router)
+
+    follow_ups = result.get("follow_up_tasks") or []
+    assert follow_ups == []
+
+
+def test_second_order_fanout_helpers_normalize_and_block() -> None:
+    """Spot-check the URL normalizer + blocklist matcher for trailing punctuation."""
+    from research_agent.orchestrator.loop import (
+        _is_url_blocked,
+        _normalize_url_for_fanout,
+    )
+
+    assert (
+        _normalize_url_for_fanout("https://Example.com/path).")
+        == "https://example.com/path"
+    )
+    assert _normalize_url_for_fanout("ftp://nope/x") is None
+    assert _normalize_url_for_fanout("not-a-url") is None
+    assert _is_url_blocked(
+        "https://mobile.twitter.com/foo", {"twitter.com"}
+    ) is True
+    assert _is_url_blocked("https://example.com/x", {"twitter.com"}) is False
+
+
+@pytest.mark.asyncio
+async def test_second_order_fanout_narrow_scope_emits_zero(
+    job: Job,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``narrow`` scope leaves drill-downs to the planner — no auto fan-out."""
+    import research_agent.orchestrator.loop as _loop_mod
+
+    _reset_blocklist_cache()
+    monkeypatch.setattr(_loop_mod, "_load_url_blocklist", lambda: set())
+
+    _persist_plan_with_full_scope(job, "narrow")
+
+    extract_url = "https://example.test/article.html"
+    source_id = _seed_source(
+        job,
+        url=extract_url,
+        body="A narrow-scope body.",
+        kind="web",
+    )
+
+    yaml_payload = (
+        "```yaml\n"
+        '- claim: "See https://primary.example/doc.pdf for the underlying record."\n'
+        '  confidence: 0.95\n'
+        '  quote: ""\n'
+        '  tags: [primary]\n'
+        "```\n"
+    )
+    router = _StubRouter(yaml_payload)
+    task = {"payload": {"source_id": source_id, "sub_question": "?"}}
+
+    result = await _run_extract_findings(job, task, router=router)
+
+    assert (result.get("follow_up_tasks") or []) == []

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -549,15 +549,16 @@ async def test_connector_fetch_handler_dispatches_to_module(
 async def test_connector_search_handler_wraps_runtime_error_as_fatal(
     job: Job, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """When a connector raises ``RuntimeError`` (its missing-credential path),
-    the handler must convert it to :class:`FatalError` so the loop marks the
-    task failed cleanly down the documented path rather than relying on the
-    daemon's catch-all guard.
+    """When a connector raises :class:`MissingCredentialError`, the handler
+    must convert it to :class:`FatalError` so the loop marks the task failed
+    cleanly down the documented path rather than relying on the daemon's
+    catch-all guard. Preserves the smoke-skip contract.
     """
     from research_agent.tools import linkedin
+    from research_agent.tools._errors import MissingCredentialError
 
     async def fake_search(query: str, **kwargs: Any) -> list[SearchResult]:
-        raise RuntimeError(
+        raise MissingCredentialError(
             "linkedin requires LINKEDIN_DATA_API_KEY (or LIX_API_KEY for lix broker)"
         )
 
@@ -574,11 +575,15 @@ async def test_connector_search_handler_wraps_runtime_error_as_fatal(
 async def test_connector_fetch_handler_wraps_runtime_error_as_fatal(
     job: Job, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``<prefix>_fetch`` mirrors the search-side FatalError wrapping."""
+    """``<prefix>_fetch`` mirrors the search-side FatalError wrapping for
+    :class:`MissingCredentialError`."""
     from research_agent.tools import courtlistener
+    from research_agent.tools._errors import MissingCredentialError
 
     async def fake_fetch(url: str) -> Any:
-        raise RuntimeError("courtlistener requires COURTLISTENER_API_TOKEN")
+        raise MissingCredentialError(
+            "courtlistener requires COURTLISTENER_API_TOKEN"
+        )
 
     monkeypatch.setattr(courtlistener, "fetch", fake_fetch)
 
@@ -591,6 +596,73 @@ async def test_connector_fetch_handler_wraps_runtime_error_as_fatal(
                 "payload": {"url": "https://www.courtlistener.com/opinion/123/"},
             },
         )
+
+
+@pytest.mark.asyncio
+async def test_connector_search_handler_does_not_wrap_unrelated_runtime_error(
+    job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-credential ``RuntimeError`` from inside a connector must NOT get
+    masked as a credential FatalError. It propagates to the loop's catch-all
+    so the original bug message surfaces in ``daemon/error`` events with
+    traceback. Issue #190.
+    """
+    from research_agent.tools import congress
+
+    bug_message = "unrecoverable: response.json() returned None"
+
+    async def fake_search(query: str, **kwargs: Any) -> list[SearchResult]:
+        raise RuntimeError(bug_message)
+
+    monkeypatch.setattr(congress, "search", fake_search)
+
+    handler = default_handlers(router=None)["congress_search"]
+    with pytest.raises(RuntimeError) as excinfo:
+        await handler(
+            job, {"kind": "congress_search", "payload": {"query": "needle"}}
+        )
+    assert not isinstance(excinfo.value, FatalError)
+    assert bug_message in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_connector_fetch_handler_does_not_wrap_unrelated_runtime_error(
+    job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mirror of the search variant for the fetch handler. Issue #190."""
+    from research_agent.tools import congress
+
+    bug_message = "boom: state-machine violation in fetch"
+
+    async def fake_fetch(url: str) -> Any:
+        raise RuntimeError(bug_message)
+
+    monkeypatch.setattr(congress, "fetch", fake_fetch)
+
+    handler = default_handlers(router=None)["congress_fetch"]
+    with pytest.raises(RuntimeError) as excinfo:
+        await handler(
+            job,
+            {
+                "kind": "congress_fetch",
+                "payload": {"url": "https://www.congress.gov/bill/118/hr/1"},
+            },
+        )
+    assert not isinstance(excinfo.value, FatalError)
+    assert bug_message in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_connector_fetch_handler_missing_url_raises_fatal(
+    job: Job,
+) -> None:
+    """A connector-fetch task without a ``url`` payload field surfaces as a
+    clean :class:`FatalError` rather than a ``KeyError`` into the daemon
+    catch-all. Issue #190.
+    """
+    handler = default_handlers(router=None)["congress_fetch"]
+    with pytest.raises(FatalError, match="missing url field"):
+        await handler(job, {"kind": "congress_fetch", "payload": {}})
 
 
 @pytest.mark.asyncio

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -665,6 +665,214 @@ async def test_connector_fetch_handler_missing_url_raises_fatal(
         await handler(job, {"kind": "congress_fetch", "payload": {}})
 
 
+# ---------------------------------------------------------------------------
+# Issue #193: bill-text fan-out via _persist_fetched_source
+# ---------------------------------------------------------------------------
+
+
+def _make_congress_source(
+    *,
+    url: str = "https://www.congress.gov/bill/117th-congress/house-bill/5376",
+    title: str = "Inflation Reduction Act of 2022",
+    bill_text_url: str | None = (
+        "https://www.congress.gov/117/bills/hr5376/BILLS-117hr5376enr.pdf"
+    ),
+    bill_text_format: str | None = "PDF",
+) -> Any:
+    from datetime import UTC, datetime
+
+    from research_agent.tools.models import Source
+
+    metadata: dict[str, Any] = {
+        "congress": 117,
+        "bill_type": "hr",
+        "bill_number": "5376",
+    }
+    if bill_text_url is not None:
+        metadata["bill_text_url"] = bill_text_url
+    if bill_text_format is not None:
+        metadata["bill_text_format"] = bill_text_format
+
+    return Source(
+        url=url,
+        title=title,
+        cleaned_text=f"# {title}\n\nMetadata roll-up.",
+        fetched_at=datetime.now(tz=UTC),
+        source_kind="congress",
+        metadata=metadata,
+    )
+
+
+def test_persist_fetched_source_emits_bill_text_followup(job: Job) -> None:
+    """A congress source with ``bill_text_url`` in metadata fans out a
+    ``web_fetch`` follow-up pointing at the bill body — not at the metadata
+    URL — and inherits ``sub_question`` from the originating task payload.
+    """
+    from research_agent.orchestrator.loop import _persist_fetched_source
+
+    bill_text_url = "https://www.congress.gov/117/bills/hr5376/BILLS-117hr5376enr.pdf"
+    source = _make_congress_source(bill_text_url=bill_text_url)
+
+    payload = {
+        "url": "https://www.congress.gov/bill/117th-congress/house-bill/5376",
+        "sub_question": "How does HR 5376 fund climate provisions?",
+    }
+    result = _persist_fetched_source(job, source, payload=payload)
+
+    assert isinstance(result, dict)
+    assert "follow_up_tasks" in result
+    follow_ups = result["follow_up_tasks"]
+    assert len(follow_ups) == 1
+    fu = follow_ups[0]
+    assert fu["kind"] == "web_fetch"
+    assert fu["payload"]["url"] == bill_text_url
+    # Critically: the follow-up's URL must be the bill text, not the metadata
+    # source URL — that's the bug #193 fixes.
+    assert fu["payload"]["url"] != source.url
+    assert fu["payload"]["sub_question"] == "How does HR 5376 fund climate provisions?"
+
+
+def test_persist_fetched_source_no_followup_when_bill_text_url_absent(
+    job: Job,
+) -> None:
+    """When the metadata has no ``bill_text_url`` (e.g. newly-introduced bill
+    with no published text yet), no follow-up is emitted and no log noise.
+    """
+    from research_agent.orchestrator.loop import _persist_fetched_source
+
+    source = _make_congress_source(bill_text_url=None, bill_text_format=None)
+    result = _persist_fetched_source(job, source, payload={"sub_question": "anything"})
+
+    assert "follow_up_tasks" not in result
+
+
+def test_persist_fetched_source_dedups_already_fetched_bill_text(
+    job: Job,
+) -> None:
+    """Anti-runaway: if the bill text URL has already been fetched for this
+    job, ``_persist_fetched_source`` must not re-emit a follow-up. Otherwise
+    tactical_replan can cycle the same bill repeatedly.
+    """
+    from research_agent.orchestrator.loop import _persist_fetched_source
+    from research_agent.storage.sources import write_source
+
+    bill_text_url = "https://www.congress.gov/117/bills/hr5376/BILLS-117hr5376enr.pdf"
+
+    # Pre-seed: the bill text has already been fetched for this job.
+    write_source(
+        job,
+        url=bill_text_url,
+        title="HR 5376 — Bill Text",
+        raw_content="Section 1. Findings. Section 2. ...",
+        kind="pdf",
+    )
+
+    source = _make_congress_source(bill_text_url=bill_text_url)
+    result = _persist_fetched_source(job, source, payload={"sub_question": "again?"})
+
+    assert "follow_up_tasks" not in result
+
+
+def test_persist_fetched_source_falls_back_sub_question_from_title(
+    job: Job,
+) -> None:
+    """When no payload sub_question is supplied, the follow-up's sub_question
+    is derived from the bill title so downstream extraction still has context.
+    """
+    from research_agent.orchestrator.loop import _persist_fetched_source
+
+    source = _make_congress_source(title="Inflation Reduction Act of 2022")
+    # Pass an empty payload (no sub_question key).
+    result = _persist_fetched_source(job, source, payload={})
+
+    follow_ups = result.get("follow_up_tasks") or []
+    assert len(follow_ups) == 1
+    sub_q = follow_ups[0]["payload"]["sub_question"]
+    assert "Inflation Reduction Act of 2022" in sub_q
+
+
+@pytest.mark.asyncio
+async def test_congress_fetch_handler_emits_bill_text_followup(
+    job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end through the handler: the ``congress_fetch`` handler returns
+    a ``follow_up_tasks`` list whose only entry is a ``web_fetch`` for the
+    bill text URL, with the originating task's ``sub_question`` propagated.
+    """
+    from research_agent.tools import congress as congress_mod
+
+    bill_text_url = "https://www.congress.gov/117/bills/hr5376/BILLS-117hr5376enr.pdf"
+    metadata_url = "https://www.congress.gov/bill/117th-congress/house-bill/5376"
+    expected_source = _make_congress_source(
+        url=metadata_url, bill_text_url=bill_text_url
+    )
+
+    async def fake_fetch(url: str) -> Any:
+        assert url == metadata_url
+        return expected_source
+
+    monkeypatch.setattr(congress_mod, "fetch", fake_fetch)
+
+    handler = default_handlers(router=None)["congress_fetch"]
+    out = await handler(
+        job,
+        {
+            "kind": "congress_fetch",
+            "payload": {
+                "url": metadata_url,
+                "sub_question": "What does HR 5376 do for energy?",
+            },
+        },
+    )
+
+    assert isinstance(out, dict)
+    assert "source_id" in out
+    follow_ups = out.get("follow_up_tasks") or []
+    assert len(follow_ups) == 1
+    fu = follow_ups[0]
+    assert fu["kind"] == "web_fetch"
+    assert fu["payload"]["url"] == bill_text_url
+    assert fu["payload"]["sub_question"] == "What does HR 5376 do for energy?"
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_handler_merges_bill_text_and_extract_followups(
+    job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #193 + the existing extract-findings fan-out interact correctly:
+    when ``web_fetch`` host-dispatches to ``congress.fetch`` and the source has
+    ``bill_text_url``, the resulting follow_up_tasks must contain BOTH the
+    bill-text web_fetch and the extract_findings task on the metadata source.
+    """
+    from research_agent.tools import web_fetch as web_fetch_mod
+
+    bill_text_url = "https://www.congress.gov/117/bills/hr5376/BILLS-117hr5376enr.pdf"
+    metadata_url = "https://www.congress.gov/bill/117th-congress/house-bill/5376"
+
+    async def fake_fetch(url: str) -> Any:
+        return _make_congress_source(url=url, bill_text_url=bill_text_url)
+
+    monkeypatch.setattr(web_fetch_mod, "fetch", fake_fetch)
+
+    handler = default_handlers(router=None)["web_fetch"]
+    out = await handler(
+        job,
+        {
+            "kind": "web_fetch",
+            "payload": {
+                "url": metadata_url,
+                "sub_question": "energy provisions?",
+            },
+        },
+    )
+
+    follow_ups = out.get("follow_up_tasks") or []
+    kinds = sorted(f["kind"] for f in follow_ups)
+    assert kinds == ["extract_findings", "web_fetch"]
+    bill_followup = next(f for f in follow_ups if f["kind"] == "web_fetch")
+    assert bill_followup["payload"]["url"] == bill_text_url
+
+
 @pytest.mark.asyncio
 async def test_connector_search_handler_drops_kwargs_connector_does_not_accept(
     job: Job, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -621,7 +621,11 @@ def test_plan_created_event_payload_includes_scope_class_when_unset(
 
 
 def _make_recent_results(n: int) -> list[dict[str, Any]]:
-    """Build ``n`` synthetic completed-task entries shaped like loop output."""
+    """Build ``n`` synthetic completed-task entries shaped like loop output.
+
+    Emits DESC order (task_id from ``n`` down to ``1``) to match the contract
+    of ``_load_recent_task_results`` (issue #188).
+    """
     return [
         {
             "task_id": i,
@@ -634,7 +638,7 @@ def _make_recent_results(n: int) -> list[dict[str, Any]]:
                 ]
             },
         }
-        for i in range(1, n + 1)
+        for i in range(n, 0, -1)
     ]
 
 
@@ -655,8 +659,8 @@ def test_tactical_replan_truncates_recent_results_to_max(
     payload = json.loads(args[0])
     sent = payload["recent_results"]
     assert len(sent) == MAX_RECENT_RESULTS_FOR_REPLAN == 25
-    # The tail — last 25 entries — must be what we sent (verified by task_id).
-    assert [r["task_id"] for r in sent] == list(range(76, 101))
+    # Newest 25 (DESC) must survive the slice — task_ids 100..76, not 1..25.
+    assert [r["task_id"] for r in sent] == list(range(100, 75, -1))
 
 
 def test_tactical_replan_emits_replan_truncated_event(

--- a/tests/test_tools_congress.py
+++ b/tests/test_tools_congress.py
@@ -581,6 +581,9 @@ async def test_fetch_bill_builds_markdown_and_caches(monkeypatch, cache_dir: Pat
     assert md["bill_number"] == "5376"
     assert md["text_url"].endswith("BILLS-117hr5376enr.htm")
     assert md["text_format"] == "Formatted Text"
+    # Issue #193: alias keys consumed by the loop's bill-text fan-out.
+    assert md["bill_text_url"] == md["text_url"]
+    assert md["bill_text_format"] == md["text_format"]
     assert isinstance(md["actions"], list)
     assert md["actions"][0]["text"].startswith("Became Public Law")
 
@@ -594,6 +597,35 @@ async def test_fetch_bill_builds_markdown_and_caches(monkeypatch, cache_dir: Pat
     s2 = await congress.fetch(url)
     assert s2 is not None
     assert len(captured["urls"]) == api_calls_before
+
+
+async def test_fetch_bill_no_public_text_omits_bill_text_url(monkeypatch, cache_dir: Path):
+    """Issue #193: when the bill has no published text yet (common for newly-
+    introduced bills), the metadata's ``bill_text_url`` must be ``None`` so the
+    loop's fan-out helper silently skips emitting a follow-up.
+    """
+
+    def _no_text_responder(url, _params):
+        if url.endswith("/bill/117/hr/5376/text"):
+            return 200, json.dumps({"textVersions": []})
+        if url.endswith("/bill/117/hr/5376/actions"):
+            return 200, json.dumps(_BILL_ACTIONS_PAYLOAD)
+        if url.endswith("/bill/117/hr/5376"):
+            return 200, json.dumps(_BILL_HEADER_PAYLOAD)
+        return 404, ""
+
+    _patch_httpx(monkeypatch, responder=_no_text_responder)
+
+    url = "https://www.congress.gov/bill/117th-congress/house-bill/5376"
+    source = await congress.fetch(url)
+
+    assert source is not None
+    md = source.metadata
+    assert md["bill_text_url"] is None
+    assert md["bill_text_format"] is None
+    # And the cleaned-text body should reflect the absence rather than
+    # showing a stale URL.
+    assert "_No public text available yet._" in source.cleaned_text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools_sos.py
+++ b/tests/test_tools_sos.py
@@ -30,6 +30,8 @@ class _FakeLocator:
         raise_on_locator: bool = False,
         raise_on_all: bool = False,
         raise_on_wait_for: bool = False,
+        detach_fill_attempts: int = 0,
+        detach_click_attempts: int = 0,
     ) -> None:
         self._text = text
         self._attrs = attrs or {}
@@ -40,6 +42,12 @@ class _FakeLocator:
         self._raise_on_locator = raise_on_locator
         self._raise_on_all = raise_on_all
         self._raise_on_wait_for = raise_on_wait_for
+        # Number of remaining ``fill``/``click`` calls that should raise a
+        # Playwright-style "element was detached from the DOM" error before
+        # succeeding. ``-1`` means "always fail" so we can drive the evaluate
+        # fallback path without a finite countdown.
+        self._detach_fill_attempts = detach_fill_attempts
+        self._detach_click_attempts = detach_click_attempts
         self.fill_calls: list[str] = []
         self.click_calls: int = 0
         self.wait_for_calls: int = 0
@@ -61,11 +69,23 @@ class _FakeLocator:
 
     async def fill(self, value: str) -> None:
         self.fill_calls.append(value)
+        if self._detach_fill_attempts != 0:
+            if self._detach_fill_attempts > 0:
+                self._detach_fill_attempts -= 1
+            raise RuntimeError(
+                "Locator.fill: element was detached from the DOM, retrying"
+            )
         if self._on_fill is not None:
             self._on_fill(value)
 
     async def click(self) -> None:
         self.click_calls += 1
+        if self._detach_click_attempts != 0:
+            if self._detach_click_attempts > 0:
+                self._detach_click_attempts -= 1
+            raise RuntimeError(
+                "Locator.click: element is not attached to the DOM"
+            )
         if self._on_click is not None:
             self._on_click()
 
@@ -86,6 +106,7 @@ class _FakePage:
         self.closed = False
         self.screenshots: list[str] = []
         self.locator_calls: list[str] = []
+        self.load_state_calls: list[str] = []
 
     def locator(self, selector: str) -> _FakeLocator:
         self.locator_calls.append(selector)
@@ -96,6 +117,16 @@ class _FakePage:
 
     async def screenshot(self, *, path: str) -> None:
         self.screenshots.append(path)
+
+    async def wait_for_load_state(
+        self, state: str = "load", *, timeout: int = 0  # noqa: ARG002
+    ) -> None:
+        self.load_state_calls.append(state)
+
+    async def evaluate(self, script: str, arg: Any = None) -> Any:  # noqa: ARG002
+        # Default evaluate is a no-op; tests that exercise the fallback path
+        # monkeypatch this with an AsyncMock so they can assert the call.
+        return True
 
 
 class _FakeContext:
@@ -383,6 +414,122 @@ async def test_search_respects_max_results(monkeypatch):
 
     results = await sos.search("anything", state="CA", max_results=3)
     assert len(results) == 3
+
+
+async def test_search_recovers_when_input_detaches_between_query_and_fill(
+    monkeypatch,
+):
+    """Regression for issue #191: bizfileonline re-renders the React tree
+    between locator query and fill, detaching the handle. ``_fill_with_retry``
+    should re-resolve and succeed without a diagnostic-screenshot bail-out.
+    """
+    recipe = sos._STATE_RECIPES["CA"]
+    rows = [
+        _build_row(
+            name="SBI BUILDERS, LLC",
+            entity_number="201234567890",
+            entity_type="Limited Liability Company",
+            status="Active",
+            formed="2012-03-15",
+            registered_agent="Jane Q Agent",
+        ),
+    ]
+    flaky_input = _FakeLocator(detach_fill_attempts=2)  # fail twice, then succeed
+    page = _FakePage(
+        {
+            recipe["query_input"]: flaky_input,
+            recipe["submit_button"]: _FakeLocator(),
+            recipe["row_selector"]: _FakeLocator(items=rows),
+        }
+    )
+    _stub_browser(monkeypatch, page)
+
+    results = await sos.search("SBI Builders", state="CA")
+
+    assert len(results) == 1
+    assert results[0].title == "SBI BUILDERS, LLC"
+    # Fake recorded three fill attempts: two raised "detached", the third won.
+    assert len(flaky_input.fill_calls) == 3
+    assert flaky_input.fill_calls == ["SBI Builders"] * 3
+    # No diagnostic screenshot — the connector recovered cleanly.
+    assert page.screenshots == []
+
+
+async def test_search_falls_back_to_evaluate_when_fill_keeps_detaching(
+    monkeypatch,
+):
+    """If every retry loses the race, ``_fill_with_retry`` must fall back to
+    ``page.evaluate`` setting ``.value`` and dispatching native input/change
+    events — the documented escape hatch for SPA forms.
+    """
+    recipe = sos._STATE_RECIPES["CA"]
+    rows = [
+        _build_row(
+            name="SBI BUILDERS, LLC",
+            entity_number="201234567890",
+            entity_type="Limited Liability Company",
+            status="Active",
+            formed="2012-03-15",
+            registered_agent="Jane Q Agent",
+        ),
+    ]
+    always_detach_input = _FakeLocator(detach_fill_attempts=-1)  # always fails
+    page = _FakePage(
+        {
+            recipe["query_input"]: always_detach_input,
+            recipe["submit_button"]: _FakeLocator(),
+            recipe["row_selector"]: _FakeLocator(items=rows),
+        }
+    )
+    eval_mock = AsyncMock(return_value=True)
+    page.evaluate = eval_mock
+    _stub_browser(monkeypatch, page)
+
+    results = await sos.search("SBI Builders", state="CA")
+
+    assert eval_mock.called, "expected evaluate fallback after retries exhausted"
+    # First positional call was the fill fallback (script + [selector, value]).
+    fill_call = eval_mock.call_args_list[0]
+    script, arg = fill_call.args
+    assert "dispatchEvent" in script
+    assert "input" in script and "change" in script
+    assert arg == [recipe["query_input"], "SBI Builders"]
+    # Three locator-fill attempts before the evaluate fallback fired.
+    assert len(always_detach_input.fill_calls) == 3
+    # Search still produced rows because the evaluate path landed the value.
+    assert len(results) == 1
+    assert results[0].title == "SBI BUILDERS, LLC"
+
+
+async def test_search_recovers_when_submit_button_detaches(monkeypatch):
+    """Submit click is wrapped in the same retry helper — a detached click
+    handle on the first attempt should not abort the search.
+    """
+    recipe = sos._STATE_RECIPES["CA"]
+    rows = [
+        _build_row(
+            name="SBI BUILDERS, LLC",
+            entity_number="201234567890",
+            entity_type="Limited Liability Company",
+            status="Active",
+            formed="2012-03-15",
+        ),
+    ]
+    flaky_button = _FakeLocator(detach_click_attempts=1)  # fails once, then succeeds
+    page = _FakePage(
+        {
+            recipe["query_input"]: _FakeLocator(),
+            recipe["submit_button"]: flaky_button,
+            recipe["row_selector"]: _FakeLocator(items=rows),
+        }
+    )
+    _stub_browser(monkeypatch, page)
+
+    results = await sos.search("SBI Builders", state="CA")
+
+    assert len(results) == 1
+    assert flaky_button.click_calls == 2
+    assert page.screenshots == []
 
 
 async def test_search_returns_empty_when_rows_never_render(

--- a/tests/test_tools_web_fetch.py
+++ b/tests/test_tools_web_fetch.py
@@ -657,6 +657,77 @@ async def test_fetch_dispatches_to_connector_for_bare_domain(
     assert result is None
 
 
+async def test_fetch_falls_through_for_congress_bill_text_url(monkeypatch):
+    """Issue #193: bill-text URLs on ``www.congress.gov`` (path
+    ``/<congress>/bills/<slug>/BILLS-...``) are raw HTML/XML bodies that
+    ``congress.fetch`` doesn't handle — its URL classifier only matches the
+    canonical ``/bill/<congress>/<chamber>/<n>`` permalink. Without the
+    carve-out, the bill-text fan-out hits ``congress.fetch`` → ``None`` →
+    ``_persist_fetched_source`` FatalErrors. This test pins the regression:
+    bill-text URLs must skip the connector and reach the generic httpx
+    extractor.
+    """
+    _disable_robots(monkeypatch)
+    _stub_archive(monkeypatch)
+
+    from research_agent.tools import congress
+
+    async def _should_not_dispatch(*args, **kwargs):
+        raise AssertionError(
+            "congress.fetch was called for a bill-text URL — should fall through"
+        )
+
+    monkeypatch.setattr(congress, "fetch", _should_not_dispatch)
+
+    httpx_calls: list[str] = []
+
+    async def _fake_httpx(url, timeout, user_agent):
+        httpx_calls.append(url)
+        return 200, ARTICLE_HTML, ARTICLE_HTML.encode("utf-8"), "text/html"
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _fake_httpx)
+
+    bill_text_url = (
+        "https://www.congress.gov/117/bills/hr5376/BILLS-117hr5376enr.htm"
+    )
+    source = await web_fetch.fetch(bill_text_url)
+    assert httpx_calls == [bill_text_url]
+    assert source is not None
+    assert source.metadata["fetched_via"] == "httpx"
+
+
+async def test_fetch_canonical_bill_url_still_dispatches_to_congress(monkeypatch):
+    """Counterpart to the bill-text carve-out: the canonical
+    ``/bill/<congress>/<chamber>/<n>`` permalink must still route to
+    ``congress.fetch`` (issue #174 contract). The carve-out only covers the
+    ``/<congress>/bills/.../BILLS-...`` content-URL shape.
+    """
+    _disable_robots(monkeypatch)
+    _stub_archive(monkeypatch)
+
+    from research_agent.tools import congress
+
+    async def _no_httpx(*args, **kwargs):
+        raise AssertionError(
+            "web_fetch fell through to httpx for a canonical bill URL"
+        )
+
+    monkeypatch.setattr(web_fetch, "_fetch_via_httpx", _no_httpx)
+
+    captured: list[str] = []
+
+    async def _fake_congress_fetch(target_url, *args, **kwargs):
+        captured.append(target_url)
+        return None
+
+    monkeypatch.setattr(congress, "fetch", _fake_congress_fetch)
+
+    canonical = "https://www.congress.gov/bill/117th-congress/house-bill/5376"
+    result = await web_fetch.fetch(canonical)
+    assert captured == [canonical]
+    assert result is None
+
+
 async def test_fetch_falls_through_to_generic_for_propublica_non_nonprofits(
     monkeypatch,
 ):

--- a/tests/test_tools_web_search.py
+++ b/tests/test_tools_web_search.py
@@ -219,6 +219,61 @@ def test_tool_registry_has_web_search():
     assert callable(TOOL_REGISTRY["web_search"])
 
 
+def test_smoke_web_search_invokes_auto_engine_only(monkeypatch):
+    """Issue #192: smoke must mirror the orchestrator (engine='auto'), not
+    hand-roll separate ddg/google scrapes."""
+    from research_agent.tools import TOOL_REGISTRY
+
+    calls: list[dict] = []
+
+    async def _fake_search(query, max_results=10, engine="auto"):
+        calls.append({"query": query, "max_results": max_results, "engine": engine})
+        return []
+
+    monkeypatch.setattr(web_search, "search", _fake_search)
+    # No Brave key → label should say ddg-fallback when results are empty.
+    monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
+
+    output = TOOL_REGISTRY["web_search"]("project 2025")
+
+    assert len(calls) == 1, "smoke must call web_search.search exactly once"
+    assert calls[0]["engine"] == "auto"
+    assert calls[0]["query"] == "project 2025"
+    # When auto resolves to ddg with zero hits, the header flags the fallback
+    # and selector drift so operators can tell it apart from a Brave miss.
+    assert "engine=ddg" in output
+    assert "selector drift" in output
+
+
+def test_smoke_web_search_brave_path_labels_engine(monkeypatch):
+    """With BRAVE_SEARCH_API_KEY set, auto routes to Brave and the smoke
+    output labels the path so operators can see which engine ran."""
+    from research_agent.tools import TOOL_REGISTRY
+    from research_agent.tools.models import SearchResult
+
+    monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "test-key")
+
+    fake_hit = SearchResult(
+        url="https://example.com/p2025",
+        title="Project 2025 implementation",
+        snippet="Heritage Foundation policy blueprint",
+        source_kind="web",
+        extras={"source_engine": "brave"},
+    )
+
+    async def _fake_brave(query, max_results):
+        return [fake_hit]
+
+    monkeypatch.setattr(web_search, "_search_brave", _fake_brave)
+
+    output = TOOL_REGISTRY["web_search"]("project 2025")
+
+    assert "engine=brave" in output
+    assert "returned 1 hits" in output
+    assert "https://example.com/p2025" in output
+    assert "Project 2025 implementation" in output
+
+
 def test_serp_rate_buckets_set_to_one_per_two_seconds():
     """Every ``search()`` call applies the 0.5 rps SERP rate (1 query/2s)."""
     browser.reset_for_tests()


### PR DESCRIPTION
## Session Summary

**Branch:** session/epic-195-epic-post-180-cleanup-smoke-regressions-and-depth-extension-follow-ups
**Issues completed:** 7 (7 succeeded, 0 failed)
**Total duration:** 81 minutes
**Completed:** 2026-05-08T04:28:25.291Z

### Issues
- #188: fix: tactical_replan tail slice picks oldest 25 instead of newest when loader returns DESC — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/198))
- #189: fix: cornerstone size-fallback (>200k chars) over-triggers on long HTML; gate to PDF or add visibility event — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/199))
- #190: fix: connector handlers catch all RuntimeError as missing-credential, masking real connector bugs — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/200))
- #191: fix: sos (CA Secretary of State) Playwright connector — DOM detached on bizfileonline.sos.ca.gov search input — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/201))
- #192: fix: _smoke_web_search tests DDG+Google scrapers, not the Brave runtime path the overnight actually uses — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/202))
- #193: feat: congress.fetch auto-fans-out a web_fetch for the bill text URL — today we index metadata but never read the substance — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/203))
- #194: feat: extract_findings should optionally auto-fan-out web_fetch for URLs cited in extracted claims (second-order URL extraction) — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/204))

Closes #188
Closes #189
Closes #190
Closes #191
Closes #192
Closes #193
Closes #194

### Session Review

**Status:** PASSED
**Summary:** Session changes integrate cleanly across issues #188-#194; boot/smoke/full suite (1389) green, cross-issue follow_up_tasks merging verified, security scan clean.

- [INFO] Comment on _CORNERSTONE_FALLBACK_MIN_CHARS at loop.py:~1207 was stale after #189 — still described the fallback as for runs whose plans pre-date #177, with no mention of the PDF gate. Updated to point at the new gate logic in _is_cornerstone_source. (fixed) — `src/research_agent/orchestrator/loop.py`

---
This PR collects all changes from this session for final review before merging to main.

Automated by alpha-loop