### PR TITLE
chore: add Epic issue template documenting bare-format checklist requirement

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,82 @@
+name: Epic
+description: A multi-issue initiative with a sub-issue checklist that alpha-loop can walk in order
+title: "epic: "
+labels: ["epic"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for epics that bundle several `ready`-labelled
+        sub-issues. `alpha-loop run --epic <N>` walks the checklist in order
+        and ships one sub-issue per PR.
+
+        **Critical:** sub-issue checklist lines must use the bare format
+        `- [ ] #211 — title` — alpha-loop's parser does NOT match
+        emphasised numbers (`**#211**`, `_#211_`, `[#211](...)`) and will
+        report "no sub-issues in checklist" if any line is decorated.
+
+  - type: textarea
+    id: vision
+    attributes:
+      label: Vision
+      description: What this epic exists to achieve. Why now.
+      placeholder: |
+        The 2026-05-08 overnight run revealed X. The orchestration layer
+        works; what remains is Y. This epic targets Z.
+    validations:
+      required: true
+
+  - type: textarea
+    id: diagnosis
+    attributes:
+      label: Diagnosis
+      description: What concrete observations motivate this epic — symptoms mapped to issues
+      placeholder: |
+        | Symptom | Issue |
+        |---|---|
+        | Mandate PDF read at ~10% coverage | #206 |
+        | Congress.gov returns 110th-Congress bills | #211/#212 |
+    validations:
+      required: true
+
+  - type: textarea
+    id: subissues
+    attributes:
+      label: Sub-issues — sequenced for impact
+      description: |
+        The checklist alpha-loop walks. **Use bare format only:**
+        `- [ ] #211 — feat: skills loader`
+        Do NOT bold, italicise, or link the issue number.
+        Group with `### Stage N — ...` headings to convey ordering.
+      value: |
+        ### Stage 1 — <theme>
+
+        - [ ] #XXX — <one-line title>
+
+        ### Stage 2 — <theme>
+
+        - [ ] #YYY — <one-line title>
+        - [ ] #ZZZ — <one-line title>
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification — what "fixed" looks like
+      description: Concrete, measurable outcomes. The next overnight should produce X.
+      placeholder: |
+        - Findings count > 250 (was 84)
+        - Departmental tracker covers all 13 departments with findings
+        - 100% of inline-cited source IDs appear in the bottom Sources list
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Skip-conditions / out of scope
+      description: What this epic does NOT address. Forward-pointers to follow-up epics.
+      placeholder: |
+        - Connector skills 6-18 — separate issue
+        - LLM scaling — orthogonal


### PR DESCRIPTION
## Summary

- Adds \`.github/ISSUE_TEMPLATE/epic.yml\` that prompts for Vision / Diagnosis / Sub-issues / Verification / Skip-conditions sections matching the format alpha-loop's epic walker expects
- Documents in the template UI that sub-issue checklist lines must use bare \`- [ ] #N — title\` format (no \`**bold**\` / \`_italic_\` / \`[link](url)\` around the issue number) — alpha-loop's parser at \`src/lib/epics.ts:13\` rejects emphasised refs

## Why

On 2026-05-08, epic #214 was authored with bold around the issue numbers (\`- [ ] **#211** — title\`). Alpha-loop reported "Epic has no sub-issues in its checklist — nothing to verify" and exited 0/0 succeeded, even though GitHub renders the checklist correctly. After manually stripping the bold, alpha-loop walked all 8 sub-issues as expected.

The template makes the bare-format requirement visible at issue-creation time so future epics get it right the first time.

## Companion fix

[alpha-loop#186](https://github.com/bradtaylorsf/alpha-loop/issues/186) tracks making the parser tolerant of markdown emphasis around issue refs. Once that ships, this template becomes soft guidance instead of a hard requirement — but bare format remains the universal-compatibility default.

## Test plan

- [ ] Visit \`https://github.com/bradtaylorsf/alpha-research/issues/new?template=epic.yml\` after merge — verify the form renders with all five sections and the checklist guidance markdown
- [ ] No code changes; existing alpha-loop / alpha-research test suites unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)