### PR TITLE
feat: feat: wikidata_search connector — Wikidata SPARQL (A10) [CPU-time-aware rate limiter] (closes #232)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,16 +94,20 @@ from `src/research_agent/tools/_registry.py` via
 | `fec_search` | Candidates, committees, schedule A/E filings (OpenFEC) | `kind: candidates\|committees\|schedules/schedule_a\|schedules/schedule_e` | `Trump 2024 committee` |
 | `fedregister_search` | Federal Register rules, proposed rules, agency notices since 1994 (no auth) | `since: YYYY-MM-DD`, `agencies: [...]` | `Schedule F` |
 | `gdelt_search` | GDELT — Global news event aggregator, no `site:` operator (no auth) | `since: YYYY-MM-DD`, `language: english` | `Project 2025 mainstream coverage` |
+| `iarchive_search` | Internet Archive texts, audio, movies, and web-archive collection metadata through advancedsearch.php | `mediatype: texts\|audio\|movies\|web`, `page: <int>` | `Pullman Strike` |
 | `lda_search` | Senate Lobbying Disclosure Act filings (registrants, contributions) | `kind: filings\|registrants\|contributions` | `Heritage Foundation` |
 | `licensing_search` | State contractor / licensing-board lookups (Playwright; CA wired, others stubs) | `state: CA\|TX\|FL\|NY` | `SBI Builders` |
 | `linkedin_search` | LinkedIn person/company lookup via Proxycurl or Lix — requires broker key | `kind: person\|company` | `Sundar Pichai` |
 | `littlesis_search` | Power-mapping database — entities, donations, board seats, family ties (lead, not evidence) | `kind: entities\|relationships` | `Peter Thiel` |
+| `loc_search` | Library of Congress digital collections, including Chronicling America through the unified loc.gov API | `collection: chronicling-america\|prints\|manuscripts\|recordings\|maps`, `page: <int>` | `battle of algiers` |
 | `nonprofits_search` | ProPublica Nonprofit Explorer (Form 990 filings, no auth) | — | `Heritage Foundation` |
 | `opencorporates_search` | Global company registry — requires `OPENCORPORATES_API_KEY` | `jurisdiction: us_ca\|gb\|...` | `Acme Holdings` |
 | `sanctions_search` | OFAC SDN + UK sanctions lists (local index, no auth) | — | `Wagner Group` |
 | `scholar_search` | Google Scholar via SerpAPI — requires `SERPAPI_KEY` | `kind: case_law\|articles` | `Section 230 appellate` |
 | `sos_search` | State Secretary-of-State business entity filings (Playwright; CA wired, others stubs) | `state: CA\|DE\|NV\|...` | `Acme Corp` |
+| `trove_search` | Trove / National Library of Australia metadata for newspapers, books, photos, magazines, oral histories; metadata-only default | `category`, `zone`, `sortby` | `White Australia Policy 1901` |
 | `usaspending_search` | Federal contracts, grants, loans (award-level detail, no auth) | `award_type: contracts\|grants\|loans` | `Heritage Foundation contract` |
+| `wikidata_search` | Wikidata Query Service raw SPARQL for biographical, relational, occupational, place, and entity-ID data | `max_results` (client-side truncation; SPARQL should include `LIMIT`) | `SELECT ?item ?itemLabel WHERE { ?item wdt:P31 wd:Q5; wdt:P19 wd:Q90 . SERVICE wikibase:label { bd:serviceParam wikibase:language "en". } } LIMIT 3` |
 
 <!-- END: direct-connector-kinds -->
 

--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -105,6 +105,8 @@ TaskKind = Literal[
     "iarchive_fetch",
     "trove_search",
     "trove_fetch",
+    "wikidata_search",
+    "wikidata_fetch",
 ]
 
 ScopeClass = Literal["narrow", "medium", "broad", "comprehensive"]

--- a/src/research_agent/skills/connectors/wikidata.md
+++ b/src/research_agent/skills/connectors/wikidata.md
@@ -1,0 +1,112 @@
+---
+name: wikidata
+description: "Wikidata raw SPARQL for entity IDs, biography facts, family ties, occupations, places, and other structured relationships."
+when_to_use: "historical figures, public figures, organizations, places, occupations, family or employment ties, party/position history, and QID/PID resolution"
+when_not_to_use: "unstructured articles, narrative interpretation, current news, or natural-language questions that have not yet been translated into SPARQL"
+---
+
+# Wikidata connector
+
+Wikidata Query Service returns structured graph data from Wikidata. Use it as a
+power-mapping primitive when the investigation needs stable entity IDs, dates,
+family relationships, occupations, offices, employers, affiliations, locations,
+or cross-wiki sitelinks.
+
+v1 takes raw SPARQL queries only. Natural-language to SPARQL translation is a
+follow-on. Build queries using the Wikidata Query Service documentation:
+https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service
+
+## Time-period / era filtering
+
+Wikidata statements can have qualifiers, ranks, and incomplete dates. For
+historical research, bind date properties directly when rough chronology is
+enough, and use statement paths (`p:`, `ps:`, `pq:`) when a start/end date or
+source qualifier matters.
+
+For broad historical classes, constrain by date or place early and always add a
+small `LIMIT`. Large unconstrained human/entity queries are expensive.
+
+## Query construction
+
+- Use `wikidata_search` only with raw SPARQL in `payload.query`.
+- Add `SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }`
+  when results need readable labels.
+- Common power-mapping patterns:
+  - `P31` instance of, with `Q5` human.
+  - `P19` place of birth.
+  - `P39` position held.
+  - `P102` member of political party.
+  - `P108` employer.
+- For entity pages, follow with `wikidata_fetch` on a `https://www.wikidata.org/wiki/Q...`
+  URL to retrieve labels, descriptions, P-claims, and sitelinks.
+
+Example:
+
+```sparql
+SELECT ?item ?itemLabel ?born WHERE {
+  ?item wdt:P31 wd:Q5;
+        wdt:P19 wd:Q90;
+        wdt:P569 ?born.
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+}
+LIMIT 25
+```
+
+## Knobs available
+
+- `max_results` - client-side truncation of returned SPARQL bindings. This does
+  not reduce server work; include `LIMIT` in the SPARQL query.
+- `timeout` - request timeout in seconds.
+
+## Anti-patterns
+
+- Do not pass natural-language questions such as "Who was born in Paris?" v1
+  does not translate them.
+- Do not emit queries that can return more than 10,000 rows. WDQS kills or
+  throttles expensive queries; use `LIMIT` aggressively.
+- Do not use a large `max_results` as a substitute for SPARQL constraints.
+  Server-side `LIMIT`, date filters, place filters, and property constraints
+  are the controls that matter.
+- Do not treat every claim as fully sourced evidence. Wikidata is a structured
+  index; fetch linked source material before making high-stakes claims.
+
+## When to fan out
+
+Fan out from Wikidata when a query resolves QIDs or relationship leads that
+need evidentiary support. Typical follow-ups are:
+
+- `wikidata_fetch` for entity metadata and sitelinks.
+- `web_fetch` on linked references or sitelinks when the synthesis needs a
+  citable narrative source.
+- Domain connectors for evidence: `congress_search`, `fec_search`,
+  `courtlistener_search`, `edgar_search`, or archival connectors when the QID
+  identifies a target but not the underlying record.
+
+## Output shape
+
+`search()` returns one `SearchResult` per binding row that contains a Wikidata
+entity. `extras.entity_id` contains the QID, and `extras.bindings` contains the
+normalized SPARQL binding values.
+
+`fetch()` returns a `Source` whose metadata includes:
+
+- `entity_id` - the QID.
+- `label` and `description` - English when available, otherwise the first
+  localized value.
+- `claims` - dict of `P...` property IDs to value lists.
+- `sitelinks` - dict of wiki/site IDs to titles and URLs when present.
+
+## Auth
+
+No auth or API key is required.
+
+The rate-limit shape is unusual: WDQS allows about 60 seconds of query CPU time
+per IP plus User-Agent per minute, not a fixed requests-per-second cap. One slow
+query can consume the whole minute. The connector tracks cumulative query wall
+time over a rolling 60-second window as a CPU-time proxy and backs off before it
+submits more SPARQL.
+
+Wikimedia requires a descriptive project-identifying User-Agent. This connector
+sends `research-agent/0.1 (+https://github.com/bradtaylorsf/alpha-research; contact: ...)`
+and honors HTTP 429 `Retry-After`. Policy reference:
+https://meta.wikimedia.org/wiki/User-Agent_policy

--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -41,6 +41,7 @@ from research_agent.tools import (  # noqa: F401, E402 — side-effecting regist
     sos,
     trove,
     usaspending,
+    wikidata,
 )
 
 
@@ -679,6 +680,30 @@ def _smoke_trove_search(query: str) -> str:
                 f"  trove_id: {trove_id} | zone: {zone} | pub_date: {pub_date}\n"
                 f"  snippet: {snippet}"
             )
