### PR TITLE
feat: fix: cornerstone size-fallback (>200k chars) over-triggers on long HTML; gate to PDF or add visibility event (closes #189)

### DIFF
--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -59,6 +59,7 @@ EventKind = Literal[
     "pdf_vlm_escalation",
     "ocr_vlm_escalation",
     "cornerstone_extract",
+    "cornerstone_fallback_triggered",
     "error",
     "warning",
 ]

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -772,7 +772,7 @@ def _load_source_text(job: Job, source_id: int) -> tuple[str, dict[str, Any]] | 
     conn = db.connect(job.db_path)
     try:
         row = conn.execute(
-            "SELECT id, url, title, md_path, archive_url FROM sources WHERE id = ?",
+            "SELECT id, url, title, md_path, archive_url, kind FROM sources WHERE id = ?",
             (source_id,),
         ).fetchone()
     finally:
@@ -788,6 +788,7 @@ def _load_source_text(job: Job, source_id: int) -> tuple[str, dict[str, Any]] | 
         "url": row["url"],
         "title": row["title"],
         "archive_url": row["archive_url"],
+        "source_kind": row["kind"],
     }
     return text, meta
 
@@ -840,25 +841,43 @@ def _normalize_url_for_compare(url: str | None) -> str | None:
     return urlunsplit((parts.scheme.lower(), netloc, path, parts.query, ""))
 
 
-def _is_cornerstone_source(job: Job, meta: dict[str, Any], text: str) -> bool:
-    """True when this source is the plan's declared cornerstone document.
+def _is_cornerstone_source(
+    job: Job, meta: dict[str, Any], text: str
+) -> tuple[bool, bool]:
+    """Return ``(is_cornerstone, via_size_fallback)`` for this source.
 
     Primary signal: the latest persisted plan's ``cornerstone_url`` matches
