### PR TITLE
fix: document DPLA key delivery for #228

### DIFF
--- a/src/research_agent/skills/connectors/dpla.md
+++ b/src/research_agent/skills/connectors/dpla.md
@@ -88,6 +88,7 @@ Requires `DPLA_API_KEY`. Request a free key with:
 curl -X POST https://api.dp.la/v2/api_key/<your-email>
 ```
 
-Registration is an HTTP POST, not a web form. The 32-character key is sent by
-email and rides on API requests as `?api_key=<key>`. Without the key,
-`dpla_search` and `_smoke-tool dpla_search` skip cleanly.
+Registration is an HTTP POST, not a web form. Key delivery is typically
+instant, but still arrives by email; the 32-character key rides on API
+requests as `?api_key=<key>`. Without the key, `dpla_search` and
+`_smoke-tool dpla_search` skip cleanly.

--- a/tests/research_agent/tools/test_dpla.py
+++ b/tests/research_agent/tools/test_dpla.py
@@ -398,6 +398,7 @@ def test_dpla_skill_covers_required_operator_topics() -> None:
     for token in (
         "DPLA_API_KEY",
         "curl -X POST https://api.dp.la/v2/api_key/<your-email>",
+        "instant",
         "provider",
         "dataProvider",
         "?provider=",


### PR DESCRIPTION
## Summary
- restores the DPLA reviewer fix documenting instant-ish email key delivery
- adds a skill coverage assertion for that required topic

## Tests
- uv run pytest tests/research_agent/tools/test_dpla.py

Refs #228