### PR TITLE
feat: feat: ukna_search connector — UK National Archives Discovery (A9) (closes #231)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ from `src/research_agent/tools/_registry.py` via
 | `si_search` | Smithsonian Open Access digitized collection objects, museum artifacts, images, 3D assets, and object metadata via api.data.gov | `max_results` | `Apollo 11` |
 | `sos_search` | State Secretary-of-State business entity filings (Playwright; CA wired, others stubs) | `state: CA\|DE\|NV\|...` | `Acme Corp` |
 | `trove_search` | Trove / National Library of Australia metadata for newspapers, books, photos, magazines, oral histories; metadata-only default | `category`, `zone`, `sortby` | `White Australia Policy 1901` |
+| `ukna_search` | UK National Archives Discovery catalogue metadata for Foreign Office, War Office, Colonial Office, and other UK archival records (no auth) | `max_results`, `page` | `Mau Mau Kenya` |
 | `usaspending_search` | Federal contracts, grants, loans (award-level detail, no auth) | `award_type: contracts\|grants\|loans` | `Heritage Foundation contract` |
 | `wikidata_search` | Wikidata Query Service raw SPARQL for biographical, relational, occupational, place, and entity-ID data | `max_results` (client-side truncation; SPARQL should include `LIMIT`) | `SELECT ?item ?itemLabel WHERE { ?item wdt:P31 wd:Q5; wdt:P19 wd:Q90 . SERVICE wikibase:label { bd:serviceParam wikibase:language "en". } } LIMIT 3` |
 | `wikisource_search` | Wikisource transcribed primary documents across per-language hosts; fetch returns the full source text in cleaned_text | `lang: en|fr|es|de|it|pt|nl|ru|zh|ja|ar`, `max_results` | `Treaty of Versailles` |

--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -119,6 +119,8 @@ TaskKind = Literal[
     "iarchive_fetch",
     "trove_search",
     "trove_fetch",
+    "ukna_search",
+    "ukna_fetch",
     "wikidata_search",
     "wikidata_fetch",
     "wikisource_search",

--- a/src/research_agent/skills/connectors/ukna.md
+++ b/src/research_agent/skills/connectors/ukna.md
@@ -1,0 +1,91 @@
+---
+name: ukna
+description: "UK National Archives Discovery catalogue metadata for Foreign Office, War Office, Colonial Office, and other UK archival records; no auth; descriptions only."
+when_to_use: "UK government and imperial/colonial archival research, especially Foreign Office, War Office, Colonial Office, declassified, military, diplomatic, and colonial-era catalogue discovery"
+when_not_to_use: "full-text document search, OCR over scanned records, contemporary news, non-UK archives, or workflows that need the body text of physical records without a separate download/fetch step"
+---
+
+# UK National Archives Discovery connector
+
+The UKNA connector searches Discovery, The National Archives catalogue. It is a
+metadata and description index for UK government records and records held by
+other archives. Use `ukna_search` before generic web search when the target has
+a British state, empire, military, diplomatic, or colonial-record angle.
+
+The Discovery API is a Beta API; schema may drift. The connector logs a clear
+warning on schema mismatch and keeps parsing useful fields instead of crashing.
+
+## Time-period / era filtering
+
+`covering_dates` is a free-text field, not ISO. Surface it raw in metadata and
+let downstream parsing decide whether `1952-1959`, `c 1948-1963`, `20th
+century`, or `n.d.` is usable for the task.
+
+For colonial-era work, add places, administrative names, and years directly to
+the query: `Mau Mau Kenya 1950s`, `Aden emergency 1967`, or `Cyprus Colonial
+Office 1955`.
+
+## Query construction
+
+- Start with compact subject + place + era terms. `Mau Mau Kenya 1950s` beats a
+  paragraph-length investigative prompt.
+- Catalogue references follow `<DEPT>/<SERIES>/<PIECE>` in operator shorthand,
+  commonly displayed with spaces such as `CO 537/...`.
+- Useful department prefixes:
+  - `CO` - Colonial Office records, often core for empire and colonial
+    administration.
+  - `WO` - War Office records, military operations and army administration.
+  - `FO` - Foreign Office records, diplomacy and overseas political reporting.
+- If a search is too broad, fan out by department prefix plus subject:
+  `CO Mau Mau Kenya`, `WO Kenya security operations`, `FO Kenya emergency`.
+
+## Knobs available
+
+- `max_results` - API page size and connector-side cap. Default 20.
+- `page` - Discovery API page number when walking deeper result pages.
+- `timeout` - HTTP timeout in seconds. Default 20.
+
+## Anti-patterns
+
+- Do not expect full-text search across actual document bodies. UKNA Discovery
+  indexes catalogue descriptions, NOT contents. The actual records are often
+  physical files, born-digital accessions, or scanned-image PDFs.
+- Do not treat `covering_dates` as machine-normalized dates.
+- Do not assume an open catalogue description means a digital document is
+  immediately downloadable.
+- Do not use this connector for US federal records; use `nara_search`.
+
+## When to fan out
+
+Fan out when the topic could sit in more than one department or series. For a
+colonial conflict, run separate focused searches across `CO`, `WO`, and `FO`
+with the place and years. Use follow-up `ukna_fetch` on selected catalogue
+records to capture the metadata card before citing a record in synthesis.
+
+Pair with `gallica_search`, `trove_search`, `loc_search`, or `nara_search` when
+the same colonial-era story has French, Australian, US, or international
+archival traces.
+
+## Output shape
+
+Each `SearchResult` has `source_kind="ukna_search"`, a Discovery detail URL,
+title, snippet, and extras:
+
+- `catalogue_reference`
+- `covering_dates`
+- `held_by`
+- `scope_content`
+- `department`
+- `catalogue_level`
+- `record_id`
+- `url_parameters`
+- `score`
+
+`fetch(url)` returns a `Source` metadata card with the required metadata keys
+`catalogue_reference`, `covering_dates`, `held_by`, and `scope_content`. It
+does not return full archival document text.
+
+## Auth
+
+No auth. No API key is required. The connector enforces a process-local 1 RPS
+polite rate for Discovery API requests.

--- a/src/research_agent/tools/__init__.py
+++ b/src/research_agent/tools/__init__.py
@@ -43,6 +43,7 @@ from research_agent.tools import (  # noqa: F401, E402 — side-effecting regist
     smithsonian,
     sos,
     trove,
+    ukna,
     usaspending,
     wikidata,
     wikisource,
@@ -1197,6 +1198,55 @@ def _smoke_gallica_search(query: str) -> str:
     return asyncio.run(_run())
 
 
+def _smoke_ukna_search(query: str) -> str:
+    """Smoke wrapper: UKNA Discovery search with catalogue metadata checks."""
+    import sys
+
+    async def _run() -> str:
+        results = await ukna.search(query, max_results=5)
+        if not results:
+            print(
+                f"_smoke-tool ukna_search: search({query!r}) returned 0 results",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+        missing = [
+            hit.title or hit.url
+            for hit in results
+            if (
+                not hit.title
+                or not hit.url
+                or "discovery.nationalarchives.gov.uk/" not in hit.url
+                or not hit.extras.get("catalogue_reference")
+            )
+        ]
+        if missing:
+            print(
+                "_smoke-tool ukna_search: missing title/Discovery URL/catalogue "
+                f"reference on {len(missing)} result(s): {missing[:3]}",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+        lines = [f"ukna_search: returned {len(results)} hits"]
+        for hit in results:
+            snippet = hit.snippet.replace("\n", " ")
+            if len(snippet) > 220:
+                snippet = snippet[:220] + "..."
+            lines.append(
+                f"- {hit.title}\n"
+                f"  url: {hit.url}\n"
+                f"  catalogue_reference: {hit.extras.get('catalogue_reference')}\n"
+                f"  covering_dates: {hit.extras.get('covering_dates') or 'none listed'}\n"
+                f"  held_by: {hit.extras.get('held_by') or 'none listed'}\n"
+                f"  snippet: {snippet}"
+            )
+        return "\n".join(lines)
+
+    return asyncio.run(_run())
+
+
 def _smoke_persee_search(query: str) -> str:
     """Smoke wrapper: Persee Playwright search with non-empty title/URL checks."""
     import sys
@@ -2077,6 +2127,7 @@ TOOL_REGISTRY: dict[str, Callable[[str], object]] = {
     "opencorporates": _smoke_opencorporates,
     "openalex_search": _smoke_openalex_search,
     "trove_search": _smoke_trove_search,
+    "ukna_search": _smoke_ukna_search,
     "wikidata_search": _smoke_wikidata_search,
     "wikisource_search": _smoke_wikisource_search,
     "openlibrary_search": _smoke_openlibrary_search,

--- a/src/research_agent/tools/models.py
+++ b/src/research_agent/tools/models.py
@@ -53,6 +53,7 @@ SourceKind = Literal[
     "loc",
     "nara_search",
     "trove_search",
+    "ukna_search",
     "wikidata_search",
     "commons_search",
     "cspan_search",

--- a/src/research_agent/tools/ukna.py
+++ b/src/research_agent/tools/ukna.py
@@ -1,0 +1,615 @@
+"""UK National Archives Discovery API connector (issue #231, A9).
+
+Public surface:
+
+* ``async def search(query, *, max_results=20) -> list[SearchResult]`` hits
+  ``https://discovery.nationalarchives.gov.uk/API/search/v1/records`` with
+  ``sps.searchQuery=<query>``.
+* ``async def fetch(url) -> Source | None`` accepts Discovery detail URLs and
+  API search URLs, re-queries the Discovery API, and renders a metadata card.
+
+Discovery is a beta JSON API and exposes catalogue descriptions, not full
+record text. This connector treats schema drift as a warning and keeps going
+with whatever useful fields remain. No auth is required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import logging
+import re
+import time
+from datetime import UTC, datetime
+from typing import Any, Literal
+from urllib.parse import parse_qs, quote, unquote, urlencode, urlparse
+
+import httpx
+
+from research_agent import config
+from research_agent.tools._registry import (
+    BaseSearchPayload as _BaseSearchPayload,
+)
+from research_agent.tools._registry import (
+    register_kind as _register_kind,
+)
+from research_agent.tools.models import SearchResult, Source
+
+logger = logging.getLogger(__name__)
+
+KIND: Literal["ukna_search"] = "ukna_search"
+
+_SEARCH_URL = "https://discovery.nationalarchives.gov.uk/API/search/v1/records"
+_SITE_BASE = "https://discovery.nationalarchives.gov.uk"
+_HOSTS = frozenset({"discovery.nationalarchives.gov.uk"})
+_RATE_LIMIT_INTERVAL = 1.0
+_MAX_RESULTS = 1000
+
+_DETAIL_PATH_RE = re.compile(r"^/details/(?P<section>[rc])/(?P<token>[^/?#]+)")
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+
+_RECORDED_TOP_KEYS = frozenset(
+    {
+        "Records",
+        "TaxonomySubjects",
+        "TimePeriods",
+        "Departments",
+        "CatalogueLevels",
+        "ClosureStatuses",
+        "Sources",
+        "Repositories",
+        "HeldByReps",
+        "ReferenceFirstLetters",
+        "TitleFirstLetters",
+        "Count",
+        "NextBatchMark",
+    }
+)
+_REQUIRED_TOP_KEYS = frozenset({"Records", "Count"})
+_TOP_KEY_ALIASES: dict[str, tuple[str, ...]] = {
+    key: (key, key[:1].lower() + key[1:]) for key in _RECORDED_TOP_KEYS
+}
+_RECORDED_RECORD_KEYS = frozenset(
+    {
+        "AltName",
+        "Places",
+        "CorpBodies",
+        "Taxonomies",
+        "FormerReferenceDep",
+        "FormerReferencePro",
+        "HeldBy",
+        "Context",
+        "Content",
+        "URLParameters",
+        "Department",
+        "Note",
+        "AdminHistory",
+        "Arrangement",
+        "MapDesignation",
+        "MapScale",
+        "PhysicalCondition",
+        "CatalogueLevel",
+        "OpeningDate",
+        "ClosureStatus",
+        "ClosureType",
+        "ClosureCode",
+        "DocumentType",
+        "CoveringDates",
+        "Description",
+        "EndDate",
+        "NumEndDate",
+        "NumStartDate",
+        "StartDate",
+        "Id",
+        "Reference",
+        "Score",
+        "Source",
+        "Title",
+    }
+)
+_REQUIRED_RECORD_KEYS = frozenset(
+    {"Title", "Reference", "CoveringDates", "HeldBy", "Content", "URLParameters"}
+)
+_RECORD_KEY_ALIASES: dict[str, tuple[str, ...]] = {
+    key: (key, key[:1].lower() + key[1:]) for key in _RECORDED_RECORD_KEYS
+}
+_RECORD_KEY_ALIASES["URLParameters"] = ("URLParameters", "urlParameters")
+
+_rate_lock = asyncio.Lock()
+_last_call_monotonic: float | None = None
+_schema_drift_warnings: set[str] = set()
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Accept": "application/json",
+        "User-Agent": config.get("RESEARCH_USER_AGENT")
+        or "research-agent/0.1 (+local; contact unset)",
+    }
+
+
+async def _rate_limit_gate() -> None:
+    """Block until the next 1 RPS Discovery API request slot is available."""
+    global _last_call_monotonic
+    async with _rate_lock:
+        if _last_call_monotonic is not None:
+            elapsed = time.monotonic() - _last_call_monotonic
+            wait = _RATE_LIMIT_INTERVAL - elapsed
+            if wait > 0:
+                await asyncio.sleep(wait)
+        _last_call_monotonic = time.monotonic()
+
+
+def _warn_schema_drift(code: str, detail: str) -> None:
+    if code in _schema_drift_warnings:
+        return
+    _schema_drift_warnings.add(code)
+    logger.warning("ukna_search: beta API schema drift: %s", detail)
+
+
+async def _request_json(
+    *,
+    params: dict[str, Any],
+    timeout: float,
+) -> dict[str, Any] | None:
+    await _rate_limit_gate()
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=_headers(),
+        ) as client:
+            response = await client.get(_SEARCH_URL, params=params)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("ukna_search: request failed: %s", exc)
+        return None
+
+    if response.status_code == 429:
+        logger.warning("ukna_search: UKNA Discovery API rate limit returned HTTP 429")
+        return None
+    if 400 <= response.status_code < 500:
+        logger.warning(
+            "ukna_search: UKNA Discovery API returned HTTP %s",
+            response.status_code,
+        )
+        return None
+    if response.status_code >= 500:
+        logger.warning(
+            "ukna_search: UKNA Discovery API server error HTTP %s",
+            response.status_code,
+        )
+        return None
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        logger.warning("ukna_search: UKNA Discovery API response was not JSON: %s", exc)
+        return None
+    if not isinstance(payload, dict):
+        _warn_schema_drift("payload_type", f"expected object, got {type(payload).__name__}")
+        return None
+    return payload
+
+
+def _clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        text = html.unescape(_TAG_RE.sub(" ", value))
+        return _WS_RE.sub(" ", text).strip()
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, dict):
+        for key in (
+            "value",
+            "name",
+            "title",
+            "label",
+            "description",
+            "text",
+            "Code",
+            "Id",
+            "code",
+            "id",
+        ):
+            text = _clean_text(value.get(key))
+            if text:
+                return text
+        for item in value.values():
+            text = _clean_text(item)
+            if text:
+                return text
+        return ""
+    if isinstance(value, (list, tuple, set)):
+        parts: list[str] = []
+        for item in value:
+            text = _clean_text(item)
+            if text and text not in parts:
+                parts.append(text)
+        return "; ".join(parts)
+    return str(value).strip()
+
+
+def _canonical_keyset(
+    keys: set[str],
+    aliases: dict[str, tuple[str, ...]],
+) -> set[str]:
+    reverse = {
+        alias: canonical
+        for canonical, key_aliases in aliases.items()
+        for alias in key_aliases
+    }
+    return {reverse.get(key, key) for key in keys}
+
+
+def _field(mapping: dict[str, Any], key: str, *fallbacks: str) -> Any:
+    for candidate in (key, *fallbacks):
+        aliases = _RECORD_KEY_ALIASES.get(candidate, ())
+        for alias in (candidate, *aliases, candidate[:1].lower() + candidate[1:]):
+            if alias in mapping:
+                return mapping[alias]
+    return None
+
+
+def _first_text(*values: Any) -> str:
+    for value in values:
+        text = _clean_text(value)
+        if text:
+            return text
+    return ""
+
+
+def _truncate(text: str, limit: int = 300) -> str:
+    text = _clean_text(text)
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "..."
+
+
+def _score(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _records_from_payload(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    top_keys = _canonical_keyset(set(payload), _TOP_KEY_ALIASES)
+    missing_top = _REQUIRED_TOP_KEYS - top_keys
+    if missing_top:
+        _warn_schema_drift(
+            "top_missing",
+            "missing expected top-level keys "
+            f"{sorted(missing_top)}; recorded keys include {sorted(_RECORDED_TOP_KEYS)}",
+        )
+    recorded_top_missing = _RECORDED_TOP_KEYS - top_keys
+    recorded_top_extra = top_keys - _RECORDED_TOP_KEYS
+    if recorded_top_missing or recorded_top_extra:
+        _warn_schema_drift(
+            "top_keyset",
+            "top-level keys differ from recorded fixture; "
+            f"missing={sorted(recorded_top_missing)} extra={sorted(recorded_top_extra)}",
+        )
+
+    records = payload.get("Records", payload.get("records"))
+    if records is None:
+        return []
+    if not isinstance(records, list):
+        _warn_schema_drift(
+            "records_type",
+            f"expected Records list, got {type(records).__name__}",
+        )
+        return []
+
+    out: list[dict[str, Any]] = []
+    for item in records:
+        if not isinstance(item, dict):
+            _warn_schema_drift(
+                "record_item_type",
+                f"expected each Records item to be object, got {type(item).__name__}",
+            )
+            continue
+        record_keys = _canonical_keyset(set(item), _RECORD_KEY_ALIASES)
+        missing_record = _REQUIRED_RECORD_KEYS - record_keys
+        if missing_record:
+            _warn_schema_drift(
+                "record_missing",
+                "record missing expected catalogue keys "
+                f"{sorted(missing_record)}; recorded keys include "
+                f"{sorted(_RECORDED_RECORD_KEYS)}",
+            )
+        recorded_record_missing = _RECORDED_RECORD_KEYS - record_keys
+        recorded_record_extra = record_keys - _RECORDED_RECORD_KEYS
+        if recorded_record_missing or recorded_record_extra:
+            _warn_schema_drift(
+                "record_keyset",
+                "record keys differ from recorded fixture; "
+                f"missing={sorted(recorded_record_missing)} "
+                f"extra={sorted(recorded_record_extra)}",
+            )
+        out.append(item)
+    return out
+
+
+def _record_reference(record: dict[str, Any]) -> str:
+    return _first_text(_field(record, "Reference"))
+
+
+def _record_title(record: dict[str, Any]) -> str:
+    return _first_text(
+        _field(record, "Title"),
+        _field(record, "Description"),
+        _record_reference(record),
+        _field(record, "Id"),
+        "UK National Archives record",
+    )
+
+
+def _scope_content(record: dict[str, Any]) -> str:
+    return _first_text(
+        _field(record, "Content"),
+        _field(record, "ScopeContent"),
+        _field(record, "Description"),
+        _field(record, "Context"),
+        _field(record, "Note"),
+    )
+
+
+def _detail_token(record: dict[str, Any]) -> str:
+    return _first_text(
+        _field(record, "URLParameters"),
+        _field(record, "Id"),
+    )
+
+
+def _record_url(record: dict[str, Any]) -> str:
+    for key in ("Url", "URL", "url", "Link"):
+        text = _clean_text(record.get(key))
+        if text.startswith(("http://", "https://")):
+            return text
+    token = _detail_token(record)
+    if token:
+        if token.startswith(("http://", "https://")):
+            return token
+        return f"{_SITE_BASE}/details/r/{quote(token, safe='')}"
+    reference = _record_reference(record)
+    if reference:
+        return f"{_SEARCH_URL}?{urlencode({'sps.searchQuery': reference})}"
+    return _SITE_BASE
+
+
+def _metadata_for_record(record: dict[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "catalogue_reference": _record_reference(record),
+        "covering_dates": _first_text(_field(record, "CoveringDates")),
+        "held_by": _first_text(_field(record, "HeldBy")),
+        "scope_content": _scope_content(record),
+        "department": _first_text(_field(record, "Department")),
+        "catalogue_level": _field(record, "CatalogueLevel"),
+        "record_id": _first_text(_field(record, "Id")),
+        "url_parameters": _detail_token(record),
+        "source": _first_text(_field(record, "Source")),
+        "closure_status": _first_text(_field(record, "ClosureStatus")),
+        "opening_date": _first_text(_field(record, "OpeningDate")),
+    }
+    return {
+        key: value
+        for key, value in metadata.items()
+        if value not in ("", None, [], {})
+    }
+
+
+def _snippet(record: dict[str, Any]) -> str:
+    parts: list[str] = []
+    if ref := _record_reference(record):
+        parts.append(f"Ref: {ref}")
+    if dates := _first_text(_field(record, "CoveringDates")):
+        parts.append(f"Dates: {dates}")
+    if held_by := _first_text(_field(record, "HeldBy")):
+        parts.append(f"Held by: {held_by}")
+    if scope := _scope_content(record):
+        parts.append(_truncate(scope, 220))
+    return " | ".join(parts)
+
+
+def _build_result(record: dict[str, Any]) -> SearchResult | None:
+    title = _record_title(record)
+    url = _record_url(record)
+    if not title or not url:
+        return None
+
+    metadata = _metadata_for_record(record)
+    score = _score(_field(record, "Score"))
+    extras = dict(metadata)
+    if score is not None:
+        extras["score"] = score
+    return SearchResult(
+        url=url,
+        title=title,
+        snippet=_snippet(record),
+        source_kind=KIND,
+        score=score,
+        extras=extras,
+    )
+
+
+async def search(
+    query: str,
+    *,
+    max_results: int = 20,
+    page: int | None = None,
+    timeout: float = 20.0,
+) -> list[SearchResult]:
+    """Search UKNA Discovery catalogue descriptions.
+
+    The API indexes catalogue metadata and descriptions, not the text inside
+    physical records or scanned images.
+    """
+    q = (query or "").strip()
+    if not q:
+        return []
+
+    rows = min(max(1, int(max_results)), _MAX_RESULTS)
+    params: dict[str, Any] = {
+        "sps.searchQuery": q,
+        "sps.resultsPageSize": rows,
+    }
+    if page is not None:
+        params["sps.page"] = page
+
+    payload = await _request_json(params=params, timeout=timeout)
+    if payload is None:
+        return []
+
+    results: list[SearchResult] = []
+    for record in _records_from_payload(payload):
+        result = _build_result(record)
+        if result is not None:
+            results.append(result)
+        if len(results) >= rows:
+            break
+    return results
+
+
+def _extract_query_from_url(url: str) -> str:
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").casefold()
+    if host not in _HOSTS:
+        return ""
+
+    match = _DETAIL_PATH_RE.match(parsed.path)
+    if match:
+        return unquote(match.group("token")).strip()
+
+    if parsed.path.rstrip("/").casefold() == "/api/search/v1/records":
+        query = parse_qs(parsed.query)
+        for key in ("sps.searchQuery", "sps.searchquery", "SearchQuery", "searchQuery"):
+            values = query.get(key)
+            if values:
+                return values[0].strip()
+    return ""
+
+
+def _normalized_lookup(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]", "", _clean_text(value).casefold())
+
+
+def _record_matches_query(record: dict[str, Any], query: str) -> bool:
+    wanted = _normalized_lookup(query)
+    if not wanted:
+        return False
+    candidates = (
+        _field(record, "URLParameters"),
+        _field(record, "Id"),
+        _field(record, "Reference"),
+    )
+    return any(_normalized_lookup(candidate) == wanted for candidate in candidates)
+
+
+async def _fetch_record(query: str, *, timeout: float) -> dict[str, Any] | None:
+    payload = await _request_json(
+        params={"sps.searchQuery": query, "sps.resultsPageSize": 10},
+        timeout=timeout,
+    )
+    if payload is None:
+        return None
+    records = _records_from_payload(payload)
+    if not records:
+        return None
+    for record in records:
+        if _record_matches_query(record, query):
+            return record
+    return records[0]
+
+
+def _render_source_text(
+    *,
+    title: str,
+    url: str,
+    metadata: dict[str, Any],
+) -> str:
+    lines = [f"# {title}", "", f"URL: {url}"]
+    if ref := metadata.get("catalogue_reference"):
+        lines.append(f"Catalogue reference: {ref}")
+    if dates := metadata.get("covering_dates"):
+        lines.append(f"Covering dates: {dates}")
+    if held_by := metadata.get("held_by"):
+        lines.append(f"Held by: {held_by}")
+    if department := metadata.get("department"):
+        lines.append(f"Department: {department}")
+    if level := metadata.get("catalogue_level"):
+        lines.append(f"Catalogue level: {level}")
+    if closure := metadata.get("closure_status"):
+        lines.append(f"Closure status: {closure}")
+    if opening := metadata.get("opening_date"):
+        lines.append(f"Opening date: {opening}")
+
+    scope = metadata.get("scope_content")
+    if isinstance(scope, str) and scope:
+        lines.extend(["", "## Scope and Content", scope])
+    return "\n".join(lines).strip()
+
+
+async def fetch(url: str, *, timeout: float = 20.0) -> Source | None:
+    """Fetch one Discovery catalogue record by detail/API URL."""
+    query = _extract_query_from_url(url)
+    if not query:
+        return None
+
+    record = await _fetch_record(query, timeout=timeout)
+    if record is None:
+        return None
+
+    canonical_url = _record_url(record)
+    title = _record_title(record)
+    metadata = _metadata_for_record(record)
+    return Source(
+        url=canonical_url,
+        title=title,
+        cleaned_text=_render_source_text(
+            title=title,
+            url=canonical_url,
+            metadata=metadata,
+        ),
+        raw_html=None,
+        fetched_at=datetime.now(UTC),
+        source_kind=KIND,
+        metadata=metadata,
+    )
+
+
+def reset_for_tests() -> None:
+    global _last_call_monotonic, _rate_lock
+    _last_call_monotonic = None
+    _rate_lock = asyncio.Lock()
+    _schema_drift_warnings.clear()
+
+
+class _PayloadSchema(_BaseSearchPayload):
+    max_results: int | None = None
+    page: int | None = None
+
+
+_register_kind(
+    KIND,
+    payload_schema=_PayloadSchema,
+    search_fn=search,
+    fetch_fn=fetch,
+    host_patterns=("discovery.nationalarchives.gov.uk",),
+    skill_name="ukna",
+    description=(
+        "UK National Archives Discovery catalogue metadata for Foreign Office,"
+        " War Office, Colonial Office, and other UK archival records (no auth)"
+    ),
+    optional_payload_knobs="`max_results`, `page`",
+    example_query="Mau Mau Kenya",
+    module_name="ukna",
+)
+
+
+__all__ = ["KIND", "fetch", "reset_for_tests", "search"]

--- a/src/research_agent/tools/web_fetch.py
+++ b/src/research_agent/tools/web_fetch.py
@@ -401,6 +401,7 @@ _TROVE_HOSTS = frozenset(
         "www.nla.gov.au",
     }
 )
+_UKNA_HOSTS = frozenset({"discovery.nationalarchives.gov.uk"})
 # ``archive.org`` is a multi-tenant host (details/, download/, web/, …).
 # Only the ``/details/<identifier>`` path is owned by the iarchive
 # connector — leave web.archive.org Wayback URLs and bare downloads on the
@@ -795,6 +796,11 @@ async def fetch(
         from research_agent.tools import trove
 
         return await trove.fetch(url)
+
+    if netloc in _UKNA_HOSTS:
+        from research_agent.tools import ukna
+
+        return await ukna.fetch(url)
 
     if netloc in _IARCHIVE_HOSTS and urlparse(url).path.startswith("/details/"):
         from research_agent.tools import iarchive

--- a/tests/fixtures/ukna/search_empty.json
+++ b/tests/fixtures/ukna/search_empty.json
@@ -1,0 +1,15 @@
+{
+  "Records": [],
+  "TaxonomySubjects": [],
+  "TimePeriods": [],
+  "Departments": [],
+  "CatalogueLevels": [],
+  "ClosureStatuses": [],
+  "Sources": [],
+  "Repositories": [],
+  "HeldByReps": [],
+  "ReferenceFirstLetters": [],
+  "TitleFirstLetters": [],
+  "Count": 0,
+  "NextBatchMark": null
+}

--- a/tests/fixtures/ukna/search_mau_mau.json
+++ b/tests/fixtures/ukna/search_mau_mau.json
@@ -1,0 +1,104 @@
+{
+  "Records": [
+    {
+      "AltName": "",
+      "Places": [
+        "Kenya"
+      ],
+      "CorpBodies": [
+        "Colonial Office"
+      ],
+      "Taxonomies": [
+        "Empire and Commonwealth"
+      ],
+      "FormerReferenceDep": "",
+      "FormerReferencePro": "",
+      "HeldBy": [
+        "The National Archives, Kew"
+      ],
+      "Context": "Colonial Office and successors: East Africa Department",
+      "Content": "Correspondence and reports concerning the Mau Mau emergency, detention camps, rehabilitation policy, and security operations in Kenya.",
+      "URLParameters": "C1234567",
+      "Department": "CO",
+      "Note": "",
+      "AdminHistory": "",
+      "Arrangement": "",
+      "MapDesignation": "",
+      "MapScale": "",
+      "PhysicalCondition": "",
+      "CatalogueLevel": 6,
+      "OpeningDate": "01 January 1987",
+      "ClosureStatus": "Open Document, Open Description",
+      "ClosureType": "",
+      "ClosureCode": "",
+      "DocumentType": "Textual record",
+      "CoveringDates": "1952-1959",
+      "Description": "Kenya: Mau Mau emergency and rehabilitation camps",
+      "EndDate": "1959",
+      "NumEndDate": 1959,
+      "NumStartDate": 1952,
+      "StartDate": "1952",
+      "Id": "1234567",
+      "Reference": "CO 822/1234",
+      "Score": 14.25,
+      "Source": "CAT",
+      "Title": "Kenya: Mau Mau emergency"
+    },
+    {
+      "AltName": "",
+      "Places": [
+        "Kenya"
+      ],
+      "CorpBodies": [
+        "War Office"
+      ],
+      "Taxonomies": [
+        "Military operations"
+      ],
+      "FormerReferenceDep": "",
+      "FormerReferencePro": "",
+      "HeldBy": [
+        "The National Archives, Kew"
+      ],
+      "Context": "War Office: Army operational records",
+      "Content": "Security reports on operations in Kenya during the Mau Mau conflict.",
+      "URLParameters": "C7654321",
+      "Department": "WO",
+      "Note": "",
+      "AdminHistory": "",
+      "Arrangement": "",
+      "MapDesignation": "",
+      "MapScale": "",
+      "PhysicalCondition": "",
+      "CatalogueLevel": 6,
+      "OpeningDate": "01 January 1989",
+      "ClosureStatus": "Open Document, Open Description",
+      "ClosureType": "",
+      "ClosureCode": "",
+      "DocumentType": "Textual record",
+      "CoveringDates": "1954-1956",
+      "Description": "Kenya: security operations against Mau Mau",
+      "EndDate": "1956",
+      "NumEndDate": 1956,
+      "NumStartDate": 1954,
+      "StartDate": "1954",
+      "Id": "7654321",
+      "Reference": "WO 276/89",
+      "Score": 8.5,
+      "Source": "CAT",
+      "Title": "Kenya: security operations"
+    }
+  ],
+  "TaxonomySubjects": [],
+  "TimePeriods": [],
+  "Departments": [],
+  "CatalogueLevels": [],
+  "ClosureStatuses": [],
+  "Sources": [],
+  "Repositories": [],
+  "HeldByReps": [],
+  "ReferenceFirstLetters": [],
+  "TitleFirstLetters": [],
+  "Count": 2,
+  "NextBatchMark": null
+}

--- a/tests/research_agent/tools/test_registry.py
+++ b/tests/research_agent/tools/test_registry.py
@@ -267,6 +267,7 @@ def test_live_registry_has_all_registered_connectors() -> None:
         "si_search",
         "sos_search",
         "trove_search",
+        "ukna_search",
         "usaspending_search",
         "wikidata_search",
         "wikisource_search",
@@ -304,6 +305,7 @@ def test_live_registry_skill_name_assignment() -> None:
         "persee_search": "persee",
         "si_search": "smithsonian",
         "trove_search": "trove",
+        "ukna_search": "ukna",
         "wikidata_search": "wikidata",
         "wikisource_search": "wikisource",
     }

--- a/tests/research_agent/tools/test_ukna.py
+++ b/tests/research_agent/tools/test_ukna.py
@@ -1,0 +1,474 @@
+"""Tests for ``research_agent.tools.ukna`` (issue #231)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from research_agent import config
+from research_agent.tools import ukna
+from research_agent.tools.models import SearchResult, Source
+
+FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "ukna"
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch: pytest.MonkeyPatch):
+    config.reset_for_tests()
+    ukna.reset_for_tests()
+    monkeypatch.setattr(ukna.asyncio, "sleep", AsyncMock())
+    yield
+    ukna.reset_for_tests()
+    config.reset_for_tests()
+
+
+class _FakeResp:
+    def __init__(self, status: int, payload) -> None:
+        self.status_code = status
+        self._payload = payload
+
+    def json(self):
+        if isinstance(self._payload, BaseException):
+            raise self._payload
+        return self._payload
+
+
+def _fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _camelize_key(key: str) -> str:
+    if key == "URLParameters":
+        return "urlParameters"
+    return key[:1].lower() + key[1:]
+
+
+def _camelize_payload(payload: dict) -> dict:
+    out = {_camelize_key(key): value for key, value in payload.items()}
+    out["records"] = [
+        {_camelize_key(key): value for key, value in record.items()}
+        for record in payload.get("Records", [])
+    ]
+    out.pop("Records", None)
+    return out
+
+
+def _patch_httpx(monkeypatch: pytest.MonkeyPatch, *, responder):
+    captured: dict[str, list] = {
+        "urls": [],
+        "headers": [],
+        "params": [],
+    }
+
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        captured["headers"].append(kwargs.get("headers"))
+
+        class _Client:
+            async def get(self, url, *, params=None, **_kwargs):
+                captured["urls"].append(url)
+                captured["params"].append(params or {})
+                status, payload = responder(url, params or {})
+                return _FakeResp(status, payload)
+
+        yield _Client()
+
+    monkeypatch.setattr(ukna.httpx, "AsyncClient", _client_factory)
+    return captured
+
+
+async def test_search_happy_path_populates_catalogue_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    payload = _fixture("search_mau_mau.json")
+
+    def _respond(url, params):
+        assert url == "https://discovery.nationalarchives.gov.uk/API/search/v1/records"
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    with caplog.at_level(logging.WARNING, logger="research_agent.tools.ukna"):
+        results = await ukna.search("Mau Mau Kenya", max_results=2, page=3)
+
+    assert "schema drift" not in caplog.text
+    assert len(results) == 2
+    first = results[0]
+    assert first.source_kind == "ukna_search"
+    assert first.title == "Kenya: Mau Mau emergency"
+    assert first.url == "https://discovery.nationalarchives.gov.uk/details/r/C1234567"
+    assert first.score == 14.25
+    assert first.extras["catalogue_reference"] == "CO 822/1234"
+    assert first.extras["covering_dates"] == "1952-1959"
+    assert first.extras["held_by"] == "The National Archives, Kew"
+    assert "detention camps" in first.extras["scope_content"]
+    assert first.extras["department"] == "CO"
+    assert first.extras["catalogue_level"] == 6
+    assert "Ref: CO 822/1234" in first.snippet
+
+    headers = captured["headers"][0]
+    assert headers["Accept"] == "application/json"
+    assert "Authorization" not in headers
+    params = captured["params"][0]
+    assert params["sps.searchQuery"] == "Mau Mau Kenya"
+    assert params["sps.resultsPageSize"] == 2
+    assert params["sps.page"] == 3
+    assert "api_key" not in params
+
+
+async def test_search_accepts_current_lower_camel_api_shape(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    payload = {
+        "records": [
+            {
+                "altName": "",
+                "places": ["Kenya"],
+                "corpBodies": ["Colonial Office"],
+                "taxonomies": ["Empire and Commonwealth"],
+                "formerReferenceDep": "",
+                "formerReferencePro": "",
+                "heldBy": ["The National Archives, Kew"],
+                "context": "Colonial Office and successors: East Africa Department",
+                "content": "Mau Mau emergency files and detention camp reports.",
+                "urlParameters": "C1234567",
+                "department": "CO",
+                "note": "",
+                "adminHistory": "",
+                "arrangement": "",
+                "mapDesignation": "",
+                "mapScale": "",
+                "physicalCondition": "",
+                "catalogueLevel": 6,
+                "openingDate": "01 January 1987",
+                "closureStatus": "Open Document, Open Description",
+                "closureType": "",
+                "closureCode": "",
+                "documentType": "Textual record",
+                "coveringDates": "1952-1959",
+                "description": "Kenya: Mau Mau emergency and rehabilitation camps",
+                "endDate": "1959",
+                "numEndDate": 1959,
+                "numStartDate": 1952,
+                "startDate": "1952",
+                "id": "1234567",
+                "reference": "CO 822/1234",
+                "score": 14.25,
+                "source": "CAT",
+                "title": "Kenya: Mau Mau emergency",
+            }
+        ],
+        "taxonomySubjects": [],
+        "timePeriods": [],
+        "departments": [],
+        "catalogueLevels": [],
+        "closureStatuses": [],
+        "sources": [],
+        "repositories": [],
+        "heldByReps": [],
+        "referenceFirstLetters": [],
+        "titleFirstLetters": [],
+        "count": 1,
+        "nextBatchMark": None,
+    }
+
+    def _respond(url, params):
+        return 200, payload
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    with caplog.at_level(logging.WARNING, logger="research_agent.tools.ukna"):
+        results = await ukna.search("Mau Mau Kenya", max_results=5)
+
+    assert "schema drift" not in caplog.text
+    assert len(results) == 1
+    first = results[0]
+    assert first.url == "https://discovery.nationalarchives.gov.uk/details/r/C1234567"
+    assert first.title == "Kenya: Mau Mau emergency"
+    assert first.extras["catalogue_reference"] == "CO 822/1234"
+    assert first.extras["covering_dates"] == "1952-1959"
+    assert first.extras["held_by"] == "The National Archives, Kew"
+    assert "detention camp reports" in first.extras["scope_content"]
+
+
+async def test_search_empty_payload_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _respond(url, params):
+        return 200, _fixture("search_empty.json")
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await ukna.search("no hits") == []
+
+
+async def test_search_accepts_live_camelcase_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    payload = _camelize_payload(_fixture("search_mau_mau.json"))
+
+    def _respond(url, params):
+        return 200, payload
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    with caplog.at_level(logging.WARNING, logger="research_agent.tools.ukna"):
+        results = await ukna.search("Mau Mau Kenya", max_results=1)
+
+    assert "schema drift" not in caplog.text
+    assert len(results) == 1
+    assert results[0].title == "Kenya: Mau Mau emergency"
+    assert results[0].url == "https://discovery.nationalarchives.gov.uk/details/r/C1234567"
+    assert results[0].extras["catalogue_reference"] == "CO 822/1234"
+    assert results[0].extras["covering_dates"] == "1952-1959"
+    assert results[0].extras["held_by"] == "The National Archives, Kew"
+
+
+async def test_search_rate_limit_gate_sleeps_between_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = [100.0]
+    sleep_calls: list[float] = []
+
+    def _monotonic() -> float:
+        return clock[0]
+
+    async def _sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        clock[0] += seconds
+
+    monkeypatch.setattr(ukna.time, "monotonic", _monotonic)
+    monkeypatch.setattr(ukna.asyncio, "sleep", _sleep)
+
+    def _respond(url, params):
+        return 200, _fixture("search_empty.json")
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    await asyncio.gather(ukna.search("a"), ukna.search("b"))
+
+    assert sleep_calls == pytest.approx([1.0])
+
+
+async def test_search_returns_empty_on_4xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _respond(url, params):
+        return 404, {}
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await ukna.search("anything") == []
+
+
+async def test_search_returns_empty_on_5xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _respond(url, params):
+        return 503, {}
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    assert await ukna.search("anything") == []
+
+
+async def test_search_returns_empty_on_transport_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    @asynccontextmanager
+    async def _client_factory(*args, **kwargs):
+        class _Client:
+            async def get(self, *_a, **_k):
+                raise httpx.ConnectError("nope")
+
+        yield _Client()
+
+    monkeypatch.setattr(ukna.httpx, "AsyncClient", _client_factory)
+
+    assert await ukna.search("anything") == []
+
+
+async def test_search_schema_drift_warning_does_not_crash(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def _respond(url, params):
+        return 200, {"Items": [{"Name": "unexpected"}], "Total": 1}
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    with caplog.at_level(logging.WARNING, logger="research_agent.tools.ukna"):
+        results = await ukna.search("Mau Mau Kenya")
+
+    assert results == []
+    assert "ukna_search: beta API schema drift" in caplog.text
+    assert "Records" in caplog.text
+
+
+async def test_fetch_detail_url_populates_required_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _fixture("search_mau_mau.json")
+
+    def _respond(url, params):
+        assert params == {"sps.searchQuery": "C1234567", "sps.resultsPageSize": 10}
+        return 200, payload
+
+    captured = _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await ukna.fetch(
+        "https://discovery.nationalarchives.gov.uk/details/r/C1234567"
+    )
+
+    assert source is not None
+    assert source.source_kind == "ukna_search"
+    assert source.url == "https://discovery.nationalarchives.gov.uk/details/r/C1234567"
+    assert source.metadata["catalogue_reference"] == "CO 822/1234"
+    assert source.metadata["covering_dates"] == "1952-1959"
+    assert source.metadata["held_by"] == "The National Archives, Kew"
+    assert "detention camps" in source.metadata["scope_content"]
+    assert "## Scope and Content" in source.cleaned_text
+    assert "Catalogue reference: CO 822/1234" in source.cleaned_text
+    assert captured["urls"] == [
+        "https://discovery.nationalarchives.gov.uk/API/search/v1/records"
+    ]
+
+
+async def test_fetch_accepts_api_search_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = _fixture("search_mau_mau.json")
+
+    def _respond(url, params):
+        assert params == {
+            "sps.searchQuery": "CO 822/1234",
+            "sps.resultsPageSize": 10,
+        }
+        return 200, payload
+
+    _patch_httpx(monkeypatch, responder=_respond)
+
+    source = await ukna.fetch(
+        "https://discovery.nationalarchives.gov.uk/API/search/v1/records"
+        "?sps.searchQuery=CO%20822%2F1234"
+    )
+
+    assert source is not None
+    assert source.metadata["catalogue_reference"] == "CO 822/1234"
+
+
+async def test_fetch_rejects_lookalike_host() -> None:
+    assert (
+        await ukna.fetch("https://discovery.nationalarchives.gov.uk.evil/details/r/C1")
+        is None
+    )
+
+
+def test_source_kind_accepts_ukna_search() -> None:
+    result = SearchResult(
+        url="https://discovery.nationalarchives.gov.uk/details/r/C1",
+        title="t",
+        snippet="s",
+        source_kind="ukna_search",
+    )
+    assert result.source_kind == "ukna_search"
+
+    source = Source(
+        url="https://discovery.nationalarchives.gov.uk/details/r/C1",
+        title="t",
+        cleaned_text="body",
+        fetched_at=ukna.datetime.now(ukna.UTC),
+        source_kind="ukna_search",
+    )
+    assert source.source_kind == "ukna_search"
+
+
+def test_module_declares_kind_constant() -> None:
+    assert ukna.KIND == "ukna_search"
+
+
+def test_smoke_registry_includes_ukna_search() -> None:
+    from research_agent.tools import TOOL_REGISTRY
+
+    assert "ukna_search" in TOOL_REGISTRY
+    assert callable(TOOL_REGISTRY["ukna_search"])
+
+
+def test_smoke_wrapper_formats_non_empty_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from research_agent.tools import TOOL_REGISTRY
+
+    async def _fake_search(query: str, *, max_results: int = 20):
+        assert query == "Mau Mau Kenya"
+        assert max_results == 5
+        return [
+            SearchResult(
+                url="https://discovery.nationalarchives.gov.uk/details/r/C1234567",
+                title="Kenya: Mau Mau emergency",
+                snippet="Ref: CO 822/1234 | Dates: 1952-1959",
+                source_kind="ukna_search",
+                extras={
+                    "catalogue_reference": "CO 822/1234",
+                    "covering_dates": "1952-1959",
+                    "held_by": "The National Archives, Kew",
+                },
+            )
+        ]
+
+    monkeypatch.setattr(ukna, "search", _fake_search)
+
+    out = TOOL_REGISTRY["ukna_search"]("Mau Mau Kenya")
+
+    assert "ukna_search: returned 1 hits" in out
+    assert "Kenya: Mau Mau emergency" in out
+    assert "CO 822/1234" in out
+    assert "The National Archives, Kew" in out
+
+
+def test_smoke_wrapper_fails_on_empty_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from research_agent.tools import TOOL_REGISTRY
+
+    async def _fake_search(query: str, *, max_results: int = 20):
+        return []
+
+    monkeypatch.setattr(ukna, "search", _fake_search)
+
+    with pytest.raises(SystemExit):
+        TOOL_REGISTRY["ukna_search"]("Mau Mau Kenya")
+
+
+def test_ukna_skill_covers_required_operator_warnings() -> None:
+    from research_agent.skills import load_skill
+
+    body = load_skill("connectors", "ukna")
+
+    for needle in (
+        "Beta API",
+        "schema may drift",
+        "CO 537",
+        "CO",
+        "WO",
+        "FO",
+        "covering_dates",
+        "free-text",
+        "NOT contents",
+        "scanned-image PDFs",
+        "No auth",
+    ):
+        assert needle in body
+
+
+def test_doctor_registry_skill_coherence_passes_for_ukna() -> None:
+    from research_agent import doctor
+
+    rows = doctor.check_registry_skill_coherence()
+    ukna_rows = [row for row in rows if row.name == "registry_skill:ukna_search"]
+    assert len(ukna_rows) == 1
+    assert ukna_rows[0].status == "ok", ukna_rows[0].detail

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -556,6 +556,7 @@ CONNECTOR_KIND_PREFIXES: tuple[str, ...] = (
     "europeana",
     "iarchive",
     "trove",
+    "ukna",
     "wikidata",
     "wikisource",
     "openalex",
@@ -572,6 +573,7 @@ _CONNECTOR_SOURCE_KIND["edgar"] = "sec"
 _CONNECTOR_SOURCE_KIND["gallica"] = "gallica_search"
 _CONNECTOR_SOURCE_KIND["nara"] = "nara_search"
 _CONNECTOR_SOURCE_KIND["trove"] = "trove_search"
+_CONNECTOR_SOURCE_KIND["ukna"] = "ukna_search"
 _CONNECTOR_SOURCE_KIND["wikidata"] = "wikidata_search"
 _CONNECTOR_SOURCE_KIND["commons"] = "commons_search"
 _CONNECTOR_SOURCE_KIND["cspan"] = "cspan_search"

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -70,6 +70,7 @@ CONNECTOR_KIND_PREFIXES: tuple[str, ...] = (
     "europeana",
     "iarchive",
     "trove",
+    "ukna",
     "wikidata",
     "wikisource",
     "openalex",

--- a/tests/test_tools_models.py
+++ b/tests/test_tools_models.py
@@ -47,6 +47,7 @@ EXPECTED_SOURCE_KINDS = (
     "loc",
     "nara_search",
     "trove_search",
+    "ukna_search",
     "wikidata_search",
     "commons_search",
     "cspan_search",

--- a/tests/test_tools_web_fetch.py
+++ b/tests/test_tools_web_fetch.py
@@ -571,6 +571,7 @@ def test_browser_module_imported_lazily(monkeypatch):
         ("https://hemerotecadigital.bne.es/hd/es/viewer?id=abc123", "bne"),
         ("https://trove.nla.gov.au/newspaper/article/18342701", "trove"),
         ("https://nla.gov.au/nla.news-article18342701", "trove"),
+        ("https://discovery.nationalarchives.gov.uk/details/r/C1234567", "ukna"),
         ("https://en.wikisource.org/wiki/Treaty_of_Versailles", "wikisource"),
         ("https://fr.wikisource.org/wiki/La_Marseillaise", "wikisource"),
         ("https://catalog.hathitrust.org/Record/000578050", "hathitrust"),


### PR DESCRIPTION
Closes #231
Part of #251

## Summary

Automated implementation of **feat: ukna_search connector — UK National Archives Discovery (A9)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

UKNA connector review passed; local unit, wiring, and doctor checks are clean, while live smoke was blocked by sandbox DNS.

- **INFO** [OPEN] `src/research_agent/tools/ukna.py`: The exact live smoke command could not be verified in this sandbox because discovery.nationalarchives.gov.uk DNS resolution failed; the smoke wrapper correctly failed on zero results instead of passing empty output.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*