### PR TITLE
feat: feat: extract_findings should optionally auto-fan-out web_fetch for URLs cited in extracted claims (second-order URL extraction) (closes #194)

### DIFF
--- a/config/url_blocklist.yaml
+++ b/config/url_blocklist.yaml
@@ -1,0 +1,25 @@
+# URL blocklist for second-order fan-out (issue #194).
+#
+# Hosts listed here are excluded from `_run_extract_findings`'s
+# auto-fan-out of `web_fetch` tasks for URLs cited inside extracted
+# findings. The match is a case-insensitive substring check against
+# the URL's hostname — so `twitter.com` blocks `mobile.twitter.com`,
+# `t.co/...` redirects we've already followed, and friends.
+#
+# Scope of this list:
+#   * Social-media surfaces that don't render meaningful content for
+#     the agent (auth wall, JS-heavy SPA, paywalled timelines).
+#   * Archive hosts that have their own connector (`archive`) and
+#     should not be fetched twice.
+#
+# This list is intentionally short. Anything that *should* be skipped
+# globally (login walls, paywalls, etc.) belongs in the per-site
+# fetch-layer handling, not here.
+- twitter.com
+- x.com
+- facebook.com
+- instagram.com
+- tiktok.com
+- linkedin.com
+- web.archive.org
+- archive.org

--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -60,6 +60,7 @@ EventKind = Literal[
     "ocr_vlm_escalation",
     "cornerstone_extract",
     "cornerstone_fallback_triggered",
+    "second_order_fanout",
     "error",
     "warning",
 ]

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -78,6 +78,37 @@ _DEFAULT_TOP_K_BY_SCOPE: dict[str, int] = {
 }
 _DEFAULT_TOP_K_FALLBACK = 3
 
+# Issue #194: how many ``web_fetch`` follow-ups ``_run_extract_findings``
+# may emit per extraction for URLs cited inside the findings it just wrote.
+# Mirrors the scope-class scaling pattern from #178: narrow runs do not
+# auto-fan-out at all (drill-downs at the planner level only), while
+# comprehensive runs ride citation chains aggressively.
+_SECOND_ORDER_MAX_BY_SCOPE: dict[str, int] = {
+    "narrow": 0,
+    "medium": 1,
+    "broad": 2,
+    "comprehensive": 3,
+}
+_SECOND_ORDER_MAX_FALLBACK = 1
+# Don't fan out from low-confidence findings — the agent's least-reliable
+# signal. ``>= 0.5`` is a starting threshold that the planner can override
+# per task via ``payload['second_order_confidence_threshold']``.
+_SECOND_ORDER_CONFIDENCE_THRESHOLD = 0.5
+# Hard cap per job across all extracts. Prevents pathological cases where
+# every fetched document carries dozens of cited URLs and the queue
+# explodes — the user can still get the planner to drill into specific
+# paths via ``tactical_replan`` once this budget is spent.
+_SECOND_ORDER_JOB_CAP = 200
+# URLs in fan-out candidates: match http/https plus a healthy slug of URL-
+# safe characters. Trailing punctuation (``.``, ``,``, ``)``, ``]``, ``}``,
+# ``>``, quotes) is stripped post-match by ``_normalize_url_for_fanout`` so
+# the regex itself stays readable.
+_URL_REGEX = re.compile(r"https?://[^\s)\]\}<>\"']+")
+# Marker key written into a follow-up task's payload so we can SQL-query
+# how many second-order tasks have already been emitted for the job (and
+# enforce the per-job cap).
+_SECOND_ORDER_PARENT_FINDING_ID_KEY = "second_order_parent_finding_id"
+
 Handler = Callable[[Job, dict[str, Any]], Awaitable[dict[str, Any] | None]]
 
 
@@ -848,6 +879,289 @@ def _build_bill_text_followup(
     )
 
 
+# ---------------------------------------------------------------------------
+# Issue #194: second-order URL fan-out from extracted findings
+# ---------------------------------------------------------------------------
+
+
+_BLOCKLIST_PATH_REL = "config/url_blocklist.yaml"
+_BLOCKLIST_CACHE: set[str] | None = None
+
+
+def _load_url_blocklist() -> set[str]:
+    """Read ``config/url_blocklist.yaml`` once; return host substrings.
+
+    The blocklist filters second-order ``web_fetch`` follow-ups so the
+    fan-out doesn't burn budget on social media surfaces, paywalled hosts,
+    or archive.org (which has its own connector). Match is host-substring,
+    case-insensitive, applied in :func:`_is_url_blocked`. Missing or
+    malformed file → empty set; we'd rather lose blocklist enforcement
+    than crash extraction.
+    """
+    global _BLOCKLIST_CACHE
+    if _BLOCKLIST_CACHE is not None:
+        return _BLOCKLIST_CACHE
+
+    from pathlib import Path
+
+    import yaml
+
+    # Walk upward from this module until we find a directory carrying both
+    # the blocklist and a ``pyproject.toml`` (the worktree root). The package
+    # is installed editable, so ``__file__`` always lives inside the project.
+    blocklist: set[str] = set()
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / _BLOCKLIST_PATH_REL
+        if (parent / "pyproject.toml").exists():
+            if candidate.exists():
+                try:
+                    data = yaml.safe_load(candidate.read_text(encoding="utf-8"))
+                except (OSError, yaml.YAMLError):
+                    data = None
+                if isinstance(data, list):
+                    for entry in data:
+                        if isinstance(entry, str) and entry.strip():
+                            blocklist.add(entry.strip().lower())
+            break
+
+    _BLOCKLIST_CACHE = blocklist
+    return _BLOCKLIST_CACHE
+
+
+def _normalize_url_for_fanout(url: str) -> str | None:
+    """Strip trailing punctuation + fragment, lowercase host. Return canonical or None.
+
+    Returns ``None`` for URLs that don't have an http/https scheme or that
+    parse to nonsense — those should never be treated as fan-out candidates.
+    Path/query are preserved as-is (no aggressive normalization that might
+    alias two genuinely different resources).
+    """
+    if not isinstance(url, str) or not url:
+        return None
+    trimmed = url.strip().rstrip(".,;:!?)\"'>]}")
+    if not trimmed:
+        return None
+    from urllib.parse import urlsplit, urlunsplit
+
+    try:
+        parts = urlsplit(trimmed)
+    except ValueError:
+        return None
+    scheme = (parts.scheme or "").lower()
+    if scheme not in ("http", "https"):
+        return None
+    host = parts.hostname or ""
+    if not host:
+        return None
+    netloc = host.lower()
+    if parts.port is not None:
+        netloc = f"{netloc}:{parts.port}"
+    return urlunsplit((scheme, netloc, parts.path, parts.query, ""))
+
+
+def _is_url_blocked(url: str, blocklist: set[str]) -> bool:
+    """Substring match against ``blocklist`` on the URL's hostname.
+
+    ``blocklist`` entries are lowercase host fragments (``twitter.com``,
+    ``web.archive.org``); we extract the URL's host once and check for
+    substring containment so ``mobile.twitter.com`` and ``t.co`` redirects
+    that resolve to the same host are both caught.
+    """
+    if not blocklist:
+        return False
+    from urllib.parse import urlsplit
+
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return False
+    host = (parts.hostname or "").lower()
+    if not host:
+        return False
+    return any(entry in host for entry in blocklist)
+
+
+def _count_second_order_emitted(job: Job) -> int:
+    """Count tasks for ``job`` whose payload carries the second-order marker.
+
+    Used to enforce the job-wide cap (:data:`_SECOND_ORDER_JOB_CAP`). We
+    count tasks in any status — pending/running/done/failed all count
+    against the budget so a long run that has already burned 200 fetches
+    on dead URLs doesn't get to keep adding more.
+    """
+    json_path = f"$.{_SECOND_ORDER_PARENT_FINDING_ID_KEY}"
+    conn = db.connect(job.db_path)
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM tasks"
+            " WHERE job_id = ?"
+            " AND json_extract(payload_json, ?) IS NOT NULL",
+            (job.id, json_path),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return 0
+    return int(row["n"])
+
+
+def _existing_job_source_urls(job: Job) -> set[str]:
+    """Return the normalized URLs of every source already linked to ``job``.
+
+    Drives same-job dedup: if extraction emits a finding citing a URL that
+    the agent has already fetched in this run, skip it. Cross-job dedup
+    is intentionally out of scope (issue #194 § "Out of scope").
+    """
+    conn = db.connect(job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT s.url AS url FROM sources s"
+            " JOIN job_sources js ON js.source_id = s.id"
+            " WHERE js.job_id = ? AND s.url IS NOT NULL",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    out: set[str] = set()
+    for row in rows:
+        norm = _normalize_url_for_fanout(row["url"])
+        if norm is not None:
+            out.add(norm)
+    return out
+
+
+def _extract_followup_urls(
+    findings: list[dict[str, Any]],
+    *,
+    max_per_extract: int,
+    confidence_threshold: float,
+    exclude_urls: set[str],
+    blocklist: set[str],
+) -> list[tuple[dict[str, Any], str]]:
+    """Pick high-confidence findings' cited URLs; return ``(finding, url)`` pairs.
+
+    Sorted by parent confidence descending so when ``max_per_extract`` clips
+    the list, the strongest signals survive. URLs are deduped within the
+    call, normalized via :func:`_normalize_url_for_fanout`, blocklist-
+    filtered via :func:`_is_url_blocked`, and any URL in ``exclude_urls``
+    (typically the job's already-fetched source URLs) is dropped before
+    the cap fires so we don't waste cap slots on dedups.
+    """
+    seen: set[str] = set()
+    candidates: list[tuple[float, dict[str, Any], str]] = []
+    for f in findings:
+        try:
+            confidence = float(f.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            continue
+        if confidence < confidence_threshold:
+            continue
+        text_parts = [str(f.get("claim") or ""), str(f.get("quote") or "")]
+        text = " ".join(text_parts)
+        for raw_url in _URL_REGEX.findall(text):
+            normalized = _normalize_url_for_fanout(raw_url)
+            if normalized is None:
+                continue
+            if normalized in seen:
+                continue
+            if normalized in exclude_urls:
+                continue
+            if _is_url_blocked(normalized, blocklist):
+                continue
+            seen.add(normalized)
+            candidates.append((confidence, f, normalized))
+    # Stable sort by descending confidence so per-extract cap retains the
+    # strongest parent signals.
+    candidates.sort(key=lambda c: -c[0])
+    return [(f, u) for _, f, u in candidates[:max_per_extract]]
+
+
+def _build_second_order_fanout(
+    job: Job,
+    findings: list[dict[str, Any]],
+    payload: dict[str, Any] | None,
+) -> list[TaskSpec]:
+    """Build ``web_fetch`` follow-ups for URLs cited inside ``findings``.
+
+    Precedence for the per-extract cap (mirrors :func:`_expand_search_to_fetches`):
+    explicit ``payload['second_order_max']`` > plan ``scope_class`` > fallback.
+    Returns an empty list when the cap is 0 (e.g. narrow scope), when the
+    job-wide cap is already exceeded, or when nothing in ``findings`` cites
+    a fan-out-eligible URL. Emits one ``second_order_fanout`` event per
+    surfaced URL so operators can audit the fan-out volume.
+    """
+    payload = payload or {}
+    if "second_order_max" in payload:
+        try:
+            max_per_extract = int(payload["second_order_max"])
+        except (TypeError, ValueError):
+            max_per_extract = _SECOND_ORDER_MAX_FALLBACK
+    else:
+        plan = _load_latest_plan(job)
+        scope = plan.scope_class if plan is not None else None
+        max_per_extract = _SECOND_ORDER_MAX_BY_SCOPE.get(
+            scope or "", _SECOND_ORDER_MAX_FALLBACK
+        )
+    if max_per_extract <= 0 or not findings:
+        return []
+
+    threshold_raw = payload.get(
+        "second_order_confidence_threshold", _SECOND_ORDER_CONFIDENCE_THRESHOLD
+    )
+    try:
+        threshold = float(threshold_raw)
+    except (TypeError, ValueError):
+        threshold = _SECOND_ORDER_CONFIDENCE_THRESHOLD
+
+    already_emitted = _count_second_order_emitted(job)
+    remaining_job_budget = _SECOND_ORDER_JOB_CAP - already_emitted
+    if remaining_job_budget <= 0:
+        return []
+    effective_cap = min(max_per_extract, remaining_job_budget)
+
+    blocklist = _load_url_blocklist()
+    exclude_urls = _existing_job_source_urls(job)
+
+    selected = _extract_followup_urls(
+        findings,
+        max_per_extract=effective_cap,
+        confidence_threshold=threshold,
+        exclude_urls=exclude_urls,
+        blocklist=blocklist,
+    )
+    if not selected:
+        return []
+
+    follow_ups: list[TaskSpec] = []
+    for finding, url in selected:
+        parent_finding_id = finding.get("finding_id")
+        sub_question = (finding.get("claim") or "").strip() or job.goal
+        emit(
+            job,
+            "INFO",
+            "loop",
+            "second_order_fanout",
+            {
+                "parent_finding_id": parent_finding_id,
+                "parent_confidence": float(finding.get("confidence", 0.0)),
+                "url": url,
+                "sub_question": sub_question,
+            },
+        )
+        follow_ups.append(
+            TaskSpec(
+                kind="web_fetch",
+                payload={
+                    "url": url,
+                    "sub_question": sub_question,
+                    _SECOND_ORDER_PARENT_FINDING_ID_KEY: parent_finding_id,
+                },
+            )
+        )
+    return follow_ups
+
+
 def _load_source_text(job: Job, source_id: int) -> tuple[str, dict[str, Any]] | None:
     """Read ``sources/<sha>.md`` for ``source_id``; return ``(text, meta)`` or None.
 
@@ -1094,6 +1408,11 @@ async def _run_extract_findings(
         )
 
     written: list[int] = []
+    # Mirror of ``written`` plus the {claim, confidence, quote} fields the
+    # second-order URL fan-out (#194) needs. We capture them at write time
+    # so the fan-out helper doesn't have to round-trip through the DB to
+    # rebuild what we already parsed.
+    written_findings: list[dict[str, Any]] = []
     skipped = 0
     for item in parsed[:findings_limit]:
         if not isinstance(item, dict):
@@ -1114,6 +1433,8 @@ async def _run_extract_findings(
             continue
         tags_raw = item.get("tags") or []
         tags_list = [str(t) for t in tags_raw if isinstance(t, (str, int))] or None
+        quote_raw = item.get("quote")
+        quote_str = quote_raw.strip() if isinstance(quote_raw, str) else ""
         try:
             fid = write_finding(
                 job,
@@ -1123,17 +1444,31 @@ async def _run_extract_findings(
                 tags=tags_list,
             )
             written.append(fid)
+            written_findings.append(
+                {
+                    "finding_id": fid,
+                    "claim": claim_raw.strip(),
+                    "confidence": conf,
+                    "quote": quote_str,
+                }
+            )
         except (ValueError, TypeError):
             skipped += 1
             continue
 
-    return {
+    result_dict: dict[str, Any] = {
         "source_id": source_id,
         "findings_written": len(written),
         "finding_ids": written,
         "skipped": skipped,
         "raw_path": raw_path,
     }
+
+    follow_ups = _build_second_order_fanout(job, written_findings, payload)
+    if follow_ups:
+        result_dict["follow_up_tasks"] = [t.model_dump() for t in follow_ups]
+
+    return result_dict
 
 
 async def _run_summarize_source(

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -1641,3 +1641,307 @@ async def test_extract_findings_planner_marker_does_not_emit_fallback(
     kinds = _read_event_kinds(db_path, job.id)
     assert "cornerstone_extract" in kinds
     assert "cornerstone_fallback_triggered" not in kinds
+
+
+# ---------------------------------------------------------------------------
+# Issue #194: second-order URL fan-out from extracted findings
+# ---------------------------------------------------------------------------
+
+
+def _persist_plan_with_full_scope(
+    job: Job,
+    scope: ScopeClass | None,
+    *,
+    cornerstone_url: str | None = None,
+) -> None:
+    p = Plan(
+        version=1,
+        objective="Investigate the target",
+        subgoals=[Subgoal(id=1, description="Gather", done=False)],
+        task_template=[TaskSpec(kind="web_search")],
+        expected_iterations=3,
+        scope_class=scope,
+        cornerstone_url=cornerstone_url,
+    )
+    write_plan(job, p.model_dump())
+
+
+def _reset_blocklist_cache() -> None:
+    """Clear the module-level blocklist cache so tests can re-stub it."""
+    import research_agent.orchestrator.loop as _loop_mod
+
+    _loop_mod._BLOCKLIST_CACHE = None
+
+
+@pytest.mark.asyncio
+async def test_second_order_fanout_skips_url_already_in_job_sources(
+    job: Job,
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Citation that points at an already-fetched URL must NOT fan out.
+
+    A finding's claim text contains 2 URLs: one already linked to this
+    job via ``job_sources`` (the agent fetched it during a prior task)
+    and one new. Only the new URL should become a ``web_fetch``
+    follow-up — same-job dedup is the whole point of this guard.
+    """
+    import research_agent.orchestrator.loop as _loop_mod
+
+    _reset_blocklist_cache()
+    monkeypatch.setattr(_loop_mod, "_load_url_blocklist", lambda: set())
+
+    _persist_plan_with_full_scope(job, "broad")
+
+    # Pre-seed: the agent has already fetched ``already.example/doc.pdf`` for
+    # this job, so a finding citing that URL must not re-fan-out.
+    already_url = "https://already.example/doc.pdf"
+    _seed_source(
+        job,
+        url=already_url,
+        body="prior fetch contents",
+        kind="pdf",
+    )
+
+    new_url = "https://new.example/citation.pdf"
+    extract_url = "https://example.test/article.html"
+    source_id = _seed_source(
+        job,
+        url=extract_url,
+        body="An article body that triggers extraction.",
+        kind="web",
+    )
+
+    yaml_payload = (
+        "```yaml\n"
+        f'- claim: "Important point — see {already_url} and also {new_url} for detail."\n'
+        '  confidence: 0.9\n'
+        '  quote: ""\n'
+        '  tags: [policy]\n'
+        "```\n"
+    )
+    router = _StubRouter(yaml_payload)
+    task = {"payload": {"source_id": source_id, "sub_question": "Detail?"}}
+
+    result = await _run_extract_findings(job, task, router=router)
+
+    follow_ups = result.get("follow_up_tasks") or []
+    urls = [f["payload"]["url"] for f in follow_ups]
+    assert urls == [new_url], (
+        f"expected only the new URL to fan out; got {urls}"
+    )
+
+    # The fanned-out follow-up must carry the marker key so the job-cap
+    # query can count it.
+    assert (
+        follow_ups[0]["payload"].get("second_order_parent_finding_id") is not None
+    )
+
+    # And one ``second_order_fanout`` event must have fired.
+    events = _read_event_kinds(db_path, job.id)
+    assert events.count("second_order_fanout") == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scope,expected_count",
+    [("comprehensive", 3), ("broad", 2)],
+)
+async def test_second_order_fanout_per_extract_cap_by_scope(
+    job: Job,
+    monkeypatch: pytest.MonkeyPatch,
+    scope: ScopeClass,
+    expected_count: int,
+) -> None:
+    """Per-extract cap follows scope: comprehensive → 3, broad → 2.
+
+    Three high-confidence findings, each citing one distinct URL. The
+    same input must produce 3 follow-ups under comprehensive and only 2
+    under broad — sorted by parent confidence so the strongest signals
+    survive the clip.
+    """
+    import research_agent.orchestrator.loop as _loop_mod
+
+    _reset_blocklist_cache()
+    monkeypatch.setattr(_loop_mod, "_load_url_blocklist", lambda: set())
+
+    _persist_plan_with_full_scope(job, scope)
+
+    extract_url = "https://example.test/article.html"
+    source_id = _seed_source(
+        job,
+        url=extract_url,
+        body=f"Body for {scope}",
+        kind="web",
+    )
+
+    yaml_payload = (
+        "```yaml\n"
+        '- claim: "Top finding cites https://a.example/one.pdf for evidence."\n'
+        '  confidence: 0.95\n'
+        '  quote: ""\n'
+        '  tags: [a]\n'
+        '- claim: "Second finding cites https://b.example/two.pdf for evidence."\n'
+        '  confidence: 0.85\n'
+        '  quote: ""\n'
+        '  tags: [b]\n'
+        '- claim: "Third finding cites https://c.example/three.pdf for evidence."\n'
+        '  confidence: 0.75\n'
+        '  quote: ""\n'
+        '  tags: [c]\n'
+        "```\n"
+    )
+    router = _StubRouter(yaml_payload)
+    task = {"payload": {"source_id": source_id, "sub_question": "Refs?"}}
+
+    result = await _run_extract_findings(job, task, router=router)
+
+    follow_ups = result.get("follow_up_tasks") or []
+    assert len(follow_ups) == expected_count
+
+    urls = [f["payload"]["url"] for f in follow_ups]
+    # Highest-confidence finding's URL must always be present (sorted-by-conf).
+    assert "https://a.example/one.pdf" in urls
+    if expected_count >= 2:
+        assert "https://b.example/two.pdf" in urls
+
+
+@pytest.mark.asyncio
+async def test_second_order_fanout_skips_low_confidence_findings(
+    job: Job,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A finding below the 0.5 confidence threshold must NOT fan out.
+
+    The agent's least-reliable signals should not trigger more fetching.
+    """
+    import research_agent.orchestrator.loop as _loop_mod
+
+    _reset_blocklist_cache()
+    monkeypatch.setattr(_loop_mod, "_load_url_blocklist", lambda: set())
+
+    _persist_plan_with_full_scope(job, "comprehensive")
+
+    extract_url = "https://example.test/article.html"
+    source_id = _seed_source(
+        job,
+        url=extract_url,
+        body="A weakly-confident article.",
+        kind="web",
+    )
+
+    yaml_payload = (
+        "```yaml\n"
+        '- claim: "Possibly relevant — see https://shaky.example/doc.pdf."\n'
+        '  confidence: 0.3\n'
+        '  quote: ""\n'
+        '  tags: [shaky]\n'
+        "```\n"
+    )
+    router = _StubRouter(yaml_payload)
+    task = {"payload": {"source_id": source_id, "sub_question": "Maybe?"}}
+
+    result = await _run_extract_findings(job, task, router=router)
+
+    follow_ups = result.get("follow_up_tasks") or []
+    assert follow_ups == []
+
+
+@pytest.mark.asyncio
+async def test_second_order_fanout_drops_blocklisted_urls(
+    job: Job,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A high-confidence finding citing a blocklisted host must NOT fan out.
+
+    The blocklist filters social-media + archive hosts (issue #194)
+    even when the parent finding is otherwise eligible.
+    """
+    import research_agent.orchestrator.loop as _loop_mod
+
+    _reset_blocklist_cache()
+    monkeypatch.setattr(
+        _loop_mod, "_load_url_blocklist", lambda: {"twitter.com"}
+    )
+
+    _persist_plan_with_full_scope(job, "comprehensive")
+
+    extract_url = "https://example.test/article.html"
+    source_id = _seed_source(
+        job,
+        url=extract_url,
+        body="An article with a Twitter citation.",
+        kind="web",
+    )
+
+    yaml_payload = (
+        "```yaml\n"
+        '- claim: "Per https://twitter.com/foo/status/123 the source confirms it."\n'
+        '  confidence: 0.9\n'
+        '  quote: ""\n'
+        '  tags: [social]\n'
+        "```\n"
+    )
+    router = _StubRouter(yaml_payload)
+    task = {"payload": {"source_id": source_id, "sub_question": "Confirms?"}}
+
+    result = await _run_extract_findings(job, task, router=router)
+
+    follow_ups = result.get("follow_up_tasks") or []
+    assert follow_ups == []
+
+
+def test_second_order_fanout_helpers_normalize_and_block() -> None:
+    """Spot-check the URL normalizer + blocklist matcher for trailing punctuation."""
+    from research_agent.orchestrator.loop import (
+        _is_url_blocked,
+        _normalize_url_for_fanout,
+    )
+
+    assert (
+        _normalize_url_for_fanout("https://Example.com/path).")
+        == "https://example.com/path"
+    )
+    assert _normalize_url_for_fanout("ftp://nope/x") is None
+    assert _normalize_url_for_fanout("not-a-url") is None
+    assert _is_url_blocked(
+        "https://mobile.twitter.com/foo", {"twitter.com"}
+    ) is True
+    assert _is_url_blocked("https://example.com/x", {"twitter.com"}) is False
+
+
+@pytest.mark.asyncio
+async def test_second_order_fanout_narrow_scope_emits_zero(
+    job: Job,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``narrow`` scope leaves drill-downs to the planner — no auto fan-out."""
+    import research_agent.orchestrator.loop as _loop_mod
+
+    _reset_blocklist_cache()
+    monkeypatch.setattr(_loop_mod, "_load_url_blocklist", lambda: set())
+
+    _persist_plan_with_full_scope(job, "narrow")
+
+    extract_url = "https://example.test/article.html"
+    source_id = _seed_source(
+        job,
+        url=extract_url,
+        body="A narrow-scope body.",
+        kind="web",
+    )
+
+    yaml_payload = (
+        "```yaml\n"
+        '- claim: "See https://primary.example/doc.pdf for the underlying record."\n'
+        '  confidence: 0.95\n'
+        '  quote: ""\n'
+        '  tags: [primary]\n'
+        "```\n"
+    )
+    router = _StubRouter(yaml_payload)
+    task = {"payload": {"source_id": source_id, "sub_question": "?"}}
+
+    result = await _run_extract_findings(job, task, router=router)
+
+    assert (result.get("follow_up_tasks") or []) == []


### PR DESCRIPTION
Closes #194
Part of #195

## Summary

Automated implementation of **feat: extract_findings should optionally auto-fan-out web_fetch for URLs cited in extracted claims (second-order URL extraction)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

All 10 acceptance criteria implemented; second-order fan-out helper wired into _run_extract_findings, scope-aware caps + job-wide cap + blocklist + dedup all enforced; 87 orchestrator tests pass.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*