### PR TITLE
feat: fix: synthesizer's bottom-of-report Sources section drops most cited IDs (24 listed vs 64 cited inline) (closes #207)

### DIFF
--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -70,6 +70,7 @@ EventKind = Literal[
     "cornerstone_dedup",
     "cornerstone_followups_emitted",
     "second_order_fanout",
+    "source_list_reconciled",
     "error",
     "warning",
 ]

--- a/src/research_agent/orchestrator/synth.py
+++ b/src/research_agent/orchestrator/synth.py
@@ -31,6 +31,7 @@ import json
 import logging
 import re
 import sqlite3
+from datetime import UTC, datetime
 from importlib.resources import files
 from typing import TYPE_CHECKING, Any
 
@@ -75,9 +76,7 @@ def _load_followup_recipes() -> str:
     if _FOLLOWUP_RECIPES is not None:
         return _FOLLOWUP_RECIPES
     try:
-        body = (files("research_agent.prompts") / "followup_recipes.md").read_text(
-            encoding="utf-8"
-        )
+        body = (files("research_agent.prompts") / "followup_recipes.md").read_text(encoding="utf-8")
     except (FileNotFoundError, OSError) as exc:
         if not _FOLLOWUP_RECIPES_WARN_LOGGED:
             logger.warning("synth: followup_recipes.md unavailable: %s", exc)
@@ -107,6 +106,7 @@ def _load_paid_unblock_recipes() -> str:
         body = ""
     _PAID_UNBLOCK_RECIPES = body
     return body
