### PR TITLE
feat: feat: drain-replan cap should be scope-aware and/or finding-floor driven (10 too few for broad/comprehensive runs) (closes #209)

### DIFF
--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -45,6 +45,8 @@ EventKind = Literal[
     "critique_done",
     "critique_written",
     "drain_replan",
+    "drain_replan_floor_extension",
+    "cap_diagnostic",
     "replan_triggered",
     "replan_truncated",
     "findings_truncated",

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -65,7 +65,51 @@ MAX_TASKS_PER_JOB = 10000
 HEURISTIC_CHECK_EVERY_N = 25
 RETRY_WAITS: tuple[int, ...] = (1, 2, 4, 8, 16, 30, 60)
 RETRY_MAX_ATTEMPTS = 5
+# Medium-scope default for drain-replan cap. Issue #209 made the runtime
+# cap scale with ``scope_class`` via ``_MAX_DRAIN_REPLANS_BY_SCOPE``; this
+# constant is preserved as the medium-scope value and is still honored as
+# the live cap when a plan has no ``scope_class`` set, so external imports
+# and tests that monkeypatch this symbol continue to work.
 MAX_DRAIN_REPLANS = 10
+
+# Issue #209: scope-aware cap for ``run_loop``'s drain-replan budget. A
+# fixed ``MAX_DRAIN_REPLANS=10`` (introduced by #117) is too tight for
+# broad/comprehensive investigations that name a cornerstone document or
+# enumerate dozens of sub-questions — a single cornerstone section-walk
+# (per #206) plus drill-down on each closed finding can consume 15-25
+# replans on its own. The medium row preserves the historical default.
+_MAX_DRAIN_REPLANS_BY_SCOPE: dict[str, int] = {
+    "narrow": 5,
+    "medium": 10,
+    "broad": 20,
+    "comprehensive": 30,
+}
+_MAX_DRAIN_REPLANS_FALLBACK = 10
+
+# Issue #209: minimum findings-per-subgoal before a goal is considered
+# "materially answered". When the drain-replan cap fires but open subgoals
+# still fall below the floor, the loop allows up to ``cap + floor`` more
+# replans targeting the under-served subgoals before terminating. Floors
+# scale with ``scope_class`` for the same reason caps do.
+_FINDING_FLOOR_BY_SCOPE: dict[str, int] = {
+    "narrow": 5,
+    "medium": 10,
+    "broad": 20,
+    "comprehensive": 30,
+}
+_FINDING_FLOOR_FALLBACK = 10
+
+# Connectors we always check for "did this fire?" when emitting the
+# ``cap_diagnostic`` event — useful when the planner's last template
+# narrowed to one or two kinds and the operator wants to see which
+# retrieval surfaces never got exercised.
+_CORE_CONNECTOR_KINDS = (
+    "web_search",
+    "congress_search",
+    "edgar_search",
+    "fedregister_search",
+    "courtlistener_search",
+)
 
 # Scope-aware default for how many top hits per search become web_fetch
 # follow-ups. Issue #178: a global default of 3 starves broad/comprehensive
@@ -671,6 +715,123 @@ def _load_pending_follow_up_questions(
             seen.add(key)
             out.append(cleaned)
     return out
+
+
+def _resolve_drain_cap(plan: Plan | None) -> int:
+    """Return the drain-replan cap for ``plan``'s ``scope_class`` (issue #209).
+
+    When no scope is set we read the live ``MAX_DRAIN_REPLANS`` symbol from
+    this module so legacy callers and tests that monkeypatch the constant
+    continue to drive the cap.
+    """
+    scope = plan.scope_class if plan is not None else None
+    if scope:
+        return _MAX_DRAIN_REPLANS_BY_SCOPE.get(scope, _MAX_DRAIN_REPLANS_FALLBACK)
+    return MAX_DRAIN_REPLANS
+
+
+def _resolve_finding_floor(plan: Plan | None) -> int:
+    """Return the per-subgoal findings-floor for ``plan``'s ``scope_class``."""
+    scope = plan.scope_class if plan is not None else None
+    return _FINDING_FLOOR_BY_SCOPE.get(scope or "", _FINDING_FLOOR_FALLBACK)
+
+
+def _under_served_subgoals(
+    plan: Plan, total_findings: int, floor: int
+) -> list[dict[str, Any]]:
+    """Identify open subgoals that may justify extending the drain-replan cap.
+
+    Findings aren't tagged by subgoal in the schema, so we estimate
+    coverage as ``total_findings // open_subgoals`` — coarse but enough to
+    distinguish "barely investigated" from "thoroughly answered". Every
+    open subgoal is reported (an unclosed subgoal is by definition not
+    materially answered) along with its estimated finding count and the
+    floor threshold, so the cap-diagnostic event is self-explanatory.
+    """
+    open_subgoals = [sg for sg in plan.subgoals if not sg.done]
+    if not open_subgoals:
+        return []
+    estimate = total_findings // max(len(open_subgoals), 1)
+    return [
+        {
+            "id": sg.id,
+            "description": sg.description,
+            "finding_count": estimate,
+            "floor": floor,
+        }
+        for sg in open_subgoals
+    ]
+
+
+def _unexercised_connectors(job: Job, plan: Plan, *, limit: int = 5) -> list[str]:
+    """Return connector kinds the planner expected but never actually ran.
+
+    Combines kinds named in ``plan.task_template`` with a small core set
+    and diffs against the distinct ``kind`` of completed tasks for the
+    job. Surfaces "we never tried EDGAR / FedRegister" before the cap hit.
+    """
+    template_kinds = {spec.kind for spec in plan.task_template}
+    candidates = template_kinds | set(_CORE_CONNECTOR_KINDS)
+    conn = db.connect(job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT DISTINCT kind FROM tasks WHERE job_id = ? AND status = 'done'",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    exercised = {r["kind"] for r in rows}
+    return sorted(k for k in candidates if k not in exercised)[:limit]
+
+
+def _next_plausible_searches(plan: Plan, limit: int = 3) -> list[str]:
+    """Pull up to ``limit`` next-search/fetch payload strings from the plan.
+
+    Looks at ``plan.task_template`` (i.e. the planner's most recent output)
+    and returns the first ``query``/``q``/``url`` it can find for each
+    ``*_search``/``*_fetch`` task — what the planner was *about* to do
+    when the cap hit, surfaced for the operator.
+    """
+    out: list[str] = []
+    for spec in plan.task_template:
+        kind = spec.kind
+        if not (kind.endswith("_search") or kind.endswith("_fetch")):
+            continue
+        payload = spec.payload or {}
+        for key in ("query", "q", "url"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                out.append(value.strip())
+                break
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _emit_cap_diagnostic(
+    job: Job,
+    plan: Plan,
+    findings: list[dict[str, Any]],
+    floor: int,
+    *,
+    cap: int,
+) -> None:
+    """Emit ``loop/cap_diagnostic`` so operators can see what wasn't done.
+
+    Issue #209: when the drain-replan cap fires, a sparse final report
+    leaves the operator guessing which subgoals were under-served and
+    which connectors never ran. This event makes that explicit.
+    """
+    payload = {
+        "scope_class": plan.scope_class,
+        "cap": cap,
+        "floor": floor,
+        "total_findings": len(findings),
+        "under_served_subgoals": _under_served_subgoals(plan, len(findings), floor),
+        "unexercised_connectors": _unexercised_connectors(job, plan),
+        "next_plausible_searches": _next_plausible_searches(plan),
+    }
+    emit(job, "WARN", "loop", "cap_diagnostic", payload)
 
 
 async def _drain_replan(
@@ -2221,15 +2382,48 @@ async def run_loop(
     while not _should_stop(job) and not plan.is_complete() and tasks_done < max_tasks:
         task = next_pending(job)
         if task is None:
-            if drain_replans >= MAX_DRAIN_REPLANS:
-                emit(
-                    job,
-                    "WARN",
-                    "loop",
-                    "warning",
-                    {"drain_replan_cap_hit": True, "cap": MAX_DRAIN_REPLANS},
-                )
-                break
+            cap = _resolve_drain_cap(plan)
+            floor = _resolve_finding_floor(plan)
+            if drain_replans >= cap:
+                # Issue #209: before bailing, check whether subgoals are
+                # materially answered. If open subgoals remain we allow up
+                # to ``cap + floor`` more replans before giving up — a
+                # broad/comprehensive run that names a 30-department
+                # tracker shouldn't terminate just because the planner
+                # hit a defensive cap, when half the goal is still open.
+                findings = _load_all_findings(job)
+                under_served = _under_served_subgoals(plan, len(findings), floor)
+                if under_served and drain_replans < cap + floor:
+                    emit(
+                        job,
+                        "INFO",
+                        "loop",
+                        "drain_replan_floor_extension",
+                        {
+                            "cap": cap,
+                            "floor": floor,
+                            "scope_class": plan.scope_class,
+                            "drain_replans": drain_replans,
+                            "extension": drain_replans - cap + 1,
+                            "under_served_count": len(under_served),
+                        },
+                    )
+                    # fall through into the replan call below
+                else:
+                    emit(
+                        job,
+                        "WARN",
+                        "loop",
+                        "warning",
+                        {
+                            "drain_replan_cap_hit": True,
+                            "cap": cap,
+                            "scope_class": plan.scope_class,
+                            "drain_replans": drain_replans,
+                        },
+                    )
+                    _emit_cap_diagnostic(job, plan, findings, floor, cap=cap)
+                    break
             new_plan = await _drain_replan(
                 job, plan, router=router, drain_count=drain_replans + 1
             )

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -1081,6 +1081,11 @@ async def test_drain_replan_respects_cap(
     _seed_tasks(job, ["web_search"])
 
     monkeypatch.setattr("research_agent.orchestrator.loop.MAX_DRAIN_REPLANS", 3)
+    # Issue #209 added a finding-floor extension that would otherwise
+    # keep this loop running past the cap when subgoals are unanswered.
+    # Disable the extension here so the test continues to verify the
+    # raw cap-hit path.
+    monkeypatch.setattr("research_agent.orchestrator.loop._FINDING_FLOOR_FALLBACK", 0)
 
     async def fake_tactical_replan(
         job_arg: Job,
@@ -1181,6 +1186,268 @@ async def test_drain_replan_break_on_empty_template(
 
 def test_max_drain_replans_default_is_ten() -> None:
     assert MAX_DRAIN_REPLANS == 10
+
+
+# ---------------------------------------------------------------------------
+# Scope-aware drain-replan cap (issue #209)
+# ---------------------------------------------------------------------------
+
+
+def _scoped_plan(job: Job, scope: ScopeClass | None) -> Plan:
+    p = Plan(
+        version=1,
+        objective="Investigate the target",
+        subgoals=[Subgoal(id=1, description="Gather", done=False)],
+        task_template=[TaskSpec(kind="web_search", payload={"q": "seed"})],
+        expected_iterations=3,
+        scope_class=scope,
+    )
+    write_plan(job, p.model_dump())
+    return p
+
+
+def _drain_replan_cap_hit_payload(db_path: Path, job_id: str) -> dict[str, Any] | None:
+    import json as _json
+
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT payload_json FROM events WHERE job_id = ? AND kind = 'warning'",
+            (job_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    for r in rows:
+        payload = _json.loads(r["payload_json"])
+        if payload.get("drain_replan_cap_hit") is True:
+            return payload
+    return None
+
+
+def _make_constant_replan(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_tactical_replan(
+        job_arg: Job,
+        prior_plan: Plan,
+        recent_results: list[dict[str, Any]],
+        *,
+        router: Any,
+        findings: list[dict[str, Any]] | None = None,
+        synthesis_md: str | None = None,
+        follow_up_questions: list[str] | None = None,
+    ) -> Plan:
+        next_version = prior_plan.version + 1
+        template = [TaskSpec(kind="web_search", payload={"q": "more"})]
+        new = Plan(
+            version=next_version,
+            objective=prior_plan.objective,
+            subgoals=prior_plan.subgoals,
+            task_template=template,
+            expected_iterations=prior_plan.expected_iterations,
+            scope_class=prior_plan.scope_class,
+        )
+        write_plan(job_arg, new.model_dump())
+        enqueue(job_arg, list(template), next_version)
+        return new
+
+    monkeypatch.setattr(plan_module, "tactical_replan", fake_tactical_replan)
+
+
+@pytest.mark.asyncio
+async def test_drain_replan_cap_scales_with_scope_broad(
+    job: Job,
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``broad`` plan must get a higher cap than the medium default."""
+    plan = _scoped_plan(job, "broad")
+    _seed_tasks(job, ["web_search"])
+
+    # Override the broad cap to a tiny value so the test runs fast — we
+    # only care that ``_resolve_drain_cap`` reads the broad row at all.
+    monkeypatch.setitem(
+        __import__(
+            "research_agent.orchestrator.loop", fromlist=["_MAX_DRAIN_REPLANS_BY_SCOPE"]
+        )._MAX_DRAIN_REPLANS_BY_SCOPE,
+        "broad",
+        4,
+    )
+    monkeypatch.setattr("research_agent.orchestrator.loop._FINDING_FLOOR_FALLBACK", 0)
+    monkeypatch.setitem(
+        __import__(
+            "research_agent.orchestrator.loop", fromlist=["_FINDING_FLOOR_BY_SCOPE"]
+        )._FINDING_FLOOR_BY_SCOPE,
+        "broad",
+        0,
+    )
+    _make_constant_replan(monkeypatch)
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": _ok_handler()},
+        retry_waits=(0,),
+    )
+
+    assert result["drain_replans"] == 4
+    payload = _drain_replan_cap_hit_payload(db_path, job.id)
+    assert payload is not None
+    assert payload["cap"] == 4
+    assert payload["scope_class"] == "broad"
+    assert payload["drain_replans"] == 4
+
+
+@pytest.mark.asyncio
+async def test_drain_replan_cap_scales_with_scope_narrow(
+    job: Job,
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``narrow`` plan caps replans at the narrow row of the map."""
+    plan = _scoped_plan(job, "narrow")
+    _seed_tasks(job, ["web_search"])
+
+    monkeypatch.setattr("research_agent.orchestrator.loop._FINDING_FLOOR_FALLBACK", 0)
+    monkeypatch.setitem(
+        __import__(
+            "research_agent.orchestrator.loop", fromlist=["_FINDING_FLOOR_BY_SCOPE"]
+        )._FINDING_FLOOR_BY_SCOPE,
+        "narrow",
+        0,
+    )
+    _make_constant_replan(monkeypatch)
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": _ok_handler()},
+        retry_waits=(0,),
+    )
+
+    assert result["drain_replans"] == 5
+    payload = _drain_replan_cap_hit_payload(db_path, job.id)
+    assert payload is not None
+    assert payload["cap"] == 5
+    assert payload["scope_class"] == "narrow"
+
+
+@pytest.mark.asyncio
+async def test_drain_replan_cap_default_for_no_scope(
+    job: Job,
+    db_path: Path,
+    plan: Plan,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A plan with ``scope_class=None`` uses the live ``MAX_DRAIN_REPLANS``."""
+    _seed_tasks(job, ["web_search"])
+
+    monkeypatch.setattr("research_agent.orchestrator.loop.MAX_DRAIN_REPLANS", 2)
+    monkeypatch.setattr("research_agent.orchestrator.loop._FINDING_FLOOR_FALLBACK", 0)
+    _make_constant_replan(monkeypatch)
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": _ok_handler()},
+        retry_waits=(0,),
+    )
+
+    assert result["drain_replans"] == 2
+    payload = _drain_replan_cap_hit_payload(db_path, job.id)
+    assert payload is not None
+    assert payload["cap"] == 2
+    assert payload["scope_class"] is None
+
+
+@pytest.mark.asyncio
+async def test_cap_diagnostic_event_emitted_on_cap_hit(
+    job: Job,
+    db_path: Path,
+    plan: Plan,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the cap fires the loop emits a structured ``cap_diagnostic`` event."""
+    _seed_tasks(job, ["web_search"])
+
+    monkeypatch.setattr("research_agent.orchestrator.loop.MAX_DRAIN_REPLANS", 2)
+    monkeypatch.setattr("research_agent.orchestrator.loop._FINDING_FLOOR_FALLBACK", 0)
+    _make_constant_replan(monkeypatch)
+
+    await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": _ok_handler()},
+        retry_waits=(0,),
+    )
+
+    import json as _json
+
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT payload_json FROM events WHERE job_id = ? AND kind = 'cap_diagnostic'",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert len(rows) == 1
+    payload = _json.loads(rows[0]["payload_json"])
+    assert "under_served_subgoals" in payload
+    assert "unexercised_connectors" in payload
+    assert "next_plausible_searches" in payload
+    assert payload["cap"] == 2
+    # The seeded plan's only subgoal stayed open, so it should appear.
+    assert any(sg["id"] == 1 for sg in payload["under_served_subgoals"])
+
+
+@pytest.mark.asyncio
+async def test_finding_floor_extends_cap_when_subgoals_under_served(
+    job: Job,
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the cap fires but no subgoal is closed, allow ``cap + floor`` replans."""
+    plan = _scoped_plan(job, "medium")
+    _seed_tasks(job, ["web_search"])
+
+    # Tiny cap and small floor for a fast test. Without the floor
+    # extension the loop would stop at drain_replans=2; with it, the loop
+    # is allowed up to 2+2=4 replans before terminating.
+    monkeypatch.setitem(
+        __import__(
+            "research_agent.orchestrator.loop", fromlist=["_MAX_DRAIN_REPLANS_BY_SCOPE"]
+        )._MAX_DRAIN_REPLANS_BY_SCOPE,
+        "medium",
+        2,
+    )
+    monkeypatch.setitem(
+        __import__(
+            "research_agent.orchestrator.loop", fromlist=["_FINDING_FLOOR_BY_SCOPE"]
+        )._FINDING_FLOOR_BY_SCOPE,
+        "medium",
+        2,
+    )
+    _make_constant_replan(monkeypatch)
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": _ok_handler()},
+        retry_waits=(0,),
+    )
+
+    assert result["drain_replans"] == 4
+    events = _read_event_kinds(db_path, job.id)
+    assert events.count("drain_replan_floor_extension") >= 1
+    payload = _drain_replan_cap_hit_payload(db_path, job.id)
+    assert payload is not None
+    assert payload["cap"] == 2
+    assert payload["drain_replans"] == 4
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #209
Part of #214

## Summary

Automated implementation of **feat: drain-replan cap should be scope-aware and/or finding-floor driven (10 too few for broad/comprehensive runs)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Issue #209 fully implemented: scope-aware drain-replan cap, finding-floor extension, and cap_diagnostic event are all in place; 100/100 loop tests pass.

- **INFO** [OPEN] `src/research_agent/orchestrator/loop.py`: _under_served_subgoals reports every open subgoal as under-served regardless of estimated finding_count vs floor. The estimate (total_findings // open_subgoals) is reported in the diagnostic but is not used to filter the list. The docstring acknowledges this as an intentional coarse simplification given findings aren't tagged per-subgoal. Behavior is reasonable; flagging only as a note.
- **INFO** [OPEN] `src/research_agent/orchestrator/loop.py`: _load_all_findings runs on every cap-boundary check during the floor-extension phase. With per-source finding caps in place this is bounded, and the boundary check fires at most once per replan, so the cost is acceptable.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*