### PR TITLE
Session: session/epic-269-epic-pre-263-loop-fixes-time-cap-subgoal-closure-critique-cadence-partial-md-cleanup — 4/4 succeeded

### DIFF
--- a/config/models.local.yaml
+++ b/config/models.local.yaml
@@ -63,6 +63,7 @@ tiers:
     provider: lmstudio
     model: google/gemma-4-26b-a4b
     timeout_s: 600
+    fallback_tier: frontier
     purpose: Critique alt — same model as frontier in local mode.
 
   frontier_speed:

--- a/src/research_agent/cli.py
+++ b/src/research_agent/cli.py
@@ -279,6 +279,8 @@ def status_command(
             cost=data["cost"],
             recent_events=data["recent_events"],
             budget_cap=data["budget_cap"],
+            time_cap_hours=data["time_cap_hours"],
+            started_at=data["started_at"],
             eta_seconds=data["eta_seconds"],
             current_task=data["current_task"],
         )

--- a/src/research_agent/daemon.py
+++ b/src/research_agent/daemon.py
@@ -331,6 +331,9 @@ DEFAULT_DISK_CAP_GB = 10.0
 # Foreground progress bar (issue #41). 2 s matches `research status --watch`
 # so the operator's two views advance in lockstep.
 FOREGROUND_PROGRESS_INTERVAL_S = 2.0
+ORPHAN_ARTIFACT_MAX_AGE_S = 300.0
+_ORPHAN_ARTIFACT_DIRS = ("plan", "synthesis", "critique")
+_ORPHAN_ARTIFACT_PATTERNS = ("*.partial.md", "*.tmp")
 
 
 def _build_router(job: Job) -> Any:
@@ -350,6 +353,83 @@ def _build_router(job: Job) -> Any:
 
     budget = BudgetTracker(job.id, cap_usd, pricing=pricing, db_path=job.db_path)
     return Router(config, budget, job=job, db_path=job.db_path)
+
+
+def _sweep_orphan_artifacts(
+    job: Job,
+    *,
+    older_than_s: float = ORPHAN_ARTIFACT_MAX_AGE_S,
+    now: float | None = None,
+) -> list[Path]:
+    """Remove stale partial/temporary artifacts left by interrupted writers."""
+    now_ts = time.time() if now is None else now
+    cleaned: list[Path] = []
+    try:
+        for dirname in _ORPHAN_ARTIFACT_DIRS:
+            root = job.root / dirname
+            if not root.is_dir():
+                continue
+            for pattern in _ORPHAN_ARTIFACT_PATTERNS:
+                for path in root.glob(pattern):
+                    try:
+                        if not path.is_file():
+                            continue
+                        stat = path.stat()
+                        age_s = max(0.0, now_ts - stat.st_mtime)
+                        if age_s < older_than_s:
+                            continue
+                        path.unlink()
+                    except FileNotFoundError:
+                        continue
+                    except OSError as exc:
+                        logger.warning(
+                            "daemon: failed to clean orphan artifact %s: %s", path, exc
+                        )
+                        try:
+                            emit(
+                                job,
+                                "WARN",
+                                "daemon",
+                                "warning",
+                                {
+                                    "stage": "orphan_artifact_sweep",
+                                    "path": str(path),
+                                    "error": str(exc),
+                                },
+                            )
+                        except Exception:
+                            pass
+                        continue
+
+                    cleaned.append(path)
+                    try:
+                        emit(
+                            job,
+                            "INFO",
+                            "daemon",
+                            "orphan_artifact_cleaned",
+                            {
+                                "path": str(path.relative_to(job.root)),
+                                "age_seconds": round(age_s, 3),
+                            },
+                        )
+                    except Exception:
+                        logger.exception(
+                            "daemon: failed to emit orphan cleanup event for %s", path
+                        )
+    except Exception as exc:  # noqa: BLE001 — startup cleanup must be best-effort
+        logger.exception("daemon: orphan artifact sweep failed for job %s", job.id)
+        try:
+            emit(
+                job,
+                "WARN",
+                "daemon",
+                "warning",
+                {"stage": "orphan_artifact_sweep", "error": str(exc)},
+            )
+        except Exception:
+            pass
+    return cleaned
 
 
 def _resolve_db_path() -> Path | None:
