### PR TITLE
Fix epic 252 review follow-ups and rollup smoke

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -16,6 +16,7 @@ When reviewing code changes (PR review, post-implementation review).
 - [ ] All acceptance criteria met
 - [ ] No scope creep (unnecessary changes)
 - [ ] Edge cases handled
+- [ ] Public entry points stay lightweight: `import research_agent`, MCP server import, and HTTP wrapper import do not eagerly load daemon/LLM/orchestrator stacks unless needed
 
 ### 2. Code Quality
 - [ ] Follows project conventions (check CLAUDE.md)
@@ -28,6 +29,7 @@ When reviewing code changes (PR review, post-implementation review).
 - [ ] No SQL injection (use parameterized queries)
 - [ ] No XSS (sanitize user input)
 - [ ] No command injection (validate shell args)
+- [ ] Public job/file identifiers are validated before fallback folder scanning, and sidecar paths cannot traverse outside the job folder
 - [ ] Auth/authz checks in place
 - [ ] No secrets in code
 
@@ -41,6 +43,7 @@ When reviewing code changes (PR review, post-implementation review).
 - [ ] No N+1 queries
 - [ ] No unnecessary re-renders
 - [ ] Large lists paginated
+- [ ] Source/citation lookups use stable IDs rather than filename or ordering assumptions
 
 ## Action on Findings
 

--- a/.agents/skills/docs-sync/SKILL.md
+++ b/.agents/skills/docs-sync/SKILL.md
@@ -33,6 +33,7 @@ When making changes that affect user-facing behavior, always update the correspo
 ### Public API or behavior changed?
 - Update relevant README sections
 - Update CLAUDE.md if architectural
+- If a public contract doc changes, update the matching reader/API docs and `AGENTS.md` contract rules in the same diff
 
 ## Rules
 

--- a/.agents/skills/scope-discipline/SKILL.md
+++ b/.agents/skills/scope-discipline/SKILL.md
@@ -32,6 +32,7 @@ If #1 and #2 are no and #3 is yes — the change is out of scope.
 | Orchestrator `task_kind`/dispatch handler edits on a connector PR | Remove unless the issue asks for orchestrator wiring. |
 | Critique-model field additions on a non-critique PR | Remove. |
 | Plan/synth prompt rewrites on a non-prompt PR | Remove. |
+| Broad contract docs, public API wrappers, or service-surface changes on a narrow MCP/HTTP issue | Split unless the issue explicitly names that contract surface. |
 
 ## When in-scope work reveals a needed change elsewhere
 

