### PR TITLE
feat: fix: orphan synth/critique '*.partial.md' files left when handler crashes mid-write (closes #267)

### DIFF
--- a/src/research_agent/daemon.py
+++ b/src/research_agent/daemon.py
@@ -331,6 +331,9 @@ DEFAULT_DISK_CAP_GB = 10.0
 # Foreground progress bar (issue #41). 2 s matches `research status --watch`
 # so the operator's two views advance in lockstep.
 FOREGROUND_PROGRESS_INTERVAL_S = 2.0
+ORPHAN_ARTIFACT_MAX_AGE_S = 300.0
+_ORPHAN_ARTIFACT_DIRS = ("plan", "synthesis", "critique")
+_ORPHAN_ARTIFACT_PATTERNS = ("*.partial.md", "*.tmp")
 
 
 def _build_router(job: Job) -> Any:
@@ -350,6 +353,83 @@ def _build_router(job: Job) -> Any:
 
     budget = BudgetTracker(job.id, cap_usd, pricing=pricing, db_path=job.db_path)
     return Router(config, budget, job=job, db_path=job.db_path)
+
+
+def _sweep_orphan_artifacts(
+    job: Job,
+    *,
+    older_than_s: float = ORPHAN_ARTIFACT_MAX_AGE_S,
+    now: float | None = None,
+) -> list[Path]:
+    """Remove stale partial/temporary artifacts left by interrupted writers."""
+    now_ts = time.time() if now is None else now
+    cleaned: list[Path] = []
+    try:
+        for dirname in _ORPHAN_ARTIFACT_DIRS:
+            root = job.root / dirname
+            if not root.is_dir():
+                continue
+            for pattern in _ORPHAN_ARTIFACT_PATTERNS:
+                for path in root.glob(pattern):
+                    try:
+                        if not path.is_file():
+                            continue
+                        stat = path.stat()
+                        age_s = max(0.0, now_ts - stat.st_mtime)
+                        if age_s < older_than_s:
+                            continue
+                        path.unlink()
+                    except FileNotFoundError:
+                        continue
+                    except OSError as exc:
+                        logger.warning(
+                            "daemon: failed to clean orphan artifact %s: %s", path, exc
+                        )
+                        try:
+                            emit(
+                                job,
+                                "WARN",
+                                "daemon",
+                                "warning",
+                                {
+                                    "stage": "orphan_artifact_sweep",
+                                    "path": str(path),
+                                    "error": str(exc),
+                                },
+                            )
+                        except Exception:
+                            pass
+                        continue
+
+                    cleaned.append(path)
+                    try:
+                        emit(
+                            job,
+                            "INFO",
+                            "daemon",
+                            "orphan_artifact_cleaned",
+                            {
+                                "path": str(path.relative_to(job.root)),
+                                "age_seconds": round(age_s, 3),
+                            },
+                        )
+                    except Exception:
+                        logger.exception(
+                            "daemon: failed to emit orphan cleanup event for %s", path
+                        )
+    except Exception as exc:  # noqa: BLE001 — startup cleanup must be best-effort
+        logger.exception("daemon: orphan artifact sweep failed for job %s", job.id)
+        try:
+            emit(
+                job,
+                "WARN",
+                "daemon",
+                "warning",
+                {"stage": "orphan_artifact_sweep", "error": str(exc)},
+            )
+        except Exception:
+            pass
+    return cleaned
 
 
 def _resolve_db_path() -> Path | None:
@@ -667,6 +747,8 @@ async def run_daemon(
     except (FileNotFoundError, KeyError, ValueError) as exc:
         logger.error("daemon: cannot load job %r: %s", job_id, exc)
         return 1
+
+    _sweep_orphan_artifacts(job)
 
     try:
         router = _build_router(job)

--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -42,6 +42,7 @@ EventKind = Literal[
     "synthesis_done",
     "synthesis_written",
     "synthesis_failed",
+    "orphan_artifact_cleaned",
     "critique_done",
     "critique_written",
     "drain_replan",

--- a/src/research_agent/orchestrator/synth.py
+++ b/src/research_agent/orchestrator/synth.py
@@ -31,6 +31,7 @@ import json
 import logging
 import re
 import sqlite3
+import traceback
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from importlib.resources import files
@@ -46,7 +47,7 @@ from research_agent.storage import db
 from research_agent.storage.markdown import (
     write_report,
     write_synthesis,
-    write_synthesis_partial,
+    write_synthesis_failed,
 )
 
 if TYPE_CHECKING:
@@ -876,12 +877,18 @@ def _write_failed_output(
     """Persist whatever content we managed to assemble + emit ``synthesis_failed``.
 
     The current call path is non-streaming so ``partial_content`` is "" — the
-    file is still written so the next attempt can spot it as prior context.
+    failed file still records the traceback for post-run debugging.
     Returns a degraded :class:`SynthesisOutput` (``model='synthesis_failed'``,
     ``truncated=True``) so callers don't have to thread an exception type.
     """
-    partial_version = write_synthesis_partial(job, partial_content, model="synthesis_failed")
-    partial_path = job.root / f"synthesis/{partial_version:04d}.partial.md"
+    traceback_text = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    failed_version = write_synthesis_failed(
+        job,
+        partial_content,
+        model="synthesis_failed",
+        traceback_text=traceback_text,
+    )
+    failed_path = job.root / f"synthesis/{failed_version:04d}.failed.md"
     emit(
         job,
         "ERROR",
@@ -891,15 +898,16 @@ def _write_failed_output(
             "tier": tier,
             "reason": str(exc),
             "attempt_count": attempt_count,
-            "partial_path": str(partial_path),
+            "failed_path": str(failed_path),
+            "traceback": traceback_text,
         },
     )
     return SynthesisOutput(
-        version=partial_version,
+        version=failed_version,
         content=partial_content,
         model="synthesis_failed",
         cost_usd=None,
-        report_path=str(partial_path),
+        report_path=str(failed_path),
         truncated=True,
     )
 

--- a/src/research_agent/storage/markdown.py
+++ b/src/research_agent/storage/markdown.py
@@ -260,29 +260,76 @@ def write_synthesis(
     return version
 
 
-def write_synthesis_partial(job: Job, content: str, model: str) -> int:
-    """Write ``synthesis/<next_version>.partial.md`` for a failed synthesis.
+def _render_failed_synthesis_md(
+    *,
+    version: int,
+    partial_content: str,
+    model: str,
+    traceback_text: str,
+    created_at: int,
+) -> str:
+    partial = partial_content.strip() or "_No partial output captured._"
+    tb = traceback_text.strip() or "No traceback captured."
+    return (
+        f"# Failed Synthesis v{version:04d}\n"
+        f"\n"
+        f"Created: {datetime.fromtimestamp(created_at, UTC).isoformat()}\n"
+        f"Model: {model}\n"
+        f"\n"
+        f"## Partial Output\n"
+        f"\n"
+        f"{partial}\n"
+        f"\n"
+        f"## Traceback\n"
+        f"\n"
+        f"```text\n"
+        f"{tb}\n"
+        f"```\n"
+    )
 
-    Used when a synthesis call exhausts retries: the (possibly empty) partial
-    output is salvaged so the next attempt can include it as context. No DB
-    row and no JSON sidecar are written — the partial file lives outside the
-    canonical ``syntheses`` table on purpose so a future successful run can
-    claim the same version number.
+
+def write_synthesis_failed(
+    job: Job,
+    partial_content: str,
+    *,
+    model: str,
+    traceback_text: str,
+) -> int:
+    """Write ``synthesis/<next_version>.failed.md`` for a failed synthesis.
+
+    Failed artifacts stay out of the canonical ``syntheses`` table and do not
+    get JSON sidecars. The next successful synthesis can still claim the same
+    DB version number while the failure remains on disk for debugging.
     """
-    if not isinstance(content, str):
-        raise ValueError(f"content must be a string; got {type(content).__name__}")
+    if not isinstance(partial_content, str):
+        raise ValueError(
+            f"partial_content must be a string; got {type(partial_content).__name__}"
+        )
     if not isinstance(model, str) or not model:
         raise ValueError("model must be a non-empty string")
+    if not isinstance(traceback_text, str):
+        raise ValueError(
+            f"traceback_text must be a string; got {type(traceback_text).__name__}"
+        )
 
+    now = _now_epoch()
     conn = db.connect(job.db_path)
     try:
         version = _next_version(conn, "syntheses", job.id)
     finally:
         conn.close()
 
-    md_rel = f"synthesis/{version:04d}.partial.md"
-    md_body = content if (not content or content.endswith("\n")) else content + "\n"
-    _atomic_write_text(job.root / md_rel, md_body)
+    md_rel = f"synthesis/{version:04d}.failed.md"
+    _atomic_write_text(
+        job.root / md_rel,
+        _render_failed_synthesis_md(
+            version=version,
+            partial_content=partial_content,
+            model=model,
+            traceback_text=traceback_text,
+            created_at=now,
+        ),
+    )
     return version
 
 
@@ -403,5 +450,5 @@ __all__ = [
     "write_plan",
     "write_report",
     "write_synthesis",
-    "write_synthesis_partial",
+    "write_synthesis_failed",
 ]

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -363,6 +363,57 @@ async def test_run_daemon_stops_on_stop_flag(
 
 
 @pytest.mark.asyncio
+async def test_run_daemon_sweeps_stale_orphan_artifacts_on_startup(
+    seeded_job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    old_partial = seeded_job.root / "synthesis" / "0004.partial.md"
+    old_tmp = seeded_job.root / "critique" / "0002.md.tmp"
+    young_partial = seeded_job.root / "plan" / "0003.partial.md"
+    old_partial.write_text("", encoding="utf-8")
+    old_tmp.write_text("half-written critique", encoding="utf-8")
+    young_partial.write_text("still being written", encoding="utf-8")
+
+    now = time.time()
+    old_mtime = now - daemon.ORPHAN_ARTIFACT_MAX_AGE_S - 1
+    os.utime(old_partial, (old_mtime, old_mtime))
+    os.utime(old_tmp, (old_mtime, old_mtime))
+    os.utime(young_partial, (now, now))
+
+    async def _instant_run_loop(job: Job, router: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"tasks_done": 0, "stopped": True, "completed": False, "cap_hit": False}
+
+    _patch_run_daemon_for_in_process(monkeypatch, run_loop_impl=_instant_run_loop)
+
+    exit_code = await daemon.run_daemon(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+
+    assert exit_code == 0
+    assert not old_partial.exists()
+    assert not old_tmp.exists()
+    assert young_partial.exists()
+
+    conn = db.connect(seeded_job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT payload_json FROM events"
+            " WHERE job_id = ? AND kind = 'orphan_artifact_cleaned'"
+            " ORDER BY id ASC",
+            (seeded_job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    cleaned_paths = {json.loads(row["payload_json"])["path"] for row in rows}
+    assert cleaned_paths == {"synthesis/0004.partial.md", "critique/0002.md.tmp"}
+    for row in rows:
+        payload = json.loads(row["payload_json"])
+        assert payload["age_seconds"] >= daemon.ORPHAN_ARTIFACT_MAX_AGE_S
+
+
+@pytest.mark.asyncio
 async def test_run_daemon_sigterm_routes_through_same_graceful_path(
     seeded_job: Job, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_orchestrator_synth.py
+++ b/tests/test_orchestrator_synth.py
@@ -353,10 +353,10 @@ def test_final_synthesis_uses_larger_top_n_and_final_flag(
     assert len(payload["findings"]) <= FINAL_TOP_N
 
 
-def test_synthesize_retry_exhaustion_writes_partial_and_emits_failed(
+def test_synthesize_retry_exhaustion_writes_failed_and_emits_failed(
     job: Job, db_path: Path, plan: Plan
 ) -> None:
-    """Terminal retry exhaustion → partial md + ``synthesis_failed`` ERROR event."""
+    """Terminal retry exhaustion → failed md + ``synthesis_failed`` ERROR event."""
     _seed_findings(job, [0.6])
     router = _StubRouter(
         side_effect={
@@ -371,15 +371,18 @@ def test_synthesize_retry_exhaustion_writes_partial_and_emits_failed(
     assert out.model == "synthesis_failed"
     assert out.cost_usd is None
 
-    # Partial md exists at the synthesis/<v>.partial.md path (no DB row written).
-    partial = job.root / f"synthesis/{out.version:04d}.partial.md"
-    assert partial.exists()
-    # Non-streaming call path — the partial is empty but its presence lets
-    # the next attempt know a prior failure happened.
-    assert partial.read_text(encoding="utf-8") == ""
+    failed_path = job.root / f"synthesis/{out.version:04d}.failed.md"
+    assert out.report_path == str(failed_path)
+    assert failed_path.exists()
+    assert list((job.root / "synthesis").glob("*.partial.md")) == []
+    failed_md = failed_path.read_text(encoding="utf-8")
+    assert "## Partial Output" in failed_md
+    assert "_No partial output captured._" in failed_md
+    assert "## Traceback" in failed_md
+    assert "RuntimeError: openrouter: connection reset after 6 retries" in failed_md
 
     rows = _read_synthesis_rows(db_path, job.id)
-    assert rows == [], "partial writes must not insert a syntheses row"
+    assert rows == [], "failed writes must not insert a syntheses row"
 
     events = _read_event_rows(db_path, job.id)
     failed = [e for e in events if e["kind"] == "synthesis_failed"]
@@ -389,7 +392,35 @@ def test_synthesize_retry_exhaustion_writes_partial_and_emits_failed(
     assert payload["tier"] == "frontier"
     assert "connection reset" in payload["reason"]
     assert payload["attempt_count"] == 1
-    assert payload["partial_path"].endswith(".partial.md")
+    assert payload["failed_path"].endswith(".failed.md")
+    assert (
+        "RuntimeError: openrouter: connection reset after 6 retries" in payload["traceback"]
+    )
+
+
+def test_failed_synthesis_artifact_includes_partial_content_and_traceback(
+    job: Job, db_path: Path
+) -> None:
+    try:
+        raise RuntimeError("handler crashed mid-write")
+    except RuntimeError as exc:
+        out = synth_module._write_failed_output(
+            job,
+            tier="frontier",
+            exc=exc,
+            attempt_count=1,
+            partial_content="# Partial report\n\nDraft body",
+        )
+
+    failed_path = job.root / f"synthesis/{out.version:04d}.failed.md"
+    failed_md = failed_path.read_text(encoding="utf-8")
+    assert "# Partial report" in failed_md
+    assert "Draft body" in failed_md
+    assert "RuntimeError: handler crashed mid-write" in failed_md
+    assert list((job.root / "synthesis").glob("*.partial.md")) == []
+
+    rows = _read_synthesis_rows(db_path, job.id)
+    assert rows == []
 
 
 def test_synthesize_emits_synthesis_written_event(job: Job, db_path: Path, plan: Plan) -> None:


### PR DESCRIPTION
Closes #267
Part of #269

## Summary

Automated implementation of **fix: orphan synth/critique '*.partial.md' files left when handler crashes mid-write**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Issue #267 code paths satisfy the orphan cleanup and failed synthesis artifact requirements.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*