### PR TITLE
feat: fix: sos (CA Secretary of State) Playwright connector — DOM detached on bizfileonline.sos.ca.gov search input (closes #191)

### DIFF
--- a/src/research_agent/tools/sos.py
+++ b/src/research_agent/tools/sos.py
@@ -66,9 +66,16 @@ _STATE_RECIPES: dict[str, dict[str, Any]] = {
     "CA": {
         "host": "bizfileonline.sos.ca.gov",
         "search_url": "https://bizfileonline.sos.ca.gov/search/business",
-        # Live DOM (verified 2026-05): the search input has placeholder
+        # Live DOM (verified 2026-05-07): the search input has placeholder
         # "Search by name or file number"; the submit control is a button
         # with aria-label="Execute search" and no type attribute.
+        # The page is a React SPA that re-renders the search input shortly
+        # after first paint (a hydration step), so a naive
+        # ``locator(...).fill(...)`` races the re-render and Playwright raises
+        # "element was detached from the DOM". Submission goes through
+        # ``_fill_with_retry`` / ``_click_with_retry`` below, which re-query
+        # the locator on each attempt and fall back to a JS evaluate that
+        # sets ``.value`` and dispatches native ``input`` + ``change`` events.
         "query_input": "input[placeholder*='Search' i]",
         "submit_button": "button[aria-label='Execute search']",
         # Optional: if/when the UI exposes name-vs-number tabs, route here.
@@ -180,6 +187,128 @@ async def _safe_attr(locator: Any, name: str) -> str:
     except Exception:  # noqa: BLE001
         return ""
     return (value or "").strip()
+
+
+# bizfileonline.sos.ca.gov re-renders its React tree shortly after first paint
+# (a hydration step). The locator resolves but Playwright's auto-retry inside
+# ``fill()`` can lose the race and raise "element was detached from the DOM".
+# Detect those errors by message-substring rather than exception type because
+# the surface is shared between Playwright's own ``Error`` and the generic
+# ``RuntimeError`` strings the SDK builds at the call site.
+_DETACHED_ERROR_HINTS = (
+    "detached from the dom",
+    "element is not attached",
+    "not attached to the dom",
+)
+
+# JS injected as the last-ditch fallback when ``fill()`` keeps racing the
+# re-render. React listens for native ``input``/``change`` events on its
+# controlled inputs, so setting ``.value`` directly without dispatching the
+# events leaves the framework state out of sync — the form will appear empty
+# the moment React re-renders. Use the prototype setter so React's
+# ``__valueTracker`` shim sees a real value change.
+_FILL_VIA_EVALUATE_JS = """
+([selector, value]) => {
+    const el = document.querySelector(selector);
+    if (!el) return false;
+    const proto = Object.getPrototypeOf(el);
+    const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+    if (desc && typeof desc.set === 'function') {
+        desc.set.call(el, value);
+    } else {
+        el.value = value;
+    }
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+    return true;
+}
+"""
+
+
+def _is_detached_error(exc: BaseException) -> bool:
+    msg = str(exc).lower()
+    return any(hint in msg for hint in _DETACHED_ERROR_HINTS)
+
+
+async def _fill_with_retry(
+    page: Any, selector: str, value: str, *, attempts: int = 3
+) -> None:
+    """Fill ``selector`` with ``value``, re-resolving the locator on detach.
+
+    Re-queries ``page.locator(selector).first`` on every attempt so a stale
+    handle from a React re-render is replaced. After ``attempts`` tries falls
+    back to ``page.evaluate`` setting ``.value`` and dispatching native
+    ``input``/``change`` events — the documented escape hatch for SPA forms.
+    """
+    last_exc: BaseException | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            await page.locator(selector).first.fill(value)
+            return
+        except Exception as exc:  # noqa: BLE001
+            if not _is_detached_error(exc):
+                raise
+            last_exc = exc
+            logger.debug(
+                "sos fill detached on attempt %d/%d (%s): %s",
+                attempt,
+                attempts,
+                selector,
+                exc,
+            )
+    logger.debug(
+        "sos fill falling back to evaluate after %d detached attempts (%s)",
+        attempts,
+        selector,
+    )
+    try:
+        await page.evaluate(_FILL_VIA_EVALUATE_JS, [selector, value])
+    except Exception as exc:  # noqa: BLE001
+        if last_exc is not None:
+            raise last_exc from exc
+        raise
+
+
+async def _click_with_retry(
+    page: Any, selector: str, *, attempts: int = 3
+) -> None:
+    """Click ``selector``, re-resolving the locator on detach.
+
+    Same retry shape as ``_fill_with_retry``; if every attempt loses the race
+    the JS fallback calls ``el.click()`` directly so React's onClick still
+    fires.
+    """
+    last_exc: BaseException | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            await page.locator(selector).first.click()
+            return
+        except Exception as exc:  # noqa: BLE001
+            if not _is_detached_error(exc):
+                raise
+            last_exc = exc
+            logger.debug(
+                "sos click detached on attempt %d/%d (%s): %s",
+                attempt,
+                attempts,
+                selector,
+                exc,
+            )
+    logger.debug(
+        "sos click falling back to evaluate after %d detached attempts (%s)",
+        attempts,
+        selector,
+    )
+    try:
+        await page.evaluate(
+            "(selector) => { const el = document.querySelector(selector); "
+            "if (el) el.click(); return !!el; }",
+            selector,
+        )
+    except Exception as exc:  # noqa: BLE001
+        if last_exc is not None:
+            raise last_exc from exc
+        raise
 
 
 async def _save_diagnostic_screenshot(page: Any, host: str) -> None:
@@ -333,17 +462,27 @@ async def search(
             try:
                 await browser.navigate(page, search_url)
 
+                # Let the React tree finish hydrating before we acquire any
+                # locators — otherwise the search input handle is detached out
+                # from under us between query and fill (see issue #191).
+                try:
+                    await page.wait_for_load_state(
+                        "networkidle", timeout=10_000
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("sos wait_for_load_state failed: %s", exc)
+
                 if recipe.get("query_kind_selector"):
                     kind = "number" if _looks_like_entity_number(query) else "name"
                     selector = recipe["query_kind_selector"].format(kind=kind)
                     try:
-                        await page.locator(selector).first.click()
+                        await _click_with_retry(page, selector)
                     except Exception as exc:  # noqa: BLE001
                         logger.debug("sos query-kind toggle failed: %s", exc)
 
                 try:
-                    await page.locator(recipe["query_input"]).first.fill(query)
-                    await page.locator(recipe["submit_button"]).first.click()
+                    await _fill_with_retry(page, recipe["query_input"], query)
+                    await _click_with_retry(page, recipe["submit_button"])
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "sos search submit failed for state=%s: %s", code, exc

--- a/tests/test_tools_sos.py
+++ b/tests/test_tools_sos.py
@@ -30,6 +30,8 @@ class _FakeLocator:
         raise_on_locator: bool = False,
         raise_on_all: bool = False,
         raise_on_wait_for: bool = False,
+        detach_fill_attempts: int = 0,
+        detach_click_attempts: int = 0,
     ) -> None:
         self._text = text
         self._attrs = attrs or {}
@@ -40,6 +42,12 @@ class _FakeLocator:
         self._raise_on_locator = raise_on_locator
         self._raise_on_all = raise_on_all
         self._raise_on_wait_for = raise_on_wait_for
+        # Number of remaining ``fill``/``click`` calls that should raise a
+        # Playwright-style "element was detached from the DOM" error before
+        # succeeding. ``-1`` means "always fail" so we can drive the evaluate
+        # fallback path without a finite countdown.
+        self._detach_fill_attempts = detach_fill_attempts
+        self._detach_click_attempts = detach_click_attempts
         self.fill_calls: list[str] = []
         self.click_calls: int = 0
         self.wait_for_calls: int = 0
@@ -61,11 +69,23 @@ class _FakeLocator:
 
     async def fill(self, value: str) -> None:
         self.fill_calls.append(value)
+        if self._detach_fill_attempts != 0:
+            if self._detach_fill_attempts > 0:
+                self._detach_fill_attempts -= 1
+            raise RuntimeError(
+                "Locator.fill: element was detached from the DOM, retrying"
+            )
         if self._on_fill is not None:
             self._on_fill(value)
 
     async def click(self) -> None:
         self.click_calls += 1
+        if self._detach_click_attempts != 0:
+            if self._detach_click_attempts > 0:
+                self._detach_click_attempts -= 1
+            raise RuntimeError(
+                "Locator.click: element is not attached to the DOM"
+            )
         if self._on_click is not None:
             self._on_click()
 
@@ -86,6 +106,7 @@ class _FakePage:
         self.closed = False
         self.screenshots: list[str] = []
         self.locator_calls: list[str] = []
+        self.load_state_calls: list[str] = []
 
     def locator(self, selector: str) -> _FakeLocator:
         self.locator_calls.append(selector)
@@ -96,6 +117,16 @@ class _FakePage:
 
     async def screenshot(self, *, path: str) -> None:
         self.screenshots.append(path)
+
+    async def wait_for_load_state(
+        self, state: str = "load", *, timeout: int = 0  # noqa: ARG002
+    ) -> None:
+        self.load_state_calls.append(state)
+
+    async def evaluate(self, script: str, arg: Any = None) -> Any:  # noqa: ARG002
+        # Default evaluate is a no-op; tests that exercise the fallback path
+        # monkeypatch this with an AsyncMock so they can assert the call.
+        return True
 
 
 class _FakeContext:
@@ -383,6 +414,122 @@ async def test_search_respects_max_results(monkeypatch):
 
     results = await sos.search("anything", state="CA", max_results=3)
     assert len(results) == 3
+
+
+async def test_search_recovers_when_input_detaches_between_query_and_fill(
+    monkeypatch,
+):
+    """Regression for issue #191: bizfileonline re-renders the React tree
+    between locator query and fill, detaching the handle. ``_fill_with_retry``
+    should re-resolve and succeed without a diagnostic-screenshot bail-out.
+    """
+    recipe = sos._STATE_RECIPES["CA"]
+    rows = [
+        _build_row(
+            name="SBI BUILDERS, LLC",
+            entity_number="201234567890",
+            entity_type="Limited Liability Company",
+            status="Active",
+            formed="2012-03-15",
+            registered_agent="Jane Q Agent",
+        ),
+    ]
+    flaky_input = _FakeLocator(detach_fill_attempts=2)  # fail twice, then succeed
+    page = _FakePage(
+        {
+            recipe["query_input"]: flaky_input,
+            recipe["submit_button"]: _FakeLocator(),
+            recipe["row_selector"]: _FakeLocator(items=rows),
+        }
+    )
+    _stub_browser(monkeypatch, page)
+
+    results = await sos.search("SBI Builders", state="CA")
+
+    assert len(results) == 1
+    assert results[0].title == "SBI BUILDERS, LLC"
+    # Fake recorded three fill attempts: two raised "detached", the third won.
+    assert len(flaky_input.fill_calls) == 3
+    assert flaky_input.fill_calls == ["SBI Builders"] * 3
+    # No diagnostic screenshot — the connector recovered cleanly.
+    assert page.screenshots == []
+
+
+async def test_search_falls_back_to_evaluate_when_fill_keeps_detaching(
+    monkeypatch,
+):
+    """If every retry loses the race, ``_fill_with_retry`` must fall back to
+    ``page.evaluate`` setting ``.value`` and dispatching native input/change
+    events — the documented escape hatch for SPA forms.
+    """
+    recipe = sos._STATE_RECIPES["CA"]
+    rows = [
+        _build_row(
+            name="SBI BUILDERS, LLC",
+            entity_number="201234567890",
+            entity_type="Limited Liability Company",
+            status="Active",
+            formed="2012-03-15",
+            registered_agent="Jane Q Agent",
+        ),
+    ]
+    always_detach_input = _FakeLocator(detach_fill_attempts=-1)  # always fails
+    page = _FakePage(
+        {
+            recipe["query_input"]: always_detach_input,
+            recipe["submit_button"]: _FakeLocator(),
+            recipe["row_selector"]: _FakeLocator(items=rows),
+        }
+    )
+    eval_mock = AsyncMock(return_value=True)
+    page.evaluate = eval_mock
+    _stub_browser(monkeypatch, page)
+
+    results = await sos.search("SBI Builders", state="CA")
+
+    assert eval_mock.called, "expected evaluate fallback after retries exhausted"
+    # First positional call was the fill fallback (script + [selector, value]).
+    fill_call = eval_mock.call_args_list[0]
+    script, arg = fill_call.args
+    assert "dispatchEvent" in script
+    assert "input" in script and "change" in script
+    assert arg == [recipe["query_input"], "SBI Builders"]
+    # Three locator-fill attempts before the evaluate fallback fired.
+    assert len(always_detach_input.fill_calls) == 3
+    # Search still produced rows because the evaluate path landed the value.
+    assert len(results) == 1
+    assert results[0].title == "SBI BUILDERS, LLC"
+
+
+async def test_search_recovers_when_submit_button_detaches(monkeypatch):
+    """Submit click is wrapped in the same retry helper — a detached click
+    handle on the first attempt should not abort the search.
+    """
+    recipe = sos._STATE_RECIPES["CA"]
+    rows = [
+        _build_row(
+            name="SBI BUILDERS, LLC",
+            entity_number="201234567890",
+            entity_type="Limited Liability Company",
+            status="Active",
+            formed="2012-03-15",
+        ),
+    ]
+    flaky_button = _FakeLocator(detach_click_attempts=1)  # fails once, then succeeds
+    page = _FakePage(
+        {
+            recipe["query_input"]: _FakeLocator(),
+            recipe["submit_button"]: flaky_button,
+            recipe["row_selector"]: _FakeLocator(items=rows),
+        }
+    )
+    _stub_browser(monkeypatch, page)
+
+    results = await sos.search("SBI Builders", state="CA")
+
+    assert len(results) == 1
+    assert flaky_button.click_calls == 2
+    assert page.screenshots == []
 
 
 async def test_search_returns_empty_when_rows_never_render(


### PR DESCRIPTION
Closes #191
Part of #195

## Summary

Automated implementation of **fix: sos (CA Secretary of State) Playwright connector — DOM detached on bizfileonline.sos.ca.gov search input**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Issue #191 fix is complete: implements all three recommended SPA-resilience strategies (networkidle wait, locator-re-resolve retry loop, page.evaluate fallback that uses the React __valueTracker prototype setter), preserves the verified-on-2026-05-07 selector recipe, and ships two regression tests covering both the retry-success and evaluate-fallback paths. Full test suite is green (1371 passed, 1 skipped).

- **INFO** [OPEN] `src/research_agent/tools/sos.py`: _safe_inner_text and _safe_attr carry a TypeError except-branch specifically to tolerate test fakes whose inner_text/get_attribute do not accept the timeout kwarg. This is a small leak of test concerns into production. Cleaner alternative: update the fake to accept (and ignore) timeout=. Not blocking — the noqa annotations document the choice and the behavior is correct.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*