@@ -667,6 +747,8 @@ async def run_daemon(
     except (FileNotFoundError, KeyError, ValueError) as exc:
         logger.error("daemon: cannot load job %r: %s", job_id, exc)
         return 1
+
+    _sweep_orphan_artifacts(job)
 
     try:
         router = _build_router(job)

--- a/src/research_agent/daemon.py
+++ b/src/research_agent/daemon.py
@@ -47,6 +47,7 @@ import httpx
 
 from research_agent.config import get as cfg_get
 from research_agent.observability.events import emit
+from research_agent.storage import db
 from research_agent.storage.jobs import DEFAULT_JOBS_ROOT, Job
 
 logger = logging.getLogger(__name__)
@@ -355,6 +356,32 @@ def _resolve_db_path() -> Path | None:
     """Pull ``RESEARCH_DB_PATH`` from the env, if set, else None for the default."""
     val = os.environ.get("RESEARCH_DB_PATH")
     return Path(val) if val else None
+
+
+def _coerce_positive_hours(raw: Any) -> float | None:
+    if raw is None or isinstance(raw, bool):
+        return None
+    try:
+        hours = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return hours if hours > 0 else None
+
+
+def _load_time_cap_hours(job: Job, intake: dict[str, Any]) -> float | None:
+    raw = intake.get("time_cap_hours")
+    if raw is not None:
+        return _coerce_positive_hours(raw)
+
+    conn = db.connect(job.db_path)
+    try:
+        row = conn.execute(
+            "SELECT time_cap_hours FROM jobs WHERE id = ?",
+            (job.id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    return _coerce_positive_hours(row["time_cap_hours"] if row is not None else None)
 
 
 def _install_stop_signal_handlers(
@@ -741,6 +768,9 @@ async def run_daemon(
         loop_kwargs: dict[str, Any] = {}
         if isinstance(max_tasks_override, int) and max_tasks_override >= 1:
             loop_kwargs["max_tasks"] = max_tasks_override
+        time_cap_override = _load_time_cap_hours(job, intake)
+        if time_cap_override is not None:
+            loop_kwargs["time_cap_hours"] = time_cap_override
         try:
             loop_result = await _loop.run_loop(job, router, **loop_kwargs)
         except BudgetExceeded as exc:
@@ -784,6 +814,9 @@ async def run_daemon(
             return 1
 
         plan = _loop._load_latest_plan(job)
+        loop_time_capped = loop_result is not None and (
+            loop_result.get("completion_reason") == "time_cap" or loop_result.get("time_cap_hit")
+        )
         if budget_capped:
             try:
                 if plan is not None:
@@ -805,32 +838,36 @@ async def run_daemon(
             final_status = "completed"
             completion_reason = "budget_cap"
         else:
-            try:
-                if plan is not None:
-                    await _synth.final_synthesis(job, plan, router=router)
-            except Exception as exc:
-                logger.warning("daemon: final synthesis failed for job %s: %s", job.id, exc)
+            if not loop_time_capped:
                 try:
-                    emit(
-                        job,
-                        "WARN",
-                        "daemon",
-                        "warning",
-                        {"stage": "final_synthesis", "error": str(exc)},
-                    )
-                except Exception:
-                    pass
+                    if plan is not None:
+                        await _synth.final_synthesis(job, plan, router=router)
+                except Exception as exc:
+                    logger.warning("daemon: final synthesis failed for job %s: %s", job.id, exc)
+                    try:
+                        emit(
+                            job,
+                            "WARN",
+                            "daemon",
+                            "warning",
+                            {"stage": "final_synthesis", "error": str(exc)},
+                        )
+                    except Exception:
+                        pass
 
-            # Re-load the plan after final_synthesis: that pass can fire a
-            # synthesizer that calls update_subgoal_done, writing a new plan
-            # version with done=True flags. Using the stale plan from before
-            # final_synthesis would miss those closures and mis-classify a
-            # clean finish as user_stopped (issue #160).
+            # Re-load the plan after any final synthesis path: that pass can
+            # fire a synthesizer that calls update_subgoal_done, writing a new
+            # plan version with done=True flags. Using the stale plan from
+            # before final_synthesis would miss those closures and mis-classify
+            # a clean finish as user_stopped (issue #160).
             plan = _loop._load_latest_plan(job)
 
             if _loop._should_stop(job):
                 final_status = "stopped"
                 completion_reason = "user_stopped"
+            elif loop_time_capped:
+                final_status = "completed"
+                completion_reason = "time_cap"
             elif loop_result is not None and loop_result.get("cap_hit"):
                 final_status = "completed"
                 completion_reason = "task_cap"

--- a/src/research_agent/llm/router.py
+++ b/src/research_agent/llm/router.py
@@ -19,8 +19,9 @@ the tier's configured ``fallback_tier`` (cloud), each emitting a WARN event
 plus a per-call cost figure so the operator can see what's being charged.
 After the window expires the router retries local; on success the tier is
 marked recovered (INFO event). When no ``fallback_tier`` is configured the
-second TimeoutError propagates — the §16 anti-pattern is silent reroutes,
-not loud ones.
+second TimeoutError propagates, except ``frontier_alt`` defaults to
+``frontier`` so critique can still run during local-model degradation. The
+§16 anti-pattern is silent reroutes, not loud ones.
 """
 
 from __future__ import annotations
@@ -323,6 +324,10 @@ class Router:
         # only after two consecutive timeouts; cleared after a successful
         # local call once the window has expired. Public for tests/inspection.
         self._tier_degraded_until: dict[str, float] = {}
+        # Metadata for the most recent successful model call. Critique and
+        # warning paths use this to report the tier/model that actually
+        # produced output after router-level fallback.
+        self.last_call_metadata: dict[str, Any] | None = None
         # Settable per-instance so tests can drop the sleep to zero without
         # monkeypatching the global asyncio loop.
         self.retry_sleep_s: float = LMSTUDIO_RETRY_SLEEP_S
@@ -413,13 +418,13 @@ class Router:
 
         # Skip local entirely while the tier is in its degraded window —
         # rerouting earliest avoids burning another timeout cycle on a swap
-        # that's known to be in flight. Without a configured fallback we fall
-        # through and try local; the §16 rule is *no silent reroutes*, not *no
-        # local attempts at all*.
+        # that's known to be in flight. Without a fallback we fall through and
+        # try local; frontier_alt gets a default frontier fallback because
+        # critique is the loop's self-correction path.
         if is_local:
             until = self._tier_degraded_until.get(tier)
             if until is not None and time.time() < until:
-                fallback_tier = spec.get("fallback_tier")
+                fallback_tier = self._lmstudio_fallback_tier(tier, spec)
                 if fallback_tier:
                     return await self._reroute_to_fallback_tier(
                         original_tier=tier,
@@ -449,6 +454,14 @@ class Router:
                     fallback_used=False,
                     cached=True,
                 )
+                self.last_call_metadata = {
+                    "tier": tier,
+                    "provider": provider,
+                    "model": model_name,
+                    "cost_usd": 0.0,
+                    "fallback_used": False,
+                    "cached": True,
+                }
                 return _CachedResult(hit)
 
         if is_cloud:
@@ -482,7 +495,7 @@ class Router:
                 # is intentionally omitted, e.g. embeddings).
                 until_ts = time.time() + self.degraded_window_s
                 self._tier_degraded_until[tier] = until_ts
-                fallback_tier = spec.get("fallback_tier")
+                fallback_tier = self._lmstudio_fallback_tier(tier, spec)
                 self._emit_lmstudio_degraded(
                     tier=tier,
                     fallback_tier=fallback_tier,
@@ -541,8 +554,24 @@ class Router:
             fallback_used=fallback_used,
             cached=False,
         )
+        self.last_call_metadata = {
+            "tier": tier,
+            "provider": provider,
+            "model": model_name,
+            "cost_usd": cost_usd,
+            "fallback_used": fallback_used,
+            "cached": False,
+        }
 
         return result
+
+    def _lmstudio_fallback_tier(self, tier: str, spec: dict[str, Any]) -> str | None:
+        configured = spec.get("fallback_tier")
+        if isinstance(configured, str) and configured:
+            return configured
+        if tier == "frontier_alt" and "frontier" in self.tiers:
+            return "frontier"
+        return None
 
     @staticmethod
     async def _run_with_timeout(
@@ -616,6 +645,12 @@ class Router:
             fallback_tier=fallback_tier,
             cost_usd=cost_usd,
         )
+        if self.last_call_metadata is not None:
+            self.last_call_metadata = {
+                **self.last_call_metadata,
+                "original_tier": original_tier,
+                "rerouted": True,
+            }
         return result
 
     # ---- Ledger + event ----------------------------------------------------

--- a/src/research_agent/llm/router.py
+++ b/src/research_agent/llm/router.py
@@ -369,18 +369,11 @@ class Router:
         )
         return Agent(model)
 
-    def _make_fallback_tier_agent(self, fallback_tier: str) -> Agent:
-        """Construct a one-shot Agent bound to the model behind ``fallback_tier``.
-
-        Used when an lmstudio tier is degraded and the router needs to dispatch
-        the call against the configured cloud equivalent. Built on every reroute
-        rather than memoized so a swap of the underlying ``OpenAIModel`` (e.g.
-        in tests via :meth:`unittest.mock.patch.object`) takes effect immediately.
-        """
+    def _fallback_model_for_tier(self, fallback_tier: str) -> OpenAIModel:
+        """Build the model behind ``fallback_tier`` for an agent-level override."""
         if fallback_tier not in self.tiers:
             raise KeyError(f"fallback_tier {fallback_tier!r} not present in router config")
-        model = _build_model_for_tier(fallback_tier, self.tiers[fallback_tier])
-        return Agent(model)
+        return _build_model_for_tier(fallback_tier, self.tiers[fallback_tier])
 
     # ---- Call wrapper ------------------------------------------------------
 
@@ -429,6 +422,7 @@ class Router:
                     return await self._reroute_to_fallback_tier(
                         original_tier=tier,
                         fallback_tier=fallback_tier,
+                        agent=agent,
                         args=args,
                         kwargs=kwargs,
                         cache_enabled=cache_enabled,
@@ -505,6 +499,7 @@ class Router:
                     return await self._reroute_to_fallback_tier(
                         original_tier=tier,
                         fallback_tier=fallback_tier,
+                        agent=agent,
                         args=args,
                         kwargs=kwargs,
                         cache_enabled=cache_enabled,
@@ -619,6 +614,7 @@ class Router:
         *,
         original_tier: str,
         fallback_tier: str,
+        agent: Any,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
         cache_enabled: bool,
@@ -632,13 +628,14 @@ class Router:
         the caller asked for plus the cost the reroute incurred so an
         operator tailing logs sees both halves.
         """
+        fallback_model = self._fallback_model_for_tier(fallback_tier)
+        kwargs = {**kwargs, "model": fallback_model}
         if cache_enabled:
             kwargs = {**kwargs, "cache": True}
-        fallback_agent = self._make_fallback_tier_agent(fallback_tier)
         # Snapshot before/after spent so cache hits show $0 reroute cost
         # while real cloud charges show their incremental cost.
         before_spent = self.budget.spent
-        result = await self.call(fallback_tier, fallback_agent, *args, **kwargs)
+        result = await self.call(fallback_tier, agent, *args, **kwargs)
         cost_usd = max(0.0, self.budget.spent - before_spent)
         self._emit_lmstudio_rerouted(
             original_tier=original_tier,

--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -73,6 +73,8 @@ EventKind = Literal[
     "cornerstone_followups_emitted",
     "second_order_fanout",
     "source_list_reconciled",
+    "synth_status_from_prose",
+    "synth_status_missing",
     "error",
     "warning",
 ]

--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -42,6 +42,7 @@ EventKind = Literal[
     "synthesis_done",
     "synthesis_written",
     "synthesis_failed",
+    "orphan_artifact_cleaned",
     "critique_done",
     "critique_written",
     "drain_replan",

--- a/src/research_agent/orchestrator/critique.py
+++ b/src/research_agent/orchestrator/critique.py
@@ -216,6 +216,17 @@ def _model_name_for(router: Router, tier: str) -> str:
     return name
 
 
+def _actual_call_tier_model(router: Router, requested_tier: str) -> tuple[str, str]:
+    """Return the tier/model that produced the last router result when available."""
+    metadata = getattr(router, "last_call_metadata", None)
+    if isinstance(metadata, dict):
+        tier = metadata.get("tier")
+        model = metadata.get("model")
+        if isinstance(tier, str) and tier and isinstance(model, str) and model:
+            return tier, model
+    return requested_tier, _model_name_for(router, requested_tier)
+
+
 def _render_critique_md(payload: CritiqueOutput) -> str:
     """Render a human-readable summary for ``critique/<v>.md``."""
     lines: list[str] = ["# Critique\n"]
@@ -350,7 +361,7 @@ async def critique(
 
     cost_raw = getattr(router.budget, "last_cost", None)
     cost_val: float | None = float(cost_raw) if isinstance(cost_raw, (int, float)) else None
-    model_name = _model_name_for(router, tier)
+    actual_tier, model_name = _actual_call_tier_model(router, tier)
 
     md_body = _render_critique_md(output)
     payload_dict = output.model_dump(exclude={"version", "model", "cost_usd", "md_path"})
@@ -380,7 +391,8 @@ async def critique(
         "critique_written",
         {
             "version": version,
-            "tier": tier,
+            "tier": actual_tier,
+            "requested_tier": tier,
             "model": model_name,
             "should_replan": bool(output.should_replan),
             "gaps_count": len(output.gaps),

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -35,6 +35,7 @@ import asyncio
 import logging
 import re
 import time
+import traceback
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -520,6 +521,8 @@ def default_handlers(router: Any) -> dict[str, Handler]:
         "synthesize": _synthesize,
         "critique": _critique,
     }
+    _annotate_heuristic_handler(_synthesize, tier="frontier", router=router)
+    _annotate_heuristic_handler(_critique, tier="frontier_alt", router=router)
     for name in _CONNECTOR_KINDS:
         registry[f"{name}_search"] = _make_connector_search_handler(name)
         registry[f"{name}_fetch"] = _make_connector_fetch_handler(name)
@@ -559,6 +562,57 @@ def _should_critique(plan: Plan, tasks_done: int) -> bool:
     """
     n = HEURISTIC_CHECK_EVERY_N * CRITIQUE_CADENCE_MULTIPLIER
     return tasks_done > 0 and tasks_done % n == 0
+
+
+def _configured_model_name(router: Any, tier: str) -> str | None:
+    tiers = getattr(router, "tiers", None)
+    if not isinstance(tiers, dict):
+        return None
+    spec = tiers.get(tier)
+    if not isinstance(spec, dict):
+        return None
+    model = spec.get("model")
+    return model if isinstance(model, str) and model else None
+
+
+def _annotate_heuristic_handler(handler: Handler, *, tier: str, router: Any) -> None:
+    """Attach static LLM context so best-effort heuristic failures are debuggable."""
+    handler._heuristic_tier = tier  # type: ignore[attr-defined]
+    model = _configured_model_name(router, tier)
+    if model is not None:
+        handler._heuristic_model = model  # type: ignore[attr-defined]
+    if router is not None:
+        handler._heuristic_router = router  # type: ignore[attr-defined]
+
+
+def _heuristic_failure_payload(
+    heuristic: str,
+    exc: Exception,
+    handler: Handler,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "heuristic": heuristic,
+        "error_type": type(exc).__name__,
+        "error": str(exc),
+        "traceback": "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+    }
+    tier = getattr(handler, "_heuristic_tier", None)
+    if isinstance(tier, str) and tier:
+        payload["tier"] = tier
+    model = getattr(handler, "_heuristic_model", None)
+    if isinstance(model, str) and model:
+        payload["model"] = model
+
+    router = getattr(handler, "_heuristic_router", None)
+    last_call = getattr(router, "last_call_metadata", None)
+    if isinstance(last_call, dict):
+        last_tier = last_call.get("tier")
+        last_model = last_call.get("model")
+        if isinstance(last_tier, str) and last_tier:
+            payload["last_llm_tier"] = last_tier
+        if isinstance(last_model, str) and last_model:
+            payload["last_llm_model"] = last_model
+    return payload
 
 
 def _load_latest_plan(job: Job) -> Plan | None:
@@ -2655,7 +2709,7 @@ async def _maybe_run_heuristic(
                     "WARN",
                     "loop",
                     "warning",
-                    {"heuristic": "synthesize", "error": str(exc)},
+                    _heuristic_failure_payload("synthesize", exc, synth),
                 )
             else:
                 checkpoint(
@@ -2674,7 +2728,7 @@ async def _maybe_run_heuristic(
                     "WARN",
                     "loop",
                     "warning",
-                    {"heuristic": "critique", "error": str(exc)},
+                    _heuristic_failure_payload("critique", exc, crit),
                 )
             else:
                 checkpoint(

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -2348,6 +2349,7 @@ async def run_loop(
     plan: Plan | None = None,
     handlers: dict[str, Handler] | None = None,
     max_tasks: int = MAX_TASKS_PER_JOB,
+    time_cap_hours: float | None = None,
     retry_waits: tuple[int, ...] = RETRY_WAITS,
     retry_max_attempts: int = RETRY_MAX_ATTEMPTS,
 ) -> dict[str, Any]:
@@ -2368,9 +2370,19 @@ async def run_loop(
             "run initial_plan() before entering the loop"
         )
 
+    start_ts = time.monotonic()
+    time_cap_seconds = (
+        float(time_cap_hours) * 3600 if time_cap_hours is not None and time_cap_hours > 0 else None
+    )
+    deadline_ts = start_ts + time_cap_seconds if time_cap_seconds is not None else None
+
+    def _within_time_cap() -> bool:
+        return deadline_ts is None or deadline_ts > time.monotonic()
+
     tasks_done = 0
     stopped = False
     cap_hit = False
+    time_cap_hit = False
     drain_replans = 0
 
     checkpoint(
@@ -2379,7 +2391,12 @@ async def run_loop(
         {"plan_version": plan.version, "objective": plan.objective},
     )
 
-    while not _should_stop(job) and not plan.is_complete() and tasks_done < max_tasks:
+    while (
+        not _should_stop(job)
+        and not plan.is_complete()
+        and tasks_done < max_tasks
+        and _within_time_cap()
+    ):
         task = next_pending(job)
         if task is None:
             cap = _resolve_drain_cap(plan)
@@ -2566,7 +2583,28 @@ async def run_loop(
             if refreshed is not None:
                 plan = refreshed
 
-    if tasks_done >= max_tasks and not _should_stop(job):
+    if (
+        deadline_ts is not None
+        and not _should_stop(job)
+        and not plan.is_complete()
+        and not _within_time_cap()
+    ):
+        time_cap_hit = True
+        emit(
+            job,
+            "WARN",
+            "loop",
+            "warning",
+            {
+                "time_cap_hit": True,
+                "time_cap_hours": time_cap_hours,
+                "tasks_done": tasks_done,
+                "elapsed_seconds": time.monotonic() - start_ts,
+            },
+        )
+        await _final_synthesis_best_effort(job, handlers)
+
+    if tasks_done >= max_tasks and not _should_stop(job) and not time_cap_hit:
         cap_hit = True
         emit(
             job,
@@ -2586,6 +2624,11 @@ async def run_loop(
         "stopped": stopped,
         "completed": plan.is_complete(),
         "cap_hit": cap_hit,
+        "time_cap_hit": time_cap_hit,
+        "completion_reason": (
+            "time_cap" if time_cap_hit else "task_cap" if cap_hit else None
+        ),
+        "elapsed_seconds": time.monotonic() - start_ts,
         "drain_replans": drain_replans,
     }
 

--- a/src/research_agent/orchestrator/synth.py
+++ b/src/research_agent/orchestrator/synth.py
@@ -31,6 +31,7 @@ import json
 import logging
 import re
 import sqlite3
+import traceback
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from importlib.resources import files
@@ -46,7 +47,7 @@ from research_agent.storage import db
 from research_agent.storage.markdown import (
     write_report,
     write_synthesis,
-    write_synthesis_partial,
+    write_synthesis_failed,
 )
 
 if TYPE_CHECKING:
@@ -876,12 +877,18 @@ def _write_failed_output(
     """Persist whatever content we managed to assemble + emit ``synthesis_failed``.
 
     The current call path is non-streaming so ``partial_content`` is "" — the
-    file is still written so the next attempt can spot it as prior context.
+    failed file still records the traceback for post-run debugging.
     Returns a degraded :class:`SynthesisOutput` (``model='synthesis_failed'``,
     ``truncated=True``) so callers don't have to thread an exception type.
     """
-    partial_version = write_synthesis_partial(job, partial_content, model="synthesis_failed")
-    partial_path = job.root / f"synthesis/{partial_version:04d}.partial.md"
+    traceback_text = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    failed_version = write_synthesis_failed(
+        job,
+        partial_content,
+        model="synthesis_failed",
+        traceback_text=traceback_text,
+    )
+    failed_path = job.root / f"synthesis/{failed_version:04d}.failed.md"
     emit(
         job,
         "ERROR",
@@ -891,15 +898,16 @@ def _write_failed_output(
             "tier": tier,
             "reason": str(exc),
             "attempt_count": attempt_count,
-            "partial_path": str(partial_path),
+            "failed_path": str(failed_path),
+            "traceback": traceback_text,
         },
     )
     return SynthesisOutput(
-        version=partial_version,
+        version=failed_version,
         content=partial_content,
         model="synthesis_failed",
         cost_usd=None,
-        report_path=str(partial_path),
+        report_path=str(failed_path),
         truncated=True,
     )
 

--- a/src/research_agent/orchestrator/synth.py
+++ b/src/research_agent/orchestrator/synth.py
@@ -31,6 +31,7 @@ import json
 import logging
 import re
 import sqlite3
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from importlib.resources import files
 from typing import TYPE_CHECKING, Any
@@ -367,65 +368,263 @@ def _build_context(
 
 
 _SUBGOAL_STATUS_FENCE_RE = re.compile(r"```[ \t]*json[ \t]*\n(.*?)\n```\s*$", re.DOTALL)
+_ANY_JSON_FENCE_RE = re.compile(r"```[ \t]*json[ \t]*\n(.*?)\n```", re.DOTALL)
+_LEVEL_TWO_HEADING_RE = re.compile(r"^##[ \t]+(?P<title>.+?)[ \t]*$", re.MULTILINE)
+_TRAILING_STATUS_KEY_RE = re.compile(
+    r'"(?:subgoal_status|closed|reopened|inconclusive)"',
+    re.IGNORECASE,
+)
+_PROSE_SUBGOAL_STATUS_RE = re.compile(
+    r"(?im)^\s*(?:#{1,6}\s*)?(?:[-*]\s*)?(?:\*\*)?"
+    r"(?:(?:H)|(?:Subgoal))\s*#?(?P<id>\d+)(?:\*\*)?\s*[:\-]\s*"
+    r"(?:\*\*)?(?P<status>confirmed|refuted|inconclusive)\b"
+)
+_STATUS_ALIASES = {
+    "confirmed": "confirmed",
+    "confirm": "confirmed",
+    "closed": "confirmed",
+    "refuted": "refuted",
+    "refute": "refuted",
+    "inconclusive": "inconclusive",
+    "open": "inconclusive",
+    "reopened": "inconclusive",
+}
 
 
-def _extract_subgoal_status(
-    job: Job,
-    raw: str,
-) -> tuple[str, dict[int, str] | None]:
-    """Split a trailing fenced ``json`` block off the markdown report.
+@dataclass(frozen=True)
+class _StatusCandidate:
+    body: str
+    stripped_md: str
+    source: str
 
-    Returns ``(stripped_md, status_map)``. ``status_map`` is ``None`` when
-    the block is missing, has malformed JSON, or its payload doesn't carry
-    a ``subgoal_status`` mapping. A WARN ``warning`` event is emitted in
-    each of those tolerated-but-degraded cases.
-    """
+
+def _stripped_with_trailer_removed(raw: str, start: int) -> str:
+    prefix = raw[:start].rstrip()
+    return prefix + ("\n" if prefix else "")
+
+
+def _coerce_subgoal_id(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        match = re.fullmatch(r"\s*(?:(?:H)|(?:Subgoal))?\s*#?(\d+)\s*", value)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def _normalize_status(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    return _STATUS_ALIASES.get(value.strip().lower())
+
+
+def _normalize_subgoal_status_payload(data: Any) -> dict[int, str] | None:
+    if not isinstance(data, dict):
+        return None
+
+    status_map: dict[int, str] = {}
+    subgoal_status = data.get("subgoal_status")
+    if isinstance(subgoal_status, dict):
+        for raw_id, raw_status in subgoal_status.items():
+            sid = _coerce_subgoal_id(raw_id)
+            status = _normalize_status(raw_status)
+            if sid is not None and status is not None:
+                status_map[sid] = status
+
+    for key, status in (
+        ("closed", "confirmed"),
+        ("reopened", "inconclusive"),
+        ("inconclusive", "inconclusive"),
+    ):
+        raw_ids = data.get(key)
+        if not isinstance(raw_ids, list):
+            continue
+        for raw_id in raw_ids:
+            sid = _coerce_subgoal_id(raw_id)
+            if sid is not None:
+                status_map[sid] = status
+
+    return status_map or None
+
+
+def _json_object_from_section_body(body: str) -> str | None:
+    matches = list(_ANY_JSON_FENCE_RE.finditer(body))
+    if matches:
+        return matches[-1].group(1).strip()
+
+    start = body.find("{")
+    end = body.rfind("}")
+    if start == -1 or end <= start:
+        return None
+    return body[start : end + 1].strip()
+
+
+def _candidate_from_final_subgoal_status_section(raw: str) -> _StatusCandidate | None:
+    headings = list(_LEVEL_TWO_HEADING_RE.finditer(raw))
+    if not headings:
+        return None
+
+    last_heading = headings[-1]
+    title = last_heading.group("title").strip().strip("#").strip().lower()
+    if title != "subgoal status":
+        return None
+
+    section_body = raw[last_heading.end() :]
+    json_body = _json_object_from_section_body(section_body)
+    if json_body is None:
+        return None
+
+    return _StatusCandidate(
+        body=json_body,
+        stripped_md=_stripped_with_trailer_removed(raw, last_heading.start()),
+        source="subgoal_status_section",
+    )
+
+
+def _candidate_from_trailing_fence(raw: str) -> _StatusCandidate | None:
     match = _SUBGOAL_STATUS_FENCE_RE.search(raw)
     if match is None:
-        emit(
-            job,
-            "WARN",
-            "synth",
-            "warning",
-            {"stage": "subgoal_status", "error": "trailing JSON fence missing"},
-        )
-        return raw, None
+        return None
+    return _StatusCandidate(
+        body=match.group(1).strip(),
+        stripped_md=_stripped_with_trailer_removed(raw, match.start()),
+        source="trailing_json_fence",
+    )
 
-    body = match.group(1).strip()
+
+def _candidate_from_raw_trailing_json(raw: str) -> _StatusCandidate | None:
+    stripped = raw.rstrip()
+    if not stripped.endswith("}"):
+        return None
+
+    decoder = json.JSONDecoder()
+    for match in reversed(list(re.finditer(r"\{", stripped))):
+        start = match.start()
+        suffix = stripped[start:]
+        if not _TRAILING_STATUS_KEY_RE.search(suffix):
+            continue
+        try:
+            _data, end = decoder.raw_decode(suffix)
+        except json.JSONDecodeError:
+            continue
+        if suffix[end:].strip():
+            continue
+        return _StatusCandidate(
+            body=suffix.strip(),
+            stripped_md=_stripped_with_trailer_removed(raw, start),
+            source="raw_trailing_json",
+        )
+    return None
+
+
+def _find_structured_status_candidate(raw: str) -> _StatusCandidate | None:
+    return (
+        _candidate_from_final_subgoal_status_section(raw)
+        or _candidate_from_trailing_fence(raw)
+        or _candidate_from_raw_trailing_json(raw)
+    )
+
+
+def _parse_status_candidate(job: Job, candidate: _StatusCandidate) -> dict[int, str] | None:
     try:
-        data = json.loads(body)
+        data = json.loads(candidate.body)
     except json.JSONDecodeError as exc:
         emit(
             job,
             "WARN",
             "synth",
             "warning",
-            {"stage": "subgoal_status", "error": f"json parse failed: {exc}"},
+            {
+                "stage": "subgoal_status",
+                "source": candidate.source,
+                "error": f"json parse failed: {exc}",
+            },
         )
-        # Still strip the fence so it never lands in report.md.
-        return raw[: match.start()].rstrip() + "\n", None
+        return None
 
-    if not isinstance(data, dict) or not isinstance(data.get("subgoal_status"), dict):
+    status_map = _normalize_subgoal_status_payload(data)
+    if status_map is None:
         emit(
             job,
             "WARN",
             "synth",
             "warning",
-            {"stage": "subgoal_status", "error": "missing or non-dict subgoal_status"},
+            {
+                "stage": "subgoal_status",
+                "source": candidate.source,
+                "error": "missing recognized subgoal status payload",
+            },
         )
-        return raw[: match.start()].rstrip() + "\n", None
+    return status_map
 
+
+def _status_event_payload(status_map: dict[int, str]) -> dict[str, Any]:
+    return {
+        "status": {str(k): v for k, v in sorted(status_map.items())},
+        "closed": sorted(k for k, v in status_map.items() if v in {"confirmed", "refuted"}),
+        "inconclusive": sorted(k for k, v in status_map.items() if v == "inconclusive"),
+    }
+
+
+def _extract_prose_subgoal_status(raw: str, subgoal_ids: set[int]) -> dict[int, str] | None:
     status_map: dict[int, str] = {}
-    for key, value in data["subgoal_status"].items():
-        try:
-            sid = int(key)
-        except (TypeError, ValueError):
+    for match in _PROSE_SUBGOAL_STATUS_RE.finditer(raw):
+        sid = _coerce_subgoal_id(match.group("id"))
+        status = _normalize_status(match.group("status"))
+        if sid is None or status is None:
             continue
-        if isinstance(value, str):
-            status_map[sid] = value
+        if subgoal_ids and sid not in subgoal_ids:
+            continue
+        status_map[sid] = status
+    return status_map or None
 
-    stripped = raw[: match.start()].rstrip() + "\n"
-    return stripped, status_map
+
+def _extract_subgoal_status(
+    job: Job,
+    raw: str,
+    *,
+    subgoal_ids: list[int] | None = None,
+) -> tuple[str, dict[int, str] | None]:
+    """Split structured subgoal status from the markdown report.
+
+    Returns ``(stripped_md, status_map)``. ``status_map`` is ``None`` when
+    no structured payload or status-like prose can be read. Structured
+    trailers are stripped before persistence even when malformed.
+    """
+    subgoal_id_set = set(subgoal_ids or [])
+    candidate = _find_structured_status_candidate(raw)
+    stripped_md = raw
+    if candidate is not None:
+        stripped_md = candidate.stripped_md
+        status_map = _parse_status_candidate(job, candidate)
+        if status_map:
+            return stripped_md, status_map
+
+    prose_status = _extract_prose_subgoal_status(stripped_md, subgoal_id_set)
+    if prose_status:
+        emit(
+            job,
+            "INFO",
+            "synth",
+            "synth_status_from_prose",
+            _status_event_payload(prose_status),
+        )
+        return stripped_md, prose_status
+
+    emit(
+        job,
+        "WARN",
+        "synth",
+        "synth_status_missing",
+        {
+            "structured_candidate": candidate.source if candidate is not None else None,
+            "subgoal_ids": sorted(subgoal_id_set),
+        },
+    )
+    return stripped_md, None
 
 
 def _apply_subgoal_status(
@@ -629,7 +828,11 @@ async def _do_synthesis(
     cost_val: float | None = float(cost) if isinstance(cost, (int, float)) else None
     model_name = _model_name_for(router, used_tier)
 
-    stripped_md, status_map = _extract_subgoal_status(job, content)
+    stripped_md, status_map = _extract_subgoal_status(
+        job,
+        content,
+        subgoal_ids=[sg.id for sg in plan.subgoals],
+    )
     stripped_md = _reconcile_sources(job, stripped_md, sources)
 
     version = write_synthesis(job, stripped_md, model=model_name, cost_usd=cost_val)
@@ -943,7 +1146,11 @@ async def final_synthesis_after_cap(
     cost_val: float | None = float(cost) if isinstance(cost, (int, float)) else None
     model_name = _model_name_for(router, fallback_tier)
 
-    stripped_md, status_map = _extract_subgoal_status(job, content)
+    stripped_md, status_map = _extract_subgoal_status(
+        job,
+        content,
+        subgoal_ids=[sg.id for sg in plan.subgoals],
+    )
     stripped_md = _reconcile_sources(job, stripped_md, sources)
 
     version = write_synthesis(job, stripped_md, model=model_name, cost_usd=cost_val)

--- a/src/research_agent/prompts/synthesizer.md
+++ b/src/research_agent/prompts/synthesizer.md
@@ -44,10 +44,10 @@ source.
   short ones into a catch-all. When the list is empty, omit the tracker
   section entirely.
 
-## Output format — RAW markdown + a trailing JSON block
+## Output format — RAW markdown report
 
-Return the report as **raw markdown text**, immediately followed by a single
-fenced ```json block carrying subgoal status. Nothing else.
+Return the report as **raw markdown text**. The final mandatory instruction at
+the end of this prompt defines the machine-readable subgoal status trailer.
 
 - Do **not** wrap the markdown body in JSON (no `{"report_markdown": "..."}`).
 - Do **not** wrap the markdown body in a code fence (no ```` ```markdown ```` ).
@@ -61,13 +61,9 @@ fenced ```json block carrying subgoal status. Nothing else.
   the critique flagged at least one paid opportunity. Omit the section
   heading entirely when the critique's `paid_opportunities` list is
   empty.
-- After the **Sources** section emit exactly one fenced ```json block whose
-  body is `{"subgoal_status": {"<id>": "confirmed"|"refuted"|"inconclusive"}}`
-  covering every subgoal id you were given. No other JSON fences anywhere
-  else in the response.
 
-The orchestrator strips the trailing JSON fence before writing `report.md`,
-so the visible report only contains the markdown body.
+The orchestrator stores only the markdown report body for readers; the
+machine-readable trailer at the end is stripped before `report.md` is written.
 
 ### Subgoal status mapping
 
@@ -307,6 +303,25 @@ union of inline citations, not a curated subset.)
 {"subgoal_status": {"1": "confirmed", "2": "inconclusive"}}
 ```
 
-(The example above is shown inside a code block for readability — your
-actual markdown report should NOT be inside any fence, but the trailing
-`subgoal_status` block IS the one ```json fence the orchestrator expects.)
+The example above is shown inside a code block for readability. Your actual
+markdown report should NOT be inside any fence.
+
+## Final mandatory subgoal-status trailer
+
+At the very end of every response, after the **Sources** section, emit exactly
+one fenced ```json block whose body is:
+
+```json
+{"subgoal_status": {"<id>": "confirmed"|"refuted"|"inconclusive"}}
+```
+
+This trailer MUST cover every subgoal id you were given.
+
+This trailer MUST be emitted on every synthesis pass, even when all subgoals
+are inconclusive.
+
+The orchestrator strips this trailing JSON fence before writing `report.md`,
+so the visible report only contains the markdown body.
+
+Do not emit any other JSON fences anywhere in the response. Do not put any
+text after the closing fence.

--- a/src/research_agent/storage/markdown.py
+++ b/src/research_agent/storage/markdown.py
@@ -260,29 +260,76 @@ def write_synthesis(
     return version
 
 
-def write_synthesis_partial(job: Job, content: str, model: str) -> int:
-    """Write ``synthesis/<next_version>.partial.md`` for a failed synthesis.
+def _render_failed_synthesis_md(
+    *,
+    version: int,
+    partial_content: str,
+    model: str,
+    traceback_text: str,
+    created_at: int,
+) -> str:
+    partial = partial_content.strip() or "_No partial output captured._"
+    tb = traceback_text.strip() or "No traceback captured."
+    return (
+        f"# Failed Synthesis v{version:04d}\n"
+        f"\n"
+        f"Created: {datetime.fromtimestamp(created_at, UTC).isoformat()}\n"
+        f"Model: {model}\n"
+        f"\n"
+        f"## Partial Output\n"
+        f"\n"
+        f"{partial}\n"
+        f"\n"
+        f"## Traceback\n"
+        f"\n"
+        f"```text\n"
+        f"{tb}\n"
+        f"```\n"
+    )
 
-    Used when a synthesis call exhausts retries: the (possibly empty) partial
-    output is salvaged so the next attempt can include it as context. No DB
-    row and no JSON sidecar are written — the partial file lives outside the
-    canonical ``syntheses`` table on purpose so a future successful run can
-    claim the same version number.
+
+def write_synthesis_failed(
+    job: Job,
+    partial_content: str,
+    *,
+    model: str,
+    traceback_text: str,
+) -> int:
+    """Write ``synthesis/<next_version>.failed.md`` for a failed synthesis.
+
+    Failed artifacts stay out of the canonical ``syntheses`` table and do not
+    get JSON sidecars. The next successful synthesis can still claim the same
+    DB version number while the failure remains on disk for debugging.
     """
-    if not isinstance(content, str):
-        raise ValueError(f"content must be a string; got {type(content).__name__}")
+    if not isinstance(partial_content, str):
+        raise ValueError(
+            f"partial_content must be a string; got {type(partial_content).__name__}"
+        )
     if not isinstance(model, str) or not model:
         raise ValueError("model must be a non-empty string")
+    if not isinstance(traceback_text, str):
+        raise ValueError(
+            f"traceback_text must be a string; got {type(traceback_text).__name__}"
+        )
 
+    now = _now_epoch()
     conn = db.connect(job.db_path)
     try:
         version = _next_version(conn, "syntheses", job.id)
     finally:
         conn.close()
 
-    md_rel = f"synthesis/{version:04d}.partial.md"
-    md_body = content if (not content or content.endswith("\n")) else content + "\n"
-    _atomic_write_text(job.root / md_rel, md_body)
+    md_rel = f"synthesis/{version:04d}.failed.md"
+    _atomic_write_text(
+        job.root / md_rel,
+        _render_failed_synthesis_md(
+            version=version,
+            partial_content=partial_content,
+            model=model,
+            traceback_text=traceback_text,
+            created_at=now,
+        ),
+    )
     return version
 
 
@@ -403,5 +450,5 @@ __all__ = [
     "write_plan",
     "write_report",
     "write_synthesis",
-    "write_synthesis_partial",
+    "write_synthesis_failed",
 ]

--- a/src/research_agent/ui/render.py
+++ b/src/research_agent/ui/render.py
@@ -13,8 +13,10 @@ from pathlib import Path
 from typing import Any
 
 from rich.console import Group
+from rich.markup import escape
 from rich.panel import Panel
 from rich.table import Table
+from rich.text import Text
 
 from research_agent.storage import db
 from research_agent.storage.jobs import Job
@@ -53,6 +55,16 @@ def _humanize_duration(seconds: float | int | None) -> str:
     if delta < 86400:
         return f"{delta // 3600}h"
     return f"{delta // 86400}d"
+
+
+def _hours_to_seconds(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        hours = float(value)
+    except (TypeError, ValueError):
+        return None
+    return hours * 3600 if hours > 0 else None
 
 
 def _truncate(text: str, limit: int = _GOAL_TRUNCATE) -> str:
@@ -113,6 +125,7 @@ _ETA_SAMPLE_LIMIT = 5
 
 def load_status_data(job: Job, *, db_path: Path | None = None) -> dict[str, Any]:
     """Pull plan version, task counts, cost, ETA, current task, and recent events."""
+    intake = job.intake or {}
     path = db_path if db_path is not None else job.db_path
     conn = db.connect(path)
     try:
@@ -128,12 +141,21 @@ def load_status_data(job: Job, *, db_path: Path | None = None) -> dict[str, Any]
         ).fetchall()
         task_counts: dict[str, int] = {str(r["status"]): int(r["n"]) for r in task_rows}
 
-        cost_row = conn.execute(
-            "SELECT cost_so_far_usd FROM jobs WHERE id = ?",
+        job_row = conn.execute(
+            "SELECT cost_so_far_usd, time_cap_hours, created_at, started_at"
+            " FROM jobs WHERE id = ?",
             (job.id,),
         ).fetchone()
-        cost_val = cost_row["cost_so_far_usd"] if cost_row else None
+        cost_val = job_row["cost_so_far_usd"] if job_row else None
         cost = float(cost_val) if cost_val else 0.0
+        time_cap_hours = (
+            job_row["time_cap_hours"]
+            if job_row is not None and job_row["time_cap_hours"] is not None
+            else intake.get("time_cap_hours")
+        )
+        started_at_val = job_row["started_at"] if job_row is not None else None
+        created_at_val = job_row["created_at"] if job_row is not None else job.created_at
+        started_at = int(started_at_val or created_at_val or job.created_at)
 
         # Rolling-average ETA from the last few finished tasks. We need both
         # started_at and finished_at populated to derive a duration; tasks
@@ -191,7 +213,6 @@ def load_status_data(job: Job, *, db_path: Path | None = None) -> dict[str, Any]
     finally:
         conn.close()
 
-    intake = job.intake or {}
     budget_cap = intake.get("budget_cap_usd")
 
     return {
@@ -199,6 +220,8 @@ def load_status_data(job: Job, *, db_path: Path | None = None) -> dict[str, Any]
         "task_counts": task_counts,
         "cost": cost,
         "budget_cap": budget_cap,
+        "time_cap_hours": time_cap_hours,
+        "started_at": started_at,
         "eta_seconds": eta_seconds,
         "current_task": current_task,
         "recent_events": recent_events,
@@ -229,6 +252,8 @@ def render_status_panel(
     recent_events: list[dict[str, Any]],
     *,
     budget_cap: float | None = None,
+    time_cap_hours: float | None = None,
+    started_at: int | None = None,
     eta_seconds: float | None = None,
     current_task: dict[str, Any] | None = None,
     now: int | None = None,
@@ -237,20 +262,29 @@ def render_status_panel(
     intake = job.intake or {}
     now_epoch = int(now) if now is not None else int(time.time())
     cap_for_display = budget_cap if budget_cap is not None else intake.get("budget_cap_usd")
+    time_cap_for_display = (
+        time_cap_hours if time_cap_hours is not None else intake.get("time_cap_hours")
+    )
+    elapsed_start = int(started_at) if started_at is not None else job.created_at
+    elapsed_seconds = max(0, now_epoch - elapsed_start)
+    time_cap_seconds = _hours_to_seconds(time_cap_for_display)
 
     summary_lines = [
         f"[bold]Status:[/bold] {_status_cell(job.status)}",
-        f"[bold]Goal:[/bold] {job.goal}",
-        f"[bold]Domain:[/bold] {job.domain or '—'}",
+        f"[bold]Goal:[/bold] {escape(job.goal)}",
+        f"[bold]Domain:[/bold] {escape(job.domain or '—')}",
         f"[bold]Plan version:[/bold] {plan_version}",
         f"[bold]Cost so far:[/bold] {_format_cost(cost)} / {_format_cost(cap_for_display)}",
-        f"[bold]Time cap (h):[/bold] {intake.get('time_cap_hours') or '—'}",
         f"[bold]Tasks:[/bold] {_format_task_counts(task_counts)}",
+        (
+            f"[bold]Elapsed / time cap:[/bold] {_humanize_duration(elapsed_seconds)} / "
+            f"{_humanize_duration(time_cap_seconds)}"
+        ),
         f"[bold]ETA:[/bold] ~{_humanize_duration(eta_seconds)}",
     ]
 
     if current_task is not None:
-        kind = current_task.get("kind") or "?"
+        kind = escape(str(current_task.get("kind") or "?"))
         started_at = current_task.get("started_at")
         age = _humanize_age(now_epoch, started_at) if started_at is not None else "—"
         summary_lines.append(f"[bold]Current:[/bold] {kind} (running {age})")
@@ -275,7 +309,7 @@ def render_status_panel(
     else:
         events_table.add_row("—", "—", "—", "(no events yet)")
 
-    body = Group(summary, events_table)
+    body = Group(Text.from_markup(summary), events_table)
     return Panel(body, title=f"job {job.id}", border_style="cyan")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,13 +148,17 @@ def _make_synthetic_job(
     today: date = date(2026, 5, 2),
     status: str = "pending",
     cost: float = 1.23,
+    time_cap_hours: int | None = None,
     plan_version: int | None = None,
     finding_text: str | None = None,
     event_lines: list[dict] | None = None,
 ) -> Job:
     """Hand-create a job, optionally seed plan/finding/events for richer tests."""
+    intake = {"goal": goal, "domain": "general"}
+    if time_cap_hours is not None:
+        intake["time_cap_hours"] = time_cap_hours
     job = Job.create(
-        {"goal": goal, "domain": "general"},
+        intake,
         jobs_root=repo / "jobs",
         db_path=repo / "data" / "index.sqlite",
         today=today,
@@ -432,6 +436,38 @@ def test_status_renders_eta_and_current_task(isolated_jobs_repo: Path):
     # Counter row uses the canonical pending/running/done/failed shape.
     assert "pending=2" in out
     assert "done=3" in out
+
+
+def test_status_panel_shows_elapsed_against_time_cap(isolated_jobs_repo: Path):
+    """`research status` data includes elapsed wall time next to the persisted cap."""
+    from rich.console import Console
+
+    job = _make_synthetic_job(
+        isolated_jobs_repo,
+        goal="timed target",
+        time_cap_hours=2,
+    )
+
+    data = render.load_status_data(job)
+    panel = render.render_status_panel(
+        job,
+        plan_version=data["plan_version"],
+        task_counts=data["task_counts"],
+        cost=data["cost"],
+        recent_events=data["recent_events"],
+        budget_cap=data["budget_cap"],
+        time_cap_hours=data["time_cap_hours"],
+        started_at=data["started_at"],
+        eta_seconds=data["eta_seconds"],
+        current_task=data["current_task"],
+        now=job.created_at + 1800,
+    )
+
+    console = Console(record=True, width=200)
+    console.print(panel)
+    rendered = console.export_text()
+    assert "Elapsed / time cap" in rendered
+    assert "30m / 2h" in rendered
 
 
 def test_status_idle_when_no_running_task(isolated_jobs_repo: Path):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -363,6 +363,57 @@ async def test_run_daemon_stops_on_stop_flag(
 
 
 @pytest.mark.asyncio
+async def test_run_daemon_sweeps_stale_orphan_artifacts_on_startup(
+    seeded_job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    old_partial = seeded_job.root / "synthesis" / "0004.partial.md"
+    old_tmp = seeded_job.root / "critique" / "0002.md.tmp"
+    young_partial = seeded_job.root / "plan" / "0003.partial.md"
+    old_partial.write_text("", encoding="utf-8")
+    old_tmp.write_text("half-written critique", encoding="utf-8")
+    young_partial.write_text("still being written", encoding="utf-8")
+
+    now = time.time()
+    old_mtime = now - daemon.ORPHAN_ARTIFACT_MAX_AGE_S - 1
+    os.utime(old_partial, (old_mtime, old_mtime))
+    os.utime(old_tmp, (old_mtime, old_mtime))
+    os.utime(young_partial, (now, now))
+
+    async def _instant_run_loop(job: Job, router: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"tasks_done": 0, "stopped": True, "completed": False, "cap_hit": False}
+
+    _patch_run_daemon_for_in_process(monkeypatch, run_loop_impl=_instant_run_loop)
+
+    exit_code = await daemon.run_daemon(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+
+    assert exit_code == 0
+    assert not old_partial.exists()
+    assert not old_tmp.exists()
+    assert young_partial.exists()
+
+    conn = db.connect(seeded_job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT payload_json FROM events"
+            " WHERE job_id = ? AND kind = 'orphan_artifact_cleaned'"
+            " ORDER BY id ASC",
+            (seeded_job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    cleaned_paths = {json.loads(row["payload_json"])["path"] for row in rows}
+    assert cleaned_paths == {"synthesis/0004.partial.md", "critique/0002.md.tmp"}
+    for row in rows:
+        payload = json.loads(row["payload_json"])
+        assert payload["age_seconds"] >= daemon.ORPHAN_ARTIFACT_MAX_AGE_S
+
+
+@pytest.mark.asyncio
 async def test_run_daemon_sigterm_routes_through_same_graceful_path(
     seeded_job: Job, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -18,6 +18,7 @@ These tests exercise the §5.1 + §6.1 contract from the implementation guide:
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import signal
 import subprocess
@@ -303,7 +304,7 @@ def _patch_run_daemon_for_in_process(
     calls: dict[str, list[tuple[Any, ...]]] = {"final_synthesis": [], "run_loop": []}
 
     async def _wrapped_run_loop(job: Job, router: Any, **kwargs: Any) -> Any:
-        calls["run_loop"].append((job.id,))
+        calls["run_loop"].append((job.id, kwargs))
         return await run_loop_impl(job, router, **kwargs)
 
     async def _final_synth_stub(job: Job, plan: Plan, *, router: Any) -> None:
@@ -433,6 +434,52 @@ async def test_run_daemon_completed_status_when_plan_is_complete(
         db_path=seeded_job.db_path,
     )
     assert refreshed.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_passes_time_cap_and_marks_time_cap_completion(
+    seeded_job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Persisted ``time_cap_hours`` is forwarded to run_loop and classified distinctly."""
+    intake = dict(seeded_job.intake)
+    intake["time_cap_hours"] = 1
+    conn = db.connect(seeded_job.db_path)
+    try:
+        with conn:
+            conn.execute(
+                "UPDATE jobs SET intake_json = ?, time_cap_hours = ? WHERE id = ?",
+                (json.dumps(intake, sort_keys=True), 1, seeded_job.id),
+            )
+    finally:
+        conn.close()
+
+    async def _time_capped_run_loop(job: Job, router: Any, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "tasks_done": 1,
+            "stopped": False,
+            "completed": False,
+            "cap_hit": False,
+            "time_cap_hit": True,
+            "completion_reason": "time_cap",
+        }
+
+    calls = _patch_run_daemon_for_in_process(monkeypatch, run_loop_impl=_time_capped_run_loop)
+
+    exit_code = await daemon.run_daemon(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    assert exit_code == 0
+    assert calls["run_loop"][0][1]["time_cap_hours"] == 1.0
+
+    refreshed = Job.load(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    assert refreshed.status == "completed"
+    assert refreshed.completion_reason == "time_cap"
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -149,6 +149,35 @@ class _FakeAgent:
         return self.result
 
 
+class _TimeoutThenSuccessAgent:
+    """Times out for N calls, then succeeds immediately.
+
+    This lets router fallback tests assert that reroutes preserve the original
+    agent object while overriding its model for the fallback tier.
+    """
+
+    def __init__(
+        self,
+        *,
+        result: Any = None,
+        timeout_attempts: int = 2,
+    ) -> None:
+        self.result = result if result is not None else _FakeResult()
+        self.timeout_attempts = timeout_attempts
+        self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    async def run(self, *args: Any, **kwargs: Any) -> Any:
+        self.calls.append((args, kwargs))
+        if len(self.calls) <= self.timeout_attempts:
+            await asyncio.sleep(1.0)
+            return None  # pragma: no cover - cancelled by router timeout
+        return self.result
+
+
+def _override_model_name(call: tuple[tuple[Any, ...], dict[str, Any]]) -> str | None:
+    return getattr(call[1].get("model"), "model_name", None)
+
+
 def _rate_limit_error() -> RateLimitError:
     request = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
     response = httpx.Response(429, request=request)
@@ -955,18 +984,18 @@ async def test_two_timeouts_marks_tier_degraded_and_routes_to_fallback(
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
     router, budget = _make_lmstudio_router(job=job, db_path=db_path)
 
-    cloud_agent = _FakeAgent(result=_FakeResult(output="cloud body"))
-    monkeypatch.setattr(router, "_make_fallback_tier_agent", lambda ft: cloud_agent)
-
-    local_agent = _FakeAgent(sleep_s=1.0)
+    local_agent = _TimeoutThenSuccessAgent(result=_FakeResult(output="cloud body"))
     result = await router.call("fast", local_agent, "do work")
 
-    assert result is cloud_agent.result
+    assert result is local_agent.result
     assert "fast" in router._tier_degraded_until
     # Retry path: agent.run was attempted twice before we gave up on local.
-    assert len(local_agent.calls) == 2
-    # The cloud (fallback_tier) call ran exactly once.
-    assert len(cloud_agent.calls) == 1
+    assert len(local_agent.calls) == 3
+    assert _override_model_name(local_agent.calls[0]) is None
+    assert _override_model_name(local_agent.calls[1]) is None
+    # The fallback tier reuses the original agent so output_type/system prompt
+    # are preserved, but overrides the model for the rerouted call.
+    assert _override_model_name(local_agent.calls[2]) == "anthropic/claude-haiku-4-5"
 
     degraded = _read_events_by_kind(job, "lmstudio_degraded")
     rerouted = _read_events_by_kind(job, "lmstudio_rerouted")
@@ -1019,31 +1048,20 @@ async def test_frontier_alt_lmstudio_degradation_defaults_to_frontier_fallback(
     router.openrouter_retry_max_delay = 0.0
     router.openrouter_retry_stop_delay = 0.0
 
-    cloud_agent = _FakeAgent(result=_FakeResult(output="frontier fallback"))
-    fallback_tiers: list[str] = []
-
-    def _fallback_agent(tier: str) -> _FakeAgent:
-        fallback_tiers.append(tier)
-        return cloud_agent
-
-    monkeypatch.setattr(router, "_make_fallback_tier_agent", _fallback_agent)
-
-    local_agent = _FakeAgent(sleep_s=1.0)
+    local_agent = _TimeoutThenSuccessAgent(result=_FakeResult(output="frontier fallback"))
     result = await router.call("frontier_alt", local_agent, "critique context")
 
-    assert result is cloud_agent.result
-    assert fallback_tiers == ["frontier"]
-    assert len(local_agent.calls) == 2
-    assert len(cloud_agent.calls) == 1
+    assert result is local_agent.result
+    assert len(local_agent.calls) == 3
+    assert _override_model_name(local_agent.calls[2]) == "anthropic/claude-opus-4-7"
     assert budget.precheck_calls == ["frontier"]
     assert len(budget.charge_calls) == 1
 
-    second_local_agent = _FakeAgent(sleep_s=1.0)
+    second_local_agent = _FakeAgent(result=_FakeResult(output="frontier fallback 2"))
     second = await router.call("frontier_alt", second_local_agent, "critique context 2")
-    assert second is cloud_agent.result
-    assert second_local_agent.calls == []
-    assert fallback_tiers == ["frontier", "frontier"]
-    assert len(cloud_agent.calls) == 2
+    assert second is second_local_agent.result
+    assert len(second_local_agent.calls) == 1
+    assert _override_model_name(second_local_agent.calls[0]) == "anthropic/claude-opus-4-7"
     assert budget.precheck_calls == ["frontier", "frontier"]
 
     degraded = _read_events_by_kind(job, "lmstudio_degraded")
@@ -1077,19 +1095,20 @@ async def test_calls_within_degraded_window_skip_local_and_reroute(
     # Pretend the prior call already degraded the tier.
     router._tier_degraded_until["fast"] = time.time() + 600.0
 
-    cloud_agent = _FakeAgent(result=_FakeResult(output="reroute"))
-    monkeypatch.setattr(router, "_make_fallback_tier_agent", lambda ft: cloud_agent)
-
-    local_agent = _FakeAgent(sleep_s=10.0)  # would hang if it were called
+    local_agent = _FakeAgent(result=_FakeResult(output="reroute"))
 
     for _ in range(3):
         out = await router.call("fast", local_agent, "x")
-        assert out is cloud_agent.result
+        assert out is local_agent.result
 
-    # Local was never even tried — the bypass kicks in before the timeout.
-    assert local_agent.calls == []
+    # Local was never tried with the original model - the bypass kicks in and
+    # every call uses the fallback model override immediately.
+    assert len(local_agent.calls) == 3
+    assert all(
+        _override_model_name(call) == "anthropic/claude-haiku-4-5"
+        for call in local_agent.calls
+    )
     # Three reroutes → three cloud calls and three WARN events with cost.
-    assert len(cloud_agent.calls) == 3
     rerouted = _read_events_by_kind(job, "lmstudio_rerouted")
     assert len(rerouted) == 3
     for ev in rerouted:
@@ -1137,13 +1156,6 @@ async def test_two_timeouts_without_fallback_tier_propagates_timeout(
     """When ``fallback_tier`` is omitted (e.g. embeddings) the second timeout raises."""
     monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
     router, budget = _make_lmstudio_router(job=job, db_path=db_path, fallback_tier=None)
-    # If the reroute path were taken anyway it would call this — fail loudly.
-    monkeypatch.setattr(
-        router,
-        "_make_fallback_tier_agent",
-        lambda ft: pytest.fail("must not build a fallback agent when fallback_tier is unset"),
-    )
-
     local_agent = _FakeAgent(sleep_s=1.0)
     with pytest.raises(asyncio.TimeoutError):
         await router.call("fast", local_agent, "x")

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -27,6 +27,7 @@ from research_agent.storage.jobs import Job
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SHIPPED_MODELS_YAML = REPO_ROOT / "config" / "models.yaml"
+SHIPPED_LOCAL_MODELS_YAML = REPO_ROOT / "config" / "models.local.yaml"
 
 
 # ---------------------------------------------------------------------------
@@ -889,6 +890,14 @@ def test_models_yaml_ships_lmstudio_fallback_tiers() -> None:
     assert "fallback_tier" not in tiers["embeddings"]
 
 
+def test_local_models_yaml_routes_frontier_alt_to_frontier() -> None:
+    """Local critique must have a declared same-family fallback tier."""
+    cfg = load_models_config(SHIPPED_LOCAL_MODELS_YAML)
+    tiers = cfg["tiers"]
+    assert tiers["frontier_alt"]["provider"] == "lmstudio"
+    assert tiers["frontier_alt"].get("fallback_tier") == "frontier"
+
+
 def _make_lmstudio_router(
     *,
     job: Job,
@@ -977,6 +986,82 @@ async def test_two_timeouts_marks_tier_degraded_and_routes_to_fallback(
     # charge) so the budget side recorded one cloud call.
     assert budget.precheck_calls == ["frontier_speed"]
     assert len(budget.charge_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_frontier_alt_lmstudio_degradation_defaults_to_frontier_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    db_path: Path,
+    job: Job,
+) -> None:
+    """Critique's local frontier_alt tier falls through to frontier even without config."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    cfg: dict[str, Any] = {
+        "tiers": {
+            t: {"provider": "lmstudio", "model": "stub", "timeout_s": 60}
+            for t in EXPECTED_TIERS
+        },
+    }
+    cfg["tiers"]["frontier_alt"] = {
+        "provider": "lmstudio",
+        "model": "local-critic",
+        "timeout_s": 0.05,
+    }
+    cfg["tiers"]["frontier"] = {
+        "provider": "openrouter",
+        "model": "anthropic/claude-opus-4-7",
+        "timeout_s": 60,
+    }
+    budget = _RecordingBudget(cost_per_call=0.17, db_path=db_path, job_id=job.id)
+    router = Router(cfg, budget, job=job, db_path=db_path)  # type: ignore[arg-type]
+    router.retry_sleep_s = 0.0
+    router.openrouter_retry_min_delay = 0.0
+    router.openrouter_retry_max_delay = 0.0
+    router.openrouter_retry_stop_delay = 0.0
+
+    cloud_agent = _FakeAgent(result=_FakeResult(output="frontier fallback"))
+    fallback_tiers: list[str] = []
+
+    def _fallback_agent(tier: str) -> _FakeAgent:
+        fallback_tiers.append(tier)
+        return cloud_agent
+
+    monkeypatch.setattr(router, "_make_fallback_tier_agent", _fallback_agent)
+
+    local_agent = _FakeAgent(sleep_s=1.0)
+    result = await router.call("frontier_alt", local_agent, "critique context")
+
+    assert result is cloud_agent.result
+    assert fallback_tiers == ["frontier"]
+    assert len(local_agent.calls) == 2
+    assert len(cloud_agent.calls) == 1
+    assert budget.precheck_calls == ["frontier"]
+    assert len(budget.charge_calls) == 1
+
+    second_local_agent = _FakeAgent(sleep_s=1.0)
+    second = await router.call("frontier_alt", second_local_agent, "critique context 2")
+    assert second is cloud_agent.result
+    assert second_local_agent.calls == []
+    assert fallback_tiers == ["frontier", "frontier"]
+    assert len(cloud_agent.calls) == 2
+    assert budget.precheck_calls == ["frontier", "frontier"]
+
+    degraded = _read_events_by_kind(job, "lmstudio_degraded")
+    rerouted = _read_events_by_kind(job, "lmstudio_rerouted")
+    assert len(degraded) == 1
+    assert degraded[0]["payload"]["tier"] == "frontier_alt"
+    assert degraded[0]["payload"]["fallback_tier"] == "frontier"
+    assert len(rerouted) == 2
+    assert rerouted[0]["payload"]["original_tier"] == "frontier_alt"
+    assert rerouted[0]["payload"]["fallback_tier"] == "frontier"
+    assert rerouted[1]["payload"]["original_tier"] == "frontier_alt"
+    assert rerouted[1]["payload"]["fallback_tier"] == "frontier"
+
+    assert router.last_call_metadata is not None
+    assert router.last_call_metadata["tier"] == "frontier"
+    assert router.last_call_metadata["model"] == "anthropic/claude-opus-4-7"
+    assert router.last_call_metadata["original_tier"] == "frontier_alt"
+    assert router.last_call_metadata["rerouted"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_orchestrator_critique.py
+++ b/tests/test_orchestrator_critique.py
@@ -255,6 +255,44 @@ def test_critique_uses_frontier_alt_tier_by_default(job: Job, db_path: Path, pla
     assert router.calls[0][0] == DEFAULT_TIER == "frontier_alt"
 
 
+def test_critique_records_actual_router_fallback_model(
+    job: Job,
+    db_path: Path,
+    plan: Plan,
+) -> None:
+    _seed_findings(job, [0.7])
+    router = _StubRouter(
+        tiers={
+            "frontier_alt": {"provider": "lmstudio", "model": "local-critic"},
+            "frontier": {"provider": "lmstudio", "model": "local-frontier"},
+        }
+    )
+    router.last_call_metadata = {
+        "tier": "frontier",
+        "provider": "lmstudio",
+        "model": "local-frontier",
+        "original_tier": "frontier_alt",
+        "rerouted": True,
+    }
+
+    out = asyncio.run(critique(job, plan, "# Synthesis\n", router=router))
+
+    assert out.model == "local-frontier"
+    rows = _read_critique_rows(db_path, job.id)
+    assert rows[0]["model"] == "local-frontier"
+
+    events = _read_event_rows(db_path, job.id)
+    written = [
+        json.loads(ev["payload_json"])
+        for ev in events
+        if ev["kind"] == "critique_written"
+    ]
+    assert written
+    assert written[0]["tier"] == "frontier"
+    assert written[0]["requested_tier"] == "frontier_alt"
+    assert written[0]["model"] == "local-frontier"
+
+
 def test_critique_file_rotation_writes_0002_on_second_call(
     job: Job, db_path: Path, plan: Plan
 ) -> None:

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -23,7 +24,6 @@ from research_agent.orchestrator.loop import (
     run_loop,
 )
 from research_agent.orchestrator.plan import Plan, ScopeClass, Subgoal, TaskSpec
-from research_agent.tools.models import SearchResult
 from research_agent.storage import db
 from research_agent.storage.jobs import Job
 from research_agent.storage.markdown import write_plan
@@ -33,6 +33,7 @@ from research_agent.storage.tasks import (
     STATUS_PENDING,
     enqueue,
 )
+from research_agent.tools.models import SearchResult
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -102,6 +103,58 @@ def _read_event_kinds(db_path: Path, job_id: str) -> list[str]:
     finally:
         conn.close()
     return [r["kind"] for r in rows]
+
+
+def _read_events_by_kind(db_path: Path, job_id: str, kind: str) -> list[dict[str, Any]]:
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT level, actor, kind, payload_json"
+            " FROM events WHERE job_id = ? AND kind = ? ORDER BY id ASC",
+            (job_id, kind),
+        ).fetchall()
+    finally:
+        conn.close()
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        item = dict(row)
+        item["payload"] = json.loads(item.pop("payload_json"))
+        out.append(item)
+    return out
+
+
+def _read_checkpoint_kinds(db_path: Path, job_id: str) -> list[str]:
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT kind FROM checkpoints WHERE job_id = ? ORDER BY id ASC",
+            (job_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [r["kind"] for r in rows]
+
+
+def _read_checkpoints_by_kind(
+    db_path: Path,
+    job_id: str,
+    kind: str,
+) -> list[dict[str, Any]]:
+    conn = db.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT kind, payload_json FROM checkpoints"
+            " WHERE job_id = ? AND kind = ? ORDER BY id ASC",
+            (job_id, kind),
+        ).fetchall()
+    finally:
+        conn.close()
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        item = dict(row)
+        item["payload"] = json.loads(item.pop("payload_json"))
+        out.append(item)
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -614,7 +667,7 @@ async def test_connector_fetch_handler_dispatches_to_module(
     persist the returned :class:`Source` via the shared helper.
     """
     import importlib
-    from datetime import datetime, timezone
+    from datetime import UTC, datetime
 
     from research_agent.tools.models import Source
 
@@ -629,7 +682,7 @@ async def test_connector_fetch_handler_dispatches_to_module(
             url=url,
             title="t",
             cleaned_text="hello world",
-            fetched_at=datetime.now(tz=timezone.utc),
+            fetched_at=datetime.now(tz=UTC),
             source_kind=sk,  # type: ignore[arg-type]
         )
 
@@ -1109,6 +1162,94 @@ async def test_loop_exits_when_subgoals_all_done(job: Job, db_path: Path) -> Non
     pending_count = sum(1 for r in rows if r["status"] == STATUS_PENDING)
     assert done_count == HEURISTIC_CHECK_EVERY_N
     assert pending_count == 0
+
+
+@pytest.mark.asyncio
+async def test_critique_cadence_repeats_over_200_tasks(
+    job: Job,
+    db_path: Path,
+    plan: Plan,
+) -> None:
+    """Critique fires every 50 completed tasks, not only the first time."""
+    total_tasks = 200
+    _seed_tasks(job, ["web_search"] * total_tasks)
+
+    critique_calls: list[int] = []
+
+    async def critique(job_arg: Job, task: dict[str, Any]) -> dict[str, Any]:
+        critique_calls.append(len(critique_calls) + 1)
+        return {"ok": True}
+
+    handlers: dict[str, Handler] = {
+        "web_search": _ok_handler(),
+        "synthesize": _ok_handler(),
+        "critique": critique,
+    }
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers=handlers,
+        max_tasks=total_tasks + HEURISTIC_CHECK_EVERY_N,
+        retry_waits=(0,),
+    )
+
+    assert result["tasks_done"] == total_tasks
+    assert len(critique_calls) == 4
+    assert len(critique_calls) >= 3
+
+    critique_checkpoints = _read_checkpoints_by_kind(db_path, job.id, "critique_done")
+    assert [c["payload"]["tasks_done"] for c in critique_checkpoints] == [50, 100, 150, 200]
+
+
+@pytest.mark.asyncio
+async def test_critique_heuristic_failure_warning_has_traceback_and_model_context(
+    job: Job,
+    db_path: Path,
+    plan: Plan,
+) -> None:
+    """A failed critique pass should be loud enough to diagnose post-run."""
+    _seed_tasks(job, ["web_search"] * (HEURISTIC_CHECK_EVERY_N * 2))
+
+    async def critique(job_arg: Job, task: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("frontier_alt unavailable")
+
+    critique._heuristic_tier = "frontier_alt"  # type: ignore[attr-defined]
+    critique._heuristic_model = "local-critic"  # type: ignore[attr-defined]
+
+    handlers: dict[str, Handler] = {
+        "web_search": _ok_handler(),
+        "synthesize": _ok_handler(),
+        "critique": critique,
+    }
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers=handlers,
+        max_tasks=HEURISTIC_CHECK_EVERY_N * 3,
+        retry_waits=(0,),
+    )
+
+    assert result["tasks_done"] == HEURISTIC_CHECK_EVERY_N * 2
+    warnings = [
+        ev["payload"]
+        for ev in _read_events_by_kind(db_path, job.id, "warning")
+        if ev["payload"].get("heuristic") == "critique"
+    ]
+    assert len(warnings) == 1
+    payload = warnings[0]
+    assert payload["tier"] == "frontier_alt"
+    assert payload["model"] == "local-critic"
+    assert payload["error_type"] == "RuntimeError"
+    assert payload["error"] == "frontier_alt unavailable"
+    assert "Traceback (most recent call last)" in payload["traceback"]
+    assert "RuntimeError: frontier_alt unavailable" in payload["traceback"]
+
+    checkpoints = _read_checkpoint_kinds(db_path, job.id)
+    assert "critique_done" not in checkpoints
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -296,6 +296,111 @@ async def test_max_tasks_cap_triggers_final_synthesis(job: Job, db_path: Path, p
 
 
 @pytest.mark.asyncio
+async def test_time_cap_terminates_with_final_synthesis(
+    job: Job,
+    db_path: Path,
+    plan: Plan,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A one-hour cap stops a large queue at the deadline and reports ``time_cap``."""
+    _seed_tasks(job, ["web_search"] * 1000)
+    clock = {"now": 0.0}
+    synth_calls = {"n": 0}
+
+    monkeypatch.setattr(
+        "research_agent.orchestrator.loop.time.monotonic",
+        lambda: clock["now"],
+    )
+
+    async def web_search(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        clock["now"] += 360.0
+        return {"hits": 1}
+
+    async def synth(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        synth_calls["n"] += 1
+        return {"ok": True}
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": web_search, "synthesize": synth},
+        time_cap_hours=1,
+        retry_waits=(0,),
+    )
+
+    assert result["completion_reason"] == "time_cap"
+    assert result["time_cap_hit"] is True
+    assert result["cap_hit"] is False
+    assert result["elapsed_seconds"] <= 1.05 * 3600
+    assert synth_calls["n"] == 1
+
+    rows = _read_task_rows(db_path, job.id)
+    done_count = sum(1 for r in rows if r["status"] == STATUS_DONE)
+    pending_count = sum(1 for r in rows if r["status"] == STATUS_PENDING)
+    assert done_count == 10
+    assert pending_count == 990
+
+
+@pytest.mark.asyncio
+async def test_time_cap_unset_preserves_legacy_drain_behavior(
+    job: Job,
+    plan: Plan,
+) -> None:
+    """Without a time cap, the loop drains the queue as it did before."""
+    _seed_tasks(job, ["web_search"] * 3)
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": _ok_handler()},
+        retry_waits=(0,),
+    )
+
+    assert result["tasks_done"] == 3
+    assert result["time_cap_hit"] is False
+    assert result["completion_reason"] is None
+
+
+@pytest.mark.asyncio
+async def test_time_cap_waits_for_in_flight_handler(
+    job: Job,
+    db_path: Path,
+    plan: Plan,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the cap expires during a handler, that task finishes before the loop exits."""
+    _seed_tasks(job, ["web_search", "web_search"])
+    clock = {"now": 0.0}
+
+    monkeypatch.setattr(
+        "research_agent.orchestrator.loop.time.monotonic",
+        lambda: clock["now"],
+    )
+
+    async def slow_handler(job: Job, task: dict[str, Any]) -> dict[str, Any]:
+        clock["now"] += 3601.0
+        return {"hits": 1}
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": slow_handler},
+        time_cap_hours=1,
+        retry_waits=(0,),
+    )
+
+    assert result["completion_reason"] == "time_cap"
+    assert result["tasks_done"] == 1
+
+    rows = _read_task_rows(db_path, job.id)
+    assert rows[0]["status"] == STATUS_DONE
+    assert rows[1]["status"] == STATUS_PENDING
+
+
+@pytest.mark.asyncio
 async def test_follow_up_tasks_get_enqueued(job: Job, db_path: Path, plan: Plan) -> None:
     """A handler returning ``follow_up_tasks`` must enqueue + process them."""
     _seed_tasks(job, ["web_search"])

--- a/tests/test_orchestrator_synth.py
+++ b/tests/test_orchestrator_synth.py
@@ -576,6 +576,100 @@ def test_synthesize_extracts_subgoal_status_and_strips_fence(
     assert sorted(payload["closed"]) == [1, 2, 3]
 
 
+def test_synthesize_extracts_raw_trailing_subgoal_status_json(
+    job: Job, db_path: Path, multi_subgoal_plan: Plan
+) -> None:
+    """A raw trailing JSON object is parsed and stripped even without a fence."""
+    _seed_findings(job, [0.9, 0.5])
+    body = (
+        "# Investigation Report\n\n"
+        "## Executive Summary\n- finding [1]\n\n"
+        '## Sources\n1. https://example.com/0 — "Title"\n'
+    )
+    raw_json = '\n{"closed": [1], "reopened": [2], "inconclusive": [3]}\n'
+    router = _StubRouter(content=body + raw_json)
+
+    asyncio.run(synthesize(job, multi_subgoal_plan, router=router))
+
+    report = (job.root / "report.md").read_text(encoding="utf-8")
+    assert '"closed"' not in report
+    assert "Investigation Report" in report
+
+    subgoals = _read_latest_plan_subgoals(db_path, job.id)
+    by_id = {sg["id"]: sg for sg in subgoals}
+    assert by_id[1]["done"] is True
+    assert by_id[2]["done"] is False
+    assert by_id[3]["done"] is False
+
+    events = _read_event_rows(db_path, job.id)
+    updated = [e for e in events if e["kind"] == "plan_subgoals_updated"]
+    assert len(updated) == 1
+    payload = json.loads(updated[0]["payload_json"])
+    assert payload["closed"] == [1]
+    assert payload["inconclusive"] == [2, 3]
+
+
+def test_synthesize_extracts_subgoal_status_section_json(
+    job: Job, db_path: Path, multi_subgoal_plan: Plan
+) -> None:
+    """A final ``## Subgoal Status`` section can carry the JSON payload."""
+    _seed_findings(job, [0.9])
+    content = (
+        "# Investigation Report\n\n"
+        "## Executive Summary\n- finding [1]\n\n"
+        '## Sources\n1. https://example.com/0 — "Title"\n\n'
+        "## Subgoal Status\n\n"
+        "```json\n"
+        '{"subgoal_status": {"1": "confirmed", "2": "inconclusive", "3": "refuted"}}'
+        "\n```\n"
+    )
+    router = _StubRouter(content=content)
+
+    asyncio.run(synthesize(job, multi_subgoal_plan, router=router))
+
+    report = (job.root / "report.md").read_text(encoding="utf-8")
+    assert "## Subgoal Status" not in report
+    assert "subgoal_status" not in report
+
+    subgoals = _read_latest_plan_subgoals(db_path, job.id)
+    by_id = {sg["id"]: sg for sg in subgoals}
+    assert by_id[1]["done"] is True
+    assert by_id[2]["done"] is False
+    assert by_id[3]["done"] is True
+
+
+def test_synthesize_extracts_subgoal_status_from_prose(
+    job: Job, db_path: Path, multi_subgoal_plan: Plan
+) -> None:
+    """Prose-only status lines are an observable fallback."""
+    _seed_findings(job, [0.9])
+    content = (
+        "# Investigation Report\n\n"
+        "## Hypotheses\n\n"
+        "Subgoal 1: Confirmed after checking filings [1].\n"
+        "Subgoal 2: Inconclusive because records are missing.\n"
+        "H3: Refuted by the permit history [1].\n"
+        "H99: Confirmed, but this is not in the active plan.\n\n"
+        '## Sources\n1. https://example.com/0 — "Title"\n'
+    )
+    router = _StubRouter(content=content)
+
+    asyncio.run(synthesize(job, multi_subgoal_plan, router=router))
+
+    subgoals = _read_latest_plan_subgoals(db_path, job.id)
+    by_id = {sg["id"]: sg for sg in subgoals}
+    assert by_id[1]["done"] is True
+    assert by_id[2]["done"] is False
+    assert by_id[3]["done"] is True
+
+    events = _read_event_rows(db_path, job.id)
+    prose_events = [e for e in events if e["kind"] == "synth_status_from_prose"]
+    assert len(prose_events) == 1
+    payload = json.loads(prose_events[0]["payload_json"])
+    assert payload["status"] == {"1": "confirmed", "2": "inconclusive", "3": "refuted"}
+    assert [e for e in events if e["kind"] == "synth_status_missing"] == []
+
+
 def test_synthesize_inconclusive_status_keeps_subgoal_open(
     job: Job, db_path: Path, multi_subgoal_plan: Plan
 ) -> None:
@@ -607,7 +701,7 @@ def test_synthesize_inconclusive_status_keeps_subgoal_open(
 def test_synthesize_missing_fence_emits_warning_and_skips_plan_bump(
     job: Job, db_path: Path, multi_subgoal_plan: Plan
 ) -> None:
-    """No trailing JSON fence: warning emitted, report still written, plan unchanged."""
+    """No structured or prose status: warning emitted, report written, plan unchanged."""
     _seed_findings(job, [0.6])
     router = _StubRouter(content="# Report\n\nNo fence at all.\n")
 
@@ -617,9 +711,9 @@ def test_synthesize_missing_fence_emits_warning_and_skips_plan_bump(
     assert _read_latest_plan_version(db_path, job.id) == multi_subgoal_plan.version
 
     events = _read_event_rows(db_path, job.id)
-    warns = [e for e in events if e["kind"] == "warning"]
-    payloads = [json.loads(e["payload_json"]) for e in warns]
-    assert any(p.get("stage") == "subgoal_status" for p in payloads)
+    missing = [e for e in events if e["kind"] == "synth_status_missing"]
+    assert len(missing) == 1
+    assert missing[0]["level"] == "WARN"
 
     updated = [e for e in events if e["kind"] == "plan_subgoals_updated"]
     assert updated == []
@@ -978,6 +1072,14 @@ def test_synthesizer_prompt_has_scope_aware_closure_rules() -> None:
     assert "5 distinct" in body
     assert "2 specific" in body
     assert "3 distinct" in body
+
+
+def test_synthesizer_prompt_ends_with_status_trailer_instruction() -> None:
+    """Keep the machine-readable trailer requirement at the end for recency."""
+    body = prompts_loader.load_prompt("synthesizer", goal="x")
+    assert "Final mandatory subgoal-status trailer" in body
+    assert "MUST be emitted on every synthesis pass" in body
+    assert body.rstrip().endswith("text after the closing fence.")
 
 
 def test_synthesize_accepts_fence_with_space_before_json_lang(

--- a/tests/test_orchestrator_synth.py
+++ b/tests/test_orchestrator_synth.py
@@ -353,10 +353,10 @@ def test_final_synthesis_uses_larger_top_n_and_final_flag(
     assert len(payload["findings"]) <= FINAL_TOP_N
 
 
-def test_synthesize_retry_exhaustion_writes_partial_and_emits_failed(
+def test_synthesize_retry_exhaustion_writes_failed_and_emits_failed(
     job: Job, db_path: Path, plan: Plan
 ) -> None:
-    """Terminal retry exhaustion → partial md + ``synthesis_failed`` ERROR event."""
+    """Terminal retry exhaustion → failed md + ``synthesis_failed`` ERROR event."""
     _seed_findings(job, [0.6])
     router = _StubRouter(
         side_effect={
@@ -371,15 +371,18 @@ def test_synthesize_retry_exhaustion_writes_partial_and_emits_failed(
     assert out.model == "synthesis_failed"
     assert out.cost_usd is None
 
-    # Partial md exists at the synthesis/<v>.partial.md path (no DB row written).
-    partial = job.root / f"synthesis/{out.version:04d}.partial.md"
-    assert partial.exists()
-    # Non-streaming call path — the partial is empty but its presence lets
-    # the next attempt know a prior failure happened.
-    assert partial.read_text(encoding="utf-8") == ""
+    failed_path = job.root / f"synthesis/{out.version:04d}.failed.md"
+    assert out.report_path == str(failed_path)
+    assert failed_path.exists()
+    assert list((job.root / "synthesis").glob("*.partial.md")) == []
+    failed_md = failed_path.read_text(encoding="utf-8")
+    assert "## Partial Output" in failed_md
+    assert "_No partial output captured._" in failed_md
+    assert "## Traceback" in failed_md
+    assert "RuntimeError: openrouter: connection reset after 6 retries" in failed_md
 
     rows = _read_synthesis_rows(db_path, job.id)
-    assert rows == [], "partial writes must not insert a syntheses row"
+    assert rows == [], "failed writes must not insert a syntheses row"
 
     events = _read_event_rows(db_path, job.id)
     failed = [e for e in events if e["kind"] == "synthesis_failed"]
@@ -389,7 +392,35 @@ def test_synthesize_retry_exhaustion_writes_partial_and_emits_failed(
     assert payload["tier"] == "frontier"
     assert "connection reset" in payload["reason"]
     assert payload["attempt_count"] == 1
-    assert payload["partial_path"].endswith(".partial.md")
+    assert payload["failed_path"].endswith(".failed.md")
+    assert (
+        "RuntimeError: openrouter: connection reset after 6 retries" in payload["traceback"]
+    )
+
+
+def test_failed_synthesis_artifact_includes_partial_content_and_traceback(
+    job: Job, db_path: Path
+) -> None:
+    try:
+        raise RuntimeError("handler crashed mid-write")
+    except RuntimeError as exc:
+        out = synth_module._write_failed_output(
+            job,
+            tier="frontier",
+            exc=exc,
+            attempt_count=1,
+            partial_content="# Partial report\n\nDraft body",
+        )
+
+    failed_path = job.root / f"synthesis/{out.version:04d}.failed.md"
+    failed_md = failed_path.read_text(encoding="utf-8")
+    assert "# Partial report" in failed_md
+    assert "Draft body" in failed_md
+    assert "RuntimeError: handler crashed mid-write" in failed_md
+    assert list((job.root / "synthesis").glob("*.partial.md")) == []
+
+    rows = _read_synthesis_rows(db_path, job.id)
+    assert rows == []
 
 
 def test_synthesize_emits_synthesis_written_event(job: Job, db_path: Path, plan: Plan) -> None:


### PR DESCRIPTION
## Session Summary

**Branch:** session/epic-269-epic-pre-263-loop-fixes-time-cap-subgoal-closure-critique-cadence-partial-md-cleanup
**Issues completed:** 4 (4 succeeded, 0 failed)
**Total duration:** 83 minutes
**Completed:** 2026-05-09T21:03:33.291Z

### Issues
- #264: fix: --time-cap flag is captured but NEVER ENFORCED — daemon ignores wall-clock budget — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/272))
- #265: fix: synth stops emitting subgoal-closure JSON fence after a few passes — subgoals stay false forever — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/273))
- #266: fix: critique only fires once per long run despite cadence saying every 50 tasks — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/274))
- #267: fix: orphan synth/critique '*.partial.md' files left when handler crashes mid-write — SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-research/pull/275))

Closes #264
Closes #265
Closes #266
Closes #267

### Session Review

**Status:** PASSED
**Summary:** Fixed a router fallback integration bug; session-scoped boot, smoke, lint, and tests pass.

- [WARNING] LM Studio degraded-tier reroutes built a fresh fallback Agent, so the new frontier_alt-to-frontier critique fallback lost the original CritiqueOutput schema and critic prompt. That could make the fallback produce unstructured output or fail after the router had successfully rerouted. Fixed by rerunning the original agent with a fallback model override. (fixed) — `src/research_agent/llm/router.py`
- [INFO] In this shell, the configured smoke command exits 0 while its pytest tail reports the pre-existing NO_COLOR-sensitive status color assertion failure. Rerunning the same smoke subset with NO_COLOR unset passed. — `.alpha-loop.yaml`

---
This PR collects all changes from this session for final review before merging to main.

Automated by alpha-loop