### PR TITLE
feat: fix: _smoke_web_search tests DDG+Google scrapers, not the Brave runtime path the overnight actually uses (closes #192)

### DIFF
--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -8,18 +8,45 @@ from collections.abc import Callable
 from research_agent.tools.models import SearchResult, Source, SourceKind
 
 
-def _smoke_web_search(query: str) -> list[SearchResult]:
-    """Smoke wrapper: run DDG then Google, return top-5 hits from each combined.
+def _smoke_web_search(query: str) -> str:
+    """Smoke wrapper: exercise the runtime ``engine="auto"`` path.
 
-    The CLI smoke verb calls this synchronously and prints ``repr`` of the
-    return value, so the output shows results from both engines per AC #14.
+    Mirrors what the orchestrator actually does: a single
+    ``web_search.search(query, engine="auto")`` call. With
+    ``BRAVE_SEARCH_API_KEY`` set, ``auto`` resolves to the Brave Search API;
+    without the key, it falls back to DDG-Playwright (which is subject to
+    selector drift and may legitimately return zero hits even when the
+    runtime is healthy). The output line marks which engine actually ran so
+    operators can tell apart a Brave miss from a Playwright fallback miss
+    without re-running.
     """
     from research_agent.tools import web_search
 
-    async def _run() -> list[SearchResult]:
-        ddg = await web_search.search(query, max_results=5, engine="ddg")
-        google = await web_search.search(query, max_results=5, engine="google")
-        return ddg + google
+    async def _run() -> str:
+        results = await web_search.search(query, max_results=10, engine="auto")
+        if results:
+            engine_used = str(results[0].extras.get("source_engine") or "?")
+        else:
+            engine_used = "brave" if web_search._brave_api_key() else "ddg"
+
+        if engine_used == "brave":
+            header = f"engine=brave: returned {len(results)} hits"
+        elif engine_used == "ddg":
+            suffix = " (selector drift?)" if not results else ""
+            header = (
+                f"engine=ddg (Playwright fallback, subject to selector drift):"
+                f" returned {len(results)} hits{suffix}"
+            )
+        else:
+            header = f"engine={engine_used}: returned {len(results)} hits"
+
+        lines: list[str] = [header]
+        for hit in results:
+            snippet = hit.snippet.replace("\n", " ")
+            if len(snippet) > 200:
+                snippet = snippet[:200] + "…"
+            lines.append(f"- {hit.title}\n  {hit.url}\n  {snippet}")
+        return "\n".join(lines)
 
     return asyncio.run(_run())
 

--- a/tests/test_tools_web_search.py
+++ b/tests/test_tools_web_search.py
@@ -219,6 +219,61 @@ def test_tool_registry_has_web_search():
     assert callable(TOOL_REGISTRY["web_search"])
 
 
+def test_smoke_web_search_invokes_auto_engine_only(monkeypatch):
+    """Issue #192: smoke must mirror the orchestrator (engine='auto'), not
+    hand-roll separate ddg/google scrapes."""
+    from research_agent.tools import TOOL_REGISTRY
+
+    calls: list[dict] = []
+
+    async def _fake_search(query, max_results=10, engine="auto"):
+        calls.append({"query": query, "max_results": max_results, "engine": engine})
+        return []
+
+    monkeypatch.setattr(web_search, "search", _fake_search)
+    # No Brave key → label should say ddg-fallback when results are empty.
+    monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
+
+    output = TOOL_REGISTRY["web_search"]("project 2025")
+
+    assert len(calls) == 1, "smoke must call web_search.search exactly once"
+    assert calls[0]["engine"] == "auto"
+    assert calls[0]["query"] == "project 2025"
+    # When auto resolves to ddg with zero hits, the header flags the fallback
+    # and selector drift so operators can tell it apart from a Brave miss.
+    assert "engine=ddg" in output
+    assert "selector drift" in output
+
+
+def test_smoke_web_search_brave_path_labels_engine(monkeypatch):
+    """With BRAVE_SEARCH_API_KEY set, auto routes to Brave and the smoke
+    output labels the path so operators can see which engine ran."""
+    from research_agent.tools import TOOL_REGISTRY
+    from research_agent.tools.models import SearchResult
+
+    monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "test-key")
+
+    fake_hit = SearchResult(
+        url="https://example.com/p2025",
+        title="Project 2025 implementation",
+        snippet="Heritage Foundation policy blueprint",
+        source_kind="web",
+        extras={"source_engine": "brave"},
+    )
+
+    async def _fake_brave(query, max_results):
+        return [fake_hit]
+
+    monkeypatch.setattr(web_search, "_search_brave", _fake_brave)
+
+    output = TOOL_REGISTRY["web_search"]("project 2025")
+
+    assert "engine=brave" in output
+    assert "returned 1 hits" in output
+    assert "https://example.com/p2025" in output
+    assert "Project 2025 implementation" in output
+
+
 def test_serp_rate_buckets_set_to_one_per_two_seconds():
     """Every ``search()`` call applies the 0.5 rps SERP rate (1 query/2s)."""
     browser.reset_for_tests()


### PR DESCRIPTION
Closes #192
Part of #195

## Summary

Automated implementation of **fix: _smoke_web_search tests DDG+Google scrapers, not the Brave runtime path the overnight actually uses**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

_smoke_web_search now calls web_search.search(query, engine="auto") and labels the resolved engine; tests cover both Brave and DDG-fallback paths. All 1373 tests pass.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*