### PR TITLE
chore: rename brand from alpha-research to muckwire (#301)

### DIFF
--- a/.alpha-loop.yaml
+++ b/.alpha-loop.yaml
@@ -1,5 +1,5 @@
 # Alpha Loop configuration
-repo: bradtaylorsf/alpha-research
+repo: bradtaylorsf/muckwire
 project: 0  # GitHub Project number (find it in your project URL)
 agent: codex  # AI agent CLI: claude, codex, opencode, lmstudio, ollama
 # model:       # AI model (omit to use agent's default, e.g., opus, gpt-5.4)

--- a/.alpha-loop/templates/agents/implementer.md
+++ b/.alpha-loop/templates/agents/implementer.md
@@ -6,7 +6,7 @@ tools: Read, Write, Edit, Glob, Grep, Bash
 skills: implementation-planning, testing-patterns, test-robustness, security-analysis, git-workflow, docs-sync, scope-discipline, smoke-verification, env-var-registration
 ---
 
-# Implementer Agent (alpha-research / Python)
+# Implementer Agent (muckwire / Python)
 
 You implement GitHub issues autonomously. You receive an issue description with acceptance criteria, and you produce working, tested, committed code.
 

--- a/.alpha-loop/templates/agents/reviewer.md
+++ b/.alpha-loop/templates/agents/reviewer.md
@@ -6,7 +6,7 @@ tools: Read, Write, Edit, Glob, Grep, Bash
 skills: code-review, security-analysis, testing-patterns, test-robustness, docs-sync, scope-discipline, smoke-verification, env-var-registration
 ---
 
-# Reviewer Agent (alpha-research / Python)
+# Reviewer Agent (muckwire / Python)
 
 You review code changes for a completed GitHub issue. You have full edit permissions — fix CRITICAL and WARNING issues directly rather than just reporting them.
 

--- a/.alpha-loop/templates/instructions.md
+++ b/.alpha-loop/templates/instructions.md
@@ -1,5 +1,5 @@
 <!-- managed by alpha-loop -->
-# Alpha Research
+# Muckwire
 
 ## Overview
 Repo for an **autonomous overnight investigative research agent** that runs on a Mac workstation, uses LM Studio for local model work and OpenRouter for cloud synthesis, and persists research as markdown + SQLite. The Python package (`research_agent`, CLI `research`) has a functional v1 CLI/daemon baseline: intake, job lifecycle, planner loop, connector dispatch, synthesis/critique, search, export, compare, source dedupe, checkpoint resume, and report history are in-tree. Connector depth, open-archive coverage, cornerstone-document handling, and long-run quality are still expanded issue-by-issue via alpha-loop. The top-level `*.md` playbooks remain strategic source material and project deliverables. Output of this work feeds the broader `Alpha*` agent ecosystem.

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -6,7 +6,7 @@ tools: Read, Write, Edit, Glob, Grep, Bash
 skills: implementation-planning, testing-patterns, test-robustness, security-analysis, git-workflow, docs-sync, scope-discipline, smoke-verification, env-var-registration
 ---
 
-# Implementer Agent (alpha-research / Python)
+# Implementer Agent (muckwire / Python)
 
 You implement GitHub issues autonomously. You receive an issue description with acceptance criteria, and you produce working, tested, committed code.
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -6,7 +6,7 @@ tools: Read, Write, Edit, Glob, Grep, Bash
 skills: code-review, security-analysis, testing-patterns, test-robustness, docs-sync, scope-discipline, smoke-verification, env-var-registration
 ---
 
-# Reviewer Agent (alpha-research / Python)
+# Reviewer Agent (muckwire / Python)
 
 You review code changes for a completed GitHub issue. You have full edit permissions — fix CRITICAL and WARNING issues directly rather than just reporting them.
 

--- a/.codex/agents/implementer.md
+++ b/.codex/agents/implementer.md
@@ -6,7 +6,7 @@ tools: Read, Write, Edit, Glob, Grep, Bash
 skills: implementation-planning, testing-patterns, test-robustness, security-analysis, git-workflow, docs-sync, scope-discipline, smoke-verification, env-var-registration
 ---
 
-# Implementer Agent (alpha-research / Python)
+# Implementer Agent (muckwire / Python)
 
 You implement GitHub issues autonomously. You receive an issue description with acceptance criteria, and you produce working, tested, committed code.
 

--- a/.codex/agents/reviewer.md
+++ b/.codex/agents/reviewer.md
@@ -6,7 +6,7 @@ tools: Read, Write, Edit, Glob, Grep, Bash
 skills: code-review, security-analysis, testing-patterns, test-robustness, docs-sync, scope-discipline, smoke-verification, env-var-registration
 ---
 
-# Reviewer Agent (alpha-research / Python)
+# Reviewer Agent (muckwire / Python)
 
 You review code changes for a completed GitHub issue. You have full edit permissions — fix CRITICAL and WARNING issues directly rather than just reporting them.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- managed by alpha-loop -->
-# Alpha Research
+# Muckwire
 
 ## Overview
 Repo for an **autonomous overnight investigative research agent** that runs on a Mac workstation, uses LM Studio for local model work and OpenRouter for cloud synthesis, and persists research as markdown + SQLite. The Python package (`research_agent`, CLI `research`) now has a functional v1 CLI/daemon baseline: intake, job lifecycle, planner loop, connector dispatch, synthesis/critique, search, export, and compare are in-tree. Connector depth and long-run quality are still being expanded issue-by-issue via alpha-loop. The top-level `*.md` playbooks remain strategic source material and project deliverables. Output of this work feeds the broader `Alpha*` agent ecosystem.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-## Project: Alpha Research
+## Project: Muckwire
 
 Research workspace for AI agent investigation, setup, and implementation patterns. The output of this work feeds into agents and tooling built elsewhere in the `Alpha*` ecosystem.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to alpha-research
+# Contributing to muckwire
 
 Thanks for your interest. This is an actively-developed research agent —
 contributions, bug reports, and connector PRs are all welcome.
@@ -16,8 +16,8 @@ If you're not sure where to start, look for issues labeled
 ## Setting up
 
 ```bash
-git clone https://github.com/bradtaylorsf/alpha-research.git
-cd alpha-research
+git clone https://github.com/bradtaylorsf/muckwire.git
+cd muckwire
 pip install -e ".[dev]"
 playwright install chromium
 cp .env.example .env  # then add your keys

--- a/OPEN_ARCHIVES_AND_MCP_HANDOFF.md
+++ b/OPEN_ARCHIVES_AND_MCP_HANDOFF.md
@@ -9,7 +9,7 @@
 
 ## What this is
 
-Two related milestones for `alpha-research`, both targeted at making the agent a
+Two related milestones for `muckwire`, both targeted at making the agent a
 better research tool for *anyone* doing primary-source / archival work — not just
 investigative-journalism / due-diligence patterns the existing connector roster
 favors:
@@ -19,7 +19,7 @@ favors:
    records, Wikimedia structured data, multilingual European archives, US
    broadcast video, and academic article corpora. Free or free-with-registration
    sources only; no paid commercial APIs.
-2. **Milestone B — `composable research service`.** Make alpha-research callable
+2. **Milestone B — `composable research service`.** Make muckwire callable
    from external agents via MCP, with a stabilized programmatic Python entry
    point and a documented per-job-folder contract. The MCP server exposes both a
    *high-level lifecycle* surface (start a job, get the report) and a
@@ -27,7 +27,7 @@ favors:
    downstream agents can choose the granularity they need.
 
 Both milestones are independent. Either can ship first. Both share the same
-end-state: alpha-research stays a generic research engine, and other tools
+end-state: muckwire stays a generic research engine, and other tools
 (including a downstream narrative-history podcast pipeline) consume it without
 forking.
 
@@ -226,7 +226,7 @@ These don't deserve their own connector issue, but do deserve issues of their ow
 - **No production-asset connectors.** SFX libraries (BBC Sound Effects,
   Freesound), royalty-free music corpora (Free Music Archive), and stock-image
   APIs are *production* tooling, not research tooling. Out of scope for
-  alpha-research; consumers handle their own asset pipelines.
+  muckwire; consumers handle their own asset pipelines.
 - **No paid data brokers beyond what's already wired.** SerpAPI / Brave /
   Proxycurl / Lix exist in v1; do not add Tavily, NewsCatcher, RapidAPI,
   ScrapingBee, etc.
@@ -237,12 +237,12 @@ These don't deserve their own connector issue, but do deserve issues of their ow
 
 ### Why this exists
 
-alpha-research today is a CLI-shaped tool. To call it from external agents,
+muckwire today is a CLI-shaped tool. To call it from external agents,
 consumers must shell out via subprocess, parse `events.jsonl`, and read
 `jobs/<id>/report.md` after the daemon finishes. That works, but it makes the
 agent feel like a black box.
 
-Three layered changes turn alpha-research into a first-class composable service
+Three layered changes turn muckwire into a first-class composable service
 without changing the daemon's lifecycle or the per-job folder format:
 
 1. **Per-job folder contract** — formalize the existing layout as a documented
@@ -405,7 +405,7 @@ The two milestones do not share a name with any consumer project. Issue
 labels: `area:open-archives` and `area:composability`. Milestones: literally
 `open-archives connector tier` and `composable research service`. Don't
 co-name with downstream projects (e.g., narrative-history podcast pipelines)
-even if a specific consumer is the catalyst — alpha-research is generic
+even if a specific consumer is the catalyst — muckwire is generic
 infrastructure.
 
 ### Testing posture

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# research-agent
+# muckwire
 
 ## What is this and why does it exist?
 
 Existing AI research agents are cloud-only, opaque about where their answers
-came from, and lock you into one vendor. **alpha-research** is a different
+came from, and lock you into one vendor. **muckwire** is a different
 shape: a CLI daemon that runs on your laptop, defaults to local models via
 LM Studio (so the wallet cost is `$0`), and treats every claim as something
 that has to land in a footnote with a Wayback archive URL behind it.
@@ -50,6 +50,29 @@ This README is the entry point. It walks an operator from "fresh laptop" to
 - [`CLAUDE.md`](CLAUDE.md) — how the
   [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) issue-driven
   build loop drives planning / build / PR flow here.
+
+## The name
+
+**muckwire** carries the spirit of the **muckrakers** — the Progressive
+Era journalists (roughly 1890–1920) who exposed corruption in government,
+the predations of big business, and the social injustices nobody in power
+wanted documented. Ida Tarbell dismantled Standard Oil claim by claim.
+Lincoln Steffens mapped the machinery of municipal graft. Upton Sinclair
+walked readers onto the meatpacking floor. Ida B. Wells indicted lynching
+in statistics nobody could wave away. Jacob Riis and Lewis Hine
+photographed tenements and child labor until the country had to look.
+Theodore Roosevelt coined the term in 1906 as an insult — borrowed from
+Bunyan's *Pilgrim's Progress*, a man so busy raking muck he never looked
+up — and the journalists wore it as a badge of honor. Their work drove
+the Pure Food and Drug Act, antitrust enforcement, child-labor laws, and
+most of the accountability infrastructure that survives today.
+
+The **"wire"** half points at the plumbing of that same tradition — the
+wire services (AP, Reuters, UPI) that moved an investigation from one
+city to readers in another by morning. This tool is built for the same
+kind of work: patient, sourced, evidence-first investigation. Every
+claim it produces lands in a footnote with a Wayback archive URL behind
+it, because the only thing that survives the pushback is the receipts.
 
 ## Architecture
 
@@ -587,7 +610,7 @@ The questions you're going to ask (and that issue reporters will ask):
 answer is "because they're solving slightly different problems" — laid
 out so you can pick the right tool for what you're doing:
 
-| | alpha-research | LangGraph | Gemini Deep Research | Perplexity Pro |
+| | muckwire | LangGraph | Gemini Deep Research | Perplexity Pro |
 |---|---|---|---|---|
 | Runs locally | ✅ | ⚠️ framework — you provide infra | ❌ | ❌ |
 | $0 default cost | ✅ | depends | ❌ | ❌ subscription |
@@ -694,12 +717,12 @@ most recent running job auto-resume. Drop a launch agent at
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>com.alpha.research.resume</string>
+  <string>com.muckwire.resume</string>
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
     <string>-lc</string>
-    <string>cd /path/to/alpha-research &amp;&amp; \
+    <string>cd /path/to/muckwire &amp;&amp; \
             JOB=$(./.venv/bin/research list --json --status running 2>/dev/null \
                   | /usr/bin/python3 -c 'import json,sys; jobs=json.load(sys.stdin); print(jobs[0]["id"]) if jobs else None') &amp;&amp; \
             [ -n "$JOB" ] &amp;&amp; ./.venv/bin/research resume "$JOB"</string>
@@ -714,8 +737,8 @@ most recent running job auto-resume. Drop a launch agent at
 </plist>
 ```
 
-Load it once: `launchctl load ~/Library/LaunchAgents/com.alpha.research.resume.plist`.
-Edit `/path/to/alpha-research` to your checkout. Inspect
+Load it once: `launchctl load ~/Library/LaunchAgents/com.muckwire.resume.plist`.
+Edit `/path/to/muckwire` to your checkout. Inspect
 `/tmp/research-resume.{out,err}.log` if a boot doesn't pick up the job
 you expected.
 
@@ -757,7 +780,7 @@ research _smoke-llm vision "Describe this" --image path/to/page.png
 research _smoke-llm embeddings "vector me"
 
 # Tool registry probes (Phase 3 connectors).
-research _smoke-tool web_search "alpha research project"
+research _smoke-tool web_search "muckraker investigative journalism"
 research _smoke-tool web_fetch "https://example.com/article"
 research _smoke-tool arxiv "transformer interpretability"
 research _smoke-tool news "federal reserve"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Autonomous CLI research agent (see research-agent-implementation-
 requires-python = ">=3.12"
 readme = "README.md"
 license = { text = "MIT" }
-authors = [{ name = "Alpha Research" }]
+authors = [{ name = "Muckwire" }]
 dependencies = [
     "pydantic>=2.7",
     "pydantic-ai>=0.0.40",

--- a/research-agent-implementation-guide.md
+++ b/research-agent-implementation-guide.md
@@ -92,7 +92,7 @@ The strategic doc made this call already (§2.2 there); v1 honors it.
 ## 4. Project layout
 
 ```
-alpha-research/
+muckwire/
 ├── pyproject.toml
 ├── README.md
 ├── .env.example

--- a/src/research_agent/skills/connectors/wikidata.md
+++ b/src/research_agent/skills/connectors/wikidata.md
@@ -107,6 +107,6 @@ time over a rolling 60-second window as a CPU-time proxy and backs off before it
 submits more SPARQL.
 
 Wikimedia requires a descriptive project-identifying User-Agent. This connector
-sends `research-agent/0.1 (+https://github.com/bradtaylorsf/alpha-research; contact: ...)`
+sends `research-agent/0.1 (+https://github.com/bradtaylorsf/muckwire; contact: ...)`
 and honors HTTP 429 `Retry-After`. Policy reference:
 https://meta.wikimedia.org/wiki/User-Agent_policy

--- a/src/research_agent/tools/_mediawiki.py
+++ b/src/research_agent/tools/_mediawiki.py
@@ -22,7 +22,7 @@ from research_agent import config
 
 logger = logging.getLogger(__name__)
 
-PROJECT_URL = "https://github.com/bradtaylorsf/alpha-research"
+PROJECT_URL = "https://github.com/bradtaylorsf/muckwire"
 RATE_LIMIT_INTERVAL = 1.0
 
 _TAG_RE = re.compile(r"<[^>]+>")

--- a/src/research_agent/tools/wikidata.py
+++ b/src/research_agent/tools/wikidata.py
@@ -47,7 +47,7 @@ KIND = "wikidata_search"
 
 _SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
 _ENTITY_DATA_BASE = "https://www.wikidata.org/wiki/Special:EntityData"
-_PROJECT_URL = "https://github.com/bradtaylorsf/alpha-research"
+_PROJECT_URL = "https://github.com/bradtaylorsf/muckwire"
 _HOSTS = {"wikidata.org", "www.wikidata.org"}
 
 _RATE_WINDOW_SECONDS = 60.0

--- a/tests/fixtures/corpus/sample.html
+++ b/tests/fixtures/corpus/sample.html
@@ -33,7 +33,7 @@
     </article>
   </main>
   <footer>
-    <p>&copy; 2026 Alpha Research</p>
+    <p>&copy; 2026 Muckwire</p>
   </footer>
 </body>
 </html>

--- a/tests/research_agent/tools/test_commons.py
+++ b/tests/research_agent/tools/test_commons.py
@@ -114,7 +114,7 @@ async def test_search_happy_path_enriches_license_metadata(
     assert headers["Accept"] == "application/json"
     assert headers["User-Agent"] == (
         "research-agent/0.1 "
-        "(+https://github.com/bradtaylorsf/alpha-research; "
+        "(+https://github.com/bradtaylorsf/muckwire; "
         "contact: operator@example.test)"
     )
 

--- a/tests/research_agent/tools/test_dpla.py
+++ b/tests/research_agent/tools/test_dpla.py
@@ -24,7 +24,7 @@ def _reset_state(monkeypatch: pytest.MonkeyPatch):
     config.reset_for_tests()
     dpla.reset_for_tests()
     monkeypatch.setenv("DPLA_API_KEY", "1234567890abcdef1234567890abcdef")
-    monkeypatch.setenv("RESEARCH_USER_AGENT", "alpha-research tests")
+    monkeypatch.setenv("RESEARCH_USER_AGENT", "muckwire tests")
     monkeypatch.setattr(dpla.asyncio, "sleep", AsyncMock())
     yield
     dpla.reset_for_tests()
@@ -110,7 +110,7 @@ async def test_search_happy_path_populates_required_metadata(
 
     headers = captured["headers"][0]
     assert headers["Accept"] == "application/json"
-    assert headers["User-Agent"] == "alpha-research tests"
+    assert headers["User-Agent"] == "muckwire tests"
     params = captured["params"][0]
     assert params == {
         "api_key": "1234567890abcdef1234567890abcdef",

--- a/tests/research_agent/tools/test_europeana.py
+++ b/tests/research_agent/tools/test_europeana.py
@@ -24,7 +24,7 @@ def _reset_state(monkeypatch: pytest.MonkeyPatch):
     config.reset_for_tests()
     europeana.reset_for_tests()
     monkeypatch.setenv("EUROPEANA_API_KEY", "europeana-test-key")
-    monkeypatch.setenv("RESEARCH_USER_AGENT", "alpha-research tests")
+    monkeypatch.setenv("RESEARCH_USER_AGENT", "muckwire tests")
     monkeypatch.setattr(europeana.asyncio, "sleep", AsyncMock())
     yield
     europeana.reset_for_tests()
@@ -114,7 +114,7 @@ async def test_search_happy_path_populates_required_metadata(
 
     headers = captured["headers"][0]
     assert headers["Accept"] == "application/json"
-    assert headers["User-Agent"] == "alpha-research tests"
+    assert headers["User-Agent"] == "muckwire tests"
     params = captured["params"][0]
     assert params == {
         "query": "Algerian war 1954",

--- a/tests/research_agent/tools/test_openalex.py
+++ b/tests/research_agent/tools/test_openalex.py
@@ -194,7 +194,7 @@ async def test_fetch_accepts_api_and_doi_urls(monkeypatch: pytest.MonkeyPatch) -
 async def test_polite_pool_mailto_and_optional_api_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("RESEARCH_USER_AGENT", "alpha-research (mailto:ops@example.org)")
+    monkeypatch.setenv("RESEARCH_USER_AGENT", "muckwire (mailto:ops@example.org)")
     monkeypatch.setenv("OPENALEX_API_KEY", "oa_test_key")
 
     def _respond(url, params):
@@ -208,14 +208,14 @@ async def test_polite_pool_mailto_and_optional_api_key(
     assert params["mailto"] == "ops@example.org"
     assert params["api_key"] == "oa_test_key"
     assert captured["headers"][0]["User-Agent"] == (
-        "alpha-research (mailto:ops@example.org)"
+        "muckwire (mailto:ops@example.org)"
     )
 
 
 async def test_anonymous_requests_omit_mailto_and_api_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("RESEARCH_USER_AGENT", "alpha-research no contact")
+    monkeypatch.setenv("RESEARCH_USER_AGENT", "muckwire no contact")
 
     def _respond(url, params):
         return _FakeResp(200, {"results": []})
@@ -258,7 +258,7 @@ async def test_rate_limit_gate_uses_5_rps_when_identified(
 async def test_rate_limit_gate_uses_1_rps_without_identification(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("RESEARCH_USER_AGENT", "alpha-research no contact")
+    monkeypatch.setenv("RESEARCH_USER_AGENT", "muckwire no contact")
     clock = [100.0]
     sleep_calls: list[float] = []
 

--- a/tests/research_agent/tools/test_openlibrary.py
+++ b/tests/research_agent/tools/test_openlibrary.py
@@ -122,7 +122,7 @@ async def test_search_empty_payload_returns_empty(monkeypatch: pytest.MonkeyPatc
 async def test_user_agent_header_includes_configured_value(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("RESEARCH_USER_AGENT", "alpha-research test ua")
+    monkeypatch.setenv("RESEARCH_USER_AGENT", "muckwire test ua")
 
     def _respond(url, params):
         return _FakeResp(200, _fixture("search_empty.json"))
@@ -131,7 +131,7 @@ async def test_user_agent_header_includes_configured_value(
 
     await openlibrary.search("Pullman Strike", max_results=1)
 
-    assert captured["headers"][0]["User-Agent"] == "alpha-research test ua"
+    assert captured["headers"][0]["User-Agent"] == "muckwire test ua"
 
 
 async def test_rate_limit_gate_sleeps_to_enforce_three_rps(

--- a/tests/research_agent/tools/test_smithsonian.py
+++ b/tests/research_agent/tools/test_smithsonian.py
@@ -24,7 +24,7 @@ def _reset_state(monkeypatch: pytest.MonkeyPatch):
     config.reset_for_tests()
     smithsonian.reset_for_tests()
     monkeypatch.setenv("DATA_GOV_API_KEY", "si-test-key")
-    monkeypatch.setenv("RESEARCH_USER_AGENT", "alpha-research tests")
+    monkeypatch.setenv("RESEARCH_USER_AGENT", "muckwire tests")
     monkeypatch.setattr(smithsonian.asyncio, "sleep", AsyncMock())
     yield
     smithsonian.reset_for_tests()
@@ -103,7 +103,7 @@ async def test_search_happy_path_populates_required_metadata(
 
     headers = captured["headers"][0]
     assert headers["Accept"] == "application/json"
-    assert headers["User-Agent"] == "alpha-research tests"
+    assert headers["User-Agent"] == "muckwire tests"
     params = captured["params"][0]
     assert params == {"api_key": "si-test-key", "q": "Apollo 11", "rows": 2}
 

--- a/tests/research_agent/tools/test_wikidata.py
+++ b/tests/research_agent/tools/test_wikidata.py
@@ -108,7 +108,7 @@ async def test_search_happy_path_raw_sparql(monkeypatch: pytest.MonkeyPatch):
     assert headers["Accept"] == "application/sparql-results+json"
     assert headers["User-Agent"] == (
         "research-agent/0.1 "
-        "(+https://github.com/bradtaylorsf/alpha-research; "
+        "(+https://github.com/bradtaylorsf/muckwire; "
         "contact: operator@example.test)"
     )
 

--- a/tests/research_agent/tools/test_wikisource.py
+++ b/tests/research_agent/tools/test_wikisource.py
@@ -99,7 +99,7 @@ async def test_search_happy_path_uses_mediawiki_search(
     assert headers["Accept"] == "application/json"
     assert headers["User-Agent"] == (
         "research-agent/0.1 "
-        "(+https://github.com/bradtaylorsf/alpha-research; "
+        "(+https://github.com/bradtaylorsf/muckwire; "
         "contact: operator@example.test)"
     )
 

--- a/tools/smoke_1hour.sh
+++ b/tools/smoke_1hour.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# 1-hour end-to-end smoke for alpha-research.
+# 1-hour end-to-end smoke for muckwire.
 #
 # Validates the full agent pipeline (every connector + skills + cornerstone PDF
 # + drain-replan + dept tracker + source reconciliation + archive/compare)


### PR DESCRIPTION
## Summary

Renames the repo brand from `alpha-research` / "Alpha Research" to **muckwire** throughout the codebase. The GitHub repo has been renamed `bradtaylorsf/alpha-research` → `bradtaylorsf/muckwire` (redirects auto-created by GitHub).

Closes #301 once merged.

## Scope

**Renamed:** every brand string in documentation, prose, code constants, configuration, and test fixtures. Final repo-wide grep for `alpha-research` / `Alpha Research` is empty (outside `.git`, `.venv`, `.alpha-loop`, `.worktrees`).

**Kept:** the Python package name `research-agent` / `research_agent` (used in `pyproject.toml`, the `src/research_agent/` directory, every import, the `research` CLI entry point, and the `research-agent/0.1` User-Agent default constants). The package name describes *what the code does*, separate from the repo brand — same pattern as `pandas-dev/pandas`. The package rename is Phase 3 in #301 and will land as a separate PR if/when the package is published.

## New `## The name` README section

Inserted between the deeper-detail list and `## Architecture`. Explains the muckraker tradition (Tarbell, Steffens, Sinclair, Wells, Riis, Hine; Roosevelt's 1906 coinage; the Progressive Era accountability legacy) and ties "wire" to the wire-service plumbing that moved investigations between cities. Two short paragraphs.

## Commits

1. `9440d2c` — Phase 1(a): brand strings not coupled to the GitHub URL (README, CLAUDE.md, AGENTS.md, pyproject.toml authors, the long-form docs, agent prompt headers).
2. `12594de` — Phase 1(b): everything that was waiting on the GitHub repo rename (CONTRIBUTING.md, `.alpha-loop.yaml`, the `PROJECT_URL` constants in `_mediawiki.py` and `wikidata.py`, the UA-asserting tests in `test_wikidata.py` / `test_commons.py` / `test_wikisource.py`, the UA docs in `wikidata.md` skill). Also cleans up arbitrary `RESEARCH_USER_AGENT` fixture values in `test_openlibrary.py`, `test_dpla.py`, `test_europeana.py`, `test_smithsonian.py`, `test_openalex.py` for visual consistency.

## Notable editorial choice

`README.md:760` smoke-test example query changed from `"alpha research project"` to `"muckraker investigative journalism"` — the original was self-referential to the old brand name; the new one preserves that.

## Test plan

- [x] `uv run pytest tests/test_storage_jobs.py` — 38/38 pass (sanity check on slugify, just merged in #300)
- [x] `uv run pytest` on every test file touched by the rename — 162/162 pass
- [ ] CI green
- [ ] Render the README on GitHub and read the new `## The name` section in context

## Still to do after this PR

These are Phase 2/Phase 3 of #301 — out of scope for this PR:

- Reserve `muckwire` on npm and PyPI
- Buy `muckwire.*` domain(s)
- Rename the local working directory `/Users/bradtaylor/Documents/GitHub/alpha-research` → `.../muckwire` (close editors first; update any worktree paths)
- Phase 3 — Python package rename (`research_agent` → `muckwire`): touches every import, the `src/` directory, `[project.scripts]`, `[tool.setuptools.packages.find]`, `[tool.setuptools.package-data]`, and the `_DEFAULT_USER_AGENT = "research-agent/0.1"` constants. Worth doing when/if publishing to PyPI under the brand name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)