### PR TITLE
feat: feat: connector skills (initial 5) — congress, edgar, fedregister, courtlistener, fec (closes #212)

### DIFF
--- a/src/research_agent/skills/connectors/congress.md
+++ b/src/research_agent/skills/connectors/congress.md
@@ -1,0 +1,54 @@
+---
+name: congress
+description: "Congress.gov v3 — bills, members, committees, hearings, congressional record. Searching without an era keyword in the query returns 110th-Congress (2007) hits ranked above modern bills."
+when_to_use: "federal legislation, bill text and status, member voting record, committee membership, House/Senate hearings, Congressional Record floor speeches"
+when_not_to_use: "executive branch policy → fedregister; lobbying disclosures → lda; campaign finance → fec; SEC filings → edgar"
+---
+
+# Congress connector
+
+Congress.gov full-text search across five resource kinds. Default `kind=bill`.
+
+## Time-period / era filtering (CRITICAL — relevance trap)
+
+The connector does **not** currently filter by congress number. You must include the era in the query string, otherwise the API ranks oldest-first and modern bills sink.
+
+| Congress | Period | Era |
+|---|---|---|
+| 117 | Jan 2021 – Jan 2023 | Biden, Inflation Reduction Act, IIJA |
+| 118 | Jan 2023 – Jan 2025 | Biden 2nd half |
+| 119 | Jan 2025 – Jan 2027 | **Trump 2nd term — current** |
+| 120 | Jan 2027 onward | future |
+
+**For Project 2025 / Trump 2nd-term policy, include "119th Congress" or "2025" in the query.** For Biden-era IRA / IIJA work, include "117th Congress" or "2022".
+
+## Query construction
+
+- Prefer keyword phrases over full bill titles. "Inflation Reduction Act 117" beats "An Act to provide for reconciliation pursuant to title II of S. Con. Res. 14".
+- Add the era keyword (`117`, `118`, `119`, or a year like `2022`) when the topic spans decades. Without it, `Inflation Reduction Act` returns 110th-Congress (2007) procedural resolutions ranked above the 2022 Biden law.
+- For member lookups, full name + state works best (`Elizabeth Warren MA`); for committees, the formal name (`Senate Banking`).
+
+## Knobs available
+
+- `kind` — one of `bill`, `member`, `committee`, `hearing`, `congressional-record`. Default `bill`.
+- `max_results` — capped at the API page size (250). Default 20.
+- `timeout` — seconds; default 15.
+
+## Anti-patterns
+
+- ❌ `search("Inflation Reduction Act")` — returns 110th-Congress (2007) procedural resolutions, not the 2022 Biden law. Add `117` or `2022` to the query.
+- ❌ Searching the full long-form title — Congress.gov FTS scores keyword overlap; verbose titles dilute the signal.
+- ❌ Using `kind=bill` to find a member's voting record. Use `kind=member` to resolve the bioguide ID, then fan out to vote-history sources.
+- ❌ Treating a `kind=bill` SearchResult as authoritative bill text — see fan-out below.
+
+## When to fan out
+
+`kind=bill` results carry a permalink to congress.gov but **bill text is not auto-fetched** (see #193). After search, emit a follow-up `fetch()` task per bill ID to pull the full text / summary before any synthesis claim cites the bill's contents. Hearings have synthesized permalinks (`/congressional-hearings/{c}th-congress/...`) that only resolve through this connector's classifier — don't paste them into a browser expecting a public HTML page.
+
+## Output shape
+
+Each `SearchResult` carries `url`, `title`, `snippet`, `published_at` (introduced/action date), and `extras` with the resource-specific identifiers (`bill_id`, `bioguide_id`, `committee_code`, `jacket_number`, etc.). The body / vote text / committee report lives behind a separate fetch.
+
+## Auth
+
+Shared `DATA_GOV_API_KEY` (also used by `fec`). Loud failure if unset.

--- a/src/research_agent/skills/connectors/congress.md
+++ b/src/research_agent/skills/connectors/congress.md
@@ -51,4 +51,4 @@ Each `SearchResult` carries `url`, `title`, `snippet`, `published_at` (introduce
 
 ## Auth
 
-Shared `DATA_GOV_API_KEY` (also used by `fec`). Loud failure if unset.
+Shared `DATA_GOV_API_KEY` (also used by `fec`). When unset, the connector logs a warning and falls back to `DEMO_KEY` (≈40 req/hr per IP — fine for `_smoke-tool`, will rate-limit any real workload). Sign up at https://api.data.gov/signup/ for the 5,000 req/hr authenticated tier.

--- a/src/research_agent/skills/connectors/courtlistener.md
+++ b/src/research_agent/skills/connectors/courtlistener.md
@@ -1,0 +1,54 @@
+---
+name: courtlistener
+description: "CourtListener — federal/state opinions, RECAP PACER dockets, oral arguments. Default kind=opinions; without a court/date constraint in the query, modern circuit decisions get buried under 19th-century cases."
+when_to_use: "case law, court opinions, federal/state appellate decisions, PACER docket filings, SCOTUS oral arguments, citation lookup"
+when_not_to_use: "agency adjudications → fedregister; legislation → congress; campaign-finance complaints (FEC enforcement) → fec; private settlements → not on CourtListener"
+---
+
+# CourtListener connector
+
+Free Law Project search across opinions, RECAP (PACER mirror) dockets, and oral arguments. Default `kind=opinions`.
+
+## Index selection
+
+| `kind` | What it is | Use for |
+|---|---|---|
+| `opinions` | Court opinions / case law | Holdings, precedent, judicial reasoning |
+| `dockets` | RECAP filings (PACER mirror) | Briefs, motions, exhibits, lower-court trial record |
+| `oral_arguments` | Audio transcripts | SCOTUS / circuit court oral argument text |
+
+`opinions` and `dockets` are different worlds — an opinion is the appellate court's published ruling; a docket is the trial-court paperwork. If the question is "what did the judge decide" use `opinions`; if it's "what evidence was filed" use `dockets`.
+
+## Query construction (citation parsing)
+
+CourtListener understands several citation forms in the query string:
+
+- **Bluebook reporter cites** — `"576 U.S. 644"` (Obergefell), `"410 F.3d 786"` — these route the query at the FTS layer.
+- **Case name** — `"Obergefell v. Hodges"`. Use `v.` (with the period) — `vs` and `versus` reduce hit rate.
+- **Date filtering** — append `decided:[2020-01-01 TO *]` to scope to the modern era. Without a date scope, 19th-century cases with overlapping keywords ("commerce", "due process") rank up.
+- **Court filtering** — append `court:scotus`, `court:ca9` (9th Circuit), `court:nysd` (SDNY) to constrain jurisdiction. Use the connector's lower-case court slug, not the formal name.
+
+## Knobs available
+
+- `kind` — `opinions` (default), `dockets`, or `oral_arguments`. Raises `ValueError` on unknown values.
+- `max_results` — default 20.
+- `timeout` — seconds; default 15.
+
+## Anti-patterns
+
+- ❌ `search("Bostock", kind="opinions")` without a date scope — the FTS surfaces same-name 19th-century cases. Use `"Bostock decided:[2018-01-01 TO *]"`.
+- ❌ Searching `kind="opinions"` for trial-court motions — those are RECAP filings; switch to `kind="dockets"`.
+- ❌ Using full citation prose like "the Supreme Court of the United States" — use `court:scotus` instead.
+- ❌ Asking for `kind="filings"` — not a valid kind. The connector raises `ValueError`.
+
+## When to fan out
+
+Opinion `SearchResult`s carry a CourtListener permalink, snippet, and case metadata. For full opinion text or the cited authorities, emit a `fetch()` per opinion. Docket results often only carry the case caption — to inspect a specific filing, fan out via the docket's child-entry URLs.
+
+## Output shape
+
+Each `SearchResult` carries `url` (courtlistener.com), `title` (case caption), `snippet` (excerpt with FTS-highlighted terms), `published_at` (date filed / decided), `source_kind="courtlistener"`, and `extras` keyed to the kind (court slug, citation list, docket number, judge names, status).
+
+## Auth
+
+Optional `COURTLISTENER_API_TOKEN` raises rate limits. Without it, the connector hits the public endpoint with stricter throttling.

--- a/src/research_agent/skills/connectors/edgar.md
+++ b/src/research_agent/skills/connectors/edgar.md
@@ -1,0 +1,57 @@
+---
+name: edgar
+description: "SEC EDGAR full-text search across public-company filings. Without form_type the planner mixes annual reports with insider trades; missing RESEARCH_USER_AGENT email fails loudly."
+when_to_use: "public-company filings, annual / quarterly reports, insider trading (Form 4), proxy statements, 8-K material events, IPO prospectuses, executive comp"
+when_not_to_use: "private companies → opencorporates; nonprofits → nonprofits (990s); state corp records → sos; campaign finance → fec"
+---
+
+# EDGAR connector
+
+SEC EDGAR full-text search. Returns up to ~10 years of filings; HTML/XML extraction happens in `fetch()`, not search.
+
+## Form-type routing (CRITICAL)
+
+Without `form_type`, EDGAR returns every filing kind interleaved. Pick the form that matches the question.
+
+| form_type | What it is | When to ask for it |
+|---|---|---|
+| `10-K` | Annual report | Yearly financials, risk factors, segment breakdowns |
+| `10-Q` | Quarterly report | Most recent quarter financials |
+| `8-K` | Current report (material event) | Cybersecurity incidents, exec departures, acquisitions, restatements |
+| `Form 4` | Insider transaction | Officer/director buys/sells; pass `["4"]` |
+| `S-1` | IPO registration | Pre-IPO disclosures |
+| `DEF 14A` | Definitive proxy | Executive comp, board nominees, shareholder proposals |
+| `13F-HR` | Institutional holdings | Quarterly long positions for funds with >$100M AUM |
+
+`form_type` accepts a string (`"10-K"`) or list (`["10-K", "10-Q"]`).
+
+## Query construction
+
+- Use the company's common name or ticker. EDGAR's FTS resolves both. Add a topic keyword for 8-Ks (`"Acme Corp cybersecurity"`).
+- For Form 4 insider lookups, query the issuer name and pass `form_type="4"`; the filer is the insider, the issuer is what you're searching.
+- CIK lookup: if you already know the CIK (10-digit zero-padded), filter post-hoc on `extras.cik` rather than encoding it in the query — EDGAR FTS is keyword-based, not identifier-routed.
+
+## Knobs available
+
+- `form_type` — string, list, or tuple of form codes (e.g. `"10-K"` or `["10-K", "10-Q"]`). Optional; omit for all forms.
+- `max_results` — default 20.
+- `timeout` — seconds; default 15.
+
+## Anti-patterns
+
+- ❌ Searching `"Acme Corp"` without `form_type` and expecting only 10-Ks — you'll get every form interleaved.
+- ❌ Running search() without setting `RESEARCH_USER_AGENT` to a contact email — SEC's published policy requires it; this connector fails loudly with a clear message instead of silently 403'ing.
+- ❌ Treating a search hit's `snippet` as the filing's content — snippets are the EDGAR FTS preview. Use `fetch()` on the accession URL for the actual document.
+- ❌ Using `form_type="10K"` (no dash) — SEC encodes it as `10-K`.
+
+## When to fan out
+
+Search returns the EDGAR index page or filing-detail URL keyed by accession number. To extract financials / risk factors / 8-K item text, emit a follow-up `fetch()` per accession — `fetch()` resolves the index, picks the primary doc (HTML 10-K, XML Form 4), and runs `trafilatura` for narrative extraction.
+
+## Output shape
+
+Each `SearchResult` carries `url` (accession-keyed), `title` (form + company), `snippet` (FTS preview), `published_at` (file date), `source_kind="sec"`, and `extras` with `cik`, `accession`, `form`, `company`, `file_type`. The actual filing body comes from `fetch()`.
+
+## Auth
+
+`RESEARCH_USER_AGENT` must be set to `"Your Name your@email"` per SEC policy. The connector enforces an `@` and fails loudly if missing.

--- a/src/research_agent/skills/connectors/fec.md
+++ b/src/research_agent/skills/connectors/fec.md
@@ -76,4 +76,4 @@ Each `SearchResult` carries `url` (fec.gov), `title`, `snippet`, `published_at` 
 
 ## Auth
 
-Shared `DATA_GOV_API_KEY` (also used by `congress`). Loud failure if unset.
+Shared `DATA_GOV_API_KEY` (also used by `congress`). When unset, the connector logs a warning and falls back to `DEMO_KEY` (≈40 req/hr per IP — fine for `_smoke-tool`, will rate-limit any real workload). Sign up at https://api.data.gov/signup/ for the 1,000 req/hr authenticated tier.

--- a/src/research_agent/skills/connectors/fec.md
+++ b/src/research_agent/skills/connectors/fec.md
@@ -1,0 +1,79 @@
+---
+name: fec
+description: "OpenFEC — federal candidates, committees, individual contributions, independent expenditures. Without cycle/year keywords in the query, results span every election since the 1980s."
+when_to_use: "federal campaign finance, candidate FEC filings, PAC / super-PAC committees, individual donor lookup, independent expenditures for or against a candidate"
+when_not_to_use: "state-level campaign finance → calaccess (CA) or sos; lobbying spend → lda; corporate political giving via 501(c)(4)s → nonprofits; FEC enforcement complaints → courtlistener"
+---
+
+# FEC connector
+
+Searches the OpenFEC REST API across four indices. Default `kind=candidates`.
+
+## Index selection
+
+| `kind` | What it is | Query target |
+|---|---|---|
+| `candidates` | Federal candidates (House / Senate / President) | Candidate name |
+| `committees` | PACs, super PACs, party committees, principal campaign committees | Committee name |
+| `schedules/schedule_a` | Individual contributions to committees | Contributor name |
+| `schedules/schedule_e` | Independent expenditures (for/against a candidate) | Payee name (vendor/firm spending the money) |
+
+For "who funded X?", route to `schedules/schedule_a` with the candidate's principal committee name in the query, not the candidate name. For "who spent against Y?", use `schedules/schedule_e`.
+
+## Cycle / year filtering (CRITICAL)
+
+The connector does **not** currently expose a `cycle` knob. Include the cycle year in the query string to scope to a specific election.
+
+| Office | Cycles |
+|---|---|
+| Presidential | 2024, 2028, 2032 (every 4 yrs) |
+| Senate | 2024, 2026, 2028 (every 2 yrs, 1/3 of seats) |
+| House | 2024, 2026, 2028 (every 2 yrs, all seats) |
+
+Without "2024" or "2026" in the query, you get hits across every cycle a candidate ever ran in.
+
+## Candidate / committee ID format
+
+OpenFEC IDs follow a strict prefix pattern:
+
+| Prefix | Type | Example |
+|---|---|---|
+| `P0…` | Presidential candidate | `P00009423` (Trump 2024) |
+| `H0…` / `H4…` / `H8…` | House candidate | `H4CA12345` |
+| `S0…` / `S4…` / `S8…` | Senate candidate | `S6OH00163` |
+| `C0…` | Committee (any kind) | `C00580100` |
+
+Resolve a candidate ID via `kind=candidates`, then pass the principal committee ID (a `C0…` from the candidate's `extras`) to the schedule searches — schedule queries route by committee, not candidate.
+
+## Query construction
+
+- For donor lookups, use the contributor's full name as it appears on the disclosure (`"Smith, John"` order is common but the API tolerates both). Add the employer or city when the name is common.
+- For committee lookups, the formal committee name beats the abbreviation (`"Trump Make America Great Again Committee"` over `"MAGA"`).
+- Cycle keyword: append the year (`"2024"`) to constrain.
+
+## Knobs available
+
+- `kind` — `candidates` (default), `committees`, `schedules/schedule_a`, or `schedules/schedule_e`.
+- `max_results` — default 20.
+- `timeout` — seconds; default 15.
+
+## Anti-patterns
+
+- ❌ `search("Donald Trump", kind="schedules/schedule_a")` — schedule_a queries the *contributor* name. Use `kind=candidates` first to resolve the principal committee ID, then pivot.
+- ❌ Searching with no cycle keyword — surfaces every cycle the person/committee ran in; modern cycles drown.
+- ❌ Treating an `H0…` ID as a committee ID — H/S/P prefixes are *candidate* IDs; committee IDs start with `C0`.
+- ❌ Using `kind="contributions"` — not a valid kind. Use `schedules/schedule_a`.
+
+## When to fan out
+
+Candidate / committee results carry the FEC.gov permalink and the full set of IDs in `extras`. Schedule results have the transaction-level row inline (amount, date, contributor employer/occupation). Fan out to:
+- the principal-committee schedule_a search to enumerate donors,
+- the schedule_e search keyed on a target candidate to find independent expenditures.
+
+## Output shape
+
+Each `SearchResult` carries `url` (fec.gov), `title`, `snippet`, `published_at` (filing date / contribution date), `source_kind="fec"`, and `extras` with `candidate_id`, `committee_id`, `cycle`, `office`, `party`, `state`, `district` (where applicable). For schedule_a, `extras` adds `contributor_name`, `contributor_employer`, `contributor_occupation`, `amount`.
+
+## Auth
+
+Shared `DATA_GOV_API_KEY` (also used by `congress`). Loud failure if unset.

--- a/src/research_agent/skills/connectors/fedregister.md
+++ b/src/research_agent/skills/connectors/fedregister.md
@@ -1,0 +1,55 @@
+---
+name: fedregister
+description: "Federal Register — executive orders, agency rules, notices, presidential documents. Without `since`, results skew historical; for Trump 2nd-term EOs use since=2025-01-20."
+when_to_use: "executive orders, proposed rules, final rules, agency notices, presidential proclamations, Federal Register-published policy"
+when_not_to_use: "legislation → congress; SEC rules in plain text → edgar; lobbying around a rule → lda; court challenges to a rule → courtlistener"
+---
+
+# Federal Register connector
+
+Searches federalregister.gov across all document types. Default endpoint paginates at 2,000 max — narrow by `since` + `agencies` rather than asking for huge `max_results`.
+
+## Time-period filtering (CRITICAL)
+
+Without `since`, the API returns matches across the full archive (1990s onward) and modern policy gets buried.
+
+| Investigation era | `since` value |
+|---|---|
+| Trump 2nd term (current) | `2025-01-20` |
+| Biden admin | `2021-01-20` to `2025-01-19` |
+| Trump 1st term | `2017-01-20` to `2021-01-19` |
+| Obama 2nd term | `2013-01-20` to `2017-01-19` |
+
+For "current administration" queries, **always** pass `since="2025-01-20"`. The 2026-05-08 Project 2025 overnight surfaced only 4/24 citations from federalregister.gov post-inauguration because date filtering was missing.
+
+## Where executive orders live
+
+Executive orders are NOT a top-level filter — they appear in the Federal Register under `document_type="presidential_document"` (subtype "Executive Order"). The connector does not currently expose a `document_type` knob; filter post-hoc on `extras.document_type` from the SearchResult, or include "executive order" in the query string.
+
+## Query construction
+
+- Pair the topic with a verb the agency would use ("rescind", "amend", "implement", "withdraw") — Federal Register prose is formulaic.
+- Use the agency's common acronym in the query when known (`EPA`, `OSHA`) — the FTS hits agency_names.
+- For rules-vs-notices triage, include the type word ("proposed rule", "final rule", "notice").
+
+## Knobs available
+
+- `since` — `date`, `datetime`, or ISO string `YYYY-MM-DD`. Maps to `conditions[publication_date][gte]`.
+- `agencies` — list of agency slugs (e.g. `["environmental-protection-agency", "department-of-labor"]`). Repeated as `conditions[agencies][]`.
+- `max_results` — capped at 200 per page; default 20.
+- `timeout` — seconds; default 15.
+
+## Anti-patterns
+
+- ❌ `search("executive order on AI")` without `since="2025-01-20"` — returns Obama and Trump-1 EOs ranked above current ones.
+- ❌ Passing `agencies=["EPA"]` (acronym) — slugs are kebab-case full names: `["environmental-protection-agency"]`. The connector silently drops unknown slugs.
+- ❌ Asking for `max_results=1000` — the page cap is 200; narrow by date instead.
+- ❌ Treating the `snippet` as the rule's binding text. Use `fetch()` to pull the full document HTML.
+
+## When to fan out
+
+Search returns metadata + a federalregister.gov URL. For the binding rule text, executive-order language, or comment-period analysis, emit a `fetch()` per document. `extras.document_number` is the stable identifier for citation.
+
+## Output shape
+
+Each `SearchResult` carries `url` (federalregister.gov), `title`, `snippet` (abstract), `published_at` (publication date), `source_kind="fedregister"`, and `extras` with `agencies` (list of names), `document_type`, `document_number`, and `significant` (bool, OIRA-flagged).

--- a/tests/test_skills_content.py
+++ b/tests/test_skills_content.py
@@ -1,0 +1,135 @@
+"""Validate the shipped connector skill markdown content.
+
+Loader behavior is covered in ``test_skills_loader.py``; this file validates
+the *content* of the 5 initial connector skills (congress, edgar, fedregister,
+courtlistener, fec) — frontmatter completeness, presence of required body
+sections, and that any knobs the skill names match the connector's actual
+``search()`` signature.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import re
+
+import pytest
+
+from research_agent.skills import loader as skills_loader
+from research_agent.skills.loader import clear_cache, list_skills, load_skill
+
+CONNECTOR_SKILLS = ("congress", "edgar", "fedregister", "courtlistener", "fec")
+
+REQUIRED_BODY_SECTIONS = ("Knobs available", "Anti-patterns")
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache() -> None:
+    clear_cache()
+    yield
+    clear_cache()
+
+
+def _connector_search_params(name: str) -> set[str]:
+    module = importlib.import_module(f"research_agent.tools.{name}")
+    sig = inspect.signature(module.search)
+    return set(sig.parameters)
+
+
+def _knobs_section_identifiers(body: str) -> set[str]:
+    """Extract backtick-wrapped identifiers from the ``## Knobs available`` section.
+
+    A skill's ``## Knobs available`` section uses bullets like
+    ``- `kind` — ...``. We collect the first backtick-wrapped token on each
+    bullet line so the test can verify those names exist on the connector's
+    ``search()`` signature.
+    """
+    match = re.search(
+        r"##\s*Knobs available\s*\n(?P<body>.*?)(?:\n##\s|\Z)",
+        body,
+        re.DOTALL,
+    )
+    if not match:
+        return set()
+    knob_section = match.group("body")
+    knobs: set[str] = set()
+    for line in knob_section.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("-"):
+            continue
+        m = re.search(r"`([A-Za-z_][A-Za-z0-9_]*)`", stripped)
+        if m:
+            knobs.add(m.group(1))
+    return knobs
+
+
+@pytest.mark.parametrize("name", CONNECTOR_SKILLS)
+def test_connector_skill_loads_with_non_empty_body(name: str) -> None:
+    body = load_skill("connectors", name)
+    assert body, f"connector skill {name!r} body is empty"
+    assert len(body) > 200, f"connector skill {name!r} body looks truncated"
+
+
+@pytest.mark.parametrize("name", CONNECTOR_SKILLS)
+def test_connector_skill_frontmatter_fields_present(name: str) -> None:
+    entries = {e["name"]: e for e in list_skills("connectors")}
+    assert name in entries, f"skill {name!r} not found in connectors index"
+    entry = entries[name]
+    assert entry["description"], f"{name}: description missing"
+    assert entry["when_to_use"], f"{name}: when_to_use missing"
+    assert entry["when_not_to_use"], f"{name}: when_not_to_use missing"
+
+
+@pytest.mark.parametrize("name", CONNECTOR_SKILLS)
+@pytest.mark.parametrize("section", REQUIRED_BODY_SECTIONS)
+def test_connector_skill_has_required_section(name: str, section: str) -> None:
+    body = load_skill("connectors", name)
+    pattern = rf"^##\s+{re.escape(section)}\s*$"
+    assert re.search(pattern, body, re.MULTILINE), (
+        f"{name}: missing required section '## {section}'"
+    )
+
+
+@pytest.mark.parametrize("name", CONNECTOR_SKILLS)
+def test_connector_skill_knobs_match_search_signature(name: str) -> None:
+    body = load_skill("connectors", name)
+    declared_knobs = _knobs_section_identifiers(body)
+    assert declared_knobs, f"{name}: no knobs found in '## Knobs available' section"
+
+    actual_params = _connector_search_params(name)
+    unknown = declared_knobs - actual_params
+    assert not unknown, (
+        f"{name}: knobs {sorted(unknown)} are not parameters of "
+        f"research_agent.tools.{name}.search() (actual: {sorted(actual_params)})"
+    )
+
+
+def test_congress_skill_carries_canonical_motivator() -> None:
+    """The 110th-Congress / IRA relevance trap is the headline reason this
+    skill exists; the body must keep that example intact."""
+    body = load_skill("connectors", "congress")
+    assert "117" in body
+    assert "119" in body
+    assert "Inflation Reduction Act" in body
+
+
+def test_skill_descriptions_are_one_line() -> None:
+    """The description is the planner-facing index signal — must stay terse
+    and single-line so it stays cheap to render across all 18 connectors."""
+    for entry in list_skills("connectors"):
+        assert "\n" not in entry["description"], (
+            f"{entry['name']}: description must be a single line"
+        )
+        assert len(entry["description"]) <= 280, (
+            f"{entry['name']}: description longer than 280 chars "
+            f"({len(entry['description'])})"
+        )
+
+
+def test_loader_module_resolves_skills_directory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sanity: skill files live where the loader expects (no install/path drift)."""
+    base = skills_loader._skills_dir("connectors")
+    assert base.is_dir(), f"connectors directory missing at {base}"
+    shipped = sorted(p.stem for p in base.glob("*.md"))
+    for name in CONNECTOR_SKILLS:
+        assert name in shipped, f"{name}.md missing from {base}"


### PR DESCRIPTION
Closes #212
Part of #214

## Summary

Automated implementation of **feat: connector skills (initial 5) — congress, edgar, fedregister, courtlistener, fec**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

All 5 connector skills meet acceptance criteria; fixed inaccurate Auth claims in congress/fec (DEMO_KEY fallback, not loud failure).

- **WARNING** [FIXED] `src/research_agent/skills/connectors/congress.md`: congress.md and fec.md Auth sections claimed 'Loud failure if unset' for DATA_GOV_API_KEY, but both connectors actually warn and fall back to DEMO_KEY (~40 req/hr). Skill content drives planner routing decisions, so inaccurate auth behavior could mislead. Updated both Auth sections to describe the real DEMO_KEY fallback behavior and rate cap.
- **INFO** [OPEN] `src/research_agent/skills/connectors/congress.md`: Acceptance criteria 4 and 5 (smoke-matrix re-run for IRA query, Project 2025 overnight re-run citation balance) are runtime/behavioral checks that cannot be validated in static review — they require executing the planner against the live skills. The skill content includes the canonical 117/119 Congress table and since=2025-01-20 guidance needed for those criteria to hold; verifying the actual outcome is out of scope here.
- **INFO** [OPEN] `tests/test_skills_content.py`: Skill bodies are well-structured: each has Knobs/Anti-patterns/Output shape sections; tests in test_skills_content.py validate frontmatter, required sections, and that declared knobs match each connector's real search() signature (28 tests pass). Knob-name validation is a good guard against drift as connectors evolve.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*