### PR TITLE
feat: batch implementation (#258, #261, #262, #304)

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,8 @@ research start --skip-intake \
     --goal "Compare Pydantic AI, LangGraph, and CrewAI" \
     --budget-usd 5.00 \
     --time-cap 24 \
-    --disk-cap-gb 10
+    --disk-cap-gb 10 \
+    --inbox
 # → Started job 2026-05-02-compare-pydantic-ai- (daemon pid 12345).
 #   Tail logs with: research logs 2026-05-02-compare-pydantic-ai- -f
 
@@ -413,9 +414,13 @@ jobs/<job-id>/
 ├── sources/              # symlinks/copies of canonical source markdown
 ├── synthesis/            # synthesis/NNNN.md (versioned)
 ├── critique/             # critique/NNNN.md (versioned)
+├── artifacts/            # structured outputs such as CSV tables
+├── inbox/                # optional human-supplied documents for live ingest
+│   └── processed/        # ingested inbox files, renamed with content hash
 ├── report.md             # current report (rotated to report.history/ on rewrite)
 ├── report.history/       # archived prior reports
 ├── events.jsonl          # append-only event log
+├── INBOX_REPLAN.json     # transient replan trigger after inbox ingest
 ├── daemon.pid            # written on spawn, removed on clean exit
 ├── daemon.out.log        # daemon stdout
 ├── daemon.err.log        # daemon stderr
@@ -451,7 +456,7 @@ Lockfiles (`uv.lock`) are committed.
 ```bash
 research start --skip-intake --goal "<goal>" \
     [--budget-usd 5.0] [--time-cap 24] [--corpus path/to/notes] \
-    [--disk-cap-gb 10] [--translate-non-english]
+    [--disk-cap-gb 10] [--translate-non-english] [--inbox]
 
 research list                      # newest first; Rich on a TTY, JSON otherwise
 research list --json
@@ -464,6 +469,7 @@ research view <job-id>             # report.md in $EDITOR (or stdout off-TTY)
 research view <job-id> --report
 research view <job-id> --findings  # latest findings/NNNNNN.md
 research view <job-id> --sources
+research view <job-id> --hypotheses
 
 research logs <job-id>             # print existing events.jsonl entries
 research logs <job-id> -f          # follow appended events
@@ -475,6 +481,10 @@ research stop <job-id> --kill      # SIGTERM, then SIGKILL after 10s
 research resume <job-id>           # respawn daemon, restore from checkpoint
 research resume <job-id> --force   # resume even when completed/failed
 
+research inbox <job-id> add <file>  # copy a human-supplied doc into the live inbox
+research inbox <job-id> list        # show pending and processed inbox files
+# Registered verb paths: research inbox add, research inbox list.
+
 research search "<query>"          # hybrid FTS5 + semantic (cross-job)
 research search "<query>" --fts-only
 research search "<query>" --job <job-id>
@@ -484,6 +494,7 @@ research search "<query>" --json
 
 research export <job-id> --zip
 research export <job-id> --md-bundle
+research export <job-id> --csv <artifact-name>
 research export <job-id> --zip --out PATH
 research export <job-id> --md-bundle --include-history
 
@@ -498,6 +509,11 @@ DB row, and spawns a detached daemon via
 `subprocess.Popen(start_new_session=True)`. The PID is written atomically
 to `jobs/<id>/daemon.pid`; the daemon's stdout/stderr land in
 `jobs/<id>/daemon.{out,err}.log`.
+
+`--inbox` enables a live `jobs/<id>/inbox/` watcher for the daemon. Files
+added with `research inbox <job-id> add <file>` are indexed into the local
+corpus, moved to `inbox/processed/`, logged as `corpus_doc_added`, and
+used to trigger a tactical replan while the daemon is still running.
 
 `--translate-non-english` is off by default. When enabled, extracted
 findings whose source metadata is non-English get a
@@ -516,7 +532,11 @@ debugging FTS5 syntax).
 `research export` bundles a job for sharing. `--zip` walks
 `jobs/<job-id>/` into a `ZIP_DEFLATED` archive; `--md-bundle` concatenates
 intake, `report.md`, every finding, and the source list into one navigable
-markdown file. Exactly one mode flag is required.
+markdown file; `--csv <artifact-name>` exports a structured table artifact
+from `jobs/<job-id>/artifacts/` with stable column order and empty cells
+for missing optional values. Exactly one mode flag is required. When
+structured artifacts exist, synthesis links them from the report instead
+of relying on prose-only list output.
 
 `research compare` diffs two runs by counts (tasks, findings, sources,
 plan versions, drain-replans, cornerstone hits), department coverage, and

--- a/src/research_agent/cli.py
+++ b/src/research_agent/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -17,12 +18,14 @@ from urllib.parse import urlparse
 import typer
 from rich.console import Console
 from rich.live import Live
+from rich.table import Table
 
 from research_agent import __version__, config, daemon, doctor, intake
 from research_agent.storage import db
 from research_agent.storage.jobs import (
     _JOB_ID_RE,
     DEFAULT_JOBS_ROOT,
+    INBOX_REPLAN_FILE,
     RESUME_REPLAN_FILE,
     Job,
     _atomic_write_json,
@@ -44,6 +47,25 @@ config_app = typer.Typer(
     no_args_is_help=True,
 )
 app.add_typer(config_app)
+
+inbox_app = typer.Typer(
+    name="inbox",
+    help="Manage jobs/<id>/inbox/ human-supplied documents.",
+    no_args_is_help=True,
+)
+app.add_typer(inbox_app)
+
+
+@inbox_app.callback()
+def inbox_callback(
+    ctx: typer.Context,
+    job_id: str = typer.Argument(  # noqa: B008
+        ...,
+        help="Job id (e.g. 2026-05-02-some-slug).",
+    ),
+) -> None:
+    """Inbox command group for one job."""
+    ctx.obj = {"job_id": job_id}
 
 
 @config_app.command(name="cache-clear")
@@ -142,6 +164,11 @@ def start_command(
         " --fresh-reset to opt out and require a clean slate (which fails with"
         " FileExistsError if the folder still exists — run _reset-job first).",
     ),
+    inbox: bool = typer.Option(
+        False,
+        "--inbox",
+        help="Enable jobs/<id>/inbox/ watcher for mid-run document ingest.",
+    ),
 ) -> None:
     """Register a new research job and spawn its background daemon."""
     if skip_intake:
@@ -155,6 +182,7 @@ def start_command(
             "budget_cap_usd": budget_usd,
             "disk_cap_gb": disk_cap_gb,
             "translate_non_english": translate_non_english,
+            "inbox": inbox,
         }
         if corpus:
             intake_data["corpus"] = corpus
@@ -167,6 +195,7 @@ def start_command(
             "corpus": answers["corpus_path"],
             "disk_cap_gb": disk_cap_gb,
             "translate_non_english": translate_non_english,
+            "inbox": inbox,
         }
 
     if max_tasks is not None:
@@ -271,6 +300,75 @@ def _load_job_or_exit(job_id: str) -> Job:
         raise typer.Exit(code=1) from e
 
 
+def _job_inbox_dir(job: Job) -> Path:
+    inbox_dir = job.root / "inbox"
+    (inbox_dir / "processed").mkdir(parents=True, exist_ok=True)
+    return inbox_dir
+
+
+@inbox_app.command(name="add")
+def inbox_add_command(
+    ctx: typer.Context,
+    file: Path = typer.Argument(  # noqa: B008
+        ...,
+        help="File to copy into jobs/<id>/inbox/.",
+    ),
+) -> None:
+    """Copy a human-supplied document into a job inbox."""
+    job_id = str((ctx.obj or {}).get("job_id") or "")
+    job = _load_job_or_exit(job_id)
+    source = Path(file)
+    if not source.is_file():
+        typer.echo(f"file not found: {source}", err=True)
+        raise typer.Exit(code=1)
+    inbox_dir = _job_inbox_dir(job)
+    dest = inbox_dir / source.name
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    try:
+        shutil.copyfile(source, tmp)
+        os.replace(tmp, dest)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+    typer.echo(str(dest))
+
+
+@inbox_app.command(name="list")
+def inbox_list_command(
+    ctx: typer.Context,
+) -> None:
+    """List pending and processed files in a job inbox."""
+    job_id = str((ctx.obj or {}).get("job_id") or "")
+    job = _load_job_or_exit(job_id)
+    inbox_dir = _job_inbox_dir(job)
+    processed_dir = inbox_dir / "processed"
+    table = Table(title=f"Inbox for {job.id}")
+    table.add_column("state")
+    table.add_column("file")
+    table.add_column("bytes", justify="right")
+
+    rows = 0
+    for path in sorted(inbox_dir.iterdir()):
+        if path.name == "processed" or not path.is_file() or path.name.endswith(".tmp"):
+            continue
+        table.add_row("pending", path.name, str(path.stat().st_size))
+        rows += 1
+    for path in sorted(processed_dir.iterdir()) if processed_dir.exists() else []:
+        if not path.is_file():
+            continue
+        table.add_row("processed", path.name, str(path.stat().st_size))
+        rows += 1
+    if (job.root / INBOX_REPLAN_FILE).exists():
+        table.add_row("replan", INBOX_REPLAN_FILE, "")
+        rows += 1
+    if rows == 0:
+        typer.echo(f"no inbox files for job {job.id}")
+        return
+    Console().print(table)
+
+
 @app.command(name="status")
 def status_command(
     job_id: str = typer.Argument(..., help="Job id (e.g. 2026-05-02-some-slug)."),
@@ -339,15 +437,52 @@ def _render_sources_block(job: Job) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _render_hypotheses_block(job: Job) -> str:
+    from research_agent.storage import hypotheses as hypotheses_store
+
+    rows = hypotheses_store.latest_for_job(job)
+    if not rows:
+        return f"# Hypotheses for {job.id}\n\n(no hypotheses recorded)\n"
+
+    table = Table(title=f"Hypotheses for {job.id}")
+    table.add_column("id", justify="right")
+    table.add_column("status")
+    table.add_column("confidence", justify="right")
+    table.add_column("supports")
+    table.add_column("refutes")
+    table.add_column("statement")
+    for row in rows:
+        table.add_row(
+            str(row["id"]),
+            str(row["status"]),
+            f"{float(row['confidence']):.2f}",
+            ",".join(str(x) for x in row.get("supports") or []),
+            ",".join(str(x) for x in row.get("refutes") or []),
+            str(row["statement"]),
+        )
+    console = Console(record=True, width=140)
+    console.print(table)
+    return console.export_text()
+
+
 @app.command(name="view")
 def view_command(
     job_id: str = typer.Argument(..., help="Job id (e.g. 2026-05-02-some-slug)."),
     report: bool = typer.Option(False, "--report", help="View report.md (default)."),
     findings: bool = typer.Option(False, "--findings", help="View the latest finding."),
     sources: bool = typer.Option(False, "--sources", help="View a list of job sources."),
+    hypotheses: bool = typer.Option(
+        False,
+        "--hypotheses",
+        help="View the current working hypotheses ledger.",
+    ),
 ) -> None:
-    """View a research artifact (report, finding, or sources list)."""
+    """View a research artifact (report, finding, sources, or hypotheses)."""
     job = _load_job_or_exit(job_id)
+
+    if sum(bool(flag) for flag in (report, findings, sources, hypotheses)) > 1:
+        typer.echo("choose only one of --report, --findings, --sources, or --hypotheses", err=True)
+        raise typer.Exit(code=2)
 
     if findings:
         path = _latest_finding_path(job.root)
@@ -357,6 +492,9 @@ def view_command(
         body = path.read_text(encoding="utf-8")
     elif sources:
         body = _render_sources_block(job)
+        path = None
+    elif hypotheses:
+        body = _render_hypotheses_block(job)
         path = None
     else:  # report (default; --report is treated as the same path)
         _ = report  # accepted explicitly even though it's the default
@@ -437,6 +575,7 @@ def reset_job_command(
                 "critiques",
                 "findings",
                 "events",
+                "hypotheses",
                 "checkpoints",
                 "syntheses",
                 "llm_calls",
@@ -696,6 +835,11 @@ def export_command(
         "--md-bundle",
         help="Concatenate report + findings + sources into one markdown file.",
     ),
+    csv_artifact: str = typer.Option(
+        None,
+        "--csv",
+        help="Export a named table artifact from jobs/<id>/artifacts/ as CSV.",
+    ),
     out: Path = typer.Option(  # noqa: B008 — Typer captures defaults at decoration time
         None,
         "--out",
@@ -707,16 +851,21 @@ def export_command(
         help="Include report.history/ in the export.",
     ),
 ) -> None:
-    """Export a job as a shareable bundle (zip archive or single markdown file)."""
-    from research_agent.storage.export import export_md_bundle, export_zip
+    """Export a job as a shareable bundle or table artifact."""
+    from research_agent.storage.artifacts import list_artifacts
+    from research_agent.storage.export import export_csv, export_md_bundle, export_zip
 
-    if zip_ == md_bundle:
-        typer.echo("exactly one of --zip or --md-bundle must be set", err=True)
+    selected = sum([bool(zip_), bool(md_bundle), bool(csv_artifact)])
+    if selected != 1:
+        typer.echo("exactly one of --zip, --md-bundle, or --csv must be set", err=True)
         raise typer.Exit(code=2)
 
     job = _load_job_or_exit(job_id)
-    suffix = ".zip" if zip_ else ".md"
-    default_name = f"{job.id}{suffix}"
+    if csv_artifact:
+        default_name = f"{job.id}-{csv_artifact}.csv"
+    else:
+        suffix = ".zip" if zip_ else ".md"
+        default_name = f"{job.id}{suffix}"
 
     if out is None:
         out_path = Path.cwd() / default_name
@@ -727,8 +876,17 @@ def export_command(
 
     if zip_:
         written = export_zip(job, out_path, include_history=include_history)
-    else:
+    elif md_bundle:
         written = export_md_bundle(job, out_path, include_history=include_history)
+    else:
+        assert csv_artifact is not None  # noqa: S101
+        try:
+            written = export_csv(job, csv_artifact, out_path)
+        except FileNotFoundError as exc:
+            available = [item["name"] for item in list_artifacts(job)]
+            suffix = f" Available artifacts: {', '.join(available)}." if available else ""
+            typer.echo(f"{exc}.{suffix}", err=True)
+            raise typer.Exit(code=1) from exc
     typer.echo(str(written))
 
 

--- a/src/research_agent/daemon.py
+++ b/src/research_agent/daemon.py
@@ -33,9 +33,11 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import hashlib
 import json
 import logging
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -49,9 +51,16 @@ import httpx
 from research_agent.config import get as cfg_get
 from research_agent.observability.events import emit
 from research_agent.storage import db
-from research_agent.storage.jobs import DEFAULT_JOBS_ROOT, RESUME_REPLAN_FILE, Job
+from research_agent.storage.jobs import (
+    DEFAULT_JOBS_ROOT,
+    INBOX_REPLAN_FILE,
+    RESUME_REPLAN_FILE,
+    Job,
+)
 
 logger = logging.getLogger(__name__)
+
+INBOX_POLL_INTERVAL_S = 30.0
 
 
 def _atomic_write_text(path: Path, data: str) -> None:
@@ -594,6 +603,130 @@ async def _disk_cap_watcher(
         return
 
 
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _inbox_topic_guess(path: Path) -> str:
+    stem = re.sub(r"[_-]+", " ", path.stem).strip()
+    return stem[:120] if stem else path.name[:120]
+
+
+def _inbox_summary(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix in {".md", ".txt", ".html", ".htm"}:
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            text = ""
+        text = " ".join(text.split())
+        if text:
+            return text[:240]
+    try:
+        size = path.stat().st_size
+    except OSError:
+        size = 0
+    return f"{path.suffix.lower().lstrip('.') or 'file'}; {size} bytes"
+
+
+def _processed_inbox_path(inbox_dir: Path, sha: str, filename: str) -> Path:
+    processed_dir = inbox_dir / "processed"
+    processed_dir.mkdir(parents=True, exist_ok=True)
+    safe_name = re.sub(r"[^A-Za-z0-9._-]+", "-", filename).strip("-") or "document"
+    return processed_dir / f"{sha}-{safe_name}"
+
+
+async def _inbox_watcher(
+    job: Job,
+    should_stop: asyncio.Event,
+    *,
+    interval_s: float | None = None,
+) -> None:
+    """Poll ``jobs/<id>/inbox`` for human-supplied documents."""
+    from research_agent.tools import local_corpus
+
+    poll_s = interval_s if interval_s is not None else INBOX_POLL_INTERVAL_S
+    inbox_dir = job.root / "inbox"
+    inbox_dir.mkdir(parents=True, exist_ok=True)
+    (inbox_dir / "processed").mkdir(parents=True, exist_ok=True)
+
+    try:
+        while not should_stop.is_set():
+            for file_path in sorted(inbox_dir.iterdir()):
+                if should_stop.is_set():
+                    break
+                if not file_path.is_file():
+                    continue
+                if file_path.name.endswith(".tmp"):
+                    continue
+                try:
+                    sha = _file_sha256(file_path)
+                    summary = _inbox_summary(file_path)
+                    topic_guess = _inbox_topic_guess(file_path)
+                    indexed = local_corpus.index(file_path, job)
+                    processed_path = _processed_inbox_path(inbox_dir, sha, file_path.name)
+                    os.replace(file_path, processed_path)
+                    note = (
+                        f"user added {file_path.name} ({summary}); "
+                        "identify NEW angles enabled by this evidence"
+                    )
+                    _atomic_write_text(
+                        job.root / INBOX_REPLAN_FILE,
+                        json.dumps(
+                            {
+                                "trigger": "inbox",
+                                "filename": file_path.name,
+                                "sha": sha,
+                                "summary": summary,
+                                "note": note,
+                            },
+                            indent=2,
+                            sort_keys=True,
+                        )
+                        + "\n",
+                    )
+                    emit(
+                        job,
+                        "INFO",
+                        "daemon",
+                        "corpus_doc_added",
+                        {
+                            "sha": sha,
+                            "filename": file_path.name,
+                            "processed_path": str(processed_path.relative_to(job.root)),
+                            "topic_guess": topic_guess,
+                            "summary_chars": len(summary),
+                            **indexed,
+                        },
+                    )
+                except Exception as exc:  # noqa: BLE001 — keep watcher alive
+                    logger.exception("inbox watcher failed for %s", file_path)
+                    try:
+                        emit(
+                            job,
+                            "WARN",
+                            "daemon",
+                            "warning",
+                            {
+                                "stage": "inbox_watcher",
+                                "path": str(file_path),
+                                "error": str(exc),
+                            },
+                        )
+                    except Exception:
+                        pass
+            try:
+                await asyncio.wait_for(should_stop.wait(), timeout=poll_s)
+            except TimeoutError:
+                continue
+    except asyncio.CancelledError:
+        return
+
+
 def _should_show_foreground_progress(stream: Any) -> bool:
     """True when the daemon should drive a Rich Progress bar on ``stream``.
 
@@ -912,6 +1045,9 @@ async def run_daemon(
         disk_cap_gb = DEFAULT_DISK_CAP_GB
     cap_bytes = max(1, int(disk_cap_gb * 1024 * 1024 * 1024))
     disk_cap_task = aloop.create_task(_disk_cap_watcher(job, cap_bytes, should_stop))
+    inbox_task: asyncio.Task | None = None
+    if intake.get("inbox") is True:
+        inbox_task = aloop.create_task(_inbox_watcher(job, should_stop))
     progress_task = aloop.create_task(_foreground_progress_task(job, should_stop))
 
     from research_agent.llm.budgets import BudgetExceeded
@@ -1052,6 +1188,8 @@ async def run_daemon(
         # synth, then sat idle for 48 min in this finally block.
         await _cancel_with_timeout(watcher_task, "stop_flag_watcher", timeout=5.0)
         await _cancel_with_timeout(disk_cap_task, "disk_cap_watcher", timeout=5.0)
+        if inbox_task is not None:
+            await _cancel_with_timeout(inbox_task, "inbox_watcher", timeout=5.0)
         await _cancel_with_timeout(progress_task, "foreground_progress_task", timeout=5.0)
         if signals_installed:
             for sig in (signal.SIGTERM, signal.SIGINT):

--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -53,6 +53,8 @@ EventKind = Literal[
     "replan_truncated",
     "findings_truncated",
     "low_yield_connector",
+    "hypothesis_updated",
+    "corpus_doc_added",
     "llm_call",
     "lmstudio_degraded",
     "lmstudio_recovered",

--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -53,7 +53,7 @@ from research_agent.orchestrator.errors import FatalError, RetriableError
 from research_agent.orchestrator.plan import Plan, TaskKind, TaskSpec
 from research_agent.skills import load_skill, load_strategies
 from research_agent.storage import db
-from research_agent.storage.jobs import Job, _atomic_write_text
+from research_agent.storage.jobs import INBOX_REPLAN_FILE, Job, _atomic_write_text
 from research_agent.storage.tasks import (
     enqueue,
     mark_done,
@@ -1274,6 +1274,78 @@ async def _drain_replan(
         productive_task_count=productive_count,
         should_continue=True,
     )
+
+
+def _consume_inbox_replan_request(job: Job) -> dict[str, Any] | None:
+    path = job.root / INBOX_REPLAN_FILE
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8") or "{}")
+    except (OSError, json.JSONDecodeError):
+        payload = {}
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    return payload if isinstance(payload, dict) else {}
+
+
+async def _inbox_replan(
+    job: Job,
+    plan: Plan,
+    *,
+    router: Any,
+    request: dict[str, Any],
+) -> Plan | None:
+    from research_agent.orchestrator.plan import (
+        _compute_prior_attempts_for_subgoal,
+        tactical_replan,
+    )
+
+    recent_results = _load_recent_task_results(job)
+    prior_attempts = _compute_prior_attempts_for_subgoal(plan, _load_all_task_attempts(job))
+    inconclusive_context = [
+        item for item in prior_attempts.values() if item.get("prior_task_kinds")
+    ]
+    kwargs: dict[str, Any] = {}
+    if inconclusive_context:
+        kwargs["inconclusive_subgoals"] = inconclusive_context
+    note = request.get("note")
+    if isinstance(note, str) and note.strip():
+        kwargs["user_note"] = note.strip()
+    emit(
+        job,
+        "INFO",
+        "loop",
+        "replan_triggered",
+        {
+            "stage": "inbox",
+            "filename": request.get("filename"),
+            "sha": request.get("sha"),
+            "has_note": "user_note" in kwargs,
+        },
+    )
+    try:
+        return await tactical_replan(
+            job,
+            plan,
+            recent_results,
+            router=router,
+            findings=_load_all_findings(job),
+            synthesis_md=_load_latest_synthesis_md(job),
+            follow_up_questions=_load_pending_follow_up_questions(recent_results),
+            **kwargs,
+        )
+    except Exception as exc:  # noqa: BLE001 — inbox replan failure must not kill loop
+        emit(
+            job,
+            "WARN",
+            "loop",
+            "warning",
+            {"inbox_replan_failed": True, "error": str(exc)},
+        )
+        return None
 
 
 def _make_wait_fn(wait_seq: tuple[int, ...]) -> Callable[[Any], int]:
@@ -3089,6 +3161,13 @@ async def run_loop(
         and tasks_done < max_tasks
         and _within_time_cap()
     ):
+        inbox_request = _consume_inbox_replan_request(job)
+        if inbox_request is not None:
+            inbox_plan = await _inbox_replan(job, plan, router=router, request=inbox_request)
+            if inbox_plan is not None:
+                plan = inbox_plan
+            continue
+
         task = next_pending(job)
         if task is None:
             cap = _resolve_drain_cap(plan)

--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -838,6 +838,9 @@ async def tactical_replan(
         "prior_plan": plan.model_dump(),
         "recent_results": summarized,
     }
+    from research_agent.storage import hypotheses
+
+    payload["hypotheses"] = hypotheses.list_hypotheses(job)
 
     # issue #179: include a bounded view of the running ``findings`` so the
     # planner can drill into named claims (Schedule F, WOTUS, mifepristone)
@@ -1046,10 +1049,13 @@ async def cloud_replan(
     """
     _assert_under_cap(job)
     next_version = plan.version + 1
+    from research_agent.storage import hypotheses
+
     context = json.dumps(
         {
             "prior_plan": plan.model_dump(),
             "critique": critique,
+            "hypotheses": hypotheses.list_hypotheses(job),
         },
         sort_keys=True,
         default=str,

--- a/src/research_agent/orchestrator/synth.py
+++ b/src/research_agent/orchestrator/synth.py
@@ -360,6 +360,498 @@ def _compute_department_coverage(findings: list[dict[str, Any]]) -> list[dict[st
     )
 
 
+def _load_jsonl_events(job: Job) -> list[dict[str, Any]]:
+    path = job.root / "events.jsonl"
+    if not path.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(item, dict):
+            events.append(item)
+    return events
+
+
+def _latest_inconclusive_subgoal_ids(job: Job) -> set[int]:
+    inconclusive: set[int] = set()
+    for event in _load_jsonl_events(job):
+        if event.get("kind") != "plan_subgoals_updated":
+            continue
+        payload = event.get("payload")
+        if not isinstance(payload, dict):
+            continue
+        raw_ids = payload.get("inconclusive")
+        if not isinstance(raw_ids, list):
+            continue
+        next_ids: set[int] = set()
+        for raw_id in raw_ids:
+            if isinstance(raw_id, bool):
+                continue
+            if isinstance(raw_id, int):
+                next_ids.add(raw_id)
+            elif isinstance(raw_id, str) and raw_id.strip().isdigit():
+                next_ids.add(int(raw_id.strip()))
+        inconclusive = next_ids
+    return inconclusive
+
+
+def _load_low_yield_records(job: Job) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, int]] = set()
+
+    def _add(item: dict[str, Any]) -> None:
+        kind = item.get("kind")
+        stem = item.get("query_stem")
+        count = item.get("count")
+        if not isinstance(kind, str) or not isinstance(stem, str):
+            return
+        try:
+            count_i = int(count)
+        except (TypeError, ValueError):
+            count_i = 0
+        if count_i < 3:
+            return
+        key = (kind, stem, count_i)
+        if key in seen:
+            return
+        seen.add(key)
+        records.append(dict(item, count=count_i))
+
+    for event in _load_jsonl_events(job):
+        if event.get("kind") != "low_yield_connector":
+            continue
+        payload = event.get("payload")
+        if isinstance(payload, dict):
+            _add(payload)
+
+    path = job.root / "synthesis" / "low_yield.json"
+    if path.exists():
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            raw = []
+        if isinstance(raw, list):
+            for item in raw:
+                if isinstance(item, dict):
+                    _add(item)
+    return records
+
+
+def _load_failed_task_rows(job: Job) -> list[dict[str, Any]]:
+    conn = db.connect(job.db_path)
+    try:
+        rows = conn.execute(
+            """
+            SELECT id, kind, payload_json, status, result_json, error
+            FROM tasks
+            WHERE job_id = ? AND status = 'failed'
+            ORDER BY id ASC
+            """,
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [dict(row) for row in rows]
+
+
+def _json_dict(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if not isinstance(raw, str) or not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _raw_query_from_payload(payload: dict[str, Any]) -> str:
+    for key in ("query", "q", "sub_question", "url", "source_id", "arxiv_id"):
+        value = payload.get(key)
+        if value not in (None, "", []):
+            return str(value)
+    return ""
+
+
+def _query_stem_for_payload(payload: dict[str, Any]) -> str:
+    from research_agent.orchestrator.plan import _attempt_query_stem
+
+    return _attempt_query_stem(payload)
+
+
+def _source_label_from_query(query: str) -> str | None:
+    city_match = re.search(r"\bcity\s+of\s+([a-z][a-z\s.'-]{2,60})", query, re.IGNORECASE)
+    if city_match:
+        name = " ".join(city_match.group(1).split())
+        return f"City of {name.title()}"
+    site_match = re.search(r"\bsite:([a-z0-9.-]+)", query, re.IGNORECASE)
+    host = site_match.group(1).lower() if site_match else ""
+    if host == "alamedaca.gov":
+        return "City of Alameda"
+    if host.endswith(".gov"):
+        label = host.split(".")[0]
+        label = re.sub(r"(ca|ny|tx|fl|wa|or|il|ma|pa|oh|mi|ga|nc|nj|va)$", "", label)
+        label = label.replace("-", " ").strip()
+        if label:
+            return label.title()
+    return None
+
+
+def _fallback_unblocker(kind: str, query: str, failure_reason: str | None) -> str:
+    lower = f"{kind} {query} {failure_reason or ''}".lower()
+    source_label = _source_label_from_query(query)
+    if source_label:
+        return f"FOIA the {source_label} Clerk or records custodian for records matching '{query}'"
+    if "courtlistener" in lower or "403" in lower:
+        return (
+            "Use a CourtListener API token from https://www.courtlistener.com/api/ "
+            f"or PACER/RECAP for '{query or kind}'"
+        )
+    if "calaccess" in lower or "form 460" in lower:
+        return (
+            "Request Form 460 records from the named city clerk or county elections "
+            f"office for '{query}'"
+        )
+    if "fec" in lower:
+        return f"Check FEC.gov candidate and committee filings directly for '{query}'"
+    if "edgar" in lower:
+        return f"Check SEC EDGAR directly or state SoS records for '{query}'"
+    if "licensing" in lower:
+        return f"Search the state licensing-board portal for '{query}'"
+    if "sos" in lower or "opencorporates" in lower:
+        return f"Search the state Secretary of State business registry for '{query}'"
+    if query:
+        return f"Ask the named records custodian or source owner for records matching '{query}'"
+    return f"Use the source owner or records custodian for {kind}"
+
+
+def _specific_unblocker(
+    *,
+    kind: str,
+    query: str,
+    failure_reason: str | None = None,
+    suggested: str | None = None,
+    gap_reason: str | None = None,
+) -> str:
+    for candidate in (suggested, gap_reason):
+        if isinstance(candidate, str) and candidate.strip():
+            text = candidate.strip().rstrip(".")
+            source_label = _source_label_from_query(query)
+            lower = text.lower()
+            if source_label and ("city clerk" in lower or "records request" in lower):
+                return f"FOIA the {source_label} Clerk for records matching '{query}'"
+            if query and query.lower() not in lower and len(text) < 180:
+                return f"{text} for '{query}'"
+            return text
+    return _fallback_unblocker(kind, query, failure_reason)
+
+
+def _topic_for_stem(stem: str, query: str) -> str:
+    text = query or stem
+    text = re.sub(r"\bsite:[^\s]+", "", text, flags=re.IGNORECASE).strip()
+    return text or "unresolved source gap"
+
+
+def _compute_confirmed_gaps(job: Job, plan: Plan) -> list[dict[str, Any]]:
+    """Aggregate failed/low-yield work into report-ready confirmed gaps."""
+    from research_agent.orchestrator.plan import _failure_reason_for_attempt, _task_matches_subgoal
+
+    subgoals_by_id = {sg.id: sg for sg in plan.subgoals}
+    inconclusive_ids = _latest_inconclusive_subgoal_ids(job)
+    low_yield_records = _load_low_yield_records(job)
+    low_yield_by_key: dict[tuple[str, str], dict[str, Any]] = {
+        (str(r.get("kind") or ""), str(r.get("query_stem") or "")): r
+        for r in low_yield_records
+    }
+    failed_rows = _load_failed_task_rows(job)
+
+    gaps: dict[str, dict[str, Any]] = {}
+    attempt_seen: set[tuple[str, str, str, str]] = set()
+    consumed_low_yield_keys: set[tuple[str, str]] = set()
+
+    def _ensure_gap(
+        topic: str,
+        *,
+        gap_reason: str | None = None,
+        suggested_unblocker: str | None = None,
+    ) -> dict[str, Any]:
+        normalized_topic = " ".join(topic.split()).strip() or "unresolved source gap"
+        gap = gaps.get(normalized_topic)
+        if gap is None:
+            gap = {
+                "topic": normalized_topic,
+                "attempts": [],
+                "failure_summary": "",
+                "suggested_unblocker": suggested_unblocker or "",
+                "_gap_reason": gap_reason,
+                "_reasons": {},
+            }
+            gaps[normalized_topic] = gap
+        else:
+            if gap_reason and not gap.get("_gap_reason"):
+                gap["_gap_reason"] = gap_reason
+            if suggested_unblocker and not gap.get("suggested_unblocker"):
+                gap["suggested_unblocker"] = suggested_unblocker
+        return gap
+
+    def _add_attempt(
+        gap: dict[str, Any],
+        *,
+        kind: str,
+        query: str,
+        failure_reason: str,
+        count: int,
+        suggested_unblocker: str | None = None,
+    ) -> None:
+        key = (str(gap["topic"]), kind, query, failure_reason)
+        if key in attempt_seen:
+            for attempt in gap["attempts"]:
+                if (
+                    attempt["task_kind"] == kind
+                    and attempt["query"] == query
+                    and attempt["failure_reason"] == failure_reason
+                ):
+                    current = int(attempt["count"])
+                    incoming = int(count)
+                    updated = max(current, incoming) if incoming > 1 else current + 1
+                    attempt["count"] = updated
+                    reasons = gap["_reasons"]
+                    reasons[failure_reason] = max(
+                        int(reasons.get(failure_reason, 0)),
+                        updated,
+                    )
+                    break
+            return
+        attempt_seen.add(key)
+        gap["attempts"].append(
+            {
+                "task_kind": kind,
+                "query": query,
+                "failure_reason": failure_reason,
+                "count": int(count),
+            }
+        )
+        reasons = gap["_reasons"]
+        reasons[failure_reason] = int(reasons.get(failure_reason, 0)) + int(count)
+        if suggested_unblocker:
+            gap["suggested_unblocker"] = suggested_unblocker
+
+    subgoal_payload_attempts: dict[int, list[tuple[dict[str, Any], dict[str, Any], str]]] = {
+        sid: [] for sid in subgoals_by_id
+    }
+    unmatched_failed: list[tuple[dict[str, Any], dict[str, Any], str]] = []
+    for row in failed_rows:
+        payload = _json_dict(row.get("payload_json"))
+        result = _json_dict(row.get("result_json"))
+        reason = _failure_reason_for_attempt(row, result) or str(row.get("error") or "failed")
+        matched_any = False
+        for sid, sg in subgoals_by_id.items():
+            if _task_matches_subgoal(sg, payload):
+                subgoal_payload_attempts.setdefault(sid, []).append((row, payload, reason))
+                matched_any = True
+        if not matched_any:
+            unmatched_failed.append((row, payload, reason))
+
+    for sid, sg in subgoals_by_id.items():
+        gap_reason = sg.gap_reason if isinstance(sg.gap_reason, str) else None
+        if sid not in inconclusive_ids and not gap_reason:
+            continue
+        representative_query = ""
+        attempts = subgoal_payload_attempts.get(sid) or []
+        if attempts:
+            representative_query = _raw_query_from_payload(attempts[0][1])
+        unblocker = _specific_unblocker(
+            kind="subgoal",
+            query=representative_query or sg.description,
+            gap_reason=gap_reason,
+        )
+        gap = _ensure_gap(
+            sg.description,
+            gap_reason=gap_reason,
+            suggested_unblocker=unblocker,
+        )
+        for row, payload, reason in attempts:
+            kind = str(row.get("kind") or "task")
+            query = _raw_query_from_payload(payload) or _query_stem_for_payload(payload)
+            stem = _query_stem_for_payload(payload)
+            low_yield_key = (kind, stem)
+            suggested = low_yield_by_key.get(low_yield_key, {}).get("suggested_unblocker")
+            attempt_unblocker = (
+                _specific_unblocker(
+                    kind=kind,
+                    query=query,
+                    failure_reason=reason,
+                    suggested=suggested,
+                )
+                if isinstance(suggested, str) and suggested.strip()
+                else None
+            )
+            _add_attempt(
+                gap,
+                kind=kind,
+                query=query,
+                failure_reason=reason,
+                count=1,
+                suggested_unblocker=attempt_unblocker,
+            )
+            if low_yield_key in low_yield_by_key:
+                consumed_low_yield_keys.add(low_yield_key)
+
+    grouped: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for row, payload, reason in unmatched_failed:
+        kind = str(row.get("kind") or "task")
+        stem = _query_stem_for_payload(payload)
+        query = _raw_query_from_payload(payload) or stem
+        key = (kind, stem, reason)
+        group = grouped.setdefault(
+            key,
+            {
+                "kind": kind,
+                "stem": stem,
+                "query": query,
+                "reason": reason,
+                "count": 0,
+            },
+        )
+        group["count"] = int(group["count"]) + 1
+
+    for group in grouped.values():
+        kind = str(group["kind"])
+        stem = str(group["stem"])
+        query = str(group["query"])
+        reason = str(group["reason"])
+        low_yield = low_yield_by_key.get((kind, stem), {})
+        suggested = low_yield.get("suggested_unblocker")
+        unblocker = _specific_unblocker(
+            kind=kind,
+            query=query,
+            failure_reason=reason,
+            suggested=suggested if isinstance(suggested, str) else None,
+        )
+        gap = _ensure_gap(_topic_for_stem(stem, query), suggested_unblocker=unblocker)
+        _add_attempt(
+            gap,
+            kind=kind,
+            query=query,
+            failure_reason=reason,
+            count=int(group["count"]),
+            suggested_unblocker=unblocker,
+        )
+        if (kind, stem) in low_yield_by_key:
+            consumed_low_yield_keys.add((kind, stem))
+
+    for record in low_yield_records:
+        kind = str(record.get("kind") or "search")
+        stem = str(record.get("query_stem") or "")
+        if (kind, stem) in consumed_low_yield_keys:
+            continue
+        query = stem
+        reason = f"0 results from {kind}"
+        suggested = record.get("suggested_unblocker")
+        unblocker = _specific_unblocker(
+            kind=kind,
+            query=query,
+            failure_reason=reason,
+            suggested=suggested if isinstance(suggested, str) else None,
+        )
+        gap = _ensure_gap(_topic_for_stem(stem, query), suggested_unblocker=unblocker)
+        _add_attempt(
+            gap,
+            kind=kind,
+            query=query,
+            failure_reason=reason,
+            count=int(record.get("count") or 3),
+            suggested_unblocker=unblocker,
+        )
+
+    out: list[dict[str, Any]] = []
+    for gap in gaps.values():
+        attempts = list(gap["attempts"])
+        if not attempts and not gap.get("_gap_reason"):
+            continue
+        reasons = gap.get("_reasons") if isinstance(gap.get("_reasons"), dict) else {}
+        if gap.get("_gap_reason"):
+            summary = f"Could not resolve {gap['topic']}: {gap['_gap_reason']}."
+        elif reasons:
+            first_reason = max(reasons.items(), key=lambda item: int(item[1]))[0]
+            kinds = sorted({a["task_kind"] for a in attempts})
+            summary = (
+                f"Tried {', '.join(kinds)} for {gap['topic']}; "
+                f"the strongest failure signal was {first_reason}."
+            )
+        else:
+            summary = f"Could not resolve {gap['topic']} from available public sources."
+        unblocker = str(gap.get("suggested_unblocker") or "").strip()
+        if not unblocker:
+            first = attempts[0] if attempts else {}
+            unblocker = _fallback_unblocker(
+                str(first.get("task_kind") or "source"),
+                str(first.get("query") or gap["topic"]),
+                str(first.get("failure_reason") or ""),
+            )
+        out.append(
+            {
+                "topic": gap["topic"],
+                "attempts": attempts,
+                "failure_summary": summary,
+                "suggested_unblocker": unblocker,
+            }
+        )
+    return sorted(out, key=lambda item: str(item["topic"]).lower())
+
+
+def _load_current_hypotheses(job: Job, findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    from research_agent.storage import hypotheses
+
+    rows = hypotheses.list_hypotheses(job)
+    if not rows:
+        return []
+    findings_by_id = {
+        int(f["id"]): f
+        for f in findings
+        if isinstance(f.get("id"), int)
+    }
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        item = {
+            "id": row["id"],
+            "statement": row["statement"],
+            "confidence": row["confidence"],
+            "supports": row["supports"],
+            "refutes": row["refutes"],
+            "status": row["status"],
+            "plan_version": row["plan_version"],
+            "supporting_findings": [
+                findings_by_id[fid]
+                for fid in row["supports"]
+                if isinstance(fid, int) and fid in findings_by_id
+            ],
+            "refuting_findings": [
+                findings_by_id[fid]
+                for fid in row["refutes"]
+                if isinstance(fid, int) and fid in findings_by_id
+            ],
+        }
+        out.append(item)
+    return out
+
+
+def _load_artifacts_for_context(job: Job) -> list[dict[str, Any]]:
+    from research_agent.storage import artifacts
+
+    return artifacts.list_artifacts(job)
+
+
 def _build_context(
     *,
     goal: str,
@@ -370,13 +862,23 @@ def _build_context(
     critique: str | None,
     followup_recipes: str,
     paid_unblock_recipes: str,
+    confirmed_gaps: list[dict[str, Any]] | None = None,
+    current_hypotheses: list[dict[str, Any]] | None = None,
+    artifacts: list[dict[str, Any]] | None = None,
     final: bool = False,
 ) -> str:
     payload: dict[str, Any] = {
         "goal": goal,
         "scope_class": str(plan.scope_class) if plan.scope_class else None,
         "subgoals": [
-            {"id": sg.id, "description": sg.description, "done": sg.done} for sg in plan.subgoals
+            {
+                "id": sg.id,
+                "description": sg.description,
+                "done": sg.done,
+                "gap_reason": sg.gap_reason,
+                "gap_status": sg.gap_status,
+            }
+            for sg in plan.subgoals
         ],
         "findings": findings,
         "sources": {str(k): v for k, v in sources.items()},
@@ -385,6 +887,9 @@ def _build_context(
         "followup_recipes": followup_recipes,
         "paid_unblock_recipes": paid_unblock_recipes,
         "department_coverage": _compute_department_coverage(findings),
+        "confirmed_gaps": confirmed_gaps or [],
+        "current_hypotheses": current_hypotheses or [],
+        "artifacts": artifacts or [],
     }
     if final:
         payload["final"] = True
@@ -398,6 +903,7 @@ _TRAILING_STATUS_KEY_RE = re.compile(
     r'"(?:subgoal_status|closed|reopened|inconclusive)"',
     re.IGNORECASE,
 )
+_HYPOTHESIS_UPDATES_KEY_RE = re.compile(r'"hypothesis_updates"', re.IGNORECASE)
 _PROSE_SUBGOAL_STATUS_RE = re.compile(
     r"(?im)^\s*(?:#{1,6}\s*)?(?:[-*]\s*)?(?:\*\*)?"
     r"(?:(?:H)|(?:Subgoal))\s*#?(?P<id>\d+)(?:\*\*)?\s*[:\-]\s*"
@@ -651,6 +1157,142 @@ def _extract_subgoal_status(
     return stripped_md, None
 
 
+def _strip_range(raw: str, start: int, end: int) -> str:
+    prefix = raw[:start].rstrip()
+    suffix = raw[end:].lstrip()
+    if prefix and suffix:
+        return prefix + "\n\n" + suffix
+    if prefix:
+        return prefix + "\n"
+    return suffix
+
+
+def _coerce_finding_id_list(value: Any) -> list[int]:
+    if not isinstance(value, list):
+        return []
+    out: list[int] = []
+    for item in value:
+        if isinstance(item, bool):
+            continue
+        if isinstance(item, int):
+            out.append(item)
+        elif isinstance(item, str) and item.strip().isdigit():
+            out.append(int(item.strip()))
+    return out
+
+
+def _normalize_hypothesis_updates_payload(data: Any) -> list[dict[str, Any]] | None:
+    if not isinstance(data, dict):
+        return None
+    raw_updates = data.get("hypothesis_updates")
+    if not isinstance(raw_updates, list):
+        return None
+    updates: list[dict[str, Any]] = []
+    for raw in raw_updates:
+        if not isinstance(raw, dict):
+            continue
+        statement = raw.get("statement")
+        status = raw.get("status")
+        confidence_raw = raw.get("confidence")
+        if not isinstance(statement, str) or not statement.strip():
+            continue
+        if status not in {"open", "confirmed", "refuted", "inconclusive"}:
+            continue
+        if not isinstance(confidence_raw, (int, float)) or isinstance(confidence_raw, bool):
+            continue
+        confidence = max(0.0, min(1.0, float(confidence_raw)))
+        item: dict[str, Any] = {
+            "statement": statement.strip(),
+            "confidence": confidence,
+            "supports": _coerce_finding_id_list(raw.get("supports")),
+            "refutes": _coerce_finding_id_list(raw.get("refutes")),
+            "status": status,
+        }
+        raw_id = raw.get("id")
+        if isinstance(raw_id, int) and not isinstance(raw_id, bool):
+            item["id"] = raw_id
+        elif isinstance(raw_id, str) and raw_id.strip().isdigit():
+            item["id"] = int(raw_id.strip())
+        updates.append(item)
+    return updates
+
+
+def _extract_hypothesis_updates(
+    job: Job,
+    raw: str,
+) -> tuple[str, list[dict[str, Any]] | None]:
+    """Split a ``hypothesis_updates`` JSON fence from the markdown report."""
+    for match in reversed(list(_ANY_JSON_FENCE_RE.finditer(raw))):
+        body = match.group(1).strip()
+        if not _HYPOTHESIS_UPDATES_KEY_RE.search(body):
+            continue
+        stripped_md = _strip_range(raw, match.start(), match.end())
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError as exc:
+            emit(
+                job,
+                "WARN",
+                "synth",
+                "warning",
+                {
+                    "stage": "hypothesis_updates",
+                    "error": f"json parse failed: {exc}",
+                },
+            )
+            return stripped_md, None
+        updates = _normalize_hypothesis_updates_payload(data)
+        if updates is None:
+            emit(
+                job,
+                "WARN",
+                "synth",
+                "warning",
+                {
+                    "stage": "hypothesis_updates",
+                    "error": "missing recognized hypothesis_updates payload",
+                },
+            )
+            return stripped_md, None
+        return stripped_md, updates
+    return raw, None
+
+
+def _apply_hypothesis_updates(
+    job: Job,
+    plan: Plan,
+    updates: list[dict[str, Any]],
+) -> list[int]:
+    from research_agent.storage import hypotheses
+
+    updated_ids: list[int] = []
+    for update in updates:
+        hid = hypotheses.upsert_hypothesis(
+            job,
+            id=update.get("id"),
+            plan_version=plan.version,
+            statement=update["statement"],
+            confidence=float(update["confidence"]),
+            supports=update.get("supports") or [],
+            refutes=update.get("refutes") or [],
+            status=update["status"],
+        )
+        updated_ids.append(hid)
+        emit(
+            job,
+            "INFO",
+            "synth",
+            "hypothesis_updated",
+            {
+                "id": hid,
+                "plan_version": plan.version,
+                "status": update["status"],
+                "confidence": float(update["confidence"]),
+            },
+        )
+    return updated_ids
+
+
 def _apply_subgoal_status(
     job: Job,
     plan: Plan,  # noqa: ARG001 — kept for clarity at call sites; helper reloads from DB
@@ -800,6 +1442,9 @@ async def _do_synthesis(
     critique = _load_latest_critique(job)
     followup_recipes = _load_followup_recipes()
     paid_unblock_recipes = _load_paid_unblock_recipes()
+    confirmed_gaps = _compute_confirmed_gaps(job, plan)
+    current_hypotheses = _load_current_hypotheses(job, findings)
+    artifact_rows = _load_artifacts_for_context(job)
 
     context = _build_context(
         goal=job.goal,
@@ -810,6 +1455,9 @@ async def _do_synthesis(
         critique=critique,
         followup_recipes=followup_recipes,
         paid_unblock_recipes=paid_unblock_recipes,
+        confirmed_gaps=confirmed_gaps,
+        current_hypotheses=current_hypotheses,
+        artifacts=artifact_rows,
         final=final,
     )
 
@@ -852,9 +1500,10 @@ async def _do_synthesis(
     cost_val: float | None = float(cost) if isinstance(cost, (int, float)) else None
     model_name = _model_name_for(router, used_tier)
 
+    content_without_hypotheses, hypothesis_updates = _extract_hypothesis_updates(job, content)
     stripped_md, status_map = _extract_subgoal_status(
         job,
-        content,
+        content_without_hypotheses,
         subgoal_ids=[sg.id for sg in plan.subgoals],
     )
     stripped_md = _reconcile_sources(job, stripped_md, sources)
@@ -865,6 +1514,8 @@ async def _do_synthesis(
 
     if status_map:
         _apply_subgoal_status(job, plan, status_map)
+    if hypothesis_updates:
+        _apply_hypothesis_updates(job, plan, hypothesis_updates)
 
     emit(
         job,
@@ -1143,6 +1794,9 @@ async def final_synthesis_after_cap(
     critique = _load_latest_critique(job)
     followup_recipes = _load_followup_recipes()
     paid_unblock_recipes = _load_paid_unblock_recipes()
+    confirmed_gaps = _compute_confirmed_gaps(job, plan)
+    current_hypotheses = _load_current_hypotheses(job, findings)
+    artifact_rows = _load_artifacts_for_context(job)
 
     context = _build_context(
         goal=job.goal,
@@ -1153,6 +1807,9 @@ async def final_synthesis_after_cap(
         critique=critique,
         followup_recipes=followup_recipes,
         paid_unblock_recipes=paid_unblock_recipes,
+        confirmed_gaps=confirmed_gaps,
+        current_hypotheses=current_hypotheses,
+        artifacts=artifact_rows,
         final=True,
     )
 
@@ -1177,9 +1834,10 @@ async def final_synthesis_after_cap(
     cost_val: float | None = float(cost) if isinstance(cost, (int, float)) else None
     model_name = _model_name_for(router, fallback_tier)
 
+    content_without_hypotheses, hypothesis_updates = _extract_hypothesis_updates(job, content)
     stripped_md, status_map = _extract_subgoal_status(
         job,
-        content,
+        content_without_hypotheses,
         subgoal_ids=[sg.id for sg in plan.subgoals],
     )
     stripped_md = _reconcile_sources(job, stripped_md, sources)
@@ -1190,6 +1848,8 @@ async def final_synthesis_after_cap(
 
     if status_map:
         _apply_subgoal_status(job, plan, status_map)
+    if hypothesis_updates:
+        _apply_hypothesis_updates(job, plan, hypothesis_updates)
 
     emit(
         job,

--- a/src/research_agent/prompts/planner.md
+++ b/src/research_agent/prompts/planner.md
@@ -375,6 +375,13 @@ The tactical-replan user payload may include:
 
 ```yaml
 user_note: "operator supplied hint, if present"
+hypotheses:
+  - id: 1
+    statement: "The delay is primarily due to permitting friction."
+    confidence: 0.62
+    supports: [12, 19]
+    refutes: []
+    status: open
 inconclusive_subgoals:
   - id: 2
     description: "..."
@@ -389,6 +396,12 @@ When `user_note` is present, treat it as authoritative high-priority
 operator guidance. Weight it ahead of inferred drill-downs and use it to
 choose the first new source surface when it names a document, portal,
 person, date, or entity.
+
+When `hypotheses` is present, use it as the current theory ledger. Weight
+new tasks toward high-confidence `open` or `inconclusive` hypotheses that
+still have weak or one-sided evidence. Prefer tasks that could clearly
+support or refute one named hypothesis; avoid generic searches that do not
+move any listed hypothesis.
 
 For each entry in `inconclusive_subgoals`, you MUST either:
 

--- a/src/research_agent/prompts/synthesizer.md
+++ b/src/research_agent/prompts/synthesizer.md
@@ -1,7 +1,7 @@
 ---
 version: "7"
 model_tier: frontier
-description: System prompt for the synthesizer. Emits a raw markdown report followed by a single fenced JSON block with subgoal status.
+description: System prompt for the synthesizer. Emits a raw markdown report followed by fenced JSON status/update blocks.
 ---
 You are the **synthesizer** for an autonomous research agent.
 
@@ -33,6 +33,20 @@ source.
   "Paid Resources That Would Unblock This Investigation" section
   described below — pull service names and cost ranges verbatim; never
   invent prices or services.
+- **confirmed_gaps:** a machine-built list of source gaps the agent
+  actually encountered. Each item has `topic`, `attempts`,
+  `failure_summary`, and `suggested_unblocker`. Use this only for the
+  "Confirmed Gaps" section described below. Do not invent extra gaps or
+  rewrite the supplied unblocker.
+- **current_hypotheses:** the working hypothesis ledger from prior
+  synthesis passes. Each entry has `id`, `statement`, `confidence`,
+  `supports`, `refutes`, and `status`, plus supporting/refuting finding
+  snippets when those findings are in the current context. Update this
+  ledger through the `hypothesis_updates` JSON trailer described below.
+- **artifacts:** structured files already generated under
+  `jobs/<id>/artifacts/`. Each entry has `name`, `row_count`, and
+  `csv_path`. When present, link these in the report instead of
+  burying list output only in prose.
 - **Critique:** the latest critic pass over the prior draft. The
   critique's `paid_opportunities` field is the only signal you should
   use to decide whether the paid-resources section appears at all.
@@ -54,13 +68,16 @@ the end of this prompt defines the machine-readable subgoal status trailer.
 - Do **not** add a preamble like "Here is the report:".
 - Your first character should be `#` (the report heading).
 - Newlines are real newlines. Do not escape them as `\n`.
-- The **Recommended Human Follow-Ups** section comes after
-  **Open questions**. The **Paid Resources That Would Unblock This
-  Investigation** section comes immediately after **Recommended Human
-  Follow-Ups** and immediately before **Sources** — but **only when**
-  the critique flagged at least one paid opportunity. Omit the section
-  heading entirely when the critique's `paid_opportunities` list is
-  empty.
+- The **Confirmed Gaps** section comes after **Open questions** and
+  before **Recommended Human Follow-Ups**, but only when the input
+  context's `confirmed_gaps` list has at least one item. The
+  **Recommended Human Follow-Ups** section comes after **Confirmed
+  Gaps** when present, otherwise after **Open questions**. The
+  **Paid Resources That Would Unblock This Investigation** section
+  comes immediately after **Recommended Human Follow-Ups** and
+  immediately before **Sources** — but **only when** the critique
+  flagged at least one paid opportunity. Omit the section heading
+  entirely when the critique's `paid_opportunities` list is empty.
 
 The orchestrator stores only the markdown report body for readers; the
 machine-readable trailer at the end is stripped before `report.md` is written.
@@ -115,8 +132,14 @@ A markdown report with:
 
 1. **Executive summary** — three to six bullets, each ending in inline
    citations like `[1]`, `[2]`.
-2. **Hypotheses** — for each, state confirmed / refuted / inconclusive,
-   with the strongest supporting and contradicting findings cited.
+2. **Working Hypotheses** — include this section when
+   `current_hypotheses` is non-empty OR when your synthesis produces
+   new/updated hypotheses. For each hypothesis, state confirmed /
+   refuted / inconclusive / open, confidence, and the strongest
+   supporting and contradicting findings cited. Reuse existing IDs
+   (`H<id>`) when present; assign temporary labels (`H-new`) in prose
+   for new hypotheses because the database assigns the real id after
+   parsing the trailer.
 3. **Connections** — relationships between people, orgs, policies, or
    events that the findings reveal but no single source spells out.
 4. **Departmental Policy Tracker** — *include this section only when the
@@ -141,7 +164,25 @@ A markdown report with:
      length of `department_coverage`.
 5. **Open questions** — what the investigation could not resolve, and why
    (e.g., source unavailable, contradictory evidence, ambiguous goal).
-6. **Recommended Human Follow-Ups** — actionable next steps for the
+6. **Confirmed Gaps** — *include this section only when
+   `confirmed_gaps` is non-empty; otherwise omit the heading entirely.*
+   These are not speculative follow-ups. They are records of work the
+   agent actually tried and could not complete.
+
+   For each gap:
+
+   - Start with a bullet: `- **<topic>** — <failure_summary> Unblocker:
+     <suggested_unblocker>`
+   - The bullet MUST end with the `suggested_unblocker` string from the
+     input context, verbatim. Never end with a generic phrase such as
+     "do a public records request"; use the supplied specific target,
+     URL, source, expert role, or paid service.
+   - Under that bullet, add one indented sub-bullet per attempt:
+     `  - Attempted <task_kind> for "<query>": <failure_reason>
+     (count: <count>).`
+   - Do not cite these bullets unless a finding directly supports the
+     same point; the attempts themselves come from the job audit log.
+7. **Recommended Human Follow-Ups** — actionable next steps for the
    operator that software cannot do alone (calls, FOIA requests, legal
    review). Use the sub-headings below; **omit a sub-heading entirely
    when no items apply** (do not print "(none)"):
@@ -170,7 +211,7 @@ A markdown report with:
    - If the report relies on government records or alleges agency
      misconduct, expect at least one FOIA candidate or whistleblower
      hotline.
-7. **Paid Resources That Would Unblock This Investigation** —
+8. **Paid Resources That Would Unblock This Investigation** —
    *include this section only when the critique's `paid_opportunities`
    list has at least one entry; otherwise omit the heading entirely.*
    Render it with the two sub-headings below, in this order:
@@ -198,7 +239,13 @@ A markdown report with:
    - Only flag a paid resource when the critique surfaced an actual
      evidenced gap. If the critique returned no `paid_opportunities`,
      omit the entire section (do not write "(none)").
-8. **Sources** — numbered list mapping `[N]` → URL + retrieved-at.
+9. **Generated Artifacts** — *include this section only when `artifacts`
+   is non-empty; otherwise omit the heading entirely.* Place it
+   immediately before **Sources**. Add one bullet per artifact:
+   `- <name>: <row_count> rows — CSV: <csv_path>`. Use `csv_path`
+   exactly as supplied so the relative link resolves under the job
+   folder.
+10. **Sources** — numbered list mapping `[N]` → URL + retrieved-at.
 
 ## Rules
 
@@ -231,8 +278,11 @@ A markdown report with:
 
 ## Hypotheses
 
+## Working Hypotheses
+
 ### H1: <hypothesis>
 **Status:** Confirmed
+**Confidence:** 0.74
 - Supporting: <fact> [1].
 - Contradicting: <fact> [2].
 
@@ -266,6 +316,17 @@ still get a section, even if it's a single bullet.)
 
 - ...
 
+## Confirmed Gaps
+
+- **Prime contractor name** — Tried city-site search and campaign-finance
+  records; the strongest failure signal was 0 results from
+  `web_search`. Unblocker: FOIA the City of Alameda Clerk for the
+  prime contract award file.
+  - Attempted `web_search` for "site:alamedaca.gov shoreline restroom
+    contractor": 0 results from `web_search` (count: 3).
+  - Attempted `calaccess_search` for "Alameda mayor Form 460": 0
+    results from `calaccess_search` (count: 3).
+
 ## Recommended Human Follow-Ups
 
 ### Adversarial fact-check targets
@@ -290,6 +351,10 @@ still get a section, even if it's a single bullet.)
   would surface trade-press coverage of Acme Co's regional contract
   awards, because the report cites only paywalled previews [2].
 
+## Generated Artifacts
+
+- candidates: 435 rows — CSV: artifacts/candidates.csv
+
 ## Sources
 
 1. https://example.com/a — "Title A" (retrieved 2026-05-06)
@@ -299,29 +364,48 @@ still get a section, even if it's a single bullet.)
 (Note: every `[N]` cited above — including grouped citations like
 `[2][3]` — must appear as `N.` here. The Sources section is the
 union of inline citations, not a curated subset.)
-``` json
+```json
 {"subgoal_status": {"1": "confirmed", "2": "inconclusive"}}
+```
+```json
+{"hypothesis_updates": [{"id": 1, "statement": "<hypothesis>", "confidence": 0.74, "supports": [1], "refutes": [2], "status": "confirmed"}]}
 ```
 
 The example above is shown inside a code block for readability. Your actual
 markdown report should NOT be inside any fence.
 
-## Final mandatory subgoal-status trailer
+## Final mandatory subgoal-status trailer and hypothesis updates
 
-At the very end of every response, after the **Sources** section, emit exactly
-one fenced ```json block whose body is:
+At the very end of every response, after the **Sources** section, emit
+exactly two fenced ```json blocks in this order:
+
+1. A subgoal-status block whose body is:
 
 ```json
 {"subgoal_status": {"<id>": "confirmed"|"refuted"|"inconclusive"}}
 ```
 
-This trailer MUST cover every subgoal id you were given.
+This subgoal trailer MUST cover every subgoal id you were given.
 
-This trailer MUST be emitted on every synthesis pass, even when all subgoals
-are inconclusive.
+This subgoal trailer MUST be emitted on every synthesis pass, even when
+all subgoals are inconclusive.
 
-The orchestrator strips this trailing JSON fence before writing `report.md`,
-so the visible report only contains the markdown body.
+2. A hypothesis-updates block whose body is:
 
-Do not emit any other JSON fences anywhere in the response. Do not put any
-text after the closing fence.
+```json
+{"hypothesis_updates": [{"id": 1, "statement": "...", "confidence": 0.0, "supports": [], "refutes": [], "status": "open"}]}
+```
+
+For `hypothesis_updates`, include one object for each hypothesis you are
+creating or changing. `id` is optional for new hypotheses and required
+when updating an existing `current_hypotheses` row. `confidence` must be
+between 0 and 1. `supports` and `refutes` are arrays of finding ids.
+`status` must be one of `open`, `confirmed`, `refuted`, or
+`inconclusive`. Emit an empty array when there are no changes:
+`{"hypothesis_updates": []}`.
+
+The orchestrator strips both trailing JSON fences before writing
+`report.md`, so the visible report only contains the markdown body.
+
+Do not emit any other JSON fences anywhere in the response. Do not put
+any text after the closing fence.

--- a/src/research_agent/storage/artifacts.py
+++ b/src/research_agent/storage/artifacts.py
@@ -1,0 +1,188 @@
+"""Structured per-job artifacts (issue #304)."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from research_agent.storage.jobs import Job, _atomic_write_text
+
+_ARTIFACT_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+
+
+class ArtifactColumn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    required: bool = False
+
+
+class ArtifactSchema(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    schema_version: int = Field(ge=1)
+    columns: list[ArtifactColumn]
+    description: str | None = None
+
+
+CANDIDATE_ROSTER_SCHEMA = ArtifactSchema(
+    name="candidates",
+    schema_version=1,
+    description="Candidate roster table.",
+    columns=[
+        ArtifactColumn(name="state", required=True),
+        ArtifactColumn(name="chamber", required=True),
+        ArtifactColumn(name="district_or_seat"),
+        ArtifactColumn(name="candidate_name", required=True),
+        ArtifactColumn(name="party"),
+        ArtifactColumn(name="candidate_status"),
+        ArtifactColumn(name="confidence"),
+        ArtifactColumn(name="official_campaign_website"),
+        ArtifactColumn(name="source_url", required=True),
+        ArtifactColumn(name="source_kind"),
+        ArtifactColumn(name="source_retrieved_at"),
+        ArtifactColumn(name="notes"),
+    ],
+)
+
+
+def _validate_name(name: str) -> str:
+    if not isinstance(name, str) or not _ARTIFACT_NAME_RE.match(name):
+        raise ValueError(
+            "artifact name must start with a letter/number and contain only "
+            "letters, numbers, underscores, or hyphens"
+        )
+    return name
+
+
+def _artifact_dir(job: Job) -> Path:
+    path = job.root / "artifacts"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _fieldnames(schema: ArtifactSchema) -> list[str]:
+    return [column.name for column in schema.columns]
+
+
+def _rows_for_csv(schema: ArtifactSchema, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    fields = _fieldnames(schema)
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        out.append({field: row.get(field, "") for field in fields})
+    return out
+
+
+def _csv_text(schema: ArtifactSchema, rows: list[dict[str, Any]]) -> str:
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=_fieldnames(schema), extrasaction="ignore")
+    writer.writeheader()
+    for row in _rows_for_csv(schema, rows):
+        writer.writerow(row)
+    return buffer.getvalue()
+
+
+def write_table_artifact(
+    job: Job,
+    name: str,
+    *,
+    schema: ArtifactSchema,
+    rows: list[dict[str, Any]],
+    source_coverage: str | None = None,
+) -> Path:
+    """Write schema, JSONL, CSV, and metadata sidecars for a table artifact."""
+    artifact_name = _validate_name(name)
+    if schema.name != artifact_name:
+        schema = schema.model_copy(update={"name": artifact_name})
+    artifact_dir = _artifact_dir(job)
+
+    schema_path = artifact_dir / f"{artifact_name}.schema.json"
+    jsonl_path = artifact_dir / f"{artifact_name}.jsonl"
+    csv_path = artifact_dir / f"{artifact_name}.csv"
+    meta_path = artifact_dir / f"{artifact_name}.meta.json"
+
+    _atomic_write_text(
+        schema_path,
+        json.dumps(schema.model_dump(), indent=2, sort_keys=True) + "\n",
+    )
+    jsonl = "".join(json.dumps(row, sort_keys=True, default=str) + "\n" for row in rows)
+    _atomic_write_text(jsonl_path, jsonl)
+    _atomic_write_text(csv_path, _csv_text(schema, rows))
+    _atomic_write_text(
+        meta_path,
+        json.dumps(
+            {
+                "artifact_name": artifact_name,
+                "schema_version": schema.schema_version,
+                "row_count": len(rows),
+                "generated_at_epoch": int(time.time()),
+                "source_job_id": job.id,
+                "source_coverage": source_coverage or "",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+    )
+    return csv_path
+
+
+def read_artifact(job: Job, name: str) -> tuple[ArtifactSchema, list[dict[str, Any]]]:
+    artifact_name = _validate_name(name)
+    artifact_dir = _artifact_dir(job)
+    schema_path = artifact_dir / f"{artifact_name}.schema.json"
+    jsonl_path = artifact_dir / f"{artifact_name}.jsonl"
+    if not schema_path.exists() or not jsonl_path.exists():
+        raise FileNotFoundError(f"artifact {artifact_name!r} not found for job {job.id}")
+    schema = ArtifactSchema.model_validate_json(schema_path.read_text(encoding="utf-8"))
+    rows: list[dict[str, Any]] = []
+    for line in jsonl_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        item = json.loads(line)
+        if isinstance(item, dict):
+            rows.append(item)
+    return schema, rows
+
+
+def list_artifacts(job: Job) -> list[dict[str, Any]]:
+    artifact_dir = _artifact_dir(job)
+    out: list[dict[str, Any]] = []
+    for meta_path in sorted(artifact_dir.glob("*.meta.json")):
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(meta, dict):
+            continue
+        name = str(meta.get("artifact_name") or meta_path.name.removesuffix(".meta.json"))
+        csv_path = artifact_dir / f"{name}.csv"
+        out.append(
+            {
+                "name": name,
+                "schema_version": meta.get("schema_version"),
+                "row_count": meta.get("row_count"),
+                "generated_at_epoch": meta.get("generated_at_epoch"),
+                "source_coverage": meta.get("source_coverage") or "",
+                "csv_path": str(csv_path.relative_to(job.root)),
+            }
+        )
+    return out
+
+
+__all__ = [
+    "ArtifactColumn",
+    "ArtifactSchema",
+    "CANDIDATE_ROSTER_SCHEMA",
+    "list_artifacts",
+    "read_artifact",
+    "write_table_artifact",
+]

--- a/src/research_agent/storage/db.py
+++ b/src/research_agent/storage/db.py
@@ -132,6 +132,21 @@ CREATE TABLE IF NOT EXISTS critiques (
     UNIQUE(job_id, version)
 );
 
+-- Per-job working hypotheses
+CREATE TABLE IF NOT EXISTS hypotheses (
+    id INTEGER PRIMARY KEY,
+    job_id TEXT NOT NULL REFERENCES jobs(id),
+    plan_version INTEGER NOT NULL,
+    statement TEXT NOT NULL,
+    confidence REAL NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+    supports TEXT NOT NULL,
+    refutes TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('open', 'confirmed', 'refuted', 'inconclusive')),
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_hypotheses_job_status ON hypotheses(job_id, status);
+
 -- Checkpoints (one per state transition)
 CREATE TABLE IF NOT EXISTS checkpoints (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -298,6 +313,30 @@ def _migrate_jobs_completion_reason(conn: sqlite3.Connection) -> None:
     conn.execute("ALTER TABLE jobs ADD COLUMN completion_reason TEXT")
 
 
+def _migrate_hypotheses_table(conn: sqlite3.Connection) -> None:
+    """Create the hypotheses ledger for DBs that predate issue #261."""
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS hypotheses (
+            id INTEGER PRIMARY KEY,
+            job_id TEXT NOT NULL REFERENCES jobs(id),
+            plan_version INTEGER NOT NULL,
+            statement TEXT NOT NULL,
+            confidence REAL NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+            supports TEXT NOT NULL,
+            refutes TEXT NOT NULL,
+            status TEXT NOT NULL CHECK (
+                status IN ('open', 'confirmed', 'refuted', 'inconclusive')
+            ),
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_hypotheses_job_status
+            ON hypotheses(job_id, status);
+        """
+    )
+
+
 def migrate(
     conn: sqlite3.Connection | None = None,
     *,
@@ -315,4 +354,5 @@ def migrate(
         _migrate_sources_md_path_nullable(conn)
         _migrate_sources_parent_source_id(conn)
         _migrate_jobs_completion_reason(conn)
+        _migrate_hypotheses_table(conn)
     return conn

--- a/src/research_agent/storage/export.py
+++ b/src/research_agent/storage/export.py
@@ -16,12 +16,15 @@ half-written output.
 
 from __future__ import annotations
 
+import csv
+import io
 import os
 import zipfile
 from datetime import UTC, datetime
 from pathlib import Path
 
 from research_agent.storage import db
+from research_agent.storage.artifacts import read_artifact
 from research_agent.storage.jobs import Job
 
 _HISTORY_DIRNAME = "report.history"
@@ -190,7 +193,26 @@ def export_md_bundle(job: Job, out_path: Path, *, include_history: bool) -> Path
     return out_path
 
 
+def export_csv(job: Job, artifact_name: str, out_path: Path) -> Path:
+    """Export one table artifact as CSV with schema-defined column ordering."""
+    schema, rows = read_artifact(job, artifact_name)
+    out_path = Path(out_path)
+    tmp_path = out_path.with_suffix(out_path.suffix + ".tmp")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fieldnames = [column.name for column in schema.columns]
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames, extrasaction="ignore")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({field: row.get(field, "") for field in fieldnames})
+    tmp_path.write_text(buffer.getvalue(), encoding="utf-8")
+    _atomic_replace(tmp_path, out_path)
+    return out_path
+
+
 __all__ = [
+    "export_csv",
     "export_md_bundle",
     "export_zip",
 ]

--- a/src/research_agent/storage/hypotheses.py
+++ b/src/research_agent/storage/hypotheses.py
@@ -1,0 +1,183 @@
+"""Per-job working hypothesis ledger (issue #261)."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from research_agent.storage import db
+from research_agent.storage.jobs import Job
+
+VALID_STATUSES = frozenset({"open", "confirmed", "refuted", "inconclusive"})
+
+
+def _now_epoch() -> int:
+    return int(time.time())
+
+
+def _coerce_id_list(values: list[Any] | tuple[Any, ...] | None, *, field: str) -> list[int]:
+    if values is None:
+        return []
+    if not isinstance(values, (list, tuple)):
+        raise TypeError(f"{field} must be a list of finding ids")
+    out: list[int] = []
+    for value in values:
+        if isinstance(value, bool):
+            raise TypeError(f"{field} values must be integer finding ids")
+        if isinstance(value, int):
+            out.append(value)
+            continue
+        if isinstance(value, str) and value.strip().isdigit():
+            out.append(int(value.strip()))
+            continue
+        raise TypeError(f"{field} values must be integer finding ids")
+    return out
+
+
+def _validate_inputs(
+    *,
+    statement: str,
+    confidence: float,
+    supports: list[Any] | tuple[Any, ...] | None,
+    refutes: list[Any] | tuple[Any, ...] | None,
+    status: str,
+) -> tuple[list[int], list[int]]:
+    if not isinstance(statement, str) or not statement.strip():
+        raise ValueError("statement must be a non-empty string")
+    if not isinstance(confidence, (int, float)) or isinstance(confidence, bool):
+        raise ValueError("confidence must be a number between 0 and 1")
+    if not 0 <= float(confidence) <= 1:
+        raise ValueError("confidence must be between 0 and 1")
+    if status not in VALID_STATUSES:
+        raise ValueError(f"status must be one of {sorted(VALID_STATUSES)}")
+    return (
+        _coerce_id_list(supports, field="supports"),
+        _coerce_id_list(refutes, field="refutes"),
+    )
+
+
+def _row_to_dict(row: Any) -> dict[str, Any]:
+    supports_raw = row["supports"]
+    refutes_raw = row["refutes"]
+    try:
+        supports = json.loads(supports_raw) if supports_raw else []
+    except (TypeError, json.JSONDecodeError):
+        supports = []
+    try:
+        refutes = json.loads(refutes_raw) if refutes_raw else []
+    except (TypeError, json.JSONDecodeError):
+        refutes = []
+    return {
+        "id": int(row["id"]),
+        "job_id": row["job_id"],
+        "plan_version": int(row["plan_version"]),
+        "statement": row["statement"],
+        "confidence": float(row["confidence"]),
+        "supports": supports if isinstance(supports, list) else [],
+        "refutes": refutes if isinstance(refutes, list) else [],
+        "status": row["status"],
+        "created_at": int(row["created_at"]),
+        "updated_at": int(row["updated_at"]),
+    }
+
+
+def upsert_hypothesis(
+    job: Job,
+    *,
+    plan_version: int,
+    statement: str,
+    confidence: float,
+    supports: list[Any] | tuple[Any, ...] | None,
+    refutes: list[Any] | tuple[Any, ...] | None,
+    status: str,
+    id: int | None = None,
+    db_path: Path | str | None = None,
+) -> int:
+    """Insert a new hypothesis or update an existing one by id."""
+    if not isinstance(plan_version, int) or plan_version < 1:
+        raise ValueError("plan_version must be an integer >= 1")
+    supports_i, refutes_i = _validate_inputs(
+        statement=statement,
+        confidence=confidence,
+        supports=supports,
+        refutes=refutes,
+        status=status,
+    )
+    now = _now_epoch()
+    conn = db.connect(db_path or job.db_path)
+    try:
+        with conn:
+            if id is None:
+                cur = conn.execute(
+                    """
+                    INSERT INTO hypotheses (
+                        job_id, plan_version, statement, confidence,
+                        supports, refutes, status, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        job.id,
+                        plan_version,
+                        statement.strip(),
+                        float(confidence),
+                        json.dumps(supports_i, sort_keys=True),
+                        json.dumps(refutes_i, sort_keys=True),
+                        status,
+                        now,
+                        now,
+                    ),
+                )
+                rowid = cur.lastrowid
+                assert rowid is not None  # noqa: S101
+                return int(rowid)
+
+            conn.execute(
+                """
+                UPDATE hypotheses
+                SET plan_version = ?, statement = ?, confidence = ?,
+                    supports = ?, refutes = ?, status = ?, updated_at = ?
+                WHERE id = ? AND job_id = ?
+                """,
+                (
+                    plan_version,
+                    statement.strip(),
+                    float(confidence),
+                    json.dumps(supports_i, sort_keys=True),
+                    json.dumps(refutes_i, sort_keys=True),
+                    status,
+                    now,
+                    int(id),
+                    job.id,
+                ),
+            )
+            return int(id)
+    finally:
+        conn.close()
+
+
+def list_hypotheses(job: Job, *, db_path: Path | str | None = None) -> list[dict[str, Any]]:
+    """Return the current hypothesis ledger for ``job`` ordered by id."""
+    conn = db.connect(db_path or job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT * FROM hypotheses WHERE job_id = ? ORDER BY id ASC",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [_row_to_dict(row) for row in rows]
+
+
+def latest_for_job(job: Job, *, db_path: Path | str | None = None) -> list[dict[str, Any]]:
+    """Return the operator-facing current set of hypotheses for ``job``."""
+    return list_hypotheses(job, db_path=db_path)
+
+
+__all__ = [
+    "VALID_STATUSES",
+    "latest_for_job",
+    "list_hypotheses",
+    "upsert_hypothesis",
+]

--- a/src/research_agent/storage/jobs.py
+++ b/src/research_agent/storage/jobs.py
@@ -37,6 +37,7 @@ from research_agent.storage import db
 
 DEFAULT_JOBS_ROOT = Path("jobs")
 RESUME_REPLAN_FILE = "RESUME_REPLAN.json"
+INBOX_REPLAN_FILE = "INBOX_REPLAN.json"
 
 # Daemon kill escalation window. Module-level so tests can monkeypatch it
 # down from 10s to keep the suite fast.
@@ -51,6 +52,9 @@ _SUBDIRS = (
     "critique",
     "report.history",
     "archive",
+    "inbox",
+    "inbox/processed",
+    "artifacts",
 )
 # Subdirs that get wiped on a soft reset; ``archive`` is preserved on purpose
 # so prior reports stay around for ``research compare``.
@@ -384,6 +388,7 @@ class Job:
                     "critiques",
                     "findings",
                     "events",
+                    "hypotheses",
                     "checkpoints",
                     "syntheses",
                     "llm_calls",
@@ -553,6 +558,7 @@ def list_jobs(
 
 __all__ = [
     "DEFAULT_JOBS_ROOT",
+    "INBOX_REPLAN_FILE",
     "KILL_ESCALATION_SECONDS",
     "KILL_POLL_INTERVAL_SECONDS",
     "Job",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 import json
 import time
 from datetime import UTC, date, datetime
@@ -11,7 +12,7 @@ import pytest
 from typer.testing import CliRunner
 
 from research_agent import __version__, cli, config
-from research_agent.storage import db
+from research_agent.storage import artifacts, db, hypotheses
 from research_agent.storage.jobs import RESUME_REPLAN_FILE, Job
 from research_agent.ui import render
 
@@ -257,6 +258,23 @@ def test_start_translate_non_english_flag_is_persisted(
     job_root = isolated_jobs_repo / "jobs" / f"{today}-translate-archival-findings"
     intake_data = json.loads((job_root / "intake.json").read_text(encoding="utf-8"))
     assert intake_data["translate_non_english"] is True
+
+
+def test_start_inbox_flag_is_persisted(isolated_jobs_repo: Path, monkeypatch) -> None:
+    monkeypatch.setattr(cli.daemon, "spawn_daemon", lambda _job_id: 12345)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        ["start", "--skip-intake", "--goal", "Inbox enabled target", "--inbox"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    job_root = isolated_jobs_repo / "jobs" / f"{today}-inbox-enabled-target"
+    intake_data = json.loads((job_root / "intake.json").read_text(encoding="utf-8"))
+    assert intake_data["inbox"] is True
+    assert (job_root / "inbox" / "processed").is_dir()
 
 
 def test_start_runs_intake_when_not_skipped(isolated_jobs_repo: Path, monkeypatch):
@@ -606,6 +624,74 @@ def test_view_findings_when_none_fails(isolated_jobs_repo: Path):
     runner = CliRunner()
     result = runner.invoke(cli.app, ["view", job.id, "--findings"], env={"EDITOR": ""})
     assert result.exit_code != 0
+
+
+def test_view_hypotheses_prints_ledger(isolated_jobs_repo: Path):
+    job = _make_synthetic_job(isolated_jobs_repo)
+    hypotheses.upsert_hypothesis(
+        job,
+        plan_version=1,
+        statement="Permitting friction is the primary delay driver.",
+        confidence=0.62,
+        supports=[10],
+        refutes=[11],
+        status="open",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["view", job.id, "--hypotheses"], env={"EDITOR": ""})
+
+    assert result.exit_code == 0, result.stdout
+    assert "Hypotheses for" in result.stdout
+    assert "Permitting friction is the primary delay driver." in result.stdout
+    assert "0.62" in result.stdout
+    assert "open" in result.stdout
+
+
+def test_view_rejects_multiple_modes(isolated_jobs_repo: Path):
+    job = _make_synthetic_job(isolated_jobs_repo)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        ["view", job.id, "--report", "--hypotheses"],
+        env={"EDITOR": ""},
+    )
+    assert result.exit_code == 2
+    assert "choose only one" in (result.stdout + (result.stderr or ""))
+
+
+def test_inbox_add_copies_file_and_list_shows_pending(isolated_jobs_repo: Path, tmp_path: Path):
+    job = _make_synthetic_job(isolated_jobs_repo)
+    source = tmp_path / "foia-response.md"
+    source.write_text("# FOIA response\n\nContract file attached.\n", encoding="utf-8")
+
+    runner = CliRunner()
+    added = runner.invoke(cli.app, ["inbox", job.id, "add", str(source)])
+
+    assert added.exit_code == 0, added.stdout
+    dest = job.root / "inbox" / source.name
+    assert dest.exists()
+    assert dest.read_text(encoding="utf-8") == source.read_text(encoding="utf-8")
+    assert not list((job.root / "inbox").glob("*.tmp"))
+
+    listed = runner.invoke(cli.app, ["inbox", job.id, "list"])
+    assert listed.exit_code == 0, listed.stdout
+    assert "pending" in listed.stdout
+    assert "foia-response.md" in listed.stdout
+
+
+def test_inbox_list_shows_processed_files(isolated_jobs_repo: Path):
+    job = _make_synthetic_job(isolated_jobs_repo)
+    processed = job.root / "inbox" / "processed" / "abc123-doc.md"
+    processed.parent.mkdir(parents=True, exist_ok=True)
+    processed.write_text("processed", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["inbox", job.id, "list"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "processed" in result.stdout
+    assert processed.name in result.stdout
 
 
 def test_logs_prints_existing_events(isolated_jobs_repo: Path):
@@ -1444,6 +1530,63 @@ def test_export_md_bundle_writes_markdown(isolated_jobs_repo: Path):
     assert "### Finding 000001" in body
     assert "## Sources" in body
     assert "https://web.archive.org/web/2026/x" in body
+
+
+def test_export_csv_writes_named_table_artifact(isolated_jobs_repo: Path):
+    job = _seed_export_job(isolated_jobs_repo)
+    rows = [
+        {
+            "state": "CA",
+            "chamber": "House",
+            "district_or_seat": "12",
+            "candidate_name": "Jane Doe",
+            "source_url": "https://example.com/jane",
+        },
+        {
+            "state": "NV",
+            "chamber": "Senate",
+            "candidate_name": "John Smith",
+            "party": "Independent",
+            "source_url": "https://example.com/john",
+        },
+    ]
+    artifacts.write_table_artifact(
+        job,
+        "candidates",
+        schema=artifacts.CANDIDATE_ROSTER_SCHEMA,
+        rows=rows,
+    )
+    out_path = isolated_jobs_repo / "candidates-export.csv"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        ["export", job.id, "--csv", "candidates", "--out", str(out_path)],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    exported = list(csv.DictReader(out_path.open()))
+    assert exported[0]["candidate_name"] == "Jane Doe"
+    assert exported[1]["party"] == "Independent"
+    assert exported[0]["official_campaign_website"] == ""
+
+
+def test_export_csv_missing_artifact_errors_with_available_names(isolated_jobs_repo: Path):
+    job = _seed_export_job(isolated_jobs_repo)
+    artifacts.write_table_artifact(
+        job,
+        "candidates",
+        schema=artifacts.CANDIDATE_ROSTER_SCHEMA,
+        rows=[],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["export", job.id, "--csv", "missing"])
+
+    assert result.exit_code == 1
+    combined = result.stdout + (result.stderr or "")
+    assert "artifact 'missing' not found" in combined
+    assert "candidates" in combined
 
 
 def test_export_requires_a_mode(isolated_jobs_repo: Path):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1143,6 +1143,69 @@ async def test_foreground_progress_updates_as_tasks_transition(
     assert final[1]["total"] == 3
 
 
+@pytest.mark.asyncio
+async def test_inbox_watcher_indexes_moves_and_requests_replan(
+    seeded_job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    inbox = seeded_job.root / "inbox"
+    inbox.mkdir(exist_ok=True)
+    doc = inbox / "foia-response.md"
+    doc.write_text("# FOIA\n\nContract award file from the clerk.\n", encoding="utf-8")
+    calls: list[Path] = []
+
+    def _fake_index(path: Path, job: Job) -> dict[str, int]:
+        calls.append(path)
+        return {
+            "files_indexed": 1,
+            "files_skipped": 0,
+            "chunks_indexed": 1,
+            "chunks_skipped": 0,
+            "embed_dim": 1024,
+        }
+
+    monkeypatch.setattr("research_agent.tools.local_corpus.index", _fake_index)
+    should_stop = asyncio.Event()
+    task = asyncio.create_task(
+        daemon._inbox_watcher(seeded_job, should_stop, interval_s=0.02)
+    )
+    try:
+        for _ in range(100):
+            if (seeded_job.root / "INBOX_REPLAN.json").exists():
+                should_stop.set()
+                break
+            await asyncio.sleep(0.02)
+        await asyncio.wait_for(task, timeout=1.0)
+    finally:
+        should_stop.set()
+        if not task.done():
+            task.cancel()
+
+    assert calls == [doc]
+    assert not doc.exists()
+    processed = list((inbox / "processed").glob("*-foia-response.md"))
+    assert len(processed) == 1
+
+    sidecar = json.loads((seeded_job.root / "INBOX_REPLAN.json").read_text(encoding="utf-8"))
+    assert sidecar["trigger"] == "inbox"
+    assert sidecar["filename"] == "foia-response.md"
+    assert "identify NEW angles" in sidecar["note"]
+
+    conn = db.connect(seeded_job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT payload_json FROM events"
+            " WHERE job_id = ? AND kind = 'corpus_doc_added'",
+            (seeded_job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    payload = json.loads(rows[0]["payload_json"])
+    assert payload["filename"] == "foia-response.md"
+    assert payload["files_indexed"] == 1
+    assert payload["chunks_indexed"] == 1
+
+
 
 # ---------------------------------------------------------------------------
 # _cancel_with_timeout — bounds daemon teardown so a hung watcher can't block exit

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -25,7 +25,7 @@ from research_agent.orchestrator.loop import (
 )
 from research_agent.orchestrator.plan import Plan, ScopeClass, Subgoal, TaskSpec
 from research_agent.storage import db
-from research_agent.storage.jobs import Job
+from research_agent.storage.jobs import INBOX_REPLAN_FILE, Job
 from research_agent.storage.markdown import write_plan
 from research_agent.storage.tasks import (
     STATUS_DONE,
@@ -1382,6 +1382,74 @@ async def test_critique_heuristic_failure_warning_has_traceback_and_model_contex
 
     checkpoints = _read_checkpoint_kinds(db_path, job.id)
     assert "critique_done" not in checkpoints
+
+
+# ---------------------------------------------------------------------------
+# Inbox replan (issue #262)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inbox_replan_sidecar_triggers_tactical_replan(
+    job: Job,
+    db_path: Path,
+    plan: Plan,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (job.root / INBOX_REPLAN_FILE).write_text(
+        json.dumps(
+            {
+                "trigger": "inbox",
+                "filename": "foia-response.md",
+                "sha": "a" * 64,
+                "note": "user added foia-response.md (contract file); identify NEW angles",
+            }
+        ),
+        encoding="utf-8",
+    )
+    captured: dict[str, Any] = {}
+
+    async def fake_tactical_replan(
+        job_arg: Job,
+        prior_plan: Plan,
+        recent_results: list[dict[str, Any]],
+        *,
+        router: Any,
+        findings: list[dict[str, Any]] | None = None,
+        synthesis_md: str | None = None,
+        follow_up_questions: list[str] | None = None,
+        user_note: str | None = None,
+    ) -> Plan:
+        captured["user_note"] = user_note
+        new = Plan(
+            version=prior_plan.version + 1,
+            objective=prior_plan.objective,
+            subgoals=[Subgoal(id=1, description="Gather", done=True)],
+            task_template=[],
+            expected_iterations=prior_plan.expected_iterations,
+        )
+        write_plan(job_arg, new.model_dump())
+        return new
+
+    monkeypatch.setattr(plan_module, "tactical_replan", fake_tactical_replan)
+
+    result = await run_loop(
+        job,
+        router=None,
+        plan=plan,
+        handlers={"web_search": _ok_handler()},
+        retry_waits=(0,),
+    )
+
+    assert captured["user_note"] == (
+        "user added foia-response.md (contract file); identify NEW angles"
+    )
+    assert not (job.root / INBOX_REPLAN_FILE).exists()
+    assert result["tasks_done"] == 0
+    events = _read_events_by_kind(db_path, job.id, "replan_triggered")
+    assert len(events) == 1
+    assert events[0]["payload"]["stage"] == "inbox"
+    assert events[0]["payload"]["filename"] == "foia-response.md"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -30,7 +30,7 @@ from research_agent.orchestrator.plan import (
     tactical_replan,
 )
 from research_agent.prompts import loader as prompts_loader
-from research_agent.storage import db
+from research_agent.storage import db, hypotheses
 from research_agent.storage.jobs import Job
 
 ALL_TASK_KINDS: tuple[str, ...] = get_args(TaskKind)
@@ -628,6 +628,33 @@ def test_tactical_replan_includes_inconclusive_subgoals_payload(
     assert payload["inconclusive_subgoals"] == inconclusive
     assert result.task_template[0].kind == "news_search"
     assert result.task_template[0].kind not in inconclusive[0]["prior_task_kinds"]
+
+
+def test_tactical_replan_includes_hypotheses_payload(
+    job: Job,
+    router_with_spy: tuple[Router, list[Any]],
+) -> None:
+    router, calls = router_with_spy
+    prior = _sample_plan()
+    hid = hypotheses.upsert_hypothesis(
+        job,
+        plan_version=1,
+        statement="Permitting friction is the primary delay driver.",
+        confidence=0.62,
+        supports=[10],
+        refutes=[],
+        status="open",
+    )
+    _StubAgent.next_plan = _sample_plan(version=2)
+
+    asyncio.run(tactical_replan(job, prior, [], router=router))
+
+    payload = json.loads(calls[0][2][0])
+    assert payload["hypotheses"][0]["id"] == hid
+    assert payload["hypotheses"][0]["statement"] == (
+        "Permitting friction is the primary delay driver."
+    )
+    assert payload["hypotheses"][0]["supports"] == [10]
 
 
 def test_tactical_replan_gap_reason_marks_subgoal_gapped(

--- a/tests/test_orchestrator_synth.py
+++ b/tests/test_orchestrator_synth.py
@@ -12,6 +12,7 @@ from typing import Any
 import pytest
 
 from research_agent.llm.budgets import BudgetExceeded
+from research_agent.observability.events import emit
 from research_agent.orchestrator import synth as synth_module
 from research_agent.orchestrator.plan import Plan, Subgoal, TaskSpec
 from research_agent.orchestrator.synth import (
@@ -22,7 +23,7 @@ from research_agent.orchestrator.synth import (
     synthesize,
 )
 from research_agent.prompts import loader as prompts_loader
-from research_agent.storage import db
+from research_agent.storage import artifacts, db, hypotheses
 from research_agent.storage.jobs import Job
 from research_agent.storage.markdown import write_finding, write_plan
 from research_agent.storage.sources import write_source
@@ -822,6 +823,267 @@ def test_synthesize_repeat_status_skips_plan_version_bump(
     events = _read_event_rows(db_path, job.id)
     updated = [e for e in events if e["kind"] == "plan_subgoals_updated"]
     assert len(updated) == 1
+
+
+# ---------------------------------------------------------------------------
+# Confirmed Gaps (issue #258)
+# ---------------------------------------------------------------------------
+
+
+def _insert_failed_task(
+    job: Job,
+    *,
+    kind: str,
+    payload: dict[str, Any],
+    error: str,
+    plan_version: int = 1,
+) -> None:
+    conn = db.connect(job.db_path)
+    try:
+        with conn:
+            conn.execute(
+                "INSERT INTO tasks"
+                " (job_id, plan_version, kind, payload_json, status, error, retry_count)"
+                " VALUES (?, ?, ?, ?, 'failed', ?, 1)",
+                (job.id, plan_version, kind, json.dumps(payload, sort_keys=True), error),
+            )
+    finally:
+        conn.close()
+
+
+def test_compute_confirmed_gaps_from_failed_tasks_plan_and_low_yield(
+    job: Job, db_path: Path
+) -> None:
+    gapped_plan = Plan(
+        version=1,
+        objective="Investigate Alameda restroom delay",
+        subgoals=[
+            Subgoal(
+                id=1,
+                description="Identify the prime contractor name",
+                done=False,
+                gap_reason="contract award file unavailable without city clerk records",
+            )
+        ],
+        task_template=[TaskSpec(kind="web_search")],
+        expected_iterations=2,
+    )
+    write_plan(job, gapped_plan.model_dump())
+    payload = {
+        "query": "site:alamedaca.gov shoreline restroom contractor",
+        "sub_question": "Identify the prime contractor name",
+        "subgoal_id": 1,
+    }
+    for _ in range(3):
+        _insert_failed_task(
+            job,
+            kind="web_search",
+            payload=payload,
+            error="0 results",
+        )
+    emit(job, "INFO", "planner", "plan_subgoals_updated", {"inconclusive": [1]})
+    stem = synth_module._query_stem_for_payload(payload)
+    (job.root / "synthesis" / "low_yield.json").write_text(
+        json.dumps(
+            [
+                {
+                    "kind": "web_search",
+                    "query_stem": stem,
+                    "count": 3,
+                    "suggested_unblocker": (
+                        "FOIA the City of Alameda Clerk for the prime contract award file"
+                    ),
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    gaps = synth_module._compute_confirmed_gaps(job, gapped_plan)
+
+    assert len(gaps) == 1
+    gap = gaps[0]
+    assert gap["topic"] == "Identify the prime contractor name"
+    assert "city clerk records" in gap["failure_summary"]
+    assert "FOIA the City of Alameda Clerk for the prime contract award file" in gap[
+        "suggested_unblocker"
+    ]
+    assert gap["attempts"] == [
+        {
+            "task_kind": "web_search",
+            "query": "site:alamedaca.gov shoreline restroom contractor",
+            "failure_reason": "0 results from web_search",
+            "count": 3,
+        }
+    ]
+
+
+def test_compute_confirmed_gaps_empty_without_failure_signals(job: Job, plan: Plan) -> None:
+    assert synth_module._compute_confirmed_gaps(job, plan) == []
+
+
+def test_build_context_includes_confirmed_gaps(job: Job, db_path: Path, plan: Plan) -> None:
+    context_json = synth_module._build_context(
+        goal=job.goal,
+        plan=plan,
+        findings=[],
+        sources={},
+        prior=None,
+        critique=None,
+        followup_recipes="",
+        paid_unblock_recipes="",
+        confirmed_gaps=[
+            {
+                "topic": "prime contractor name",
+                "attempts": [],
+                "failure_summary": "No public source identified.",
+                "suggested_unblocker": "FOIA the City of Alameda Clerk",
+            }
+        ],
+        final=False,
+    )
+    payload = json.loads(context_json)
+    assert payload["confirmed_gaps"][0]["topic"] == "prime contractor name"
+    assert payload["subgoals"][0]["gap_reason"] is None
+
+
+def test_synthesize_preserves_confirmed_gaps_section_and_strips_status_fence(
+    job: Job, db_path: Path, multi_subgoal_plan: Plan
+) -> None:
+    _seed_findings(job, [0.9])
+    content = (
+        "# Investigation Report\n\n"
+        "## Executive Summary\n\n- finding [1].\n\n"
+        "## Confirmed Gaps\n\n"
+        "- **Prime contractor name** — Tried city records. Unblocker: "
+        "FOIA the City of Alameda Clerk\n"
+        "  - Attempted `web_search` for \"site:alamedaca.gov contractor\": "
+        "0 results (count: 3).\n\n"
+        "## Sources\n"
+        '1. https://example.com/0 — "Title" (retrieved 2026-05-06)\n'
+        "\n```json\n"
+        '{"subgoal_status": {"1": "inconclusive", "2": "inconclusive", "3": "inconclusive"}}'
+        "\n```\n"
+    )
+    router = _StubRouter(content=content)
+
+    asyncio.run(synthesize(job, multi_subgoal_plan, router=router))
+
+    report = (job.root / "report.md").read_text(encoding="utf-8")
+    assert "## Confirmed Gaps" in report
+    assert "FOIA the City of Alameda Clerk" in report
+    assert "subgoal_status" not in report
+
+
+# ---------------------------------------------------------------------------
+# Working hypotheses (issue #261)
+# ---------------------------------------------------------------------------
+
+
+def test_synthesize_extracts_hypothesis_updates_and_strips_fence(
+    job: Job, db_path: Path, multi_subgoal_plan: Plan
+) -> None:
+    _source_ids, finding_ids = _seed_findings(job, [0.9])
+    content = (
+        "# Investigation Report\n\n"
+        "## Executive Summary\n\n- finding [1].\n\n"
+        "## Working Hypotheses\n\n"
+        "### H-new: Contractor underbid\n"
+        "**Status:** Open\n"
+        "**Confidence:** 0.65\n"
+        "- Supporting: finding [1].\n\n"
+        "## Sources\n"
+        '1. https://example.com/0 — "Title" (retrieved 2026-05-06)\n'
+        "\n```json\n"
+        '{"subgoal_status": {"1": "inconclusive", "2": "inconclusive", "3": "inconclusive"}}'
+        "\n```\n"
+        "```json\n"
+        '{"hypothesis_updates": ['
+        '{"statement": "The contractor underbid and is slow-walking change orders.", '
+        '"confidence": 0.65, '
+        f'"supports": [{finding_ids[0]}], '
+        '"refutes": [], "status": "open"}]}'
+        "\n```\n"
+    )
+    router = _StubRouter(content=content)
+
+    asyncio.run(synthesize(job, multi_subgoal_plan, router=router))
+
+    report = (job.root / "report.md").read_text(encoding="utf-8")
+    assert "## Working Hypotheses" in report
+    assert "hypothesis_updates" not in report
+    assert "subgoal_status" not in report
+
+    rows = hypotheses.list_hypotheses(job)
+    assert len(rows) == 1
+    assert rows[0]["statement"] == "The contractor underbid and is slow-walking change orders."
+    assert rows[0]["confidence"] == pytest.approx(0.65)
+    assert rows[0]["supports"] == [finding_ids[0]]
+    assert rows[0]["status"] == "open"
+
+    events = _read_event_rows(db_path, job.id)
+    updated = [e for e in events if e["kind"] == "hypothesis_updated"]
+    assert len(updated) == 1
+    payload = json.loads(updated[0]["payload_json"])
+    assert payload["id"] == rows[0]["id"]
+    assert payload["status"] == "open"
+
+
+def test_synthesize_context_includes_current_hypotheses(job: Job, plan: Plan) -> None:
+    _source_ids, finding_ids = _seed_findings(job, [0.8])
+    hid = hypotheses.upsert_hypothesis(
+        job,
+        plan_version=1,
+        statement="Permitting friction is the primary delay driver.",
+        confidence=0.55,
+        supports=[finding_ids[0]],
+        refutes=[],
+        status="open",
+    )
+    router = _StubRouter()
+
+    asyncio.run(synthesize(job, plan, router=router))
+
+    _tier, args, _kwargs = router.calls[0]
+    payload = json.loads(args[0])
+    assert payload["current_hypotheses"][0]["id"] == hid
+    assert payload["current_hypotheses"][0]["statement"] == (
+        "Permitting friction is the primary delay driver."
+    )
+    assert payload["current_hypotheses"][0]["supports"] == [finding_ids[0]]
+    assert payload["current_hypotheses"][0]["supporting_findings"][0]["id"] == finding_ids[0]
+
+
+def test_synthesize_context_includes_generated_artifacts(job: Job, plan: Plan) -> None:
+    artifacts.write_table_artifact(
+        job,
+        "candidates",
+        schema=artifacts.CANDIDATE_ROSTER_SCHEMA,
+        rows=[
+            {
+                "state": "CA",
+                "chamber": "House",
+                "candidate_name": "Jane Doe",
+                "source_url": "https://example.com/jane",
+            }
+        ],
+    )
+    router = _StubRouter()
+
+    asyncio.run(synthesize(job, plan, router=router))
+
+    _tier, args, _kwargs = router.calls[0]
+    payload = json.loads(args[0])
+    assert payload["artifacts"] == [
+        {
+            "name": "candidates",
+            "schema_version": 1,
+            "row_count": 1,
+            "generated_at_epoch": payload["artifacts"][0]["generated_at_epoch"],
+            "source_coverage": "",
+            "csv_path": "artifacts/candidates.csv",
+        }
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_storage_artifacts.py
+++ b/tests/test_storage_artifacts.py
@@ -1,0 +1,97 @@
+"""Tests for structured table artifacts."""
+
+from __future__ import annotations
+
+import csv
+import json
+from datetime import date
+from pathlib import Path
+
+from research_agent.storage import artifacts, db
+from research_agent.storage.jobs import Job
+
+
+def _job(tmp_path: Path) -> Job:
+    db_path = tmp_path / "index.sqlite"
+    db.migrate(path=db_path).close()
+    return Job.create(
+        {"goal": "Build candidate roster"},
+        jobs_root=tmp_path / "jobs",
+        db_path=db_path,
+        today=date(2026, 5, 15),
+    )
+
+
+def test_write_table_artifact_writes_schema_jsonl_csv_and_meta(tmp_path: Path) -> None:
+    job = _job(tmp_path)
+    rows = [
+        {
+            "state": "CA",
+            "chamber": "House",
+            "district_or_seat": "1",
+            "candidate_name": "Jane Doe",
+            "source_url": "https://example.com/ca",
+        },
+        {
+            "state": "NV",
+            "chamber": "Senate",
+            "candidate_name": "John Smith",
+            "source_url": "https://example.com/nv",
+            "party": "Independent",
+        },
+    ]
+
+    csv_path = artifacts.write_table_artifact(
+        job,
+        "candidates",
+        schema=artifacts.CANDIDATE_ROSTER_SCHEMA,
+        rows=rows,
+        source_coverage="2 states",
+    )
+
+    artifact_dir = job.root / "artifacts"
+    assert csv_path == artifact_dir / "candidates.csv"
+    assert (artifact_dir / "candidates.schema.json").exists()
+    assert (artifact_dir / "candidates.jsonl").exists()
+    assert (artifact_dir / "candidates.meta.json").exists()
+    assert list(artifact_dir.glob("*.tmp")) == []
+
+    schema = json.loads((artifact_dir / "candidates.schema.json").read_text(encoding="utf-8"))
+    assert schema["name"] == "candidates"
+    assert [column["name"] for column in schema["columns"]][:4] == [
+        "state",
+        "chamber",
+        "district_or_seat",
+        "candidate_name",
+    ]
+
+    csv_rows = list(csv.DictReader((artifact_dir / "candidates.csv").open()))
+    assert csv_rows[0]["party"] == ""
+    assert csv_rows[1]["party"] == "Independent"
+    assert "official_campaign_website" in csv_rows[0]
+
+    meta = json.loads((artifact_dir / "candidates.meta.json").read_text(encoding="utf-8"))
+    assert meta["artifact_name"] == "candidates"
+    assert meta["row_count"] == 2
+    assert meta["source_job_id"] == job.id
+    assert meta["source_coverage"] == "2 states"
+
+
+def test_read_and_list_artifacts_round_trip(tmp_path: Path) -> None:
+    job = _job(tmp_path)
+    rows = [{"state": "CA", "chamber": "House", "candidate_name": "Jane", "source_url": "u"}]
+    artifacts.write_table_artifact(
+        job,
+        "candidates",
+        schema=artifacts.CANDIDATE_ROSTER_SCHEMA,
+        rows=rows,
+    )
+
+    schema, loaded_rows = artifacts.read_artifact(job, "candidates")
+    listed = artifacts.list_artifacts(job)
+
+    assert schema.name == "candidates"
+    assert loaded_rows == rows
+    assert listed[0]["name"] == "candidates"
+    assert listed[0]["row_count"] == 1
+    assert listed[0]["csv_path"] == "artifacts/candidates.csv"

--- a/tests/test_storage_hypotheses.py
+++ b/tests/test_storage_hypotheses.py
@@ -1,0 +1,132 @@
+"""Tests for the per-job hypothesis ledger."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from research_agent.storage import db, hypotheses
+from research_agent.storage.jobs import Job
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "index.sqlite"
+    db.migrate(path=path).close()
+    return path
+
+
+@pytest.fixture
+def job(tmp_path: Path, db_path: Path) -> Job:
+    return Job.create(
+        {"goal": "Investigate hypothesis ledger"},
+        jobs_root=tmp_path / "jobs",
+        db_path=db_path,
+        today=date(2026, 5, 15),
+    )
+
+
+def test_upsert_hypothesis_inserts_and_round_trips_json_lists(job: Job) -> None:
+    hid = hypotheses.upsert_hypothesis(
+        job,
+        plan_version=1,
+        statement="The delay is due to permitting friction.",
+        confidence=0.6,
+        supports=[1, "2"],
+        refutes=[3],
+        status="open",
+    )
+
+    rows = hypotheses.list_hypotheses(job)
+
+    assert len(rows) == 1
+    assert rows[0]["id"] == hid
+    assert rows[0]["statement"] == "The delay is due to permitting friction."
+    assert rows[0]["confidence"] == pytest.approx(0.6)
+    assert rows[0]["supports"] == [1, 2]
+    assert rows[0]["refutes"] == [3]
+    assert rows[0]["status"] == "open"
+
+
+def test_upsert_hypothesis_updates_existing_id(job: Job) -> None:
+    hid = hypotheses.upsert_hypothesis(
+        job,
+        plan_version=1,
+        statement="The contractor underbid.",
+        confidence=0.4,
+        supports=[],
+        refutes=[],
+        status="open",
+    )
+
+    same = hypotheses.upsert_hypothesis(
+        job,
+        id=hid,
+        plan_version=2,
+        statement="The contractor underbid and change orders slowed delivery.",
+        confidence=0.7,
+        supports=[10],
+        refutes=[11, 12],
+        status="inconclusive",
+    )
+
+    assert same == hid
+    rows = hypotheses.list_hypotheses(job)
+    assert len(rows) == 1
+    assert rows[0]["plan_version"] == 2
+    assert rows[0]["statement"] == "The contractor underbid and change orders slowed delivery."
+    assert rows[0]["confidence"] == pytest.approx(0.7)
+    assert rows[0]["supports"] == [10]
+    assert rows[0]["refutes"] == [11, 12]
+    assert rows[0]["status"] == "inconclusive"
+
+
+def test_upsert_hypothesis_validates_confidence_and_status(job: Job) -> None:
+    with pytest.raises(ValueError, match="confidence"):
+        hypotheses.upsert_hypothesis(
+            job,
+            plan_version=1,
+            statement="Bad confidence",
+            confidence=1.2,
+            supports=[],
+            refutes=[],
+            status="open",
+        )
+
+    with pytest.raises(ValueError, match="status"):
+        hypotheses.upsert_hypothesis(
+            job,
+            plan_version=1,
+            statement="Bad status",
+            confidence=0.5,
+            supports=[],
+            refutes=[],
+            status="maybe",
+        )
+
+
+def test_latest_for_job_returns_current_rows(job: Job) -> None:
+    first = hypotheses.upsert_hypothesis(
+        job,
+        plan_version=1,
+        statement="H1",
+        confidence=0.2,
+        supports=[],
+        refutes=[],
+        status="open",
+    )
+    second = hypotheses.upsert_hypothesis(
+        job,
+        plan_version=2,
+        statement="H2",
+        confidence=0.8,
+        supports=[5],
+        refutes=[],
+        status="confirmed",
+    )
+
+    rows = hypotheses.latest_for_job(job)
+
+    assert [row["id"] for row in rows] == [first, second]


### PR DESCRIPTION
Closes #258
Closes #261
Closes #262
Closes #304

## Summary

Batch implementation of 4 issues:
- **#258**: feat: synth report has '## Confirmed Gaps' section listing what was tried, what failed, and what would unblock
- **#261**: feat: per-job hypothesis ledger — track competing theories with confidence + supporting/refuting evidence
- **#262**: feat: jobs/<id>/inbox/ — drop human-supplied docs (FOIA responses, etc) for mid-run ingest + auto-replan
- **#304**: feat: structured artifacts + CSV export for list-building jobs

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |

## Code Review

All 4 issues fully implemented and wired end-to-end; full test suite (2139 tests) passes; no critical or warning findings.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Batch mode · Full logs in `.alpha-loop/sessions/`*