--- a/.alpha-loop/templates/agents/implementer.md
+++ b/.alpha-loop/templates/agents/implementer.md
@@ -41,6 +41,7 @@ This repo is Python 3.12 + uv + pytest + Playwright. Not TypeScript. Not pnpm. T
   ```
   If it fails on main with the same error, it is pre-existing and unrelated to your diff — note it in the commit/PR body, do not burn retries trying to fix it. (Issue #117 cost two retry cycles on `test_cli.py::test_start_skip_intake_*` failures that already existed on main; #156 similar.)
 - **For new connectors / tools, ensure `setup_command` installs the CLI globally.** The verifier shells out as `/bin/sh -c "research _smoke-tool ..."`, not `uv run research ...` — so `uv tool install -e .` is required, not just `uv pip install -e .`.
+- **Public service surfaces must pass a lightweight-import audit.** For changes to `research_agent.__init__`, `research_agent.api`, `research_agent.mcp`, or `research_agent.http`, verify that simple imports do not eagerly load daemon, LLM, or orchestrator stacks. Prefer lazy imports for start/resume-only dependencies.
 - **Validate Playwright selectors against live DOM for every distinct page type.** A connector with working `search()` selectors and reused but unverified `fetch()` profile selectors will silently return `?` placeholders (#101 CA SoS, #95 BBB rollup). Live-verify each page type, not just the entry page.
 - **Verify URL constants against the actual upstream schema.** Test fixtures that mirror the parser's expected shape can hide URL/schema mismatches that would index zero entries in production (#116 SDN advanced XML pointing at relational `<DistinctParty>` schema while parser expected flat `<sdnEntry>`). Cross-check the URL's documented schema against what the parser consumes.
 - **Trusted-host validation must use exact match or proper suffix** (`netloc == host or netloc.endswith("." + host)`). Substring `"host.com" in netloc` is spoofable.
@@ -62,6 +63,7 @@ Before your final commit, answer each question explicitly. If any answer is "no"
 5. **CLI surface:** For every new verb / subcommand in `cli.py`, did I update `README.md`?
 6. **Pre-existing failures:** If tests are failing, did I confirm they fail on `origin/main` before retrying? If yes, did I note them rather than burn retries?
 7. **Selector coverage:** For Playwright connectors, did I live-verify selectors for every distinct page type (search, profile, detail), not just the entry page?
+8. **Lightweight imports:** For public API/MCP/HTTP changes, did I verify import side effects and avoid process-global state mutation for per-request settings?
 
 ## Code Style
 

--- a/.alpha-loop/templates/agents/reviewer.md
+++ b/.alpha-loop/templates/agents/reviewer.md
@@ -74,14 +74,31 @@ If it fails on main too, it's pre-existing — flag in summary, do not block on 
 - **Substring host match**: `if "trusted.com" in netloc` is spoofable. Require `netloc == host or netloc.endswith("." + host)`.
 - **`tempfile.mkstemp(...)[1]` discarding fd**: leak. Demand `os.close(fd)` or a helper.
 - **In-function `import json as _json`** when module-level `import json` already exists: cleanup, not blocker.
+- **Traversal-shaped identifiers**: public APIs must validate job IDs before fallback folder scans, and sidecar `md_path` fields must stay relative to the job folder.
+- **Process-global request settings**: HTTP/API wrappers must not mutate `os.environ` for per-request daemon options; pass explicit child-process env instead.
 
-### 8. Connector schema/URL contract
+### 8. Lightweight import audit
+
+For changes to `research_agent.__init__`, `research_agent.api`, `research_agent.mcp`, or `research_agent.http`, run a quick import-side-effect check:
+
+```bash
+uv run python - <<'PY'
+import sys
+import research_agent
+print("research_agent.daemon" in sys.modules)
+print("research_agent.llm.router" in sys.modules)
+PY
+```
+
+If the output is `True` for daemon/LLM modules before the caller uses start/resume behavior, flag it and prefer lazy imports.
+
+### 9. Connector schema/URL contract
 
 For connectors fetching XML/JSON from a documented upstream:
 - Verify the URL constant points at the schema the parser actually understands. **Test fixtures that mirror the parser's expected shape can hide URL/schema mismatches** — this is exactly how #116 (SDN advanced URL pointing at relational `<DistinctParty>`/`<Profile>` schema while parser expected flat `<sdnEntry>`) almost shipped a connector that would have indexed zero entries in prod. Cross-check: open the URL's documented schema or sample document and confirm it matches the parser's expected element/field names.
 - For `setup_command`-installed CLIs, confirm `uv tool install -e .` is present so the verifier's bare `research` shell-out resolves.
 
-### 9. Test suites that mask signature/contract bugs
+### 10. Test suites that mask signature/contract bugs
 
 - Parametrized dispatch tests using `**kwargs`-accepting fakes silently swallow signature mismatches across connectors (#180 had this — masked 10 of 18 connectors with mismatched kwargs from the planner). Look for fakes that take `**kwargs` and consider whether the test would actually catch a real signature drift.
 

--- a/.alpha-loop/templates/skills/code-review/SKILL.md
+++ b/.alpha-loop/templates/skills/code-review/SKILL.md
@@ -16,6 +16,7 @@ When reviewing code changes (PR review, post-implementation review).
 - [ ] All acceptance criteria met
 - [ ] No scope creep (unnecessary changes)
 - [ ] Edge cases handled
+- [ ] Public entry points stay lightweight: `import research_agent`, MCP server import, and HTTP wrapper import do not eagerly load daemon/LLM/orchestrator stacks unless needed
 
 ### 2. Code Quality
 - [ ] Follows project conventions (check CLAUDE.md)
@@ -28,6 +29,7 @@ When reviewing code changes (PR review, post-implementation review).
 - [ ] No SQL injection (use parameterized queries)
 - [ ] No XSS (sanitize user input)
 - [ ] No command injection (validate shell args)
+- [ ] Public job/file identifiers are validated before fallback folder scanning, and sidecar paths cannot traverse outside the job folder
 - [ ] Auth/authz checks in place
 - [ ] No secrets in code
 
@@ -41,6 +43,7 @@ When reviewing code changes (PR review, post-implementation review).
 - [ ] No N+1 queries
 - [ ] No unnecessary re-renders
 - [ ] Large lists paginated
+- [ ] Source/citation lookups use stable IDs rather than filename or ordering assumptions
 
 ## Action on Findings
 

--- a/.alpha-loop/templates/skills/docs-sync/SKILL.md
+++ b/.alpha-loop/templates/skills/docs-sync/SKILL.md
@@ -33,6 +33,7 @@ When making changes that affect user-facing behavior, always update the correspo
 ### Public API or behavior changed?
 - Update relevant README sections
 - Update CLAUDE.md if architectural
+- If a public contract doc changes, update the matching reader/API docs and `AGENTS.md` contract rules in the same diff
 
 ## Rules
 

--- a/.alpha-loop/templates/skills/scope-discipline/SKILL.md
+++ b/.alpha-loop/templates/skills/scope-discipline/SKILL.md
@@ -32,6 +32,7 @@ If #1 and #2 are no and #3 is yes — the change is out of scope.
 | Orchestrator `task_kind`/dispatch handler edits on a connector PR | Remove unless the issue asks for orchestrator wiring. |
 | Critique-model field additions on a non-critique PR | Remove. |
 | Plan/synth prompt rewrites on a non-prompt PR | Remove. |
+| Broad contract docs, public API wrappers, or service-surface changes on a narrow MCP/HTTP issue | Split unless the issue explicitly names that contract surface. |
 
 ## When in-scope work reveals a needed change elsewhere
 

--- a/scripts/smoke_composability.sh
+++ b/scripts/smoke_composability.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Rollup smoke for the composable research service epic (#252).
+# Spawns research-mcp and walks lifecycle, read, export, and tool-level MCP surfaces.
+
+set -euo pipefail
+
+UV_CACHE_DIR="${UV_CACHE_DIR:-.uv-cache}" uv run python tests/integration/rollup_composability.py "$@"
+
+echo "PASS: composability rollup smoke green"

--- a/src/research_agent/__init__.py
+++ b/src/research_agent/__init__.py
@@ -1,34 +1,86 @@
-"""Research agent package - autonomous CLI research tool."""
+"""Research agent package - autonomous CLI research tool.
 
-from research_agent.api import (
-    ExportResult,
-    FindingResult,
-    JobStatus,
-    JobSummary,
-    ReportResult,
-    ResumeJobResult,
-    SearchFindingResult,
-    StartJobResult,
-    StopJobResult,
-    export_job,
-    get_findings,
-    get_job_status,
-    get_report,
-    list_jobs,
-    resume_job,
-    search_findings,
-    start_job,
-    stop_job,
-)
-from research_agent.errors import (
-    BudgetExceeded,
-    InvalidGoal,
-    JobAlreadyRunning,
-    JobNotFound,
-    ResearchAgentError,
-)
+The public API is re-exported lazily so a simple ``import research_agent`` does
+not also import daemon/orchestrator modules. Embedders can still use
+``from research_agent import start_job`` and receive the same object.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from research_agent.api import (
+        ExportResult,
+        FindingResult,
+        JobStatus,
+        JobSummary,
+        ReportResult,
+        ResumeJobResult,
+        SearchFindingResult,
+        StartJobResult,
+        StopJobResult,
+        export_job,
+        get_findings,
+        get_job_status,
+        get_report,
+        list_jobs,
+        resume_job,
+        search_findings,
+        start_job,
+        stop_job,
+    )
+    from research_agent.errors import (
+        BudgetExceeded,
+        InvalidGoal,
+        JobAlreadyRunning,
+        JobNotFound,
+        ResearchAgentError,
+    )
 
 __version__ = "0.1.0"
+
+_API_EXPORTS = {
+    "ExportResult",
+    "FindingResult",
+    "JobStatus",
+    "JobSummary",
+    "ReportResult",
+    "ResumeJobResult",
+    "SearchFindingResult",
+    "StartJobResult",
+    "StopJobResult",
+    "export_job",
+    "get_findings",
+    "get_job_status",
+    "get_report",
+    "list_jobs",
+    "resume_job",
+    "search_findings",
+    "start_job",
+    "stop_job",
+}
+
+_ERROR_EXPORTS = {
+    "BudgetExceeded",
+    "InvalidGoal",
+    "JobAlreadyRunning",
+    "JobNotFound",
+    "ResearchAgentError",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _API_EXPORTS:
+        value = getattr(import_module("research_agent.api"), name)
+    elif name in _ERROR_EXPORTS:
+        value = getattr(import_module("research_agent.errors"), name)
+    else:
+        raise AttributeError(f"module 'research_agent' has no attribute {name!r}")
+    globals()[name] = value
+    return value
+
 
 __all__ = [
     "BudgetExceeded",

--- a/src/research_agent/api.py
+++ b/src/research_agent/api.py
@@ -12,7 +12,6 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from research_agent import daemon
 from research_agent.contract import iter_findings, read_job, read_report, tail_events
 from research_agent.errors import InvalidGoal, JobAlreadyRunning, JobNotFound
 from research_agent.storage import db
@@ -24,6 +23,7 @@ from research_agent.storage.jobs import (
     RESUME_REPLAN_FILE,
     Job,
     _atomic_write_json,
+    _validate_job_id,
 )
 from research_agent.storage.search import ALLOWED_KINDS, search_fts, search_hybrid
 from research_agent.tools.models import Source
@@ -129,9 +129,18 @@ def _load_job(job_id: str, *, jobs_root: Path | str, db_path: Path | str) -> Job
 
 
 def _job_root(job_id: str, jobs_root: Path | str) -> Path:
+    try:
+        _validate_job_id(job_id)
+    except ValueError as exc:
+        raise JobNotFound(f"job not found: {job_id}") from exc
+
     root = Path(jobs_root) / job_id
     if (root / "job.json").exists():
-        return root
+        try:
+            if read_job(root).id == job_id:
+                return root
+        except Exception:
+            pass
     jobs_root_p = Path(jobs_root)
     if jobs_root_p.is_dir():
         for child in jobs_root_p.iterdir():
@@ -143,6 +152,21 @@ def _job_root(job_id: str, jobs_root: Path | str) -> Path:
             except Exception:
                 continue
     raise JobNotFound(f"job not found: {job_id}")
+
+
+def _filter_rows_for_jobs_root(
+    rows: list[dict[str, Any]],
+    jobs_root: Path | str,
+) -> list[dict[str, Any]]:
+    filtered: list[dict[str, Any]] = []
+    for row in rows:
+        job_id = str(row.get("id") or "")
+        try:
+            _job_root(job_id, jobs_root)
+        except JobNotFound:
+            continue
+        filtered.append(row)
+    return filtered
 
 
 def _fallback_job_summaries(jobs_root: Path | str) -> list[JobSummary]:
@@ -178,6 +202,8 @@ def _last_event_summary(root: Path) -> str | None:
 
 
 def _is_daemon_alive(job_id: str, jobs_root: Path | str) -> bool:
+    from research_agent import daemon
+
     try:
         return daemon.is_daemon_alive(job_id, jobs_root=jobs_root)
     except TypeError as exc:
@@ -186,18 +212,66 @@ def _is_daemon_alive(job_id: str, jobs_root: Path | str) -> bool:
         return daemon.is_daemon_alive(job_id)
 
 
-def _spawn_daemon(job_id: str, jobs_root: Path | str) -> int:
+def _spawn_daemon(
+    job_id: str,
+    jobs_root: Path | str,
+    *,
+    env: dict[str, str] | None = None,
+) -> int:
+    from research_agent import daemon
+
+    def _spawn_without_env() -> int:
+        try:
+            return daemon.spawn_daemon(job_id, jobs_root=jobs_root)
+        except TypeError as exc:
+            if "unexpected keyword argument" not in str(exc):
+                raise
+            return daemon.spawn_daemon(job_id)
+
     try:
-        return daemon.spawn_daemon(job_id, jobs_root=jobs_root)
+        return daemon.spawn_daemon(job_id, jobs_root=jobs_root, env=env)
     except TypeError as exc:
         if "unexpected keyword argument" not in str(exc):
             raise
-        return daemon.spawn_daemon(job_id)
+        if env:
+            old_values = {key: os.environ.get(key) for key in env}
+            os.environ.update(env)
+            try:
+                return _spawn_without_env()
+            finally:
+                for key, old_value in old_values.items():
+                    if old_value is None:
+                        os.environ.pop(key, None)
+                    else:
+                        os.environ[key] = old_value
+        return _spawn_without_env()
 
 
-def _source_url_for_ids(root: Path, source_ids: list[int]) -> str | None:
+def _source_url_for_ids(
+    root: Path,
+    source_ids: list[int],
+    *,
+    db_path: Path | str,
+) -> str | None:
     if not source_ids:
         return None
+    try:
+        job_id = read_job(root).id
+        conn = db.connect(db_path)
+        try:
+            row = conn.execute(
+                "SELECT s.url FROM sources s"
+                " JOIN job_sources js ON js.source_id = s.id"
+                " WHERE js.job_id = ? AND s.id = ?",
+                (job_id, source_ids[0]),
+            ).fetchone()
+        finally:
+            conn.close()
+        if row is not None:
+            return row["url"] or None
+    except Exception:
+        pass
+
     try:
         report = read_report(root)
     except Exception:
@@ -265,15 +339,16 @@ def start_job(
 
     if max_tasks is not None:
         intake_data["max_tasks"] = max_tasks
+    daemon_env: dict[str, str] = {}
     if local:
         local_cfg = Path("config/models.local.yaml")
         if not local_cfg.exists():
             raise InvalidGoal(f"--local requires {local_cfg} (not found)")
-        os.environ["RESEARCH_MODELS_CONFIG"] = str(local_cfg)
-        os.environ["RESEARCH_DAEMON_SKIP_HEALTH_CHECKS"] = "1"
+        daemon_env["RESEARCH_MODELS_CONFIG"] = str(local_cfg)
+        daemon_env["RESEARCH_DAEMON_SKIP_HEALTH_CHECKS"] = "1"
         intake_data["local"] = True
     if fragments or intake_data.get("fragments"):
-        os.environ["RESEARCH_FRAGMENT_SYNTH"] = "1"
+        daemon_env["RESEARCH_FRAGMENT_SYNTH"] = "1"
         intake_data["fragments"] = True
     if input_csv is not None:
         intake_data["input_csv_artifact"] = artifact_name
@@ -342,7 +417,7 @@ def start_job(
             target_columns=list(target_columns or []),
         )
 
-    pid = _spawn_daemon(job.id, jobs_root_p)
+    pid = _spawn_daemon(job.id, jobs_root_p, env=daemon_env or None)
     return StartJobResult(
         job_id=job.id,
         daemon_pid=pid,
@@ -415,6 +490,8 @@ def list_jobs(
         rows = []
     except Exception:
         rows = []
+    if rows:
+        rows = _filter_rows_for_jobs_root([dict(row) for row in rows], jobs_root)
     if rows:
         return [JobSummary.model_validate(row) for row in rows]
     summaries = _fallback_job_summaries(jobs_root)
@@ -509,6 +586,7 @@ def get_findings(
     job_id: str,
     *,
     jobs_root: Path | str = DEFAULT_JOBS_ROOT,
+    db_path: Path | str = db.DEFAULT_DB_PATH,
 ) -> list[FindingResult]:
     """Read finding files from a job folder.
 
@@ -524,7 +602,7 @@ def get_findings(
                 title=finding.claim,
                 body=finding.body_md,
                 citations=finding.source_ids,
-                source_url=_source_url_for_ids(root, finding.source_ids),
+                source_url=_source_url_for_ids(root, finding.source_ids, db_path=db_path),
                 created_at=finding.created_at,
             )
         )
@@ -571,7 +649,12 @@ def search_findings(
         rows = []
 
     if not rows:
-        rows = _search_fixture_findings(query, job_id=job_id, jobs_root=jobs_root)
+        rows = _search_fixture_findings(
+            query,
+            job_id=job_id,
+            jobs_root=jobs_root,
+            db_path=db_path,
+        )
     return [SearchFindingResult.model_validate(row) for row in rows]
 
 
@@ -580,6 +663,7 @@ def _search_fixture_findings(
     *,
     job_id: str | None,
     jobs_root: Path | str,
+    db_path: Path | str,
 ) -> list[dict[str, Any]]:
     tokens = [token.lower() for token in query.split() if token.strip()]
     if not tokens:
@@ -601,7 +685,11 @@ def _search_fixture_findings(
                     "score": 1.0,
                     "kind": "finding",
                     "snippet": finding.claim,
-                    "source_url": _source_url_for_ids(root, finding.source_ids),
+                    "source_url": _source_url_for_ids(
+                        root,
+                        finding.source_ids,
+                        db_path=db_path,
+                    ),
                     "job_id": read_job(root).id,
                     "id": finding.id,
                     "md_path": finding.md_path,

--- a/src/research_agent/contract.py
+++ b/src/research_agent/contract.py
@@ -88,6 +88,13 @@ def _read_json(path: Path) -> dict[str, Any]:
     return data
 
 
+def _safe_relative_path(value: str, *, field_name: str) -> Path:
+    rel = Path(value)
+    if rel.is_absolute() or ".." in rel.parts:
+        raise ContractReadError(f"{field_name} must stay inside the job folder: {value!r}")
+    return rel
+
+
 def read_job(path: str | Path) -> JobMetadata:
     """Read ``job.json`` from a job folder.
 
@@ -116,7 +123,7 @@ def iter_findings(path: str | Path) -> Iterable[Finding]:
         for sidecar in sorted(findings_dir.glob("[0-9][0-9][0-9][0-9][0-9][0-9].json")):
             data = _read_json(sidecar)
             md_rel = str(data.get("md_path") or f"findings/{sidecar.stem}.md")
-            md_path = root / md_rel
+            md_path = root / _safe_relative_path(md_rel, field_name="finding md_path")
             try:
                 body_md = md_path.read_text(encoding="utf-8")
             except FileNotFoundError as exc:
@@ -141,7 +148,8 @@ def _source_from_sidecar(sidecar: Path) -> Source:
     data = _read_json(sidecar)
     md_rel = data.get("md_path")
     if isinstance(md_rel, str) and md_rel:
-        candidate = sidecar.parent.parent / md_rel
+        rel = _safe_relative_path(md_rel, field_name="source md_path")
+        candidate = sidecar.parent.parent / rel
         md_path = candidate if candidate.exists() else sidecar.with_suffix(".md")
     else:
         md_path = sidecar.with_suffix(".md")

--- a/src/research_agent/daemon.py
+++ b/src/research_agent/daemon.py
@@ -77,7 +77,12 @@ def _atomic_write_text(path: Path, data: str) -> None:
     os.replace(tmp, path)
 
 
-def spawn_daemon(job_id: str, *, jobs_root: Path | str = DEFAULT_JOBS_ROOT) -> int:
+def spawn_daemon(
+    job_id: str,
+    *,
+    jobs_root: Path | str = DEFAULT_JOBS_ROOT,
+    env: dict[str, str] | None = None,
+) -> int:
     """Fork off the daemon for ``job_id``; return the child PID.
 
     Per §5.1: a plain :func:`subprocess.Popen` with ``start_new_session=True``
@@ -102,6 +107,7 @@ def spawn_daemon(job_id: str, *, jobs_root: Path | str = DEFAULT_JOBS_ROOT) -> i
     # Append-mode: re-launching the daemon must not clobber prior log lines.
     # The subprocess dups these fds into its own stdout/stderr; the parent's
     # copies are closed when the with-block exits.
+    child_env = None if env is None else {**os.environ, **env}
     with open(out_log, "ab") as out_fh, open(err_log, "ab") as err_fh:
         proc = subprocess.Popen(
             [sys.executable, "-m", "research_agent.daemon", job_id],
@@ -111,6 +117,7 @@ def spawn_daemon(job_id: str, *, jobs_root: Path | str = DEFAULT_JOBS_ROOT) -> i
             start_new_session=True,
             close_fds=True,
             cwd=Path.cwd(),
+            env=child_env,
         )
 
     _atomic_write_text(job_root / "daemon.pid", f"{proc.pid}\n")

--- a/src/research_agent/http/__init__.py
+++ b/src/research_agent/http/__init__.py
@@ -1,2 +1,1 @@
 """HTTP wrapper package for the public research-agent API."""
-

--- a/src/research_agent/http/server.py
+++ b/src/research_agent/http/server.py
@@ -186,7 +186,7 @@ def get_report(job_id: str, context: ContextDep) -> public_api.ReportResult:
     response_model=list[public_api.FindingResult],
 )
 def get_findings(job_id: str, context: ContextDep) -> list[public_api.FindingResult]:
-    return public_api.get_findings(job_id, jobs_root=context.jobs_root)
+    return public_api.get_findings(job_id, jobs_root=context.jobs_root, db_path=context.db_path)
 
 
 @router.post(

--- a/tests/integration/check_mcp_lifecycle.py
+++ b/tests/integration/check_mcp_lifecycle.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import shutil
 import sys
 
 import anyio
@@ -23,14 +22,10 @@ EXPECTED = {
 
 
 async def _main() -> None:
-    executable = shutil.which("research-mcp")
-    if executable:
-        params = StdioServerParameters(command=executable)
-    else:
-        params = StdioServerParameters(
-            command=sys.executable,
-            args=["-m", "research_agent.mcp.server"],
-        )
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "research_agent.mcp.server"],
+    )
     async with stdio_client(params) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()

--- a/tests/integration/check_mcp_tool_level.py
+++ b/tests/integration/check_mcp_tool_level.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import shutil
 import sys
 
 import anyio
@@ -15,18 +14,11 @@ async def _main() -> None:
     import research_agent.tools  # noqa: F401 - populate local registry
     from research_agent.tools._registry import iter_kinds
 
-    executable = shutil.which("research-mcp")
-    if executable:
-        params = StdioServerParameters(
-            command=executable,
-            env={**os.environ, "MUCKWIRE_MCP_TEST_FAKE_CONNECTOR": "1"},
-        )
-    else:
-        params = StdioServerParameters(
-            command=sys.executable,
-            args=["-m", "research_agent.mcp.server"],
-            env={**os.environ, "MUCKWIRE_MCP_TEST_FAKE_CONNECTOR": "1"},
-        )
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "research_agent.mcp.server"],
+        env={**os.environ, "MUCKWIRE_MCP_TEST_FAKE_CONNECTOR": "1"},
+    )
 
     async with stdio_client(params) as (read, write):
         async with ClientSession(read, write) as session:

--- a/tests/integration/rollup_composability.py
+++ b/tests/integration/rollup_composability.py
@@ -1,0 +1,194 @@
+"""Rollup smoke for the composable research service MCP surface.
+
+Default mode is fixture-backed and deterministic: it spawns the real MCP
+server in a temporary workspace, reads a materialized fixture job through MCP,
+exports it, and calls one registry-driven connector tool. Pass ``--live`` to
+exercise ``start_research_job`` against the configured daemon/model stack.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import anyio
+from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+SAMPLE_JOB_ID = "2026-05-16-investigate-widget-co-financials"
+FIXTURE_JOB_ROOT = Path("tests/fixtures/jobs/sample")
+LIFECYCLE_TOOLS = {
+    "start_research_job",
+    "get_job_status",
+    "list_jobs",
+    "stop_job",
+    "resume_job",
+    "get_report",
+    "get_findings",
+    "search_findings",
+    "export_job",
+}
+
+
+def _structured(result: Any) -> dict[str, Any]:
+    data = getattr(result, "structuredContent", None)
+    if not isinstance(data, dict):
+        raise AssertionError(f"MCP result did not include structured content: {result!r}")
+    return data
+
+
+async def _spawn_session(workdir: Path, *, fake_connector: bool) -> ClientSession:
+    env = dict(os.environ)
+    if fake_connector:
+        env["MUCKWIRE_MCP_TEST_FAKE_CONNECTOR"] = "1"
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "research_agent.mcp.server"],
+        cwd=str(workdir),
+        env=env,
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            yield session
+
+
+async def _assert_tools(session: ClientSession, *, expect_fake: bool) -> set[str]:
+    tools = await session.list_tools()
+    names = {tool.name for tool in tools.tools}
+    missing = LIFECYCLE_TOOLS - names
+    assert not missing, f"missing lifecycle tools: {sorted(missing)}"
+    connector_tools = {name for name in names if name.endswith("_search")}
+    assert connector_tools, "no registry-driven connector tools exposed"
+    if expect_fake:
+        assert "fake_search" in names
+    return names
+
+
+async def _run_fixture_rollup(workdir: Path) -> None:
+    jobs_dir = workdir / "jobs"
+    jobs_dir.mkdir(parents=True)
+    shutil.copytree(FIXTURE_JOB_ROOT, jobs_dir / "sample")
+    export_path = workdir / "exports" / "fixture.md"
+
+    async for session in _spawn_session(workdir, fake_connector=True):
+        names = await _assert_tools(session, expect_fake=True)
+        assert len(names) >= len(LIFECYCLE_TOOLS) + 1
+
+        listed = _structured(await session.call_tool("list_jobs", {}))
+        jobs = listed.get("jobs")
+        assert isinstance(jobs, list) and jobs, "list_jobs returned no jobs"
+        assert any(row.get("job_id") == SAMPLE_JOB_ID for row in jobs), jobs
+
+        report = _structured(await session.call_tool("get_report", {"job_id": SAMPLE_JOB_ID}))
+        assert str(report.get("report_md") or "").startswith("# Report")
+        assert isinstance(report.get("sources"), list) and report["sources"]
+
+        findings = _structured(await session.call_tool("get_findings", {"job_id": SAMPLE_JOB_ID}))
+        assert isinstance(findings.get("findings"), list) and findings["findings"]
+
+        exported = _structured(
+            await session.call_tool(
+                "export_job",
+                {
+                    "job_id": SAMPLE_JOB_ID,
+                    "md_bundle": True,
+                    "out": str(export_path),
+                },
+            )
+        )
+        assert exported["bytes"] > 0
+        assert export_path.read_text(encoding="utf-8").startswith("# Report")
+
+        connector = _structured(
+            await session.call_tool(
+                "fake_search",
+                {"query": "fixture", "sub_question": "fixture", "max_results": 1},
+            )
+        )
+        rows = connector.get("results")
+        assert isinstance(rows, list) and rows, "fake_search returned no rows"
+        assert {"url", "title", "snippet", "source_kind"} <= set(rows[0])
+
+
+async def _run_live_rollup(workdir: Path) -> None:
+    async for session in _spawn_session(workdir, fake_connector=False):
+        names = await _assert_tools(session, expect_fake=False)
+        assert "web_search" in names, "live rollup expects free web_search connector"
+
+        started = _structured(
+            await session.call_tool(
+                "start_research_job",
+                {
+                    "goal": "A 100-word brief on the WPA Federal Writers Project",
+                    "budget_usd": 0.10,
+                    "time_cap": 1,
+                },
+            )
+        )
+        job_id = started["job_id"]
+        deadline = time.monotonic() + 900
+        while True:
+            status = _structured(await session.call_tool("get_job_status", {"job_id": job_id}))
+            if status.get("status") in {"completed", "failed", "stopped"}:
+                break
+            if time.monotonic() > deadline:
+                raise AssertionError(f"job {job_id} did not finish before timeout: {status}")
+            await anyio.sleep(5)
+        assert status["status"] == "completed", status
+
+        report = _structured(await session.call_tool("get_report", {"job_id": job_id}))
+        assert len(str(report.get("report_md") or "").strip()) > 100
+
+        web_rows = _structured(
+            await session.call_tool(
+                "web_search",
+                {
+                    "query": "WPA Federal Writers Project",
+                    "sub_question": "WPA Federal Writers Project",
+                    "max_results": 1,
+                },
+            )
+        ).get("results")
+        assert isinstance(web_rows, list) and web_rows, "web_search returned no rows"
+
+        export_path = workdir / "exports" / f"{job_id}.md"
+        exported = _structured(
+            await session.call_tool(
+                "export_job",
+                {"job_id": job_id, "md_bundle": True, "out": str(export_path)},
+            )
+        )
+        assert exported["bytes"] > 0
+        assert export_path.read_text(encoding="utf-8").strip()
+
+
+async def _main(live: bool) -> None:
+    with tempfile.TemporaryDirectory(prefix="muckwire-composability-") as raw:
+        workdir = Path(raw)
+        (workdir / "data").mkdir()
+        if live:
+            await _run_live_rollup(workdir)
+        else:
+            await _run_fixture_rollup(workdir)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Run a real daemon-backed MCP job instead of the deterministic fixture rollup.",
+    )
+    args = parser.parse_args()
+    anyio.run(_main, args.live)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from research_agent.contract import (
+    ContractReadError,
     Finding,
     JobMetadata,
     Report,
@@ -69,3 +72,27 @@ def test_read_source_accepts_job_root_when_single_source_exists() -> None:
 
     assert source.title == "Widget Co Sample Filing"
     assert source.metadata["pub_date"] == "2026-05-16"
+
+
+def test_read_source_rejects_sidecar_md_path_traversal(tmp_path: Path) -> None:
+    sources_dir = tmp_path / "sources"
+    sources_dir.mkdir()
+    sidecar = sources_dir / "bad.json"
+    sidecar.write_text(
+        """
+        {
+          "sha256": "bad",
+          "url": "https://example.com/bad",
+          "title": "Bad",
+          "fetched_at": 1778956860,
+          "archive_url": "",
+          "kind": "web",
+          "md_path": "../secret.md",
+          "metadata": {}
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ContractReadError):
+        read_source(sidecar)

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -10,6 +10,7 @@ pytest.importorskip("fastapi")
 
 from fastapi.testclient import TestClient  # noqa: E402
 
+from research_agent import daemon as daemon_mod  # noqa: E402
 from research_agent.errors import InvalidGoal, JobAlreadyRunning  # noqa: E402
 from research_agent.http import server  # noqa: E402
 from research_agent.storage import db  # noqa: E402
@@ -31,8 +32,8 @@ def test_http_lifecycle_routes_delegate_to_programmatic_api(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     jobs_root = tmp_path / "jobs"
-    monkeypatch.setattr(server.public_api.daemon, "spawn_daemon", lambda _job_id, **_kw: 4242)
-    monkeypatch.setattr(server.public_api.daemon, "is_daemon_alive", lambda *_a, **_kw: False)
+    monkeypatch.setattr(daemon_mod, "spawn_daemon", lambda _job_id, **_kw: 4242)
+    monkeypatch.setattr(daemon_mod, "is_daemon_alive", lambda *_a, **_kw: False)
     client = TestClient(server.create_app(jobs_root=jobs_root, db_path=db_path))
 
     started = client.post(

--- a/tests/test_programmatic_api.py
+++ b/tests/test_programmatic_api.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
 
+from research_agent import daemon as daemon_mod
 from research_agent import (
     export_job,
     get_findings,
@@ -18,8 +20,11 @@ from research_agent import (
     stop_job,
 )
 from research_agent.api import ExportResult, StartJobResult
+from research_agent.errors import JobNotFound
 from research_agent.storage import db
 from research_agent.storage.jobs import Job
+from research_agent.storage.markdown import write_finding
+from research_agent.storage.sources import write_source
 
 SAMPLE_JOB_ID = "2026-05-16-investigate-widget-co-financials"
 FIXTURE_JOBS_ROOT = Path("tests/fixtures/jobs")
@@ -66,8 +71,8 @@ def test_start_stop_resume_entry_points_use_plain_args(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     jobs_root = tmp_path / "jobs"
-    monkeypatch.setattr("research_agent.api.daemon.spawn_daemon", lambda _job_id, **_kw: 4242)
-    monkeypatch.setattr("research_agent.api.daemon.is_daemon_alive", lambda *_a, **_kw: False)
+    monkeypatch.setattr(daemon_mod, "spawn_daemon", lambda _job_id, **_kw: 4242)
+    monkeypatch.setattr(daemon_mod, "is_daemon_alive", lambda *_a, **_kw: False)
 
     started = start_job(
         "Investigate API lifecycle",
@@ -88,6 +93,37 @@ def test_start_stop_resume_entry_points_use_plain_args(
     assert not (jobs_root / started.job_id / "STOP").exists()
 
 
+def test_start_job_local_passes_env_to_daemon_without_mutating_process(
+    tmp_path: Path,
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    jobs_root = tmp_path / "jobs"
+    captured_env: dict[str, str] = {}
+
+    def _spawn(_job_id: str, **kwargs) -> int:  # type: ignore[no-untyped-def]
+        captured_env.update(kwargs.get("env") or {})
+        return 4242
+
+    monkeypatch.delenv("RESEARCH_MODELS_CONFIG", raising=False)
+    monkeypatch.delenv("RESEARCH_DAEMON_SKIP_HEALTH_CHECKS", raising=False)
+    monkeypatch.setattr(daemon_mod, "spawn_daemon", _spawn)
+    monkeypatch.setattr(daemon_mod, "is_daemon_alive", lambda *_a, **_kw: False)
+
+    started = start_job(
+        "Investigate local API lifecycle",
+        local=True,
+        jobs_root=jobs_root,
+        db_path=db_path,
+    )
+
+    assert started.daemon_pid == 4242
+    assert captured_env["RESEARCH_MODELS_CONFIG"] == "config/models.local.yaml"
+    assert captured_env["RESEARCH_DAEMON_SKIP_HEALTH_CHECKS"] == "1"
+    assert "RESEARCH_MODELS_CONFIG" not in os.environ
+    assert "RESEARCH_DAEMON_SKIP_HEALTH_CHECKS" not in os.environ
+
+
 def test_list_jobs_reads_db_rows(tmp_path: Path, db_path: Path) -> None:
     jobs_root = tmp_path / "jobs"
     job = Job.create(
@@ -100,3 +136,67 @@ def test_list_jobs_reads_db_rows(tmp_path: Path, db_path: Path) -> None:
 
     assert rows[0].job_id == job.id
     assert rows[0].goal == "Programmatic list job"
+
+
+def test_list_jobs_scopes_db_rows_to_supplied_jobs_root(
+    tmp_path: Path,
+    db_path: Path,
+) -> None:
+    other_job = Job.create(
+        {"goal": "Programmatic list job", "domain": "general"},
+        jobs_root=tmp_path / "other-jobs",
+        db_path=db_path,
+    )
+
+    rows = list_jobs(jobs_root=FIXTURE_JOBS_ROOT, db_path=db_path)
+
+    assert any(row.job_id == SAMPLE_JOB_ID for row in rows)
+    assert all(row.job_id != other_job.id for row in rows)
+
+
+def test_entry_points_reject_invalid_job_id_before_folder_lookup(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "job.json").write_text("{}", encoding="utf-8")
+    jobs_root = tmp_path / "jobs"
+    jobs_root.mkdir()
+
+    with pytest.raises(JobNotFound):
+        get_report("../outside", jobs_root=jobs_root)
+
+
+def test_get_findings_maps_source_url_by_db_source_id(
+    tmp_path: Path,
+    db_path: Path,
+) -> None:
+    jobs_root = tmp_path / "jobs"
+    job = Job.create(
+        {"goal": "Programmatic finding source lookup", "domain": "general"},
+        jobs_root=jobs_root,
+        db_path=db_path,
+    )
+    first_source = write_source(
+        job,
+        url="https://example.com/first",
+        title="First",
+        raw_content="First source body",
+        kind="web",
+    )
+    second_source = write_source(
+        job,
+        url="https://example.com/second",
+        title="Second",
+        raw_content="Second source body",
+        kind="web",
+    )
+    write_finding(
+        job,
+        "The second source supports this finding.",
+        0.9,
+        source_ids=[second_source],
+    )
+
+    findings = get_findings(job.id, jobs_root=jobs_root, db_path=db_path)
+
+    assert first_source != second_source
+    assert findings[0].source_url == "https://example.com/second"


### PR DESCRIPTION
## Summary

Follow-up for the epic #252 session review. This PR sits on top of the epic session branch and closes #337.

It does three things:

- Keeps the alpha-loop session-review fixes that were left in the local worktree after PR #334 was updated.
- Adds the missing composability rollup smoke script and deterministic MCP fixture driver.
- Applies the session learnings around lightweight public imports, daemon child environment handling, and future review checklists.

## Changes

### Service Surface Hardening

- Makes `research_agent` top-level API exports lazy so `import research_agent` does not eagerly load daemon, LLM, or orchestrator modules.
- Passes daemon-only environment overrides into the spawned child process instead of mutating the parent HTTP/API process environment.
- Keeps compatibility with existing one-argument `spawn_daemon` test doubles.

### Contract And MCP Review Fixes

- Validates job IDs before fallback job-folder lookup.
- Filters `list_jobs(jobs_root=...)` to the requested job root when SQLite has unrelated rows.
- Resolves finding citation URLs by DB source ID rather than source-file ordering.
- Rejects `md_path` traversal in contract sidecars.
- Runs MCP smoke scripts against the current checkout module instead of any stale globally installed `research-mcp` executable.

### Composability Smoke

- Adds `scripts/smoke_composability.sh`.
- Adds `tests/integration/rollup_composability.py`.
- Default mode is fixture-backed and deterministic for CI/local review.
- `--live` mode is available for the daemon-backed operator smoke described in the epic handoff.

### Learnings Captured

- Updates alpha-loop agent templates and local skills with checks for:
  - lightweight public imports,
  - path traversal in public contract readers,
  - stable source/citation ID mapping,
  - public contract documentation sync,
  - scope discipline around broad service-surface changes.

## Verification

| Check | Result |
|---|---|
| `UV_CACHE_DIR=.uv-cache bash scripts/test.sh` | Pass: 2248 passed, 2 skipped, 43 warnings |
| `UV_CACHE_DIR=.uv-cache bash scripts/smoke_composability.sh` | Pass: composability rollup smoke green |
| `UV_CACHE_DIR=.uv-cache uv run python tests/integration/check_programmatic_api.py` | Pass |
| `UV_CACHE_DIR=.uv-cache uv run python tests/integration/check_mcp_lifecycle.py` | Pass |
| `UV_CACHE_DIR=.uv-cache uv run python tests/integration/check_mcp_tool_level.py` | Pass |
| Import audit for `research_agent` | Pass: daemon and LLM router are not imported by package import |
| `git diff --check` | Pass |
| `UV_CACHE_DIR=.uv-cache uv run ruff check <touched files>` | Pass |

## Not Run

- `scripts/smoke_composability.sh --live`

The live mode starts a real daemon-backed MCP job and depends on the local model/provider setup. The deterministic fixture smoke was run and verifies non-empty MCP lifecycle, read, export, and tool-level responses.

Closes #337
Refs #252
Refs #334