-    the source's URL (after light normalization). Fallback: the source's
-    body exceeds :data:`_CORNERSTONE_FALLBACK_MIN_CHARS`, which catches
-    runs whose plans pre-date #177 — better to over-trigger here than to
-    cap a 920-page document at 8 findings because the planner forgot to
-    set the marker.
+    the source's URL (after light normalization).
+
+    Fallback (issue #189): a source whose ``source_kind == "pdf"`` and whose
+    body exceeds :data:`_CORNERSTONE_FALLBACK_MIN_CHARS` is treated as the
+    cornerstone even when no planner marker matches. The PDF gate exists
+    because long-form HTML (Wikipedia full-text articles, archive.org
+    transcripts, scraped book chapters) can also exceed 200k chars without
+    being investigation cornerstones, and routing them through the
+    structured-index prompt with the 500-finding ceiling causes the exact
+    report-padding regression #177 was meant to prevent. PDFs of this size
+    are nearly always the kind of monograph/filing the cornerstone path is
+    calibrated for, so the fallback only fires for them.
+
+    The second return value is ``True`` only when the size-fallback path
+    fires (i.e. the planner did not mark the source); the call site uses
+    this to emit a ``cornerstone_fallback_triggered`` event so operators
+    can see the fallback was responsible for the lifted cap.
     """
     plan = _load_latest_plan(job)
     if plan is not None and plan.cornerstone_url:
         norm_plan = _normalize_url_for_compare(plan.cornerstone_url)
         norm_src = _normalize_url_for_compare(meta.get("url"))
         if norm_plan and norm_src and norm_plan == norm_src:
-            return True
-    if isinstance(text, str) and len(text) >= _CORNERSTONE_FALLBACK_MIN_CHARS:
-        return True
-    return False
+            return True, False
+    if (
+        meta.get("source_kind") == "pdf"
+        and isinstance(text, str)
+        and len(text) >= _CORNERSTONE_FALLBACK_MIN_CHARS
+    ):
+        return True, True
+    return False, False
 
 
 _YAML_FENCE_RE = re.compile(r"```(?:yaml|yml)?\s*\n(.*?)\n```", re.DOTALL | re.IGNORECASE)
@@ -923,11 +942,24 @@ async def _run_extract_findings(
 
     sub_question = payload.get("sub_question") or job.goal
 
-    is_cornerstone = _is_cornerstone_source(job, meta, text)
+    is_cornerstone, via_size_fallback = _is_cornerstone_source(job, meta, text)
     if is_cornerstone:
         prompt_name = "researcher_cornerstone"
         text_limit = _CORNERSTONE_EXTRACT_TEXT_LIMIT
         findings_limit = _CORNERSTONE_FINDINGS_PER_SOURCE_LIMIT
+        if via_size_fallback:
+            emit(
+                job,
+                "WARN",
+                "loop",
+                "cornerstone_fallback_triggered",
+                {
+                    "source_id": source_id,
+                    "url": meta.get("url"),
+                    "source_kind": meta.get("source_kind"),
+                    "cleaned_chars": len(text),
+                },
+            )
         emit(
             job,
             "INFO",

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -16,6 +16,8 @@ from research_agent.orchestrator.loop import (
     RETRY_MAX_ATTEMPTS,
     Handler,
     _expand_search_to_fetches,
+    _is_cornerstone_source,
+    _load_source_text,
     _run_extract_findings,
     default_handlers,
     run_loop,
@@ -1018,7 +1020,7 @@ class _StubRouter:
         return _Result()
 
 
-def _seed_source(job: Job, *, url: str, body: str) -> int:
+def _seed_source(job: Job, *, url: str, body: str, kind: str = "web") -> int:
     from research_agent.storage.sources import write_source
 
     return write_source(
@@ -1026,7 +1028,7 @@ def _seed_source(job: Job, *, url: str, body: str) -> int:
         url=url,
         title="Cornerstone Document",
         raw_content=body,
-        kind="web",
+        kind=kind,
     )
 
 
@@ -1211,3 +1213,151 @@ async def test_extract_findings_non_cornerstone_uses_default_cap(
     assert result["findings_written"] == 8
     assert "researcher" in loaded_prompts
     assert "researcher_cornerstone" not in loaded_prompts
+
+
+def test_is_cornerstone_source_size_fallback_gated_to_pdf(
+    job: Job,
+) -> None:
+    """Issue #189: size-fallback only fires for ``source_kind == "pdf"``.
+
+    Three cases — all share the same 250k-char body, only ``source_kind``
+    and the planner marker differ:
+
+    * HTML, no planner match → ``(False, False)`` — long-form HTML must
+      not be promoted to cornerstone, or #177's report-padding regression
+      comes back.
+    * PDF, no planner match  → ``(True, True)`` — the second flag tells
+      the call site to emit ``cornerstone_fallback_triggered``.
+    * Planner-marked URL     → ``(True, False)`` — primary signal wins,
+      no fallback event regardless of kind/size.
+    """
+    # Bodies must differ — sources dedupe by content sha256 across kinds.
+    html_id = _seed_source(
+        job,
+        url="https://example.test/long-article.html",
+        body="H" * 250_000,
+        kind="html",
+    )
+    pdf_id = _seed_source(
+        job,
+        url="https://example.test/big-doc.pdf",
+        body="P" * 250_000,
+        kind="pdf",
+    )
+    marked_id = _seed_source(
+        job,
+        url="https://example.test/marked.html",
+        body="short body",
+        kind="html",
+    )
+
+    _persist_plan_with_cornerstone(job, "https://example.test/marked.html")
+
+    html_loaded = _load_source_text(job, html_id)
+    pdf_loaded = _load_source_text(job, pdf_id)
+    marked_loaded = _load_source_text(job, marked_id)
+    assert html_loaded is not None
+    assert pdf_loaded is not None
+    assert marked_loaded is not None
+
+    html_text, html_meta = html_loaded
+    pdf_text, pdf_meta = pdf_loaded
+    marked_text, marked_meta = marked_loaded
+
+    assert _is_cornerstone_source(job, html_meta, html_text) == (False, False)
+    assert _is_cornerstone_source(job, pdf_meta, pdf_text) == (True, True)
+    assert _is_cornerstone_source(job, marked_meta, marked_text) == (True, False)
+
+
+@pytest.mark.asyncio
+async def test_extract_findings_pdf_fallback_emits_event(
+    job: Job,
+    db_path: Path,
+) -> None:
+    """PDF size-fallback path emits ``cornerstone_fallback_triggered`` (WARN).
+
+    The planner did not mark this URL; only the PDF size-fallback path
+    routes the source through the cornerstone prompt, so the operator-
+    visible WARN event must fire alongside the existing INFO
+    ``cornerstone_extract`` event.
+    """
+    url = "https://example.test/forgot-to-mark.pdf"
+    _persist_plan_with_cornerstone(job, "https://example.test/something-else.pdf")
+    source_id = _seed_source(job, url=url, body="P" * 250_000, kind="pdf")
+
+    router = _StubRouter("```yaml\n[]\n```\n")
+    task = {"payload": {"source_id": source_id, "sub_question": "What?"}}
+
+    await _run_extract_findings(job, task, router=router)
+
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT level, kind, payload_json FROM events"
+            " WHERE job_id = ? AND kind = 'cornerstone_fallback_triggered'",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    assert rows[0]["level"] == "WARN"
+    import json as _json
+
+    payload = _json.loads(rows[0]["payload_json"])
+    assert payload["source_id"] == source_id
+    assert payload["url"] == url
+    assert payload["source_kind"] == "pdf"
+    # md_path is written as ``cleaned + "\n"`` so the read-back text adds
+    # one byte to the body length; tolerate that without fixing the value.
+    assert payload["cleaned_chars"] >= 250_000
+
+    # Both the fallback WARN and the standard cornerstone_extract INFO must fire.
+    kinds = _read_event_kinds(db_path, job.id)
+    assert "cornerstone_fallback_triggered" in kinds
+    assert "cornerstone_extract" in kinds
+
+
+@pytest.mark.asyncio
+async def test_extract_findings_html_size_does_not_emit_fallback(
+    job: Job,
+    db_path: Path,
+) -> None:
+    """A 250k-char HTML source must NOT trigger the size fallback.
+
+    Long-form HTML (Wikipedia, archive.org transcripts) frequently
+    crosses the 200k-char threshold without being investigation
+    cornerstones — the gate must keep them on the regular extraction
+    path with the 8-finding cap intact.
+    """
+    url = "https://example.test/very-long.html"
+    _persist_plan_with_cornerstone(job, "https://example.test/something-else.pdf")
+    source_id = _seed_source(job, url=url, body="H" * 250_000, kind="html")
+
+    router = _StubRouter("```yaml\n[]\n```\n")
+    task = {"payload": {"source_id": source_id, "sub_question": "What?"}}
+
+    await _run_extract_findings(job, task, router=router)
+
+    kinds = _read_event_kinds(db_path, job.id)
+    assert "cornerstone_fallback_triggered" not in kinds
+    assert "cornerstone_extract" not in kinds
+
+
+@pytest.mark.asyncio
+async def test_extract_findings_planner_marker_does_not_emit_fallback(
+    job: Job,
+    db_path: Path,
+) -> None:
+    """Planner-marked cornerstone never emits the fallback WARN event."""
+    url = "https://example.test/policy.md"
+    _persist_plan_with_cornerstone(job, url)
+    source_id = _seed_source(job, url=url, body=_CORNERSTONE_BODY)
+
+    router = _StubRouter("```yaml\n[]\n```\n")
+    task = {"payload": {"source_id": source_id, "sub_question": "What?"}}
+
+    await _run_extract_findings(job, task, router=router)
+
+    kinds = _read_event_kinds(db_path, job.id)
+    assert "cornerstone_extract" in kinds
+    assert "cornerstone_fallback_triggered" not in kinds


### PR DESCRIPTION
Closes #189
Part of #195

## Summary

Automated implementation of **fix: cornerstone size-fallback (>200k chars) over-triggers on long HTML; gate to PDF or add visibility event**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Cornerstone size-fallback gated to PDF, WARN visibility event emitted, event kind registered, all four tests pass.

- **INFO** [OPEN] `src/research_agent/orchestrator/plan.py`: Diff vs origin/main includes commit 980361e (#188 tactical_replan slice fix) that was previously merged to the session branch via PR #198 but has not yet reached main. It is unrelated to #189 but appears in the diff because it sits on the same stacked branch. Not a scope violation by this PR — flagging only so the reviewer is not surprised.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*