### PR TITLE
feat: feat: wikisource_search connector — Wikisource (A12) (closes #234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ from `src/research_agent/tools/_registry.py` via
 | `trove_search` | Trove / National Library of Australia metadata for newspapers, books, photos, magazines, oral histories; metadata-only default | `category`, `zone`, `sortby` | `White Australia Policy 1901` |
 | `usaspending_search` | Federal contracts, grants, loans (award-level detail, no auth) | `award_type: contracts\|grants\|loans` | `Heritage Foundation contract` |
 | `wikidata_search` | Wikidata Query Service raw SPARQL for biographical, relational, occupational, place, and entity-ID data | `max_results` (client-side truncation; SPARQL should include `LIMIT`) | `SELECT ?item ?itemLabel WHERE { ?item wdt:P31 wd:Q5; wdt:P19 wd:Q90 . SERVICE wikibase:label { bd:serviceParam wikibase:language "en". } } LIMIT 3` |
+| `wikisource_search` | Wikisource transcribed primary documents across per-language hosts; fetch returns the full source text in cleaned_text | `lang: en|fr|es|de|it|pt|nl|ru|zh|ja|ar`, `max_results` | `Treaty of Versailles` |
 
 <!-- END: direct-connector-kinds -->
 

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -194,6 +194,7 @@ _CONNECTOR_SEARCH_PASSTHROUGH: frozenset[str] = frozenset(
         "jurisdiction",
         "award_type",
         "language",
+        "lang",
         "category",
         "zone",
         "sortby",

--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -109,6 +109,8 @@ TaskKind = Literal[
     "trove_fetch",
     "wikidata_search",
     "wikidata_fetch",
+    "wikisource_search",
+    "wikisource_fetch",
 ]
 
 ScopeClass = Literal["narrow", "medium", "broad", "comprehensive"]

--- a/src/research_agent/skills/connectors/wikisource.md
+++ b/src/research_agent/skills/connectors/wikisource.md
@@ -1,0 +1,90 @@
+---
+name: wikisource
+description: "Wikisource public-domain and freely licensed transcribed primary documents; fetch full text into cleaned_text."
+when_to_use: "named source texts such as treaties, speeches, manifestos, court opinions, founding-era pamphlets, statutes, and historical proclamations"
+when_not_to_use: "living-author or copyrighted modern content; encyclopedia facts -> web_search/Wikipedia; media assets -> commons_search"
+---
+
+# Wikisource connector
+
+Wikisource is a multilingual library of public-domain and freely licensed
+transcribed source texts. Use `wikisource_search` when the research target needs
+the actual words of a primary document: treaties, speeches, manifestos, court
+opinions, founding-era pamphlets, historical legislation, proclamations, and
+similar source texts.
+
+The connector uses per-language MediaWiki hosts:
+`<lang>.wikisource.org/w/api.php`. The default is `lang=en`; supported language
+knobs include `en`, `fr`, `es`, `de`, `it`, `pt`, `nl`, `ru`, `zh`, `ja`, and
+`ar`.
+
+The important contract is that `fetch()` returns the full transcribed body in
+`Source.cleaned_text`. These are searchable primary documents, so do not leave
+the document body only in metadata or snippets.
+
+## Time-period / era filtering
+
+Wikisource search has no first-class date filter in this connector. Include the
+era in the query when a title is ambiguous: `Treaty of Versailles 1919`,
+`Federalist No. 10 1787`, `Declaration of Independence 1776`.
+
+For non-English documents, pair the connector with the
+`multilingual-source-handling` strategy. Query the local-language title on the
+matching language host and keep the original-language text visible in evidence.
+
+## Query construction
+
+- Prefer specific named documents over broad keyword discovery:
+  `Treaty of Versailles`, `Federalist No. 10`, `Emancipation Proclamation`,
+  `Declaration of Algerian Independence`.
+- Use the title as printed where possible. Add author, year, or jurisdiction
+  only when the title is ambiguous.
+- For translated or multilingual topics, fan out by language: English title on
+  `lang=en`, French title on `lang=fr`, Spanish title on `lang=es`, and so on.
+- Wikisource is not Wikipedia. Search for source texts, not encyclopedia topic
+  summaries.
+
+## Knobs available
+
+- `lang` - Wikisource language host. Default `en`. Minimum supported set:
+  `en|fr|es|de|it|pt|nl|ru|zh|ja|ar`.
+- `max_results` - client-side result cap; default 20.
+
+## Anti-patterns
+
+- Do not search for living-author or copyrighted modern content. Wikisource only
+  carries public-domain or freely licensed transcribed texts.
+- Do not use Wikisource for images, scans, or reusable media assets; use
+  `commons_search`.
+- Do not cite a search snippet as the document body. Emit a fetch follow-up so
+  the full transcription lands in `Source.cleaned_text`.
+- Do not treat a translated page as equivalent to the original-language
+  source without saying which language host supplied it.
+
+## When to fan out
+
+Fan out across language hosts when the subject is multilingual, colonial,
+diplomatic, or likely to have authoritative source texts in more than one
+language. Pair that with `multilingual-source-handling` so the planner preserves
+language, title, and translation caveats.
+
+Fan out from search to fetch for every candidate document you intend to cite.
+The search result is only a locator; the evidentiary content is the fetched
+full text in `Source.cleaned_text`.
+
+## Output shape
+
+Each `SearchResult` carries a Wikisource page URL, title, snippet, and `extras`
+with `wikisource_lang`, `page_title`, `page_id`, `word_count`, and `size`.
+
+`fetch()` returns a `Source` with:
+
+- `cleaned_text` - the full transcribed document body, headed by the page title.
+- `metadata["wikisource_lang"]` - language host used.
+- `metadata["page_title"]` - resolved page title.
+- `metadata["revision_id"]` - MediaWiki revision ID used for citation/audit.
+
+## Auth
+
+No auth or API key. Requests use a project-identifying User-Agent and the shared
+1 RPS Wikimedia MediaWiki limiter.

--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -43,6 +43,7 @@ from research_agent.tools import (  # noqa: F401, E402 — side-effecting regist
     trove,
     usaspending,
     wikidata,
+    wikisource,
 )
 
 
@@ -766,6 +767,70 @@ def _smoke_commons_search(query: str) -> str:
     return asyncio.run(_run())
 
 
+def _smoke_wikisource_search(query: str) -> str:
+    """Smoke wrapper: Wikisource search plus top-hit full-text fetch."""
+    import sys
+
+    async def _run() -> str:
+        results = await wikisource.search(query, max_results=5)
+        if not results:
+            print(
+                f"_smoke-tool wikisource_search: search({query!r}) returned 0 results",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+        missing = [hit.title for hit in results if not hit.title or not hit.url]
+        if missing:
+            print(
+                "_smoke-tool wikisource_search: missing title/url on "
+                f"{len(missing)} result(s): {missing[:3]}",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+        source = await wikisource.fetch(results[0].url)
+        if (
+            source is None
+            or not source.cleaned_text.strip()
+            or not source.metadata.get("wikisource_lang")
+            or not source.metadata.get("page_title")
+            or source.metadata.get("revision_id") in (None, "")
+        ):
+            print(
+                "_smoke-tool wikisource_search: fetch(top_hit) did not populate "
+                "cleaned_text and required Wikisource metadata",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+        lines = [f"wikisource_search: returned {len(results)} hits"]
+        for hit in results:
+            snippet = hit.snippet.replace("\n", " ")
+            if len(snippet) > 200:
+                snippet = snippet[:200] + "..."
+            lines.append(
+                f"- {hit.title}\n"
+                f"  url: {hit.url}\n"
+                f"  lang: {hit.extras.get('wikisource_lang') or '?'}\n"
+                f"  snippet: {snippet}"
+            )
+        preview = source.cleaned_text.replace("\n", " ")
+        if len(preview) > 240:
+            preview = preview[:240] + "..."
+        lines.append(
+            "fetched: "
+            f"title={source.title!r} "
+            f"lang={source.metadata['wikisource_lang']} "
+            f"revision_id={source.metadata['revision_id']} "
+            f"chars={len(source.cleaned_text)}"
+        )
+        lines.append(f"preview: {preview}")
+        return "\n".join(lines)
+
+    return asyncio.run(_run())
+
+
 def _smoke_sos(query: str) -> str:
     """Smoke wrapper: California Secretary of State business registry.
 
@@ -1422,6 +1487,7 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "opencorporates": _smoke_opencorporates,
     "trove_search": _smoke_trove_search,
     "wikidata_search": _smoke_wikidata_search,
+    "wikisource_search": _smoke_wikisource_search,
     "sos": _smoke_sos,
     "licensing": _smoke_licensing,
     "sanctions": _smoke_sanctions,

--- a/src/research_agent/tools/models.py
+++ b/src/research_agent/tools/models.py
@@ -53,6 +53,7 @@ SourceKind = Literal[
     "trove_search",
     "wikidata_search",
     "commons_search",
+    "wikisource_search",
 ]
 
 

--- a/src/research_agent/tools/web_fetch.py
+++ b/src/research_agent/tools/web_fetch.py
@@ -387,6 +387,21 @@ _TROVE_HOSTS = frozenset(
 # connector — leave web.archive.org Wayback URLs and bare downloads on the
 # generic httpx + trafilatura path.
 _IARCHIVE_HOSTS = frozenset({"archive.org", "www.archive.org"})
+_WIKISOURCE_HOSTS = frozenset(
+    {
+        "ar.wikisource.org",
+        "de.wikisource.org",
+        "en.wikisource.org",
+        "es.wikisource.org",
+        "fr.wikisource.org",
+        "it.wikisource.org",
+        "ja.wikisource.org",
+        "nl.wikisource.org",
+        "pt.wikisource.org",
+        "ru.wikisource.org",
+        "zh.wikisource.org",
+    }
+)
 
 _PDF_CONTENT_TYPE = "application/pdf"
 
@@ -717,6 +732,11 @@ async def fetch(
         from research_agent.tools import iarchive
 
         return await iarchive.fetch(url)
+
+    if netloc in _WIKISOURCE_HOSTS:
+        from research_agent.tools import wikisource
+
+        return await wikisource.fetch(url)
 
     user_agent = _resolve_user_agent()
 

--- a/src/research_agent/tools/wikisource.py
+++ b/src/research_agent/tools/wikisource.py
@@ -1,0 +1,299 @@
+"""Wikisource connector (issue #234, A12).
+
+Public surface:
+
+* ``async def search(query, *, lang="en", max_results=20)`` hits the
+  per-language Wikisource MediaWiki Action API with
+  ``action=query&list=search``.
+* ``async def fetch(url)`` resolves ``<lang>.wikisource.org/wiki/...`` URLs
+  and returns the full transcribed page body in ``Source.cleaned_text``.
+
+No auth required. Wikimedia traffic goes through the shared MediaWiki helper's
+project-identifying User-Agent and 1 RPS host-family limiter.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import parse_qs, quote, unquote, urlparse
+
+from research_agent.tools import _mediawiki
+from research_agent.tools._registry import (
+    BaseSearchPayload as _BaseSearchPayload,
+)
+from research_agent.tools._registry import (
+    register_kind as _register_kind,
+)
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+KIND = "wikisource_search"
+
+SUPPORTED_LANGS: frozenset[str] = frozenset(
+    {"en", "fr", "es", "de", "it", "pt", "nl", "ru", "zh", "ja", "ar"}
+)
+
+_HOST_RE = re.compile(r"^(?P<lang>[a-z]{2,3})\.wikisource\.org$", re.IGNORECASE)
+_WS_RE = re.compile(r"[ \t\r\f\v]+")
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _normalize_lang(lang: str) -> str:
+    normalized = (lang or "").strip().lower()
+    if normalized not in SUPPORTED_LANGS:
+        logger.warning("wikisource unsupported lang=%r", lang)
+        return ""
+    return normalized
+
+
+def _api_url(lang: str) -> str:
+    return f"https://{lang}.wikisource.org/w/api.php"
+
+
+def _page_url(lang: str, title: str) -> str:
+    encoded = quote(title.strip().replace(" ", "_"), safe="/:")
+    return f"https://{lang}.wikisource.org/wiki/{encoded}"
+
+
+def _title_from_url(url: str) -> tuple[str, str] | None:
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+    if parsed.scheme not in {"http", "https"}:
+        return None
+
+    host = (parsed.hostname or "").lower()
+    match = _HOST_RE.match(host)
+    if match is None:
+        return None
+    lang = _normalize_lang(match.group("lang"))
+    if not lang:
+        return None
+
+    title = ""
+    if parsed.path.startswith("/wiki/"):
+        title = parsed.path[len("/wiki/") :]
+    elif parsed.path == "/w/index.php":
+        values = parse_qs(parsed.query).get("title") or []
+        title = values[0] if values else ""
+    if not title:
+        return None
+
+    normalized_title = unquote(title).replace("_", " ").strip()
+    if not normalized_title:
+        return None
+    return lang, normalized_title
+
+
+def _parse_text_from_payload(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        raw = value.get("*")
+        return raw if isinstance(raw, str) else ""
+    return ""
+
+
+def _clean_body_html(raw_html: str) -> str:
+    """Extract page-body text from MediaWiki parse HTML.
+
+    Wikisource is valuable because the transcribed primary-document body is
+    searchable. Prefer BeautifulSoup so headings and paragraph boundaries
+    survive; fall back to the lightweight shared tag-stripper if the optional
+    parser is unavailable.
+    """
+    if not raw_html:
+        return ""
+
+    try:
+        from bs4 import BeautifulSoup  # type: ignore[import-untyped]
+
+        soup = BeautifulSoup(raw_html, "html.parser")
+        for tag in soup(["script", "style", "noscript"]):
+            tag.decompose()
+        for tag in soup.select(".mw-editsection, .noprint, .metadata"):
+            tag.decompose()
+        root = soup.select_one(".mw-parser-output") or soup
+        text = root.get_text(separator="\n")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("wikisource bs4 parse failed: %s", exc)
+        text = _mediawiki.clean_text(raw_html)
+
+    lines = [_WS_RE.sub(" ", line).strip() for line in text.splitlines()]
+    return "\n".join(line for line in lines if line).strip()
+
+
+def _search_result_from_hit(hit: dict[str, Any], *, lang: str) -> SearchResult | None:
+    title = str(hit.get("title") or "").strip()
+    if not title:
+        return None
+    snippet = (
+        _mediawiki.clean_text(hit.get("snippet"))
+        or _mediawiki.clean_text(hit.get("titlesnippet"))
+        or title
+    )
+    page_id = hit.get("pageid")
+    return SearchResult(
+        url=_page_url(lang, title),
+        title=title,
+        snippet=snippet,
+        published_at=_parse_timestamp(hit.get("timestamp")),
+        source_kind=KIND,
+        extras={
+            "wikisource_lang": lang,
+            "page_title": title,
+            "page_id": page_id,
+            "word_count": hit.get("wordcount"),
+            "size": hit.get("size"),
+        },
+    )
+
+
+async def search(
+    query: str,
+    *,
+    lang: str = "en",
+    max_results: int = 20,
+    timeout: float = 15.0,
+) -> list[SearchResult]:
+    """Search one Wikisource language host for transcribed source documents."""
+    q = query.strip()
+    lang_code = _normalize_lang(lang)
+    if not q or max_results <= 0 or not lang_code:
+        return []
+
+    payload = await _mediawiki.request_json(
+        _api_url(lang_code),
+        params={
+            "action": "query",
+            "list": "search",
+            "srsearch": q,
+            "srlimit": min(max_results, 50),
+            "srprop": "snippet|timestamp|titlesnippet|size|wordcount",
+            "format": "json",
+            "formatversion": "2",
+        },
+        timeout=timeout,
+    )
+    if payload is None:
+        return []
+    query_root = payload.get("query")
+    hits = query_root.get("search") if isinstance(query_root, dict) else None
+    if not isinstance(hits, list):
+        logger.warning("wikisource search response missing query.search")
+        return []
+
+    results: list[SearchResult] = []
+    seen: set[str] = set()
+    for hit in hits:
+        if not isinstance(hit, dict):
+            continue
+        result = _search_result_from_hit(hit, lang=lang_code)
+        if result is None or result.title in seen:
+            continue
+        seen.add(result.title)
+        results.append(result)
+        if len(results) >= max_results:
+            break
+    return results
+
+
+async def fetch(url: str, *, timeout: float = 15.0) -> Source | None:
+    """Fetch a Wikisource page and return its full transcribed body."""
+    parsed = _title_from_url(url)
+    if parsed is None:
+        return None
+    lang, title = parsed
+
+    payload = await _mediawiki.request_json(
+        _api_url(lang),
+        params={
+            "action": "parse",
+            "page": title,
+            "prop": "text|revid|displaytitle",
+            "redirects": "1",
+            "format": "json",
+            "formatversion": "2",
+        },
+        timeout=timeout,
+    )
+    if payload is None:
+        return None
+
+    parse_root = payload.get("parse")
+    if not isinstance(parse_root, dict):
+        logger.warning("wikisource parse response missing parse root for %s", url)
+        return None
+
+    resolved_title = str(parse_root.get("title") or title).strip()
+    raw_body = _parse_text_from_payload(parse_root.get("text"))
+    body = _clean_body_html(raw_body)
+    if not body:
+        return None
+
+    revision_id = parse_root.get("revid")
+    page_id = parse_root.get("pageid")
+    metadata: dict[str, Any] = {
+        "wikisource_lang": lang,
+        "page_title": resolved_title,
+        "revision_id": revision_id,
+        "page_id": page_id,
+    }
+
+    return Source(
+        url=_page_url(lang, resolved_title),
+        title=resolved_title,
+        cleaned_text=f"# {resolved_title}\n\n{body}".strip(),
+        raw_html=raw_body,
+        fetched_at=datetime.now(UTC),
+        source_kind=KIND,
+        metadata=metadata,
+    )
+
+
+def reset_for_tests() -> None:
+    """Clear shared MediaWiki limiter state. Test-only."""
+    _mediawiki.reset_for_tests()
+
+
+class _PayloadSchema(_BaseSearchPayload):
+    lang: str | None = None
+    max_results: int | None = None
+    timeout: float | None = None
+
+
+_register_kind(
+    KIND,
+    payload_schema=_PayloadSchema,
+    search_fn=search,
+    fetch_fn=fetch,
+    host_patterns=tuple(f"{lang}.wikisource.org" for lang in sorted(SUPPORTED_LANGS)),
+    skill_name="wikisource",
+    description=(
+        "Wikisource transcribed primary documents across per-language hosts;"
+        " fetch returns the full source text in cleaned_text"
+    ),
+    optional_payload_knobs="`lang: en|fr|es|de|it|pt|nl|ru|zh|ja|ar`, `max_results`",
+    example_query="Treaty of Versailles",
+    module_name="wikisource",
+)
+
+
+__all__ = ["KIND", "SUPPORTED_LANGS", "fetch", "reset_for_tests", "search"]

--- a/tests/fixtures/wikisource/parse_fr.json
+++ b/tests/fixtures/wikisource/parse_fr.json
@@ -1,0 +1,9 @@
+{
+  "parse": {
+    "title": "La Marseillaise",
+    "pageid": 777,
+    "revid": 222333444,
+    "displaytitle": "La Marseillaise",
+    "text": "<div class=\"mw-parser-output\"><p>Allons enfants de la Patrie, le jour de gloire est arrive.</p><p>Contre nous de la tyrannie l'etendard sanglant est leve.</p></div>"
+  }
+}

--- a/tests/fixtures/wikisource/parse_treaty.json
+++ b/tests/fixtures/wikisource/parse_treaty.json
@@ -1,0 +1,9 @@
+{
+  "parse": {
+    "title": "Treaty of Versailles",
+    "pageid": 12345,
+    "revid": 987654321,
+    "displaytitle": "Treaty of Versailles",
+    "text": "<div class=\"mw-parser-output\"><p>This full body appears only in the fetched page, not in the search snippet.</p><h2><span class=\"mw-headline\" id=\"Article_1\">Article 1</span><span class=\"mw-editsection\">edit</span></h2><p>The High Contracting Parties agree that Germany accepts the following obligations.</p><p>Done at Versailles, the twenty-eighth day of June, one thousand nine hundred and nineteen.</p></div>"
+  }
+}

--- a/tests/fixtures/wikisource/search_empty.json
+++ b/tests/fixtures/wikisource/search_empty.json
@@ -1,0 +1,9 @@
+{
+  "batchcomplete": true,
+  "query": {
+    "searchinfo": {
+      "totalhits": 0
+    },
+    "search": []
+  }
+}

--- a/tests/fixtures/wikisource/search_fr.json
+++ b/tests/fixtures/wikisource/search_fr.json
@@ -1,0 +1,19 @@
+{
+  "batchcomplete": true,
+  "query": {
+    "searchinfo": {
+      "totalhits": 1
+    },
+    "search": [
+      {
+        "ns": 0,
+        "title": "La Marseillaise",
+        "pageid": 777,
+        "size": 9000,
+        "wordcount": 1100,
+        "snippet": "Allons enfants de la Patrie.",
+        "timestamp": "2022-05-01T00:00:00Z"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/wikisource/search_treaty.json
+++ b/tests/fixtures/wikisource/search_treaty.json
@@ -1,0 +1,28 @@
+{
+  "batchcomplete": true,
+  "query": {
+    "searchinfo": {
+      "totalhits": 2
+    },
+    "search": [
+      {
+        "ns": 0,
+        "title": "Treaty of Versailles",
+        "pageid": 12345,
+        "size": 245000,
+        "wordcount": 31200,
+        "snippet": "<span class=\"searchmatch\">Treaty</span> of Versailles, signed at Versailles on 28 June 1919.",
+        "timestamp": "2023-01-02T03:04:05Z"
+      },
+      {
+        "ns": 0,
+        "title": "Treaty of Versailles/Part I",
+        "pageid": 12346,
+        "size": 12000,
+        "wordcount": 1600,
+        "snippet": "Part I of the <span class=\"searchmatch\">Treaty</span> text.",
+        "timestamp": "2023-01-03T03:04:05Z"
+      }
+    ]
+  }
+}

--- a/tests/research_agent/tools/test_registry.py
+++ b/tests/research_agent/tools/test_registry.py
@@ -259,6 +259,7 @@ def test_live_registry_has_all_registered_connectors() -> None:
         "trove_search",
         "usaspending_search",
         "wikidata_search",
+        "wikisource_search",
     }
     actual = {entry.name for entry in iter_kinds()}
     assert expected == actual
@@ -284,4 +285,5 @@ def test_live_registry_skill_name_assignment() -> None:
         "loc_search": "loc",
         "trove_search": "trove",
         "wikidata_search": "wikidata",
+        "wikisource_search": "wikisource",
     }

--- a/tests/research_agent/tools/test_wikisource.py
+++ b/tests/research_agent/tools/test_wikisource.py
@@ -1,0 +1,344 @@
+"""Tests for ``research_agent.tools.wikisource`` (issue #234)."""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from research_agent.tools import wikisource
+from research_agent.tools.models import SearchResult, Source
+
+FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "wikisource"
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch: pytest.MonkeyPatch):
+    wikisource.reset_for_tests()
+    monkeypatch.setenv("RESEARCH_USER_AGENT", "operator@example.test")
+    monkeypatch.setattr(wikisource._mediawiki.asyncio, "sleep", AsyncMock())
+    yield
+    wikisource.reset_for_tests()
+
+
+class _FakeResp:
+    def __init__(self, status: int, payload) -> None:
+        self.status_code = status
+        self._payload = payload
+
+    def json(self):
+        if isinstance(self._payload, BaseException):
+            raise self._payload
+        return self._payload
+
+
+def _fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _patch_httpx(monkeypatch: pytest.MonkeyPatch, *, responder):
+    captured: dict[str, list] = {
+        "urls": [],
+        "headers": [],
+        "params": [],
+    }
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        captured["headers"].append(kwargs.get("headers"))
+
+        class _Client:
+            async def get(self, url, *, params=None, **_kwargs):
+                captured["urls"].append(url)
+                captured["params"].append(params)
+                return responder(url, params or {})
+
+        yield _Client()
+
+    monkeypatch.setattr(wikisource._mediawiki.httpx, "AsyncClient", _client_factory)
+    return captured
+
+
+async def test_search_happy_path_uses_mediawiki_search(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    search_payload = _fixture("search_treaty.json")
+
+    def _respond(url, params):
+        assert url == "https://en.wikisource.org/w/api.php"
+        return _FakeResp(200, search_payload)
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await wikisource.search("Treaty of Versailles", max_results=2)
+
+    assert len(results) == 2
+    first = results[0]
+    assert first.source_kind == "wikisource_search"
+    assert first.title == "Treaty of Versailles"
+    assert first.url == "https://en.wikisource.org/wiki/Treaty_of_Versailles"
+    assert "Treaty of Versailles" in first.snippet
+    assert first.published_at == datetime(2023, 1, 2, 3, 4, 5, tzinfo=UTC)
+    assert first.extras["wikisource_lang"] == "en"
+    assert first.extras["page_title"] == "Treaty of Versailles"
+    assert first.extras["page_id"] == 12345
+    assert first.extras["word_count"] == 31200
+
+    params = captured["params"][0]
+    assert params["action"] == "query"
+    assert params["list"] == "search"
+    assert params["srsearch"] == "Treaty of Versailles"
+    assert params["format"] == "json"
+    assert params["formatversion"] == "2"
+    headers = captured["headers"][0]
+    assert headers["Accept"] == "application/json"
+    assert headers["User-Agent"] == (
+        "research-agent/0.1 "
+        "(+https://github.com/bradtaylorsf/alpha-research; "
+        "contact: operator@example.test)"
+    )
+
+
+async def test_search_empty_payload_returns_empty(monkeypatch: pytest.MonkeyPatch):
+    def _respond(url, params):
+        return _FakeResp(200, _fixture("search_empty.json"))
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await wikisource.search("no such source text", max_results=5) == []
+    assert captured["urls"] == ["https://en.wikisource.org/w/api.php"]
+
+
+async def test_search_routes_to_requested_language_host(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def _respond(url, params):
+        assert url == "https://fr.wikisource.org/w/api.php"
+        return _FakeResp(200, _fixture("search_fr.json"))
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    results = await wikisource.search("La Marseillaise", lang="fr", max_results=1)
+
+    assert len(results) == 1
+    assert results[0].url == "https://fr.wikisource.org/wiki/La_Marseillaise"
+    assert results[0].extras["wikisource_lang"] == "fr"
+    assert captured["params"][0]["srsearch"] == "La Marseillaise"
+
+
+async def test_search_unsupported_language_returns_empty_without_request(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def _respond(url, params):
+        raise AssertionError("unsupported language must not make an HTTP request")
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await wikisource.search("Treaty of Versailles", lang="xx") == []
+    assert captured["urls"] == []
+
+
+async def test_fetch_page_puts_full_transcribed_body_in_cleaned_text(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def _respond(url, params):
+        assert url == "https://en.wikisource.org/w/api.php"
+        assert params["action"] == "parse"
+        assert params["page"] == "Treaty of Versailles"
+        assert params["prop"] == "text|revid|displaytitle"
+        return _FakeResp(200, _fixture("parse_treaty.json"))
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await wikisource.fetch("https://en.wikisource.org/wiki/Treaty_of_Versailles")
+
+    assert source is not None
+    assert source.source_kind == "wikisource_search"
+    assert source.url == "https://en.wikisource.org/wiki/Treaty_of_Versailles"
+    assert source.title == "Treaty of Versailles"
+    assert source.cleaned_text.startswith("# Treaty of Versailles")
+    assert "This full body appears only in the fetched page" in source.cleaned_text
+    assert "The High Contracting Parties agree" in source.cleaned_text
+    assert "Done at Versailles" in source.cleaned_text
+    assert source.metadata["wikisource_lang"] == "en"
+    assert source.metadata["page_title"] == "Treaty of Versailles"
+    assert source.metadata["revision_id"] == 987654321
+
+
+async def test_fetch_index_php_title_url_and_fr_host(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def _respond(url, params):
+        assert url == "https://fr.wikisource.org/w/api.php"
+        assert params["page"] == "La Marseillaise"
+        return _FakeResp(200, _fixture("parse_fr.json"))
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await wikisource.fetch("https://fr.wikisource.org/w/index.php?title=La_Marseillaise")
+
+    assert source is not None
+    assert source.metadata["wikisource_lang"] == "fr"
+    assert source.metadata["page_title"] == "La Marseillaise"
+    assert "Allons enfants de la Patrie" in source.cleaned_text
+
+
+async def test_search_returns_empty_on_transport_error(monkeypatch: pytest.MonkeyPatch):
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_args, **_kwargs):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(wikisource._mediawiki.httpx, "AsyncClient", _client_factory)
+
+    assert await wikisource.search("Treaty of Versailles") == []
+
+
+async def test_search_returns_empty_on_4xx(monkeypatch: pytest.MonkeyPatch):
+    def _respond(url, params):
+        return _FakeResp(404, {"error": "not found"})
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await wikisource.search("Treaty of Versailles") == []
+
+
+async def test_search_returns_empty_on_5xx(monkeypatch: pytest.MonkeyPatch):
+    def _respond(url, params):
+        return _FakeResp(503, {"error": "unavailable"})
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await wikisource.search("Treaty of Versailles") == []
+
+
+async def test_fetch_returns_none_on_4xx(monkeypatch: pytest.MonkeyPatch):
+    def _respond(url, params):
+        return _FakeResp(404, {"error": "not found"})
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await wikisource.fetch("https://en.wikisource.org/wiki/Treaty_of_Versailles") is None
+
+
+async def test_fetch_returns_none_on_5xx(monkeypatch: pytest.MonkeyPatch):
+    def _respond(url, params):
+        return _FakeResp(503, {"error": "unavailable"})
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await wikisource.fetch("https://en.wikisource.org/wiki/Treaty_of_Versailles") is None
+
+
+async def test_fetch_rejects_non_wikisource_url() -> None:
+    assert await wikisource.fetch("https://example.com/wiki/Treaty_of_Versailles") is None
+    assert (
+        await wikisource.fetch(
+            "https://en.wikisource.org.attacker.example/wiki/Treaty_of_Versailles"
+        )
+        is None
+    )
+
+
+async def test_wikisource_rate_limit_is_shared_across_language_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = [100.0]
+    sleep_calls: list[float] = []
+
+    def fake_monotonic() -> float:
+        return clock[0]
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        clock[0] += seconds
+
+    monkeypatch.setattr(wikisource._mediawiki.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(wikisource._mediawiki.asyncio, "sleep", fake_sleep)
+
+    await wikisource._mediawiki.rate_limit("https://en.wikisource.org/w/api.php")
+    await wikisource._mediawiki.rate_limit("https://fr.wikisource.org/w/api.php")
+
+    assert sleep_calls == [1.0]
+
+
+def test_smoke_registry_includes_wikisource_search() -> None:
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "wikisource_search" in TOOL_REGISTRY
+    assert callable(TOOL_REGISTRY["wikisource_search"])
+
+
+def test_smoke_wrapper_requires_fetched_cleaned_text(monkeypatch: pytest.MonkeyPatch):
+    from research_agent.tools import TOOL_REGISTRY
+
+    async def fake_search(query: str, *, max_results: int = 20):
+        return [
+            SearchResult(
+                url="https://en.wikisource.org/wiki/Treaty_of_Versailles",
+                title="Treaty of Versailles",
+                snippet="Treaty snippet",
+                source_kind="wikisource_search",
+                extras={"wikisource_lang": "en"},
+            )
+        ]
+
+    async def fake_fetch(url: str):
+        return Source(
+            url=url,
+            title="Treaty of Versailles",
+            cleaned_text="Full Treaty of Versailles body",
+            fetched_at=datetime.now(UTC),
+            source_kind="wikisource_search",
+            metadata={
+                "wikisource_lang": "en",
+                "page_title": "Treaty of Versailles",
+                "revision_id": 987,
+            },
+        )
+
+    monkeypatch.setattr(wikisource, "search", fake_search)
+    monkeypatch.setattr(wikisource, "fetch", fake_fetch)
+
+    out = TOOL_REGISTRY["wikisource_search"]("Treaty of Versailles")
+
+    assert "wikisource_search: returned 1 hits" in out
+    assert "Treaty of Versailles" in out
+    assert "chars=" in out
+    assert "Full Treaty of Versailles body" in out
+
+
+def test_registered_kind_links_wikisource_skill() -> None:
+    from research_agent.tools._registry import get_kind
+
+    entry = get_kind("wikisource_search")
+    assert entry is not None
+    assert entry.skill_name == "wikisource"
+    assert entry.fetch_fn is wikisource.fetch
+    assert "lang" in entry.optional_payload_knobs
+
+
+def test_wikisource_skill_covers_required_operator_topics() -> None:
+    from research_agent.skills import load_skill
+
+    body = load_skill("connectors", "wikisource")
+
+    for needle in (
+        "<lang>.wikisource.org/w/api.php",
+        "default is `lang=en`",
+        "Source.cleaned_text",
+        "Treaty of Versailles",
+        "Federalist No. 10",
+        "multilingual-source-handling",
+        "living-author",
+        "public-domain",
+    ):
+        assert needle in body

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -437,6 +437,8 @@ def test_check_registry_skill_coherence_skips_grandfathered() -> None:
     assert commons_row.status == "ok"
     wikidata_row = by_name["registry_skill:wikidata_search"]
     assert wikidata_row.status == "ok"
+    wikisource_row = by_name["registry_skill:wikisource_search"]
+    assert wikisource_row.status == "ok"
 
 
 def test_check_registry_skill_coherence_fails_when_skill_file_missing(

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -552,6 +552,7 @@ CONNECTOR_KIND_PREFIXES: tuple[str, ...] = (
     "iarchive",
     "trove",
     "wikidata",
+    "wikisource",
 )
 
 # Connector module name → ``source_kind`` Literal value. Most connectors
@@ -561,6 +562,7 @@ _CONNECTOR_SOURCE_KIND["edgar"] = "sec"
 _CONNECTOR_SOURCE_KIND["trove"] = "trove_search"
 _CONNECTOR_SOURCE_KIND["wikidata"] = "wikidata_search"
 _CONNECTOR_SOURCE_KIND["commons"] = "commons_search"
+_CONNECTOR_SOURCE_KIND["wikisource"] = "wikisource_search"
 
 
 def test_default_handlers_covers_every_task_kind() -> None:

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -65,6 +65,7 @@ CONNECTOR_KIND_PREFIXES: tuple[str, ...] = (
     "iarchive",
     "trove",
     "wikidata",
+    "wikisource",
 )
 
 

--- a/tests/test_tools_models.py
+++ b/tests/test_tools_models.py
@@ -47,6 +47,7 @@ EXPECTED_SOURCE_KINDS = (
     "trove_search",
     "wikidata_search",
     "commons_search",
+    "wikisource_search",
 )
 
 

--- a/tests/test_tools_web_fetch.py
+++ b/tests/test_tools_web_fetch.py
@@ -553,6 +553,8 @@ def test_browser_module_imported_lazily(monkeypatch):
         ("https://www.bbb.org/us/ca/santa-clara/profile/general-contractor/sbi", "bbb"),
         ("https://trove.nla.gov.au/newspaper/article/18342701", "trove"),
         ("https://nla.gov.au/nla.news-article18342701", "trove"),
+        ("https://en.wikisource.org/wiki/Treaty_of_Versailles", "wikisource"),
+        ("https://fr.wikisource.org/wiki/La_Marseillaise", "wikisource"),
     ],
 )
 async def test_fetch_dispatches_to_connector_by_host(monkeypatch, url, module_name):


### PR DESCRIPTION
Closes #234
Part of #251

## Summary

Automated implementation of **feat: wikisource_search connector — Wikisource (A12)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Review passed; no critical or warning code issues found for wikisource_search.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*