### PR TITLE
feat: fix: tactical_replan tail slice picks oldest 25 instead of newest when loader returns DESC (closes #188)

### DIFF
--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -512,11 +512,14 @@ async def tactical_replan(
     next_version = plan.version + 1
 
     # issue #176: bound the payload regardless of caller. recent_results is
-    # truncated to the last MAX_RECENT_RESULTS_FOR_REPLAN entries and each is
+    # truncated to the newest MAX_RECENT_RESULTS_FOR_REPLAN entries and each is
     # replaced by a compact summary; older results are already reflected in
     # the running plan + findings so dropping them is safe.
+    # Contract (issue #188): ``recent_results`` arrives newest-first (DESC) per
+    # ``_load_recent_task_results`` (loop.py ORDER BY id DESC), so a head slice
+    # keeps the newest entries.
     original_len = len(recent_results)
-    tail = recent_results[-MAX_RECENT_RESULTS_FOR_REPLAN:]
+    tail = recent_results[:MAX_RECENT_RESULTS_FOR_REPLAN]
     summarized = [_summarize_recent_result(r) for r in tail]
 
     payload: dict[str, Any] = {

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -621,7 +621,11 @@ def test_plan_created_event_payload_includes_scope_class_when_unset(
 
 
 def _make_recent_results(n: int) -> list[dict[str, Any]]:
-    """Build ``n`` synthetic completed-task entries shaped like loop output."""
+    """Build ``n`` synthetic completed-task entries shaped like loop output.
+
+    Emits DESC order (task_id from ``n`` down to ``1``) to match the contract
+    of ``_load_recent_task_results`` (issue #188).
+    """
     return [
         {
             "task_id": i,
@@ -634,7 +638,7 @@ def _make_recent_results(n: int) -> list[dict[str, Any]]:
                 ]
             },
         }
-        for i in range(1, n + 1)
+        for i in range(n, 0, -1)
     ]
 
 
@@ -655,8 +659,8 @@ def test_tactical_replan_truncates_recent_results_to_max(
     payload = json.loads(args[0])
     sent = payload["recent_results"]
     assert len(sent) == MAX_RECENT_RESULTS_FOR_REPLAN == 25
-    # The tail — last 25 entries — must be what we sent (verified by task_id).
-    assert [r["task_id"] for r in sent] == list(range(76, 101))
+    # Newest 25 (DESC) must survive the slice — task_ids 100..76, not 1..25.
+    assert [r["task_id"] for r in sent] == list(range(100, 75, -1))
 
 
 def test_tactical_replan_emits_replan_truncated_event(


### PR DESCRIPTION
Closes #188
Part of #195

## Summary

Automated implementation of **fix: tactical_replan tail slice picks oldest 25 instead of newest when loader returns DESC**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Fix correctly switches tail slice to head slice for DESC-ordered recent_results; test fixture now exercises DESC and asserts newest 25 task_ids; ordering contract documented at slice site.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*