### PR TITLE
feat: feat: strategy skills (initial 3) — modern-policy-era-filtering, cornerstone-extraction, triangulation (closes #213)

### DIFF
--- a/src/research_agent/skills/strategies/cornerstone-extraction.md
+++ b/src/research_agent/skills/strategies/cornerstone-extraction.md
@@ -1,0 +1,41 @@
+---
+name: cornerstone-extraction
+description: "When the goal names a specific primary document (Mandate for Leadership, a 10-K, a court opinion, a bill), exhaustively index it section-by-section before fanning out to breadth searches."
+when_to_use: "goal names a specific document by title, URL, or unambiguous reference; investigations anchored on a single primary source the synthesis must trace back to"
+when_not_to_use: "open-ended exploratory queries with no anchor document; broad survey of a topic across many sources"
+---
+
+# Cornerstone extraction
+
+When the goal is anchored on a specific named document — **Mandate for Leadership**, a company's **10-K**, a **court opinion**, a **bill text**, an **executive order** — extract that document exhaustively *before* issuing breadth searches. The cornerstone is the spine of the report; everything else fans out from findings inside it.
+
+## Why ordering matters
+
+A breadth-first search ("AI policy 2025") returns surface-level commentary about the cornerstone before you've read the cornerstone itself. You end up citing other people's summaries instead of the source document. Worse, you miss claims that *only* appear in the cornerstone — buried in chapter 23, section 4, footnote 12 — because no breadth search will surface them by topic keyword. Read the primary first, then fan out into specifics.
+
+## Procedure
+
+1. **Identify the cornerstone URL or DOI.** If the goal names the document but not the URL, resolve it explicitly (one targeted search, not a topic dragnet). Save the canonical URL — every finding will cite back to it with a section breadcrumb.
+2. **Fetch the full document.** Use the connector that owns this artifact: `edgar` for SEC filings, `congress` for bill text / committee reports, `courtlistener` for opinions, `fedregister` for executive orders / final rules, generic web fetch for advocacy reports / academic papers. Long PDFs (>~50 pages) get chunked per #206 — once that lands, lean on the chunker; until then, paginate manually.
+3. **Walk the document in order.** Sections for short documents; chapters for books / multi-hundred-page reports; opinions for court decisions (majority → concurrences → dissents); items for an 8-K. Don't jump around — you'll miss connective tissue.
+4. **Emit findings tagged with a section breadcrumb.** Format: `Mandate for Leadership > Ch. 3 (Central Personnel Agencies) > p. 87`. Every finding must carry the breadcrumb so synthesis can trace each claim back to its exact location and reviewers can verify in seconds.
+5. **Only after the index is complete, fan out.** Now issue breadth searches that drill into specific findings: "Who is Russell Vought" (named in the cornerstone), "OPM Schedule F litigation" (a specific proposal in the cornerstone), "Heritage Foundation budget 2024" (publisher of the cornerstone). The cornerstone tells you *what to fan out on*; without reading it first, you're guessing.
+
+## Output discipline
+
+- **Every finding from the cornerstone gets the breadcrumb.** Anonymous "the report says..." claims are unreviewable.
+- **Findings that *contradict* something in the cornerstone are flagged**, not silently merged. The cornerstone is one source — a contradicting source doesn't override it without `triangulation` evidence.
+- **The synthesis section structure should mirror the cornerstone's structure** when the goal is "summarize / analyze the cornerstone." When the goal is broader ("policy landscape, with the cornerstone as one input"), the cornerstone becomes one section among many, but its findings still cite back with breadcrumbs.
+
+## Pairing with other strategies
+
+- **#206 (chunked PDF handling, when shipped):** Long cornerstones (Mandate for Leadership is ~900 pages) require chunked extraction. Until #206, document the chunking strategy in the run log so reviewers can see what was skipped.
+- **`modern-policy-era-filtering`:** Apply era filters to the *fan-out searches*, not the cornerstone fetch — the cornerstone is whatever the goal names, even if it's old.
+- **`triangulation`:** Single-cornerstone-sourced claims are by definition single-sourced. For claims the synthesis elevates to the executive summary, find a second independent source that confirms or contradicts the cornerstone's assertion.
+
+## Anti-patterns
+
+- Skimming the cornerstone for keywords matching the goal and citing only those passages — misses the document's argument structure and the proposals that don't share the goal's vocabulary.
+- Issuing 20 breadth searches before reading the cornerstone — you'll spend the budget on commentary about the document rather than the document itself.
+- Citing the cornerstone with no breadcrumb (`"per Mandate for Leadership"`) — reviewers can't verify; treat as an unsupported claim.
+- Treating a Wikipedia summary or a news article *about* the cornerstone as a substitute for fetching the cornerstone itself — these are derivative sources, not primary.

--- a/src/research_agent/skills/strategies/modern-policy-era-filtering.md
+++ b/src/research_agent/skills/strategies/modern-policy-era-filtering.md
@@ -1,0 +1,41 @@
+---
+name: modern-policy-era-filtering
+description: "Apply recency filters across all connectors when investigating current-era policy. Government APIs default to relevance, not recency — without this strategy, queries surface decades-old precedent ranked above current actions."
+when_to_use: "goal mentions current admin, this term, recent, 2025+, ongoing policy, Project 2025, Trump 2nd term, executive orders this year"
+when_not_to_use: "historical comparison, precedent research, longitudinal trend analysis, anything explicitly requesting older eras"
+---
+
+# Modern-policy-era filtering
+
+When the goal is about current/recent federal policy (default era for the 119th Congress / Trump 2nd term: **on or after 2025-01-20**), apply the directives below across every connector that fires. Government search APIs default to relevance ranking, not recency — without this filter the planner surfaces Clinton-era statutes and Obama EOs ranked above current actions.
+
+## Per-connector recency directives
+
+Knob shape varies. Some connectors take a real date parameter; the rest only accept query-string scoping. Read carefully — passing `since=2025-01-20` to a connector that doesn't accept it is a silent no-op.
+
+| Connector | Mechanism | Modern-era value |
+|---|---|---|
+| `congress` | **No `congress=` knob.** Include era in `query` string. | Append `"119th Congress"` or `"2025"` |
+| `edgar` | **No date knob.** Filter `SearchResult.published_at >= 2025-01-20` post-hoc. | `published_at >= 2025-01-20` |
+| `fedregister` | Real `since=` knob (ISO `YYYY-MM-DD`). | `since="2025-01-20"` |
+| `courtlistener` | **No `date_filed_after` knob.** Append CourtListener's FTS date scope to `query`. | Append `decided:[2025-01-20 TO *]` |
+| `fec` | **No `cycle=` knob.** Include cycle year in `query`. | Append `"2024"` (presidential), `"2026"` (midterms) |
+| `usaspending` (when shipped) | `fiscal_year_min` | `2025` |
+| `nonprofits` (when shipped) | `tax_year` | most recent available |
+| `sanctions` (when shipped) | `added_after` | `2025-01-20` |
+
+## Executive Order numbering
+
+Trump 2nd-term EOs start at roughly **EO 14148** (2025-01-20). Filter `extras.document_number` (Federal Register) or the EO number in the title `> 14150` to catch the current term while excluding the 2017–2021 EO range (≈13765–14013) and Biden's range (≈14014–14147).
+
+## When to override
+
+Override the recency filter only when the goal explicitly asks about historical comparison, original-intent / precedent research, or longitudinal trends. If the goal mentions a specific older administration, scope to *that* era's window instead — don't drop recency entirely.
+
+## Anti-pattern
+
+Searching `"AI regulation"` with no recency filter returns Clinton-era Telecommunications Act fragments and Obama-era NIST guidance ranked above Biden's 2023 EO 14110 and Trump's 2025 actions. The 2026-05-08 Project 2025 overnight surfaced 0/24 citations from the 119th Congress and 4/24 from federalregister.gov post-2025-01-20 because this strategy was not invoked. Always pass the era filter on current-policy investigations.
+
+## Cross-stacking with other strategies
+
+This strategy is purely additive — it constrains the search window without changing query semantics, so it composes cleanly with `cornerstone-extraction` (extract the cornerstone in full, then apply era filters when fanning out) and `triangulation` (require ≥2 *modern-era* sources, not 1 modern + 1 historical).

--- a/src/research_agent/skills/strategies/triangulation.md
+++ b/src/research_agent/skills/strategies/triangulation.md
@@ -1,0 +1,50 @@
+---
+name: triangulation
+description: "For high-stakes claims (executive summary, contested facts, legal/financial assertions), require ≥2 independent sources before marking confirmed; distinguish single-sourced from confirmed in synthesis."
+when_to_use: "investigative reporting, fact-tracking, legal analysis, financial verification, any claim destined for the executive summary or that contradicts another finding"
+when_not_to_use: "uncontested background facts, well-known historical events, claims sourced directly from a primary cornerstone where attribution alone suffices"
+---
+
+# Triangulation
+
+For any claim a synthesis elevates to the **executive summary**, marks as **contested**, or treats as a **legal / financial / criminal-conduct assertion**, require **≥2 independent sources** before flagging the claim as `confirmed`. Single-sourced high-stakes claims must be flagged `inconclusive` or `single-sourced` — never `confirmed`.
+
+## What "independent" means
+
+Two sources are **independent** when they have:
+
+1. **Different publishers** — not two outlets republishing the same wire story (AP, Reuters, AFP). A Reuters story syndicated to 40 newspapers is *one* source, not 40.
+2. **Different chains of provenance** — a press release quoted in two outlets is one source (the press release). An anonymous source quoted by two reporters at the same publication is one source.
+3. **Different evidentiary basis** — a primary document plus a secondary report citing that document is *one and a half* sources for the document's contents; the secondary report only counts as a second source if it adds independent reporting (interviews, additional documents, on-the-record confirmation).
+
+Examples of *non*-independent pairs that look independent:
+- Two news outlets both citing "according to a White House statement" — the statement is one source.
+- A Wikipedia article and a news article that Wikipedia cites — Wikipedia is downstream of the news article.
+- Two academic papers by overlapping co-authors using the same dataset — the dataset is one source.
+- A 10-K and an 8-K from the same issuer disclosing the same fact — the issuer is one voice; you have one corporate source, not two.
+
+Examples of genuinely independent pairs:
+- A Federal Register publication of an executive order *and* a court opinion in litigation challenging that EO that quotes the operative text.
+- An FEC filing showing a contribution *and* an independent reporter's interview with the contributor confirming the donation.
+- A 10-K disclosing an acquisition *and* the target company's own SEC filing or board minutes confirming.
+
+## Procedure
+
+1. **Classify the claim.** Tag every finding as `executive-summary` (lead claim), `contested` (contradicts another finding), `legal-or-financial` (court holding, regulatory action, dollar amount, criminal allegation), or `background` (uncontested context). Background claims do not need triangulation; the other three categories do.
+2. **Count independent sources.** For a high-stakes claim, list the sources. If ≥2 are independent by the definition above, mark the claim `confirmed`.
+3. **Single-sourced high-stakes claims:** mark `single-sourced` (or `inconclusive` if the source is weak — anonymous, paywalled-rumor, social media). Schedule a follow-up task to find a corroborating second source. Do not silently elevate to the executive summary.
+4. **Conflicting sources:** **surface both with the conflict noted.** Do not drop either. Format: `Source A reports X (URL, date); Source B reports Y (URL, date); conflict unresolved.` Schedule a follow-up to find a third source that breaks the tie or to fetch the underlying primary document if both are secondary.
+5. **In the synthesis output:** every executive-summary claim carries an explicit `[confirmed]`, `[single-sourced]`, or `[contested]` tag. Reviewers should be able to see the evidentiary status without re-reading the source list.
+
+## Anti-patterns
+
+- Counting two reposts of the same wire story as two sources — they are one (provenance test).
+- Treating an organization's press release plus a news write-up of that press release as confirmation — the news write-up is downstream.
+- Dropping the lower-quality source in a conflict to avoid having to discuss it — the conflict is itself a finding; surface it.
+- Marking a single-sourced claim `confirmed` because the source is "reputable" — reputation is not independence; the executive-summary tag is reserved for ≥2 independent sources regardless of source prestige.
+- Failing to schedule the follow-up task on `single-sourced` claims — they will quietly persist into the final report unless someone tries to upgrade them.
+
+## Pairing with other strategies
+
+- **`cornerstone-extraction`:** A claim sourced *only* to the cornerstone is single-sourced by definition. For executive-summary claims, find a second independent source confirming or contradicting.
+- **`modern-policy-era-filtering`:** When triangulating modern-policy claims, both sources should be modern-era. A modern claim "confirmed" by a 2008 source is not actually confirmed for the current policy environment.

--- a/tests/test_skills_content.py
+++ b/tests/test_skills_content.py
@@ -1,10 +1,11 @@
-"""Validate the shipped connector skill markdown content.
+"""Validate the shipped connector and strategy skill markdown content.
 
 Loader behavior is covered in ``test_skills_loader.py``; this file validates
 the *content* of the 5 initial connector skills (congress, edgar, fedregister,
-courtlistener, fec) — frontmatter completeness, presence of required body
-sections, and that any knobs the skill names match the connector's actual
-``search()`` signature.
+courtlistener, fec) and the 3 initial strategy skills (modern-policy-era-
+filtering, cornerstone-extraction, triangulation) — frontmatter completeness,
+presence of required body sections, and that any knobs the skill names match
+the connector's actual ``search()`` signature.
 """
 
 from __future__ import annotations
@@ -19,6 +20,12 @@ from research_agent.skills import loader as skills_loader
 from research_agent.skills.loader import clear_cache, list_skills, load_skill
 
 CONNECTOR_SKILLS = ("congress", "edgar", "fedregister", "courtlistener", "fec")
+
+STRATEGY_SKILLS = (
+    "modern-policy-era-filtering",
+    "cornerstone-extraction",
+    "triangulation",
+)
 
 REQUIRED_BODY_SECTIONS = ("Knobs available", "Anti-patterns")
 
@@ -132,4 +139,67 @@ def test_loader_module_resolves_skills_directory(monkeypatch: pytest.MonkeyPatch
     assert base.is_dir(), f"connectors directory missing at {base}"
     shipped = sorted(p.stem for p in base.glob("*.md"))
     for name in CONNECTOR_SKILLS:
+        assert name in shipped, f"{name}.md missing from {base}"
+
+
+# ---------------------------------------------------------------------------
+# Strategy skills
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", STRATEGY_SKILLS)
+def test_strategy_skill_loads_with_non_empty_body(name: str) -> None:
+    body = load_skill("strategies", name)
+    assert body, f"strategy skill {name!r} body is empty"
+    assert len(body) > 200, f"strategy skill {name!r} body looks truncated"
+
+
+@pytest.mark.parametrize("name", STRATEGY_SKILLS)
+def test_strategy_skill_frontmatter_fields_present(name: str) -> None:
+    entries = {e["name"]: e for e in list_skills("strategies")}
+    assert name in entries, f"skill {name!r} not found in strategies index"
+    entry = entries[name]
+    assert entry["description"], f"{name}: description missing"
+    assert entry["when_to_use"], f"{name}: when_to_use missing"
+
+
+def test_strategy_descriptions_are_one_line() -> None:
+    """The description is the planner-facing index signal — single-line, terse."""
+    for entry in list_skills("strategies"):
+        assert "\n" not in entry["description"], (
+            f"{entry['name']}: description must be a single line"
+        )
+        assert len(entry["description"]) <= 280, (
+            f"{entry['name']}: description longer than 280 chars "
+            f"({len(entry['description'])})"
+        )
+
+
+def test_modern_policy_era_filtering_references_every_connector() -> None:
+    """The strategy's value prop is "stack onto every connector" — its body
+    must concretely name each shipped connector and reference the one real
+    date knob (`since` on fedregister), so the planner gets actionable
+    guidance instead of generic principles."""
+    body = load_skill("strategies", "modern-policy-era-filtering")
+    for connector in CONNECTOR_SKILLS:
+        assert connector in body, (
+            f"modern-policy-era-filtering: body must reference connector "
+            f"{connector!r} so planner gets per-connector directive"
+        )
+    assert "since" in body, (
+        "modern-policy-era-filtering: must reference the `since` knob "
+        "(the one real date parameter on fedregister.search())"
+    )
+    assert "2025-01-20" in body, (
+        "modern-policy-era-filtering: must reference the 119th-Congress / "
+        "Trump-2-inauguration anchor date"
+    )
+
+
+def test_strategies_directory_resolves() -> None:
+    """Sanity: strategy files live where the loader expects."""
+    base = skills_loader._skills_dir("strategies")
+    assert base.is_dir(), f"strategies directory missing at {base}"
+    shipped = sorted(p.stem for p in base.glob("*.md"))
+    for name in STRATEGY_SKILLS:
         assert name in shipped, f"{name}.md missing from {base}"


### PR DESCRIPTION
Closes #213
Part of #214

## Summary

Automated implementation of **feat: strategy skills (initial 3) — modern-policy-era-filtering, cornerstone-extraction, triangulation**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

All 3 strategy skill files ship at the correct paths with valid frontmatter, concrete per-connector directives, and pass 37/37 content tests; end-to-end wiring (planner -> plan.active_strategies -> loop.load_strategies) is intact.

- **INFO** [OPEN] `src/research_agent/skills/strategies/modern-policy-era-filtering.md`: Strategy correctly diverges from the issue's example knob list (congress=, edgar since=, courtlistener date_filed_after=) which don't exist on the actual connector signatures. The skill instead documents the real shape: only fedregister has a since= date knob; the rest get era-scoped via the query string. This is faithful-to-reality and the right call.
- **INFO** [OPEN] `src/research_agent/skills/strategies/modern-policy-era-filtering.md`: Acceptance criterion 'on a re-run of the Project 2025 overnight, >=80% of fetched congress.gov sources are from the 119th Congress' is a runtime criterion that cannot be validated in code review and depends on the planner actually invoking the strategy. The wiring exists; verifying the metric requires an actual run.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*