### PR TITLE
feat: fix: synthesizer Departmental Tracker uses fixed 4-5-section template — drops departments with findings (closes #208)

### DIFF
--- a/src/research_agent/orchestrator/synth.py
+++ b/src/research_agent/orchestrator/synth.py
@@ -239,6 +239,102 @@ def _load_latest_critique(job: Job) -> str | None:
     return md_path.read_text(encoding="utf-8")
 
 
+_DEPARTMENT_ALIASES: list[tuple[str, list[str]]] = [
+    ("DOJ", ["DOJ", "Department of Justice", "Justice Department", "Justice"]),
+    (
+        "HHS",
+        [
+            "HHS",
+            "Department of Health and Human Services",
+            "Health and Human Services",
+            "Department of Health",
+            "Health Department",
+            "FDA",
+            "Food and Drug Administration",
+        ],
+    ),
+    (
+        "DOD",
+        ["DOD", "Department of Defense", "Defense Department", "Pentagon", "Defense"],
+    ),
+    ("DHS", ["DHS", "Department of Homeland Security", "Homeland Security"]),
+    (
+        "Education",
+        ["Department of Education", "Education Department"],
+    ),
+    (
+        "Commerce",
+        ["Department of Commerce", "Commerce Department", "NOAA"],
+    ),
+    (
+        "Treasury",
+        ["Department of the Treasury", "Treasury Department", "Treasury"],
+    ),
+    ("State", ["Department of State", "State Department"]),
+    (
+        "USDA",
+        ["USDA", "Department of Agriculture", "Agriculture Department"],
+    ),
+    ("EPA", ["EPA", "Environmental Protection Agency"]),
+    (
+        "VA",
+        ["Department of Veterans Affairs", "Veterans Affairs", "Veterans"],
+    ),
+    ("HUD", ["HUD", "Housing and Urban Development"]),
+    (
+        "Labor",
+        ["Department of Labor", "Labor Department", "DOL"],
+    ),
+    (
+        "Interior",
+        ["Department of the Interior", "Interior Department"],
+    ),
+    ("OPM", ["OPM", "Office of Personnel Management", "Personnel"]),
+]
+
+
+_DEPARTMENT_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    (
+        canonical,
+        re.compile(
+            r"\b(?:" + "|".join(re.escape(a) for a in aliases) + r")\b",
+            re.IGNORECASE,
+        ),
+    )
+    for canonical, aliases in _DEPARTMENT_ALIASES
+]
+
+
+def _compute_department_coverage(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Scan finding ``claim`` text for federal department mentions.
+
+    Returns a list of ``{"department": <canonical>, "count": <n>}`` ranked
+    high→low by count (canonical name as a stable tiebreaker). Each finding
+    contributes at most one increment per department even if multiple
+    aliases for that department appear in its claim text. The result feeds
+    the synthesizer prompt as a structural hint so it can enumerate the
+    Departmental Policy Tracker by data rather than by template.
+    """
+    counts: dict[str, int] = {}
+    for f in findings:
+        claim = f.get("claim", "")
+        if not isinstance(claim, str) or not claim:
+            continue
+        seen_in_finding: set[str] = set()
+        for canonical, pattern in _DEPARTMENT_PATTERNS:
+            if canonical in seen_in_finding:
+                continue
+            if pattern.search(claim):
+                seen_in_finding.add(canonical)
+        for c in seen_in_finding:
+            counts[c] = counts.get(c, 0) + 1
+
+    return sorted(
+        [{"department": d, "count": c} for d, c in counts.items()],
+        key=lambda item: (-int(item["count"]), str(item["department"])),
+    )
+
+
 def _build_context(
     *,
     goal: str,
@@ -263,6 +359,7 @@ def _build_context(
         "critique": critique,
         "followup_recipes": followup_recipes,
         "paid_unblock_recipes": paid_unblock_recipes,
+        "department_coverage": _compute_department_coverage(findings),
     }
     if final:
         payload["final"] = True

--- a/src/research_agent/prompts/synthesizer.md
+++ b/src/research_agent/prompts/synthesizer.md
@@ -1,5 +1,5 @@
 ---
-version: "6"
+version: "7"
 model_tier: frontier
 description: System prompt for the synthesizer. Emits a raw markdown report followed by a single fenced JSON block with subgoal status.
 ---
@@ -36,6 +36,13 @@ source.
 - **Critique:** the latest critic pass over the prior draft. The
   critique's `paid_opportunities` field is the only signal you should
   use to decide whether the paid-resources section appears at all.
+- **department_coverage:** a structural hint — a ranked list of
+  `{department, count}` entries derived from finding claim text, ordered
+  high→low by mention count. Use this to drive the **Departmental Policy
+  Tracker** section: enumerate by data, not by template. Generate one
+  section per department in this list — do not omit any, do not collapse
+  short ones into a catch-all. When the list is empty, omit the tracker
+  section entirely.
 
 ## Output format — RAW markdown + a trailing JSON block
 
@@ -116,9 +123,29 @@ A markdown report with:
    with the strongest supporting and contradicting findings cited.
 3. **Connections** — relationships between people, orgs, policies, or
    events that the findings reveal but no single source spells out.
-4. **Open questions** — what the investigation could not resolve, and why
+4. **Departmental Policy Tracker** — *include this section only when the
+   input context's `department_coverage` list is non-empty.* Enumerate
+   sections **by data, not by template**. Rules:
+
+   - Generate one `### <Department>` section for **every** entry in
+     `department_coverage`. Do not omit any department, even if it has
+     only 1–2 findings — a single bullet is fine; coverage is the goal.
+   - Order sections by `count` high→low, exactly as they appear in the
+     `department_coverage` list. Do not reorder by an arbitrary
+     "importance" or alphabetical scheme.
+   - Departments with ≥3 findings warrant subsections (`#### Personnel`,
+     `#### Restructuring`, `#### Litigation`, etc.) when the findings
+     cluster into themes; departments with 1–2 findings can use a flat
+     bullet list.
+   - Do **not** use a "General Federal & Administrative Policy" catch-all
+     to absorb departments that have their own findings. Reserve that
+     heading for findings that genuinely span departments — and even
+     then, only when at least one such finding exists. There is no fixed
+     4–5-section template to mimic; the number of sections equals the
+     length of `department_coverage`.
+5. **Open questions** — what the investigation could not resolve, and why
    (e.g., source unavailable, contradictory evidence, ambiguous goal).
-5. **Recommended Human Follow-Ups** — actionable next steps for the
+6. **Recommended Human Follow-Ups** — actionable next steps for the
    operator that software cannot do alone (calls, FOIA requests, legal
    review). Use the sub-headings below; **omit a sub-heading entirely
    when no items apply** (do not print "(none)"):
@@ -147,7 +174,7 @@ A markdown report with:
    - If the report relies on government records or alleges agency
      misconduct, expect at least one FOIA candidate or whistleblower
      hotline.
-6. **Paid Resources That Would Unblock This Investigation** —
+7. **Paid Resources That Would Unblock This Investigation** —
    *include this section only when the critique's `paid_opportunities`
    list has at least one entry; otherwise omit the heading entirely.*
    Render it with the two sub-headings below, in this order:
@@ -175,7 +202,7 @@ A markdown report with:
    - Only flag a paid resource when the critique surfaced an actual
      evidenced gap. If the critique returned no `paid_opportunities`,
      omit the entire section (do not write "(none)").
-7. **Sources** — numbered list mapping `[N]` → URL + retrieved-at.
+8. **Sources** — numbered list mapping `[N]` → URL + retrieved-at.
 
 ## Rules
 
@@ -216,6 +243,28 @@ A markdown report with:
 ## Connections
 
 - ...
+
+## Departmental Policy Tracker
+
+### DOJ
+#### Personnel
+- <finding> [1].
+#### Litigation
+- <finding> [2].
+
+### HHS
+- <finding> [3].
+
+### Education
+- <finding> [4].
+
+### EPA
+- <finding> [5].
+
+(Sections appear in the order given by `department_coverage` — ranked
+high→low by finding count. Every department listed in
+`department_coverage` gets a section; departments with 1–2 findings
+still get a section, even if it's a single bullet.)
 
 ## Open Questions
 

--- a/tests/test_orchestrator_synth.py
+++ b/tests/test_orchestrator_synth.py
@@ -1171,3 +1171,154 @@ def test_synthesizer_prompt_requires_sources_union_rule() -> None:
     # lists are not acceptable.
     assert "union" in body.lower()
     assert "Sources" in body
+
+
+# ---------------------------------------------------------------------------
+# Departmental Policy Tracker (issue #208)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_department_coverage_aliases_and_ranking() -> None:
+    """Aliases collapse to canonicals; result is ranked high→low by count."""
+    findings: list[dict[str, Any]] = [
+        # DOJ via 'DOJ' and 'Justice Department' — counts once for the finding.
+        {"claim": "DOJ filed suit. The Justice Department announced changes."},
+        # DOJ via 'Justice' alias.
+        {"claim": "Justice issued new guidance to prosecutors."},
+        # HHS via FDA + Health and Human Services — counts once.
+        {"claim": "HHS and FDA approved the policy across Health and Human Services."},
+        # HHS via Health Department.
+        {"claim": "The Department of Health changed Medicare rules."},
+        # DOD: 'Department of Defense' + 'Pentagon' + 'DOD'.
+        {"claim": "DOD reorganization at the Pentagon was confirmed by Department of Defense."},
+        # DHS.
+        {"claim": "Department of Homeland Security raised the alert level."},
+        # OPM via 'Office of Personnel Management' + 'Personnel'.
+        {"claim": "OPM rolled out new federal Personnel rules."},
+        # Education via 'Department of Education'.
+        {"claim": "Department of Education announced new Title IX guidance."},
+        # No federal department mention.
+        {"claim": "A private company released a quarterly report."},
+    ]
+
+    coverage = synth_module._compute_department_coverage(findings)
+    by_dept = {item["department"]: item["count"] for item in coverage}
+
+    # Aliases collapsed correctly (DOJ counts == 2, HHS == 2, others == 1 each).
+    assert by_dept["DOJ"] == 2
+    assert by_dept["HHS"] == 2
+    assert by_dept["DOD"] == 1
+    assert by_dept["DHS"] == 1
+    assert by_dept["OPM"] == 1
+    assert by_dept["Education"] == 1
+
+    # No false-positive entries from the unrelated finding.
+    assert "Treasury" not in by_dept
+    assert "EPA" not in by_dept
+
+    # Ranked high→low by count; tied departments use canonical name as
+    # stable tiebreaker (alphabetical: DOJ before HHS).
+    counts = [item["count"] for item in coverage]
+    assert counts == sorted(counts, reverse=True)
+    top_two = [item["department"] for item in coverage[:2]]
+    assert top_two == ["DOJ", "HHS"]
+
+
+def test_compute_department_coverage_empty_findings_returns_empty_list() -> None:
+    """No findings → empty list (the prompt uses this to omit the section)."""
+    assert synth_module._compute_department_coverage([]) == []
+
+
+def test_compute_department_coverage_handles_missing_or_non_string_claims() -> None:
+    """Findings with missing/empty/non-string claim are skipped without erroring."""
+    findings: list[dict[str, Any]] = [
+        {"claim": "DOJ acted."},
+        {"claim": ""},
+        {"claim": None},
+        {},  # no 'claim' key at all
+    ]
+    coverage = synth_module._compute_department_coverage(findings)
+    assert coverage == [{"department": "DOJ", "count": 1}]
+
+
+def test_build_context_exposes_department_coverage(job: Job) -> None:
+    """``_build_context`` renders ``department_coverage`` as an ordered list
+    with the expected canonical/count pairs for a multi-department fixture."""
+    plan_obj = Plan(
+        version=1,
+        objective="Project 2025 implementation tracker",
+        subgoals=[Subgoal(id=1, description="map departments", done=False)],
+        task_template=[TaskSpec(kind="web_search")],
+        expected_iterations=1,
+    )
+    findings: list[dict[str, Any]] = [
+        {"id": 1, "claim": "DOJ filed three lawsuits.", "confidence": 0.9, "source_ids": []},
+        {"id": 2, "claim": "Justice Department reorganized.", "confidence": 0.8, "source_ids": []},
+        {"id": 3, "claim": "DOJ briefed Congress.", "confidence": 0.7, "source_ids": []},
+        {"id": 4, "claim": "HHS announced new rules.", "confidence": 0.6, "source_ids": []},
+        {"id": 5, "claim": "FDA approved a vaccine.", "confidence": 0.5, "source_ids": []},
+        {"id": 6, "claim": "EPA cut regulations.", "confidence": 0.4, "source_ids": []},
+    ]
+
+    context_json = synth_module._build_context(
+        goal="x",
+        plan=plan_obj,
+        findings=findings,
+        sources={},
+        prior=None,
+        critique=None,
+        followup_recipes="",
+        paid_unblock_recipes="",
+        final=False,
+    )
+    payload = json.loads(context_json)
+
+    coverage = payload["department_coverage"]
+    assert isinstance(coverage, list)
+    # Order is high→low by count: DOJ(3), HHS(2), EPA(1).
+    assert coverage == [
+        {"department": "DOJ", "count": 3},
+        {"department": "HHS", "count": 2},
+        {"department": "EPA", "count": 1},
+    ]
+
+
+def test_build_context_empty_findings_emits_empty_department_coverage(job: Job) -> None:
+    """Key is always present; an empty list signals the prompt to omit the section."""
+    plan_obj = Plan(
+        version=1,
+        objective="x",
+        subgoals=[Subgoal(id=1, description="x", done=False)],
+        task_template=[TaskSpec(kind="web_search")],
+        expected_iterations=1,
+    )
+    context_json = synth_module._build_context(
+        goal="x",
+        plan=plan_obj,
+        findings=[],
+        sources={},
+        prior=None,
+        critique=None,
+        followup_recipes="",
+        paid_unblock_recipes="",
+        final=False,
+    )
+    payload = json.loads(context_json)
+    assert payload["department_coverage"] == []
+
+
+def test_synthesizer_prompt_requires_departmental_policy_tracker() -> None:
+    """The synthesizer prompt must drive the tracker off ``department_coverage``
+    rather than a fixed 4–5-section template (issue #208)."""
+    body = prompts_loader.load_prompt("synthesizer", goal="x")
+    # The structural-hint input is documented.
+    assert "department_coverage" in body
+    # The new section is named explicitly.
+    assert "Departmental Policy Tracker" in body
+    # Ranking is by count, not by template.
+    assert "high→low" in body or "high→low" in body
+    # The ≥1-finding inclusion rule is present (or the equivalent "do not
+    # omit" instruction).
+    assert "do not omit" in body.lower() or "every entry" in body.lower()
+    # The ≥3-findings → subsection threshold is named.
+    assert "≥3" in body or "≥3" in body


### PR DESCRIPTION
Closes #208
Part of #214

## Summary

Automated implementation of **fix: synthesizer Departmental Tracker uses fixed 4-5-section template — drops departments with findings**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Issue #208 fix is correctly implemented: department_coverage list drives the Departmental Policy Tracker; all acceptance criteria met at the code level; 6 new tests pass.

- **INFO** [OPEN] `src/research_agent/orchestrator/synth.py`: Generic single-word aliases ('Justice', 'Defense', 'Treasury', 'Personnel', 'Veterans') trigger false positives on non-federal contexts (e.g., 'Justice Sotomayor', 'self-defense', 'treasury bonds'). For Project 2025 / federal-policy investigations this is fine and matches the issue's symptom counts; for unrelated goals it could spawn spurious one-bullet department sections. Acceptable tradeoff for now (recall over precision); worth tightening in a follow-up by either dropping bare-word aliases or gating the tracker section on a federal-policy heuristic.
- **INFO** [OPEN] `tests/test_orchestrator_synth.py`: Two test assertions use redundant 'X in body or X in body' (lines 1319, 1324 of tests/test_orchestrator_synth.py) — both sides of the `or` are identical. Harmless (the test still works) but appears to be a copy/paste artifact where one side was intended to be a fallback variant.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*