### PR TITLE
fix: normalize forbidden chars in _slugify instead of rejecting (#299)

### DIFF
--- a/src/research_agent/storage/jobs.py
+++ b/src/research_agent/storage/jobs.py
@@ -65,15 +65,10 @@ def _slugify(text: str, max_len: int = 60) -> str:
 
     Lowercases, collapses runs of non-alphanumeric characters into ``-``,
     strips leading/trailing dashes, truncates to ``max_len``. Raises
-    :class:`ValueError` if the input contains a path-traversal sequence
-    or normalizes to an empty string.
+    :class:`ValueError` if the input normalizes to an empty string.
     """
     if not isinstance(text, str):
         raise ValueError(f"slug input must be a string; got {type(text).__name__}")
-
-    for bad in _SLUG_FORBIDDEN:
-        if bad in text:
-            raise ValueError(f"slug input contains forbidden sequence {bad!r}: {text!r}")
 
     lowered = text.strip().lower()
     collapsed = re.sub(r"[^a-z0-9]+", "-", lowered).strip("-")
@@ -83,6 +78,9 @@ def _slugify(text: str, max_len: int = 60) -> str:
     truncated = collapsed[:max_len].rstrip("-")
     if not truncated:
         raise ValueError(f"slug input collapsed to empty after truncation: {text!r}")
+    for bad in _SLUG_FORBIDDEN:
+        if bad in truncated:
+            raise ValueError(f"slug output contains forbidden sequence {bad!r}: {truncated!r}")
     return truncated
 
 

--- a/tests/test_storage_jobs.py
+++ b/tests/test_storage_jobs.py
@@ -86,6 +86,11 @@ def test_slugify_truncation_strips_trailing_dash() -> None:
     assert not out.endswith("-")
 
 
+def test_slugify_normalizes_slashes() -> None:
+    assert _slugify("FEC/OpenFEC records") == "fec-openfec-records"
+    assert _slugify("foo\\bar") == "foo-bar"
+
+
 def test_slugify_rejects_empty() -> None:
     with pytest.raises(ValueError):
         _slugify("")
@@ -95,10 +100,10 @@ def test_slugify_rejects_empty() -> None:
         _slugify("!!!---!!!")
 
 
-@pytest.mark.parametrize("traversal", ["foo/bar", "foo\\bar", "../etc/passwd", ".."])
-def test_slugify_rejects_path_traversal(traversal: str) -> None:
+def test_slugify_normalizes_path_traversal_text() -> None:
+    assert _slugify("../etc/passwd") == "etc-passwd"
     with pytest.raises(ValueError):
-        _slugify(traversal)
+        _slugify("..")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `_slugify` rejected raw inputs containing `/`, `\`, or `..` as a path-traversal defense. This blocked reasonable names like `"FEC/OpenFEC records"` even though the regex would collapse the slash to a dash anyway.
- Move the forbidden-sequence check from input to normalized output. Slashes/backslashes get collapsed to `-` by the existing regex; anything still forbidden after normalization (like a bare `".."`, which collapses to empty) still raises.
- Tests updated: replaced `test_slugify_rejects_path_traversal` with `test_slugify_normalizes_slashes` and `test_slugify_normalizes_path_traversal_text`.

## Effect
| Input | Before | After |
|---|---|---|
| `"FEC/OpenFEC records"` | raises | `"fec-openfec-records"` |
| `"../etc/passwd"` | raises | `"etc-passwd"` |
| `".."` | raises | raises |
| `"foo\\bar"` | raises | `"foo-bar"` |

Path-traversal safety preserved — any `..` that survives normalization still raises.

Closes #299

## Test plan
- [x] `uv run pytest tests/test_storage_jobs.py` — 38/38 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)