+
 
 _BUDGET_STUB_REPORT = (
     "# Report (truncated)\n\n"
@@ -255,8 +255,7 @@ def _build_context(
         "goal": goal,
         "scope_class": str(plan.scope_class) if plan.scope_class else None,
         "subgoals": [
-            {"id": sg.id, "description": sg.description, "done": sg.done}
-            for sg in plan.subgoals
+            {"id": sg.id, "description": sg.description, "done": sg.done} for sg in plan.subgoals
         ],
         "findings": findings,
         "sources": {str(k): v for k, v in sources.items()},
@@ -270,9 +269,7 @@ def _build_context(
     return json.dumps(payload, sort_keys=True, default=str)
 
 
-_SUBGOAL_STATUS_FENCE_RE = re.compile(
-    r"```[ \t]*json[ \t]*\n(.*?)\n```\s*$", re.DOTALL
-)
+_SUBGOAL_STATUS_FENCE_RE = re.compile(r"```[ \t]*json[ \t]*\n(.*?)\n```\s*$", re.DOTALL)
 
 
 def _extract_subgoal_status(
@@ -343,6 +340,106 @@ def _apply_subgoal_status(
     from research_agent.orchestrator import plan as _plan_mod
 
     _plan_mod.update_subgoal_done(job, status_map)
+
+
+_CITATION_RE = re.compile(r"\[(\d+(?:,\s*\d+)*)\]")
+_SOURCES_HEADING_RE = re.compile(r"^##\s+Sources\s*$", re.MULTILINE)
+_NUMBERED_LINE_RE = re.compile(r"^(\d+)\.\s", re.MULTILINE)
+
+
+def _format_source_line(sid: int, src: dict[str, Any]) -> str:
+    """Render the canonical synthesizer Sources-section line shape (issue #207)."""
+    url = src.get("url") or "(no url)"
+    title = src.get("title") or "(untitled)"
+    fetched_at = src.get("fetched_at")
+    if fetched_at is None:
+        date_str = "unknown"
+    else:
+        date_str = datetime.fromtimestamp(int(fetched_at), tz=UTC).strftime("%Y-%m-%d")
+    return f'{sid}. {url} — "{title}" (retrieved {date_str})'
+
+
+def _reconcile_sources(
+    job: Job,
+    md: str,
+    sources_by_id: dict[int, dict[str, Any]],
+) -> str:
+    """Append inline-cited source IDs that the model dropped from ``## Sources``.
+
+    Issue #207: synthesizer often emits a curated Sources list that is a
+    strict subset of the IDs cited inline. Parse every ``[N]`` (and grouped
+    ``[N, M]``) citation in the body, parse the IDs the model enumerated
+    under the trailing ``## Sources`` heading, and append any missing ones
+    using the canonical row shape so a reader can resolve every cited ID.
+
+    Emits a ``source_list_reconciled`` INFO event whenever any inline-cited
+    ID was missing from the enumerated section, recording both the IDs we
+    appended (``added``) and any IDs we couldn't resolve against
+    ``sources_by_id`` (``unresolved``).
+    """
+    headings = list(_SOURCES_HEADING_RE.finditer(md))
+    if headings:
+        last = headings[-1]
+        body_text = md[: last.start()]
+        sources_text = md[last.start() :]
+    else:
+        body_text = md
+        sources_text = ""
+
+    cited_in_body: list[int] = []
+    seen: set[int] = set()
+    for match in _CITATION_RE.finditer(body_text):
+        for token in match.group(1).split(","):
+            try:
+                sid = int(token.strip())
+            except ValueError:
+                continue
+            if sid not in seen:
+                seen.add(sid)
+                cited_in_body.append(sid)
+
+    enumerated: set[int] = set()
+    for match in _NUMBERED_LINE_RE.finditer(sources_text):
+        try:
+            enumerated.add(int(match.group(1)))
+        except ValueError:
+            continue
+
+    missing = [sid for sid in cited_in_body if sid not in enumerated]
+    if not missing:
+        return md
+
+    added: list[int] = []
+    unresolved: list[int] = []
+    new_lines: list[str] = []
+    for sid in missing:
+        src = sources_by_id.get(sid)
+        if src is None:
+            unresolved.append(sid)
+            continue
+        added.append(sid)
+        new_lines.append(_format_source_line(sid, src))
+
+    emit(
+        job,
+        "INFO",
+        "synth",
+        "source_list_reconciled",
+        {
+            "added": added,
+            "unresolved": unresolved,
+            "already_listed": len(enumerated),
+            "cited_total": len(cited_in_body),
+        },
+    )
+
+    if not new_lines:
+        return md
+
+    suffix = "\n".join(new_lines) + "\n"
+    if md.endswith("\n"):
+        return md + suffix
+    return md + "\n" + suffix
 
 
 async def _run_synth(
@@ -436,6 +533,7 @@ async def _do_synthesis(
     model_name = _model_name_for(router, used_tier)
 
     stripped_md, status_map = _extract_subgoal_status(job, content)
+    stripped_md = _reconcile_sources(job, stripped_md, sources)
 
     version = write_synthesis(job, stripped_md, model=model_name, cost_usd=cost_val)
     synth_md = (job.root / f"synthesis/{version:04d}.md").read_text(encoding="utf-8")
@@ -749,6 +847,7 @@ async def final_synthesis_after_cap(
     model_name = _model_name_for(router, fallback_tier)
 
     stripped_md, status_map = _extract_subgoal_status(job, content)
+    stripped_md = _reconcile_sources(job, stripped_md, sources)
 
     version = write_synthesis(job, stripped_md, model=model_name, cost_usd=cost_val)
     synth_md = (job.root / f"synthesis/{version:04d}.md").read_text(encoding="utf-8")

--- a/src/research_agent/prompts/synthesizer.md
+++ b/src/research_agent/prompts/synthesizer.md
@@ -187,6 +187,14 @@ A markdown report with:
   ambiguous, say so.
 - Citation numbers in the body must reference entries in your Sources
   list. Do not cite numbers higher than the count of sources you list.
+- **The `## Sources` section MUST enumerate exactly the union of every
+  source ID cited inline in the report body, in order of first
+  appearance.** No curation, no omissions, no "top sources" subset — if
+  `[131]` appears anywhere above, then `131.` MUST appear as a numbered
+  line below. Reuse each source row's primary-key id from the input
+  context as the leading number; do NOT renumber to a contiguous
+  1..N range. A reader who sees `[131]` in the body must be able to scroll
+  to `131.` below to verify the URL and retrieval timestamp.
 
 ## Concrete example of the expected format
 
@@ -241,6 +249,11 @@ A markdown report with:
 
 1. https://example.com/a — "Title A" (retrieved 2026-05-06)
 2. https://example.com/b — "Title B" (retrieved 2026-05-06)
+3. https://example.com/c — "Title C" (retrieved 2026-05-06)
+
+(Note: every `[N]` cited above — including grouped citations like
+`[2][3]` — must appear as `N.` here. The Sources section is the
+union of inline citations, not a curated subset.)
 ``` json
 {"subgoal_status": {"1": "confirmed", "2": "inconclusive"}}
 ```

--- a/tests/test_orchestrator_synth.py
+++ b/tests/test_orchestrator_synth.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -545,12 +546,10 @@ def test_synthesize_extracts_subgoal_status_and_strips_fence(
     body = (
         "# Investigation Report\n\n"
         "## Executive Summary\n- finding [1]\n\n"
-        "## Sources\n1. https://example.com/0 — \"Title\"\n"
+        '## Sources\n1. https://example.com/0 — "Title"\n'
     )
     fence = (
-        '\n```json\n'
-        '{"subgoal_status": {"1": "confirmed", "2": "refuted", "3": "confirmed"}}'
-        '\n```\n'
+        '\n```json\n{"subgoal_status": {"1": "confirmed", "2": "refuted", "3": "confirmed"}}\n```\n'
     )
     router = _StubRouter(content=body + fence)
 
@@ -582,11 +581,11 @@ def test_synthesize_inconclusive_status_keeps_subgoal_open(
 ) -> None:
     """An ``inconclusive`` status leaves the subgoal ``done=False``."""
     _seed_findings(job, [0.7])
-    body = "# Report\n\n## Sources\n1. https://x — \"t\"\n"
+    body = '# Report\n\n## Sources\n1. https://x — "t"\n'
     fence = (
-        '\n```json\n'
+        "\n```json\n"
         '{"subgoal_status": {"1": "confirmed", "2": "inconclusive", "3": "refuted"}}'
-        '\n```\n'
+        "\n```\n"
     )
     router = _StubRouter(content=body + fence)
 
@@ -631,8 +630,8 @@ def test_synthesize_malformed_fence_emits_warning_and_skips_plan_bump(
 ) -> None:
     """A trailing JSON fence with invalid JSON is tolerated: warn + no plan bump."""
     _seed_findings(job, [0.6])
-    body = "# Report\n\n## Sources\n1. https://x — \"t\"\n"
-    fence = '\n```json\n{not valid json\n```\n'
+    body = '# Report\n\n## Sources\n1. https://x — "t"\n'
+    fence = "\n```json\n{not valid json\n```\n"
     router = _StubRouter(content=body + fence)
 
     asyncio.run(synthesize(job, multi_subgoal_plan, router=router))
@@ -677,11 +676,11 @@ def test_synthesize_repeat_status_skips_plan_version_bump(
     through MAX_PLAN_VERSIONS (200) long before the plan actually changed.
     """
     _seed_findings(job, [0.7])
-    body = "# Report\n\n## Sources\n1. https://x — \"t\"\n"
+    body = '# Report\n\n## Sources\n1. https://x — "t"\n'
     fence = (
-        '\n```json\n'
+        "\n```json\n"
         '{"subgoal_status": {"1": "confirmed", "2": "inconclusive", "3": "confirmed"}}'
-        '\n```\n'
+        "\n```\n"
     )
     router = _StubRouter(content=body + fence)
 
@@ -739,9 +738,7 @@ def test_critic_prompt_flags_missing_followups() -> None:
     assert "fact-check" in body
 
 
-def test_build_context_exposes_goal_and_licensing_board_guidance(
-    job: Job, db_path: Path
-) -> None:
+def test_build_context_exposes_goal_and_licensing_board_guidance(job: Job, db_path: Path) -> None:
     """SBI Builders fixture-style structural check.
 
     Feeds a goal naming a subject + agency through ``_build_context`` and
@@ -942,16 +939,16 @@ def test_synthesize_broad_scope_corpus_remains_inconclusive(
     # Seed a 45-task-style corpus so the test mirrors the failure repro.
     _seed_findings(job, [0.7] * 45)
 
-    body = "# Report\n\n## Sources\n1. https://x — \"t\"\n"
+    body = '# Report\n\n## Sources\n1. https://x — "t"\n'
     fence = (
-        '\n```json\n'
+        "\n```json\n"
         '{"subgoal_status": {'
         '"1": "confirmed",'
         '"2": "inconclusive",'
         '"3": "inconclusive",'
         '"4": "inconclusive"'
-        '}}'
-        '\n```\n'
+        "}}"
+        "\n```\n"
     )
     router = _StubRouter(content=body + fence)
 
@@ -994,11 +991,11 @@ def test_synthesize_accepts_fence_with_space_before_json_lang(
     parsing must accept either form.
     """
     _seed_findings(job, [0.7])
-    body = "# Report\n\n## Sources\n1. https://x — \"t\"\n"
+    body = '# Report\n\n## Sources\n1. https://x — "t"\n'
     fence = (
-        '\n``` json\n'
+        "\n``` json\n"
         '{"subgoal_status": {"1": "confirmed", "2": "confirmed", "3": "confirmed"}}'
-        '\n```\n'
+        "\n```\n"
     )
     router = _StubRouter(content=body + fence)
 
@@ -1009,3 +1006,168 @@ def test_synthesize_accepts_fence_with_space_before_json_lang(
 
     subgoals = _read_latest_plan_subgoals(db_path, job.id)
     assert all(sg["done"] is True for sg in subgoals)
+
+
+# ---------------------------------------------------------------------------
+# Sources-section reconciliation (issue #207)
+# ---------------------------------------------------------------------------
+
+
+def _seed_sources_with_finding(job: Job, n: int) -> list[int]:
+    """Seed ``n`` sources + one finding citing all of them.
+
+    Returns the list of source IDs (ascending). The single finding
+    guarantees ``synth._load_sources_for`` picks up every seeded source so
+    the reconciliation helper can resolve any of them by ID.
+    """
+    sids = [_seed_source(job, f"https://example.com/url-{i}", f"content {i}") for i in range(n)]
+    write_finding(job, "claim citing many sources", 0.9, sids)
+    return sids
+
+
+def test_synthesize_reconciles_dropped_inline_citations(
+    job: Job, db_path: Path, plan: Plan
+) -> None:
+    """A model output that cites ``[1][2][3, 5]`` but enumerates only ``1.`` and
+    ``2.`` must end up with reconciled entries for ``3.`` and ``5.``.
+    """
+    sids = _seed_sources_with_finding(job, 5)
+    # IDs are autoincrement on a fresh DB → sids == [1, 2, 3, 4, 5].
+    assert sids == [1, 2, 3, 4, 5]
+
+    body = (
+        "# Investigation Report\n\n"
+        "## Executive Summary\n"
+        "- Finding A [1].\n"
+        "- Finding B [2][3, 5].\n\n"
+        "## Sources\n\n"
+        '1. https://example.com/url-0 — "T0" (retrieved 2026-05-06)\n'
+        '2. https://example.com/url-1 — "T1" (retrieved 2026-05-06)\n'
+    )
+    router = _StubRouter(content=body)
+
+    asyncio.run(synthesize(job, plan, router=router))
+
+    report = (job.root / "report.md").read_text(encoding="utf-8")
+    # The model's enumerated lines survive verbatim.
+    assert re.search(r"^1\. https://example\.com/url-0 — ", report, re.MULTILINE)
+    assert re.search(r"^2\. https://example\.com/url-1 — ", report, re.MULTILINE)
+    # Reconciliation appended canonical lines for the dropped IDs (3 and 5).
+    assert re.search(
+        r'^3\. https://example\.com/url-2 — "[^"]+" \(retrieved \d{4}-\d{2}-\d{2}\)',
+        report,
+        re.MULTILINE,
+    )
+    assert re.search(
+        r'^5\. https://example\.com/url-4 — "[^"]+" \(retrieved \d{4}-\d{2}-\d{2}\)',
+        report,
+        re.MULTILINE,
+    )
+    # The persisted synthesis version must also include the reconciled lines.
+    synth_md = (job.root / "synthesis/0001.md").read_text(encoding="utf-8")
+    assert re.search(r"^3\. https://example\.com/url-2 — ", synth_md, re.MULTILINE)
+    assert re.search(r"^5\. https://example\.com/url-4 — ", synth_md, re.MULTILINE)
+
+
+def test_synthesize_emits_source_list_reconciled_event(job: Job, db_path: Path, plan: Plan) -> None:
+    """A drop event records exactly the IDs the helper appended."""
+    sids = _seed_sources_with_finding(job, 5)
+    assert sids == [1, 2, 3, 4, 5]
+
+    body = (
+        "# Report\n\n"
+        "- a [1].\n"
+        "- b [2][3, 5].\n\n"
+        "## Sources\n\n"
+        '1. https://example.com/url-0 — "T0" (retrieved 2026-05-06)\n'
+        '2. https://example.com/url-1 — "T1" (retrieved 2026-05-06)\n'
+    )
+    router = _StubRouter(content=body)
+
+    asyncio.run(synthesize(job, plan, router=router))
+
+    events = _read_event_rows(db_path, job.id)
+    reconciled = [e for e in events if e["kind"] == "source_list_reconciled"]
+    assert len(reconciled) == 1
+    assert reconciled[0]["level"] == "INFO"
+    payload = json.loads(reconciled[0]["payload_json"])
+    assert payload["added"] == [3, 5]
+    assert payload["unresolved"] == []
+    assert payload["already_listed"] == 2
+    assert payload["cited_total"] == 4
+
+
+def test_synthesize_no_reconciliation_when_sources_already_complete(
+    job: Job, db_path: Path, plan: Plan
+) -> None:
+    """When the model enumerated every cited ID, no event fires and the body
+    is byte-for-byte unchanged below the heading.
+    """
+    sids = _seed_sources_with_finding(job, 3)
+    assert sids == [1, 2, 3]
+
+    body = (
+        "# Report\n\n"
+        "- a [1].\n"
+        "- b [2][3].\n\n"
+        "## Sources\n\n"
+        '1. https://example.com/url-0 — "T0" (retrieved 2026-05-06)\n'
+        '2. https://example.com/url-1 — "T1" (retrieved 2026-05-06)\n'
+        '3. https://example.com/url-2 — "T2" (retrieved 2026-05-06)\n'
+    )
+    router = _StubRouter(content=body)
+
+    asyncio.run(synthesize(job, plan, router=router))
+
+    events = _read_event_rows(db_path, job.id)
+    reconciled = [e for e in events if e["kind"] == "source_list_reconciled"]
+    assert reconciled == []
+
+    report = (job.root / "report.md").read_text(encoding="utf-8")
+    # Sources section should contain exactly the three model-emitted lines —
+    # no duplicates from a stray reconciliation pass.
+    assert report.count("https://example.com/url-0") == 1
+    assert report.count("https://example.com/url-1") == 1
+    assert report.count("https://example.com/url-2") == 1
+
+
+def test_synthesize_unresolved_inline_citation_logs_without_appending(
+    job: Job, db_path: Path, plan: Plan
+) -> None:
+    """A body cite for an ID that doesn't exist in the source dict logs as
+    ``unresolved`` and does NOT inject a bogus ``999.`` line.
+    """
+    sids = _seed_sources_with_finding(job, 2)
+    assert sids == [1, 2]
+
+    body = (
+        "# Report\n\n"
+        "- a [1].\n"
+        "- b [999].\n\n"
+        "## Sources\n\n"
+        '1. https://example.com/url-0 — "T0" (retrieved 2026-05-06)\n'
+    )
+    router = _StubRouter(content=body)
+
+    asyncio.run(synthesize(job, plan, router=router))
+
+    report = (job.root / "report.md").read_text(encoding="utf-8")
+    # Reconciliation must not invent a 999. line.
+    assert not re.search(r"^999\. ", report, re.MULTILINE)
+
+    events = _read_event_rows(db_path, job.id)
+    reconciled = [e for e in events if e["kind"] == "source_list_reconciled"]
+    assert len(reconciled) == 1
+    payload = json.loads(reconciled[0]["payload_json"])
+    assert payload["added"] == []
+    assert payload["unresolved"] == [999]
+
+
+def test_synthesizer_prompt_requires_sources_union_rule() -> None:
+    """The synthesizer prompt must instruct the model to emit the union of
+    inline-cited IDs in the Sources section (issue #207)."""
+    body = prompts_loader.load_prompt("synthesizer", goal="x")
+    # The new rule names the union explicitly so the model knows partial
+    # lists are not acceptable.
+    assert "union" in body.lower()
+    assert "Sources" in body


### PR DESCRIPTION
Closes #207
Part of #214

## Summary

Automated implementation of **fix: synthesizer's bottom-of-report Sources section drops most cited IDs (24 listed vs 64 cited inline)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Issue #207 fix is correctly and minimally implemented: deterministic post-synth reconciliation appends missing inline-cited source IDs, prompt strengthens the union rule, observability event emitted, all 1469 tests pass.

- **INFO** [FIXED] `src/research_agent/orchestrator/synth.py`: _reconcile_sources is wired into both _do_synthesis and final_synthesis_after_cap, covering all three public entry points (synthesize, final_synthesis, final_synthesis_after_cap). Verified at synth.py:536 and synth.py:850.
- **INFO** [FIXED] `src/research_agent/observability/events.py`: EventKind literal updated to include 'source_list_reconciled' so emit() accepts the new kind without runtime error.
- **INFO** [FIXED] `src/research_agent/orchestrator/synth.py`: Acceptance criteria all met: (1) reconciled section is exact union of cited IDs, (2) source_list_reconciled event records added/unresolved/already_listed/cited_total, (3) line shape preserved as 'N. URL — "title" (retrieved YYYY-MM-DD)', (4) IDs are NOT renumbered to 1..N (preserves primary-key id per out-of-scope note).
- **INFO** [FIXED] `tests/test_orchestrator_synth.py`: Tests cover: dropped-citation reconciliation, event payload shape, no-op when complete, unresolved (hallucinated) ID case, and prompt-rule presence. 5 new tests, all green; full suite (1469 tests) green.
- **INFO** [OPEN] `src/research_agent/orchestrator/synth.py`: Edge case: _SOURCES_HEADING_RE is case- and level-sensitive ('## Sources' only). If the model ever emits '### Sources' or '## sources', the heading-split would treat the report as having no Sources section and append all cited IDs at the very end of the file (after the model's malformed Sources section). Acceptable risk — the prompt explicitly specifies '## Sources' and concrete example reinforces it.
- **INFO** [OPEN] `src/research_agent/orchestrator/synth.py`: Edge case: _CITATION_RE would match a markdown reference-style link like '[text][1]' as a citation of ID 1. In practice the synthesizer prompt produces inline '[N]' citations and not reference links, so this is unlikely to fire — but if it did, the worst case is appending an already-enumerated valid ID (deduplicated by 'enumerated' set) or marking a non-existent ID as unresolved (no bogus line written). Safe.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*