+        return "\n".join(lines)
+
+    return asyncio.run(_run())
+
+
+def _smoke_wikidata_search(query: str) -> str:
+    """Smoke wrapper: raw SPARQL query against Wikidata Query Service."""
+    import sys
+
+    async def _run() -> str:
+        results = await wikidata.search(query, max_results=10)
+        if not results:
+            print(
+                f"_smoke-tool wikidata_search: search({query!r}) returned 0 results",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        lines = [f"wikidata_search: returned {len(results)} hits"]
+        for hit in results:
+            snippet = hit.snippet.replace("\n", " ")
+            if len(snippet) > 240:
+                snippet = snippet[:240] + "..."
+            entity_id = hit.extras.get("entity_id") or "?"
+            lines.append(f"- {hit.title} ({entity_id})\n  {hit.url}\n  {snippet}")
         return "\n".join(lines)
 
     return asyncio.run(_run())
@@ -1338,6 +1363,7 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "littlesis": _smoke_littlesis,
     "opencorporates": _smoke_opencorporates,
     "trove_search": _smoke_trove_search,
+    "wikidata_search": _smoke_wikidata_search,
     "sos": _smoke_sos,
     "licensing": _smoke_licensing,
     "sanctions": _smoke_sanctions,

--- a/src/research_agent/tools/models.py
+++ b/src/research_agent/tools/models.py
@@ -51,6 +51,7 @@ SourceKind = Literal[
     "iarchive",
     "loc",
     "trove_search",
+    "wikidata_search",
 ]
 
 

--- a/src/research_agent/tools/wikidata.py
+++ b/src/research_agent/tools/wikidata.py
@@ -1,0 +1,650 @@
+"""Wikidata Query Service connector (issue #232, A10).
+
+Public surface:
+
+* ``async def search(query, *, max_results=20) -> list[SearchResult]`` runs a
+  raw SPARQL query against ``https://query.wikidata.org/sparql`` and returns
+  entity-shaped rows. v1 deliberately accepts raw SPARQL only; natural-language
+  to SPARQL translation is a follow-on.
+* ``async def fetch(url) -> Source | None`` resolves ``wikidata.org/wiki/Q...``
+  URLs through ``Special:EntityData`` and returns labels, descriptions, claims,
+  and sitelinks in ``Source.metadata``.
+
+No auth required. WDQS rate limiting is query-CPU-time based rather than RPS:
+one client (IP + User-Agent) gets 60 seconds of processing time per 60 seconds.
+The connector tracks local wall-clock query duration as a conservative proxy
+and backs off once the rolling minute reaches 50 seconds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import time
+from collections import deque
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from research_agent import config
+from research_agent.tools._registry import (
+    BaseSearchPayload as _BaseSearchPayload,
+)
+from research_agent.tools._registry import (
+    register_kind as _register_kind,
+)
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+KIND = "wikidata_search"
+
+_SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
+_ENTITY_DATA_BASE = "https://www.wikidata.org/wiki/Special:EntityData"
+_PROJECT_URL = "https://github.com/bradtaylorsf/alpha-research"
+_HOSTS = {"wikidata.org", "www.wikidata.org"}
+
+_RATE_WINDOW_SECONDS = 60.0
+_CPU_BUDGET_SECONDS = 60.0
+_BACKOFF_THRESHOLD_SECONDS = _CPU_BUDGET_SECONDS - 10.0
+_DEFAULT_RETRY_AFTER_SECONDS = 60.0
+
+_QID_RE = re.compile(r"\bQ[1-9]\d*\b")
+_EMAIL_RE = re.compile(r"[\w.!#$%&'*+/=?^`{|}~-]+@[\w-]+(?:\.[\w-]+)+")
+
+_rate_lock = asyncio.Lock()
+_query_durations: deque[tuple[float, float]] = deque()
+
+
+class _SparqlBindingValue(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    type: str | None = None
+    value: Any
+    datatype: str | None = None
+    xml_lang: str | None = Field(default=None, alias="xml:lang")
+
+
+class _SparqlResults(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    bindings: list[dict[str, _SparqlBindingValue]]
+
+
+class _SparqlResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    head: dict[str, Any]
+    results: _SparqlResults
+
+
+def _contact_from_user_agent() -> str:
+    raw = config.get("RESEARCH_USER_AGENT") or ""
+    match = _EMAIL_RE.search(raw)
+    return match.group(0) if match else "unset"
+
+
+def _user_agent() -> str:
+    return (
+        "research-agent/0.1 "
+        f"(+{_PROJECT_URL}; contact: {_contact_from_user_agent()})"
+    )
+
+
+def _sparql_headers() -> dict[str, str]:
+    return {
+        "Accept": "application/sparql-results+json",
+        "User-Agent": _user_agent(),
+    }
+
+
+def _json_headers() -> dict[str, str]:
+    return {
+        "Accept": "application/json",
+        "User-Agent": _user_agent(),
+    }
+
+
+def _prune_durations(now: float) -> None:
+    while _query_durations and now - _query_durations[0][0] >= _RATE_WINDOW_SECONDS:
+        _query_durations.popleft()
+
+
+async def _rate_limit_gate() -> None:
+    """Wait until the rolling WDQS CPU budget is comfortably below 60s/min."""
+    async with _rate_lock:
+        while True:
+            now = time.monotonic()
+            _prune_durations(now)
+            used = sum(duration for _, duration in _query_durations)
+            if used < _BACKOFF_THRESHOLD_SECONDS:
+                return
+            if not _query_durations:
+                return
+            wait = max(_query_durations[0][0] + _RATE_WINDOW_SECONDS - now, 0.1)
+            logger.info(
+                "wikidata CPU-budget backoff: %.2fs used in rolling %.0fs; sleeping %.2fs",
+                used,
+                _RATE_WINDOW_SECONDS,
+                wait,
+            )
+            await asyncio.sleep(wait)
+
+
+async def _record_query_duration(duration: float) -> None:
+    async with _rate_lock:
+        now = time.monotonic()
+        _prune_durations(now)
+        _query_durations.append((now, max(duration, 0.0)))
+
+
+def _parse_retry_after(value: str | None) -> float:
+    if not value:
+        return _DEFAULT_RETRY_AFTER_SECONDS
+    text = value.strip()
+    try:
+        return max(float(text), 0.0)
+    except ValueError:
+        pass
+    try:
+        parsed = parsedate_to_datetime(text)
+    except (TypeError, ValueError):
+        return _DEFAULT_RETRY_AFTER_SECONDS
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return max((parsed - datetime.now(UTC)).total_seconds(), 0.0)
+
+
+async def _request_sparql(
+    query: str,
+    *,
+    timeout: float,
+) -> dict[str, Any] | None:
+    for attempt in range(2):
+        await _rate_limit_gate()
+        started = time.monotonic()
+        try:
+            async with httpx.AsyncClient(
+                follow_redirects=True,
+                timeout=timeout,
+                headers=_sparql_headers(),
+            ) as client:
+                response = await client.post(_SPARQL_ENDPOINT, data={"query": query})
+        except (httpx.HTTPError, OSError) as exc:
+            await _record_query_duration(time.monotonic() - started)
+            logger.warning("wikidata SPARQL request failed: %s", exc)
+            return None
+
+        await _record_query_duration(time.monotonic() - started)
+
+        if response.status_code == 429:
+            retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+            if attempt == 0:
+                logger.warning(
+                    "wikidata SPARQL returned 429; honoring Retry-After %.2fs",
+                    retry_after,
+                )
+                await asyncio.sleep(retry_after)
+                continue
+            logger.warning("wikidata SPARQL returned repeated HTTP 429")
+            return None
+
+        if response.status_code != 200:
+            logger.warning("wikidata SPARQL returned HTTP %s", response.status_code)
+            return None
+
+        try:
+            payload = response.json()
+        except (json.JSONDecodeError, ValueError) as exc:
+            logger.warning("wikidata SPARQL returned non-JSON response: %s", exc)
+            return None
+        if not isinstance(payload, dict):
+            logger.warning("wikidata SPARQL JSON root was %s", type(payload).__name__)
+            return None
+        return payload
+    return None
+
+
+def _entity_id_from_value(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    match = _QID_RE.search(value)
+    return match.group(0) if match else ""
+
+
+def _display_value(value: _SparqlBindingValue) -> str:
+    raw = value.value
+    qid = _entity_id_from_value(raw)
+    if qid and isinstance(raw, str) and "wikidata.org/entity/" in raw:
+        return qid
+    if isinstance(raw, str):
+        return raw.strip()
+    return str(raw).strip()
+
+
+def _normalize_binding_value(value: _SparqlBindingValue) -> dict[str, Any]:
+    normalized: dict[str, Any] = {
+        "type": value.type or "",
+        "value": value.value,
+    }
+    if value.datatype:
+        normalized["datatype"] = value.datatype
+    if value.xml_lang:
+        normalized["lang"] = value.xml_lang
+    qid = _entity_id_from_value(value.value)
+    if qid:
+        normalized["entity_id"] = qid
+    return normalized
+
+
+def _find_entity_binding(bindings: dict[str, _SparqlBindingValue]) -> tuple[str, str]:
+    for name in ("item", "entity", "person", "subject", "human"):
+        value = bindings.get(name)
+        if value is not None:
+            qid = _entity_id_from_value(value.value)
+            if qid:
+                return name, qid
+    for name, value in bindings.items():
+        qid = _entity_id_from_value(value.value)
+        if qid:
+            return name, qid
+    return "", ""
+
+
+def _first_literal(
+    bindings: dict[str, _SparqlBindingValue],
+    candidates: list[str],
+) -> tuple[str, str]:
+    seen = set(candidates)
+    for name in list(bindings):
+        if name.endswith("Label") and name not in seen:
+            candidates.append(name)
+            seen.add(name)
+    for name in candidates:
+        value = bindings.get(name)
+        if value is None:
+            continue
+        text = _display_value(value)
+        if text:
+            return name, text
+    return "", ""
+
+
+def _snippet_for_row(
+    bindings: dict[str, _SparqlBindingValue],
+    *,
+    entity_var: str,
+    qid: str,
+    label_var: str,
+) -> str:
+    _, description = _first_literal(
+        bindings,
+        [
+            f"{entity_var}Description",
+            "itemDescription",
+            "entityDescription",
+            "description",
+        ],
+    )
+    parts: list[str] = []
+    if description:
+        parts.append(description)
+
+    skip = {entity_var, label_var}
+    for name, value in bindings.items():
+        if name in skip or name.endswith("Label") or name.endswith("Description"):
+            continue
+        text = _display_value(value)
+        if text:
+            parts.append(f"{name}: {text}")
+        if len(parts) >= 5:
+            break
+    return "; ".join(parts) or f"Wikidata entity {qid}"
+
+
+def _build_search_result(bindings: dict[str, _SparqlBindingValue]) -> SearchResult | None:
+    entity_var, qid = _find_entity_binding(bindings)
+    if not qid:
+        return None
+
+    label_var, label = _first_literal(
+        bindings,
+        [
+            f"{entity_var}Label",
+            "itemLabel",
+            "entityLabel",
+            "personLabel",
+            "label",
+            "name",
+        ],
+    )
+    title = label or qid
+    url = f"https://www.wikidata.org/wiki/{qid}"
+    normalized_bindings = {
+        name: _normalize_binding_value(value) for name, value in bindings.items()
+    }
+    return SearchResult(
+        url=url,
+        title=title,
+        snippet=_snippet_for_row(
+            bindings,
+            entity_var=entity_var,
+            qid=qid,
+            label_var=label_var,
+        ),
+        source_kind=KIND,
+        extras={
+            "entity_id": qid,
+            "entity_var": entity_var,
+            "bindings": normalized_bindings,
+        },
+    )
+
+
+async def search(
+    query: str,
+    *,
+    max_results: int = 20,
+    timeout: float = 30.0,
+) -> list[SearchResult]:
+    """Run a raw SPARQL query against WDQS and return entity-shaped rows."""
+    if max_results <= 0:
+        return []
+    sparql = query.strip()
+    if not sparql:
+        return []
+
+    payload = await _request_sparql(sparql, timeout=timeout)
+    if payload is None:
+        return []
+    try:
+        parsed = _SparqlResponse.model_validate(payload)
+    except ValidationError as exc:
+        logger.warning("wikidata SPARQL response failed schema validation: %s", exc)
+        return []
+
+    results: list[SearchResult] = []
+    for row in parsed.results.bindings:
+        result = _build_search_result(row)
+        if result is None:
+            continue
+        results.append(result)
+        if len(results) >= max_results:
+            break
+    return results
+
+
+def _extract_qid_from_url(url: str) -> str:
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return ""
+    if parsed.scheme not in {"http", "https"}:
+        return ""
+    host = (parsed.hostname or "").lower()
+    if host not in _HOSTS:
+        return ""
+    path = unquote(parsed.path or "")
+    match = _QID_RE.search(path)
+    return match.group(0) if match else ""
+
+
+def _localized_value(bucket: Any) -> str:
+    if not isinstance(bucket, dict) or not bucket:
+        return ""
+    preferred = bucket.get("en")
+    if isinstance(preferred, dict) and isinstance(preferred.get("value"), str):
+        return preferred["value"].strip()
+    for entry in bucket.values():
+        if isinstance(entry, dict) and isinstance(entry.get("value"), str):
+            text = entry["value"].strip()
+            if text:
+                return text
+    return ""
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_jsonable(v) for v in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _claim_value(claim: Any) -> Any:
+    if not isinstance(claim, dict):
+        return None
+    mainsnak = claim.get("mainsnak")
+    if not isinstance(mainsnak, dict):
+        return None
+    datavalue = mainsnak.get("datavalue")
+    if not isinstance(datavalue, dict):
+        return None
+    value = datavalue.get("value")
+    if isinstance(value, dict):
+        if isinstance(value.get("id"), str):
+            return value["id"]
+        if isinstance(value.get("time"), str):
+            return value["time"]
+        if isinstance(value.get("text"), str):
+            return value["text"]
+        if "latitude" in value and "longitude" in value:
+            return {
+                "latitude": value.get("latitude"),
+                "longitude": value.get("longitude"),
+                "precision": value.get("precision"),
+                "globe": value.get("globe"),
+            }
+        if isinstance(value.get("amount"), str):
+            return value["amount"]
+        return _jsonable(value)
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    return None
+
+
+def _normalize_claims(raw_claims: Any) -> dict[str, list[Any]]:
+    if not isinstance(raw_claims, dict):
+        return {}
+    claims: dict[str, list[Any]] = {}
+    for pid, entries in raw_claims.items():
+        if not isinstance(pid, str) or not pid.startswith("P"):
+            continue
+        values: list[Any] = []
+        if isinstance(entries, list):
+            for claim in entries:
+                value = _claim_value(claim)
+                if value is not None:
+                    values.append(value)
+        if values:
+            claims[pid] = values
+    return claims
+
+
+def _normalize_sitelinks(raw_sitelinks: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(raw_sitelinks, dict):
+        return {}
+    sitelinks: dict[str, dict[str, Any]] = {}
+    for site, entry in raw_sitelinks.items():
+        if not isinstance(site, str) or not isinstance(entry, dict):
+            continue
+        title = entry.get("title")
+        if not isinstance(title, str) or not title:
+            continue
+        url = entry.get("url")
+        badges = entry.get("badges")
+        sitelinks[site] = {
+            "title": title,
+            "url": url if isinstance(url, str) else "",
+            "badges": badges if isinstance(badges, list) else [],
+        }
+    return sitelinks
+
+
+def _property_sort_key(pid: str) -> tuple[int, str]:
+    try:
+        return (int(pid[1:]), pid)
+    except ValueError:
+        return (10**9, pid)
+
+
+def _format_md_value(value: Any) -> str:
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=True, sort_keys=True)
+    return str(value)
+
+
+def _metadata_markdown(
+    *,
+    qid: str,
+    label: str,
+    description: str,
+    claims: dict[str, list[Any]],
+    sitelinks: dict[str, dict[str, Any]],
+) -> str:
+    lines = [f"# {label or qid}", "", f"Entity: {qid}"]
+    if description:
+        lines.extend(["", description])
+    lines.extend(["", "## Claims"])
+    if claims:
+        for pid in sorted(claims, key=_property_sort_key):
+            values = claims[pid]
+            preview = ", ".join(_format_md_value(v) for v in values[:5])
+            if len(values) > 5:
+                preview += f", ... (+{len(values) - 5} more)"
+            lines.append(f"- {pid}: {preview}")
+    else:
+        lines.append("- (none)")
+    lines.extend(["", "## Sitelinks"])
+    if sitelinks:
+        for site in sorted(sitelinks)[:20]:
+            entry = sitelinks[site]
+            lines.append(f"- {site}: {entry['title']}")
+    else:
+        lines.append("- (none)")
+    return "\n".join(lines).strip()
+
+
+async def _fetch_entity_json(qid: str, *, timeout: float) -> dict[str, Any] | None:
+    url = f"{_ENTITY_DATA_BASE}/{qid}.json"
+    for attempt in range(2):
+        try:
+            async with httpx.AsyncClient(
+                follow_redirects=True,
+                timeout=timeout,
+                headers=_json_headers(),
+            ) as client:
+                response = await client.get(url)
+        except (httpx.HTTPError, OSError) as exc:
+            logger.warning("wikidata entity fetch failed for %s: %s", qid, exc)
+            return None
+        if response.status_code == 429 and attempt == 0:
+            retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+            logger.warning(
+                "wikidata entity fetch returned 429; honoring Retry-After %.2fs",
+                retry_after,
+            )
+            await asyncio.sleep(retry_after)
+            continue
+        if response.status_code != 200:
+            logger.warning(
+                "wikidata entity fetch returned HTTP %s for %s",
+                response.status_code,
+                qid,
+            )
+            return None
+        try:
+            payload = response.json()
+        except (json.JSONDecodeError, ValueError) as exc:
+            logger.warning("wikidata entity fetch returned non-JSON body: %s", exc)
+            return None
+        return payload if isinstance(payload, dict) else None
+    return None
+
+
+async def fetch(url: str, *, timeout: float = 20.0) -> Source | None:
+    """Fetch a Wikidata entity URL and return structured metadata."""
+    qid = _extract_qid_from_url(url)
+    if not qid:
+        return None
+
+    payload = await _fetch_entity_json(qid, timeout=timeout)
+    if payload is None:
+        return None
+    entities = payload.get("entities")
+    if not isinstance(entities, dict):
+        return None
+    entity = entities.get(qid)
+    if not isinstance(entity, dict):
+        return None
+
+    label = _localized_value(entity.get("labels")) or qid
+    description = _localized_value(entity.get("descriptions"))
+    claims = _normalize_claims(entity.get("claims"))
+    sitelinks = _normalize_sitelinks(entity.get("sitelinks"))
+    canonical = f"https://www.wikidata.org/wiki/{qid}"
+    metadata = {
+        "entity_id": qid,
+        "label": label,
+        "description": description,
+        "claims": claims,
+        "sitelinks": sitelinks,
+    }
+    return Source(
+        url=canonical,
+        title=label,
+        cleaned_text=_metadata_markdown(
+            qid=qid,
+            label=label,
+            description=description,
+            claims=claims,
+            sitelinks=sitelinks,
+        ),
+        raw_html=None,
+        fetched_at=datetime.now(UTC),
+        source_kind=KIND,
+        metadata=metadata,
+    )
+
+
+def reset_for_tests() -> None:
+    """Clear per-process rate-limit state. Test-only."""
+    global _rate_lock
+    _query_durations.clear()
+    _rate_lock = asyncio.Lock()
+
+
+class _PayloadSchema(_BaseSearchPayload):
+    max_results: int | None = None
+    timeout: float | None = None
+
+
+_register_kind(
+    KIND,
+    payload_schema=_PayloadSchema,
+    search_fn=search,
+    fetch_fn=fetch,
+    host_patterns=("wikidata.org", "www.wikidata.org", "query.wikidata.org"),
+    skill_name="wikidata",
+    description=(
+        "Wikidata Query Service raw SPARQL for biographical, relational,"
+        " occupational, place, and entity-ID data"
+    ),
+    optional_payload_knobs="`max_results` (client-side truncation; SPARQL should include `LIMIT`)",
+    example_query=(
+        'SELECT ?item ?itemLabel WHERE { ?item wdt:P31 wd:Q5; wdt:P19 wd:Q90 . '
+        'SERVICE wikibase:label { bd:serviceParam wikibase:language "en". } } LIMIT 3'
+    ),
+    module_name="wikidata",
+)
+
+
+__all__ = ["KIND", "fetch", "reset_for_tests", "search"]

--- a/tests/fixtures/wikidata/entity_q42.json
+++ b/tests/fixtures/wikidata/entity_q42.json
@@ -1,0 +1,92 @@
+{
+  "entities": {
+    "Q42": {
+      "id": "Q42",
+      "labels": {
+        "en": {
+          "language": "en",
+          "value": "Douglas Adams"
+        }
+      },
+      "descriptions": {
+        "en": {
+          "language": "en",
+          "value": "English writer and humorist"
+        }
+      },
+      "claims": {
+        "P31": [
+          {
+            "mainsnak": {
+              "datavalue": {
+                "type": "wikibase-entityid",
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 5,
+                  "id": "Q5"
+                }
+              }
+            }
+          }
+        ],
+        "P569": [
+          {
+            "mainsnak": {
+              "datavalue": {
+                "type": "time",
+                "value": {
+                  "time": "+1952-03-11T00:00:00Z",
+                  "timezone": 0,
+                  "before": 0,
+                  "after": 0,
+                  "precision": 11,
+                  "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+                }
+              }
+            }
+          }
+        ],
+        "P106": [
+          {
+            "mainsnak": {
+              "datavalue": {
+                "type": "wikibase-entityid",
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 36180,
+                  "id": "Q36180"
+                }
+              }
+            }
+          },
+          {
+            "mainsnak": {
+              "datavalue": {
+                "type": "wikibase-entityid",
+                "value": {
+                  "entity-type": "item",
+                  "numeric-id": 6625963,
+                  "id": "Q6625963"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "sitelinks": {
+        "enwiki": {
+          "site": "enwiki",
+          "title": "Douglas Adams",
+          "badges": [],
+          "url": "https://en.wikipedia.org/wiki/Douglas_Adams"
+        },
+        "commonswiki": {
+          "site": "commonswiki",
+          "title": "Douglas Adams",
+          "badges": [],
+          "url": "https://commons.wikimedia.org/wiki/Douglas_Adams"
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/wikidata/search_empty.json
+++ b/tests/fixtures/wikidata/search_empty.json
@@ -1,0 +1,10 @@
+{
+  "head": {
+    "vars": [
+      "item"
+    ]
+  },
+  "results": {
+    "bindings": []
+  }
+}

--- a/tests/fixtures/wikidata/search_paris_humans.json
+++ b/tests/fixtures/wikidata/search_paris_humans.json
@@ -1,0 +1,61 @@
+{
+  "head": {
+    "vars": [
+      "item",
+      "itemLabel",
+      "itemDescription",
+      "birth",
+      "img"
+    ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "item": {
+          "type": "uri",
+          "value": "http://www.wikidata.org/entity/Q535"
+        },
+        "itemLabel": {
+          "xml:lang": "en",
+          "type": "literal",
+          "value": "Victor Hugo"
+        },
+        "itemDescription": {
+          "xml:lang": "en",
+          "type": "literal",
+          "value": "French poet, novelist, and dramatist"
+        },
+        "birth": {
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "type": "literal",
+          "value": "1802-02-26T00:00:00Z"
+        },
+        "img": {
+          "type": "uri",
+          "value": "http://commons.wikimedia.org/wiki/Special:FilePath/Victor%20Hugo.jpg"
+        }
+      },
+      {
+        "item": {
+          "type": "uri",
+          "value": "http://www.wikidata.org/entity/Q5593"
+        },
+        "itemLabel": {
+          "xml:lang": "en",
+          "type": "literal",
+          "value": "Simone de Beauvoir"
+        },
+        "itemDescription": {
+          "xml:lang": "en",
+          "type": "literal",
+          "value": "French writer, intellectual, existentialist philosopher, political activist, feminist and social theorist"
+        },
+        "birth": {
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "type": "literal",
+          "value": "1908-01-09T00:00:00Z"
+        }
+      }
+    ]
+  }
+}

--- a/tests/research_agent/tools/test_registry.py
+++ b/tests/research_agent/tools/test_registry.py
@@ -257,6 +257,7 @@ def test_live_registry_has_all_registered_connectors() -> None:
         "sos_search",
         "trove_search",
         "usaspending_search",
+        "wikidata_search",
     }
     actual = {entry.name for entry in iter_kinds()}
     assert expected == actual
@@ -280,4 +281,5 @@ def test_live_registry_skill_name_assignment() -> None:
         "iarchive_search": "iarchive",
         "loc_search": "loc",
         "trove_search": "trove",
+        "wikidata_search": "wikidata",
     }

--- a/tests/research_agent/tools/test_wikidata.py
+++ b/tests/research_agent/tools/test_wikidata.py
@@ -1,0 +1,254 @@
+"""Tests for ``research_agent.tools.wikidata`` (issue #232)."""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from research_agent.tools import wikidata
+
+FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "wikidata"
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch: pytest.MonkeyPatch):
+    wikidata.reset_for_tests()
+    monkeypatch.setenv("RESEARCH_USER_AGENT", "operator@example.test")
+    monkeypatch.setattr(wikidata.asyncio, "sleep", AsyncMock())
+    yield
+    wikidata.reset_for_tests()
+
+
+class _FakeResp:
+    def __init__(
+        self,
+        status: int,
+        payload,
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.status_code = status
+        self._payload = payload
+        self.headers = headers or {}
+
+    def json(self):
+        if isinstance(self._payload, BaseException):
+            raise self._payload
+        return self._payload
+
+
+def _fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _patch_httpx(monkeypatch: pytest.MonkeyPatch, *, responder):
+    captured: dict[str, list] = {
+        "urls": [],
+        "headers": [],
+        "data": [],
+        "methods": [],
+    }
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        captured["headers"].append(kwargs.get("headers"))
+
+        class _Client:
+            async def post(self, url, *, data=None, **_kwargs):
+                captured["methods"].append("post")
+                captured["urls"].append(url)
+                captured["data"].append(data)
+                return responder("post", url, data)
+
+            async def get(self, url, **_kwargs):
+                captured["methods"].append("get")
+                captured["urls"].append(url)
+                captured["data"].append(None)
+                return responder("get", url, None)
+
+        yield _Client()
+
+    monkeypatch.setattr(wikidata.httpx, "AsyncClient", _client_factory)
+    return captured
+
+
+async def test_search_happy_path_raw_sparql(monkeypatch: pytest.MonkeyPatch):
+    payload = _fixture("search_paris_humans.json")
+    query = (
+        "SELECT ?item ?itemLabel WHERE { "
+        "?item wdt:P31 wd:Q5; wdt:P19 wd:Q90 } LIMIT 3"
+    )
+
+    def _respond(method, url, data):
+        return _FakeResp(200, payload)
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await wikidata.search(query, max_results=1)
+
+    assert len(results) == 1
+    first = results[0]
+    assert first.source_kind == "wikidata_search"
+    assert first.title == "Victor Hugo"
+    assert first.url == "https://www.wikidata.org/wiki/Q535"
+    assert "French poet" in first.snippet
+    assert first.extras["entity_id"] == "Q535"
+    assert first.extras["bindings"]["item"]["entity_id"] == "Q535"
+    assert first.extras["bindings"]["birth"]["value"] == "1802-02-26T00:00:00Z"
+
+    assert captured["methods"] == ["post"]
+    assert captured["urls"] == ["https://query.wikidata.org/sparql"]
+    assert captured["data"] == [{"query": query}]
+    headers = captured["headers"][0]
+    assert headers["Accept"] == "application/sparql-results+json"
+    assert headers["User-Agent"] == (
+        "research-agent/0.1 "
+        "(+https://github.com/bradtaylorsf/alpha-research; "
+        "contact: operator@example.test)"
+    )
+
+
+async def test_search_empty_payload_returns_empty(monkeypatch: pytest.MonkeyPatch):
+    payload = _fixture("search_empty.json")
+
+    def _respond(method, url, data):
+        return _FakeResp(200, payload)
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await wikidata.search("SELECT ?item WHERE {} LIMIT 1") == []
+
+
+async def test_search_honors_429_retry_after(monkeypatch: pytest.MonkeyPatch):
+    payload = _fixture("search_paris_humans.json")
+    calls = {"count": 0}
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr(wikidata.asyncio, "sleep", fake_sleep)
+
+    def _respond(method, url, data):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return _FakeResp(429, {}, headers={"Retry-After": "2"})
+        return _FakeResp(200, payload)
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await wikidata.search("SELECT ?item WHERE {} LIMIT 1")
+
+    assert len(results) == 2
+    assert calls["count"] == 2
+    assert sleep_calls == [2.0]
+
+
+async def test_cpu_budget_backoff_when_rolling_duration_exceeds_50s(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    payload = _fixture("search_empty.json")
+    clock = [100.0]
+    sleep_calls: list[float] = []
+
+    def fake_monotonic() -> float:
+        return clock[0]
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        clock[0] += seconds
+
+    monkeypatch.setattr(wikidata.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(wikidata.asyncio, "sleep", fake_sleep)
+    await wikidata._record_query_duration(51.0)
+
+    def _respond(method, url, data):
+        return _FakeResp(200, payload)
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    await wikidata.search("SELECT ?item WHERE {} LIMIT 1")
+
+    assert sleep_calls == [60.0]
+
+
+async def test_search_schema_fail_returns_empty(monkeypatch: pytest.MonkeyPatch):
+    def _respond(method, url, data):
+        return _FakeResp(200, {"head": {"vars": ["item"]}, "results": {"bindings": {}}})
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await wikidata.search("SELECT ?item WHERE {} LIMIT 1") == []
+
+
+async def test_search_returns_empty_on_transport_error(monkeypatch: pytest.MonkeyPatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def post(self, *_args, **_kwargs):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(wikidata.httpx, "AsyncClient", _client_factory)
+
+    assert await wikidata.search("SELECT ?item WHERE {} LIMIT 1") == []
+
+
+async def test_fetch_entity_populates_metadata_claims_and_sitelinks(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    payload = _fixture("entity_q42.json")
+
+    def _respond(method, url, data):
+        return _FakeResp(200, payload)
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await wikidata.fetch("https://www.wikidata.org/wiki/Q42")
+
+    assert source is not None
+    assert source.source_kind == "wikidata_search"
+    assert source.url == "https://www.wikidata.org/wiki/Q42"
+    assert source.title == "Douglas Adams"
+    assert "English writer and humorist" in source.cleaned_text
+    assert "P31: Q5" in source.cleaned_text
+    assert source.metadata["entity_id"] == "Q42"
+    assert source.metadata["label"] == "Douglas Adams"
+    assert source.metadata["description"] == "English writer and humorist"
+    assert source.metadata["claims"]["P31"] == ["Q5"]
+    assert source.metadata["claims"]["P569"] == ["+1952-03-11T00:00:00Z"]
+    assert source.metadata["claims"]["P106"] == ["Q36180", "Q6625963"]
+    assert source.metadata["sitelinks"]["enwiki"]["title"] == "Douglas Adams"
+    assert source.metadata["sitelinks"]["enwiki"]["url"] == (
+        "https://en.wikipedia.org/wiki/Douglas_Adams"
+    )
+    assert captured["methods"] == ["get"]
+    assert captured["urls"] == ["https://www.wikidata.org/wiki/Special:EntityData/Q42.json"]
+    assert captured["headers"][0]["Accept"] == "application/json"
+
+
+async def test_fetch_rejects_non_wikidata_q_url() -> None:
+    assert await wikidata.fetch("https://example.com/wiki/Q42") is None
+    assert await wikidata.fetch("https://www.wikidata.org/wiki/NotQ") is None
+
+
+def test_smoke_registry_includes_wikidata_search() -> None:
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "wikidata_search" in TOOL_REGISTRY
+    assert callable(TOOL_REGISTRY["wikidata_search"])
+
+
+def test_registered_kind_links_wikidata_skill() -> None:
+    from research_agent.tools._registry import get_kind
+
+    entry = get_kind("wikidata_search")
+    assert entry is not None
+    assert entry.skill_name == "wikidata"
+    assert entry.fetch_fn is wikidata.fetch

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -433,6 +433,8 @@ def test_check_registry_skill_coherence_skips_grandfathered() -> None:
     # ``congress_search`` ships a skill — must be ok.
     ok_row = by_name["registry_skill:congress_search"]
     assert ok_row.status == "ok"
+    wikidata_row = by_name["registry_skill:wikidata_search"]
+    assert wikidata_row.status == "ok"
 
 
 def test_check_registry_skill_coherence_fails_when_skill_file_missing(

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -550,6 +550,7 @@ CONNECTOR_KIND_PREFIXES: tuple[str, ...] = (
     "linkedin",
     "iarchive",
     "trove",
+    "wikidata",
 )
 
 # Connector module name → ``source_kind`` Literal value. Most connectors
@@ -557,6 +558,7 @@ CONNECTOR_KIND_PREFIXES: tuple[str, ...] = (
 _CONNECTOR_SOURCE_KIND: dict[str, str] = {p: p for p in CONNECTOR_KIND_PREFIXES}
 _CONNECTOR_SOURCE_KIND["edgar"] = "sec"
 _CONNECTOR_SOURCE_KIND["trove"] = "trove_search"
+_CONNECTOR_SOURCE_KIND["wikidata"] = "wikidata_search"
 
 
 def test_default_handlers_covers_every_task_kind() -> None:

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -63,6 +63,7 @@ CONNECTOR_KIND_PREFIXES: tuple[str, ...] = (
     "linkedin",
     "iarchive",
     "trove",
+    "wikidata",
 )
 
 

--- a/tests/test_tools_models.py
+++ b/tests/test_tools_models.py
@@ -45,6 +45,7 @@ EXPECTED_SOURCE_KINDS = (
     "iarchive",
     "loc",
     "trove_search",
+    "wikidata_search",
 )
 
 


### PR DESCRIPTION
Closes #232
Part of #251

## Summary

Automated implementation of **feat: wikidata_search connector — Wikidata SPARQL (A10) [CPU-time-aware rate limiter]**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Review fixes applied for Wikidata fetch dispatch and timeout passthrough; focused verification passes, live WDQS smoke blocked by sandbox DNS.

- **CRITICAL** [FIXED] `src/research_agent/tools/web_fetch.py`: wikidata_search results were expanded to web_fetch follow-ups, but web_fetch did not dispatch wikidata.org entity URLs to wikidata.fetch, so the default pipeline would fetch generic HTML instead of structured entity metadata with claims and sitelinks.
- **WARNING** [FIXED] `src/research_agent/orchestrator/loop.py`: The Wikidata skill and payload schema exposed a timeout knob, but the orchestrator passthrough allowlist dropped timeout before calling wikidata.search.
- **INFO** [OPEN] `tests/test_observability_events.py`: Full pytest has an unrelated filesystem watcher failure in test_tail_events_follow_yields_appended in this sandbox; the suite passes when that single pre-existing test is deselected.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*