### PR TITLE
feat: migrate web search to support Tavily as additive engine option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,12 @@ OPENROUTER_API_KEY=
 # faster, more reliable, no fingerprinting risk.
 BRAVE_SEARCH_API_KEY=
 
+# Optional: Tavily Search API key (free tier: 1,000 credits/month). When set,
+# `web_search` engine="auto" prefers Tavily over Brave and DDG-Playwright —
+# purpose-built for LLM workflows, no fingerprinting risk.
+# Sign up at https://app.tavily.com
+TAVILY_API_KEY=
+
 # Optional: override default User-Agent sent by httpx and Playwright.
 RESEARCH_USER_AGENT=
 

--- a/docs/API_KEYS.md
+++ b/docs/API_KEYS.md
@@ -16,6 +16,7 @@ connector. Sign up only for the connectors you actually plan to use.
 |---|---|---|---|
 | `OPENROUTER_API_KEY` | yes (cloud mode only) | <https://openrouter.ai/settings/keys> | pay-per-token |
 | `BRAVE_SEARCH_API_KEY` | optional but recommended | <https://api.search.brave.com/app/keys> | **free** 2K/mo |
+| `TAVILY_API_KEY` | optional | <https://app.tavily.com> | **free** 1K credits/mo |
 
 If you only run with `--local` (LM Studio, gemma), even OpenRouter is
 optional — LM Studio is your inference backend and there's nothing to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "mlx-whisper>=0.4; platform_machine=='arm64' and sys_platform=='darwin'",
     "yt-dlp>=2024.4",
     "mcp>=1.27",
+    "tavily-python>=0.3",
 ]
 
 [project.optional-dependencies]

--- a/src/research_agent/config.py
+++ b/src/research_agent/config.py
@@ -38,6 +38,14 @@ EXPECTED_ENV_KEYS: tuple[EnvKey, ...] = (
         ),
     ),
     EnvKey(
+        name="TAVILY_API_KEY",
+        required=False,
+        description=(
+            "Tavily Search API key. When set, web_search 'auto' prefers Tavily"
+            " over Brave and DDG-Playwright. Free tier: 1,000 credits/month."
+        ),
+    ),
+    EnvKey(
         name="RESEARCH_USER_AGENT",
         required=False,
         description=(

--- a/src/research_agent/tools/web_search.py
+++ b/src/research_agent/tools/web_search.py
@@ -494,6 +494,12 @@ async def search(
             engine = "ddg"
 
     if engine == "tavily":
+        if normalized_lang:
+            logger.info(
+                "web_search lang=%r ignored for engine=%s; lang is Brave-only",
+                normalized_lang,
+                engine,
+            )
         return await _search_tavily(query, max_results)
 
     if engine == "brave":

--- a/src/research_agent/tools/web_search.py
+++ b/src/research_agent/tools/web_search.py
@@ -30,7 +30,7 @@ from research_agent.tools.models import SearchResult
 
 logger = logging.getLogger(__name__)
 
-Engine = Literal["auto", "brave", "ddg", "google"]
+Engine = Literal["auto", "brave", "ddg", "google", "tavily"]
 
 BRAVE_SEARCH_URL = "https://api.search.brave.com/res/v1/web/search"
 BRAVE_HTTP_TIMEOUT_S = 15.0
@@ -323,6 +323,11 @@ def _brave_api_key() -> str | None:
     return config.get("BRAVE_SEARCH_API_KEY")
 
 
+def _tavily_api_key() -> str | None:
+    """Resolve the Tavily API key from env / config, or None."""
+    return config.get("TAVILY_API_KEY")
+
+
 def _normalize_lang(lang: str | None) -> str | None:
     """Return a non-empty Brave language token, or None when unset."""
     if not isinstance(lang, str):
@@ -405,6 +410,54 @@ async def _search_brave(
     return results
 
 
+async def _search_tavily(
+    query: str,
+    max_results: int,
+) -> list[SearchResult]:
+    """Hit the Tavily Search API and return up to ``max_results`` hits.
+
+    Uses the tavily-python AsyncTavilyClient. Free tier allows 1,000
+    API credits/month. ``search_depth="basic"`` costs 1 credit per query.
+    """
+    api_key = _tavily_api_key()
+    if not api_key:
+        logger.warning("tavily search requested but TAVILY_API_KEY not set")
+        return []
+
+    try:
+        from tavily import AsyncTavilyClient
+    except ImportError:
+        logger.warning("tavily-python is not installed; cannot use engine='tavily'")
+        return []
+
+    try:
+        client = AsyncTavilyClient(api_key=api_key)
+        response = await client.search(
+            query=query,
+            max_results=min(max_results, 20),
+            search_depth="basic",
+        )
+    except Exception as exc:  # noqa: BLE001 — network / auth errors must not crash search
+        logger.warning("tavily search failed for %r: %s", query, exc)
+        return []
+
+    results: list[SearchResult] = []
+    for hit in (response.get("results") or [])[:max_results]:
+        url = hit.get("url")
+        if not url:
+            continue
+        results.append(
+            SearchResult(
+                url=url,
+                title=hit.get("title") or url,
+                snippet=hit.get("content") or "",
+                source_kind="web",
+                extras={"source_engine": "tavily", "tavily_score": hit.get("score")},
+            )
+        )
+    return results
+
+
 async def search(
     query: str,
     max_results: int = 10,
@@ -416,8 +469,9 @@ async def search(
 
     Engine selection:
 
-    * ``"auto"`` (default) — Brave Search API when ``BRAVE_SEARCH_API_KEY`` is
-      set, else DDG-Playwright. Keeps callers blissfully unaware.
+    * ``"auto"`` (default) — Tavily when ``TAVILY_API_KEY`` is set, then
+      Brave when ``BRAVE_SEARCH_API_KEY`` is set, else DDG-Playwright.
+    * ``"tavily"`` — force Tavily; returns ``[]`` if the key is missing.
     * ``"brave"`` — force Brave; returns ``[]`` if the key is missing.
     * ``"ddg"`` / ``"google"`` — force the respective Playwright SERP scrape.
 
@@ -432,7 +486,15 @@ async def search(
     normalized_lang = _normalize_lang(lang)
 
     if engine == "auto":
-        engine = "brave" if _brave_api_key() else "ddg"
+        if _tavily_api_key():
+            engine = "tavily"
+        elif _brave_api_key():
+            engine = "brave"
+        else:
+            engine = "ddg"
+
+    if engine == "tavily":
+        return await _search_tavily(query, max_results)
 
     if engine == "brave":
         return await _search_brave(query, max_results, lang=normalized_lang)

--- a/tests/test_tools_web_search.py
+++ b/tests/test_tools_web_search.py
@@ -303,6 +303,7 @@ async def test_search_brave_omits_search_lang_when_unset(monkeypatch):
 
 
 async def test_search_auto_brave_includes_lang_when_key_set(monkeypatch):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
     payload = _load_json("web_search/lang-fr.json")
     captured = _patch_brave_httpx(monkeypatch, payload=payload)
     monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "test-key")
@@ -318,6 +319,7 @@ async def test_search_auto_ddg_fallback_logs_lang_ignored_and_proceeds(
     monkeypatch,
     caplog,
 ):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
     monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
     page = FakePage(_load("web_search_ddg.html"))
     _patch_browser_session(monkeypatch, page)
@@ -340,6 +342,7 @@ async def test_search_auto_ddg_fallback_with_lang_zero_results_is_quiet(
     tmp_path,
     caplog,
 ):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
     monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
     monkeypatch.chdir(tmp_path)
     page = FakePage("<html><body>no matches here</body></html>")
@@ -369,6 +372,7 @@ async def test_search_auto_ddg_fallback_with_lang_session_failure_is_quiet(
         raise web_search.PlaywrightError("launch denied")
         yield
 
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
     monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
     monkeypatch.setattr(browser, "browser_session", _broken_session)
 
@@ -380,6 +384,171 @@ async def test_search_auto_ddg_fallback_with_lang_session_failure_is_quiet(
     assert any("lang='fr' ignored" in message for message in messages)
     assert not any("browser session failed" in message for message in messages)
     assert not any(record.levelno >= logging.WARNING for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Tavily engine tests
+# ---------------------------------------------------------------------------
+
+
+async def test_search_tavily_maps_results_with_score(monkeypatch):
+    """Successful Tavily search maps results to SearchResult with tavily_score."""
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-test-key")
+
+    fake_response = {
+        "results": [
+            {
+                "url": "https://example.com/tavily-hit",
+                "title": "Tavily Hit One",
+                "content": "Snippet from Tavily",
+                "score": 0.95,
+            },
+            {
+                "url": "https://example.com/tavily-hit-2",
+                "title": "Tavily Hit Two",
+                "content": "Another snippet",
+                "score": 0.80,
+            },
+        ]
+    }
+
+    class _FakeAsyncTavilyClient:
+        def __init__(self, api_key):
+            self._api_key = api_key
+
+        async def search(self, *, query, max_results, search_depth):
+            return fake_response
+
+    monkeypatch.setattr(
+        "tavily.AsyncTavilyClient", _FakeAsyncTavilyClient, raising=False
+    )
+    # Force re-import so the lazy import inside _search_tavily picks up the mock.
+    import tavily
+
+    monkeypatch.setattr(tavily, "AsyncTavilyClient", _FakeAsyncTavilyClient)
+
+    results = await web_search.search("test query", max_results=5, engine="tavily")
+
+    assert len(results) == 2
+    assert all(isinstance(r, SearchResult) for r in results)
+    assert results[0].url == "https://example.com/tavily-hit"
+    assert results[0].title == "Tavily Hit One"
+    assert results[0].snippet == "Snippet from Tavily"
+    assert results[0].source_kind == "web"
+    assert results[0].extras["source_engine"] == "tavily"
+    assert results[0].extras["tavily_score"] == 0.95
+    assert results[1].extras["tavily_score"] == 0.80
+
+
+async def test_search_tavily_no_key_returns_empty(monkeypatch, caplog):
+    """Missing TAVILY_API_KEY → warning + empty list."""
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+
+    caplog.set_level(logging.WARNING, logger="research_agent.tools.web_search")
+    results = await web_search.search("test", engine="tavily")
+
+    assert results == []
+    assert any("TAVILY_API_KEY not set" in r.getMessage() for r in caplog.records)
+
+
+async def test_search_tavily_exception_returns_empty(monkeypatch, caplog):
+    """Network/auth errors in Tavily → warning + empty list, no crash."""
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-test-key")
+
+    class _BrokenClient:
+        def __init__(self, api_key):
+            pass
+
+        async def search(self, **kwargs):
+            raise RuntimeError("connection refused")
+
+    import tavily
+
+    monkeypatch.setattr(tavily, "AsyncTavilyClient", _BrokenClient)
+
+    caplog.set_level(logging.WARNING, logger="research_agent.tools.web_search")
+    results = await web_search.search("test", engine="tavily")
+
+    assert results == []
+    assert any("tavily search failed" in r.getMessage() for r in caplog.records)
+
+
+async def test_search_tavily_import_error_returns_empty(monkeypatch, caplog):
+    """If tavily-python is not installed, _search_tavily warns and returns []."""
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-test-key")
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _block_tavily(name, *args, **kwargs):
+        if name == "tavily":
+            raise ImportError("no module named 'tavily'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block_tavily)
+
+    caplog.set_level(logging.WARNING, logger="research_agent.tools.web_search")
+    results = await web_search.search("test", engine="tavily")
+
+    assert results == []
+    assert any("tavily-python is not installed" in r.getMessage() for r in caplog.records)
+
+
+async def test_search_tavily_logs_lang_ignored(monkeypatch, caplog):
+    """Tavily does not support lang; passing it logs an info message like DDG/Google."""
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-test-key")
+
+    class _FakeAsyncTavilyClient:
+        def __init__(self, api_key):
+            pass
+
+        async def search(self, **kwargs):
+            return {"results": [{"url": "https://example.com/x", "title": "X", "content": "c", "score": 0.5}]}
+
+    import tavily
+
+    monkeypatch.setattr(tavily, "AsyncTavilyClient", _FakeAsyncTavilyClient)
+
+    caplog.set_level(logging.INFO, logger="research_agent.tools.web_search")
+    results = await web_search.search("test", engine="tavily", lang="fr")
+
+    assert len(results) == 1
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("lang='fr' ignored" in m and "engine=tavily" in m for m in messages)
+
+
+async def test_search_auto_prefers_tavily_when_key_set(monkeypatch):
+    """engine='auto' with TAVILY_API_KEY set routes to Tavily."""
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-test-key")
+    monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "brave-key-also-set")
+
+    fake_response = {
+        "results": [
+            {
+                "url": "https://example.com/auto-tavily",
+                "title": "Auto Tavily",
+                "content": "Found via auto",
+                "score": 0.9,
+            },
+        ]
+    }
+
+    class _FakeAsyncTavilyClient:
+        def __init__(self, api_key):
+            pass
+
+        async def search(self, **kwargs):
+            return fake_response
+
+    import tavily
+
+    monkeypatch.setattr(tavily, "AsyncTavilyClient", _FakeAsyncTavilyClient)
+
+    results = await web_search.search("test", max_results=5)
+
+    assert len(results) == 1
+    assert results[0].extras["source_engine"] == "tavily"
 
 
 # ---------------------------------------------------------------------------
@@ -406,7 +575,8 @@ def test_smoke_web_search_invokes_auto_engine_only(monkeypatch):
         return []
 
     monkeypatch.setattr(web_search, "search", _fake_search)
-    # No Brave key → label should say ddg-fallback when results are empty.
+    # No API keys → label should say ddg-fallback when results are empty.
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
     monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
 
     output = TOOL_REGISTRY["web_search"]("project 2025")
@@ -426,6 +596,7 @@ def test_smoke_web_search_brave_path_labels_engine(monkeypatch):
     from research_agent.tools import TOOL_REGISTRY
     from research_agent.tools.models import SearchResult
 
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
     monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "test-key")
 
     fake_hit = SearchResult(


### PR DESCRIPTION
## Summary

Adds Tavily as a configurable search engine option in `web_search.py`, alongside the existing Brave Search API, DuckDuckGo, and Google Playwright scrapers. This is an **additive** migration — all existing providers remain fully intact.

**What changed:**
- Extended `Engine` literal type to include `'tavily'`
- Implemented `_search_tavily()` using the `tavily-python` `AsyncTavilyClient`, mapping results to `SearchResult` with `source_engine='tavily'`
- Updated `'auto'` engine selection: Tavily (if `TAVILY_API_KEY` set) → Brave (if `BRAVE_SEARCH_API_KEY` set) → DDG fallback
- Registered `TAVILY_API_KEY` as an optional `EnvKey` in `config.py` `EXPECTED_ENV_KEYS`
- Added `TAVILY_API_KEY` to `.env.example` with signup URL
- Documented `TAVILY_API_KEY` in `docs/API_KEYS.md` under recommended optional keys

## Files changed

- `src/research_agent/tools/web_search.py` — new `_search_tavily()`, updated Engine type and auto-resolution
- `src/research_agent/config.py` — new `TAVILY_API_KEY` EnvKey entry
- `.env.example` — new `TAVILY_API_KEY=` line
- `docs/API_KEYS.md` — documented Tavily key in recommended table
- `pyproject.toml` — added `tavily-python>=0.3` dependency

## Dependency changes

- Added `tavily-python>=0.3` to `[project].dependencies` in `pyproject.toml`

## Environment variable changes

- Added `TAVILY_API_KEY` (optional) — registered in `config.py`, `.env.example`, and `docs/API_KEYS.md`

## Notes for reviewers

- Auto mode now prefers Tavily over Brave when both keys are set. This can be overridden by explicitly setting `engine='brave'`.
- The `tavily-python` import is deferred inside `_search_tavily()` to avoid import errors if the package is missing at runtime.
- Tavily's `content` field maps to `snippet` in `SearchResult`; the relevance `score` is passed through in `extras`.


### Automated Review

- Passed after 2 attempt(s)
- Final review: The Tavily migration is correct, complete, and consistent with the existing codebase. The implementation properly adds Tavily as a first-priority engine in auto-resolution (Tavily > Brave > DDG), guards against missing key / ImportError / network errors, logs lang-ignored at INFO level matching the DDG/Google pattern, and fixes all 6 pre-existing auto-resolution tests to be deterministic in CI when TAVILY_API_KEY is present. All required registrations (pyproject.toml, config.py EXPECTED_ENV_KEYS, .env.example, docs/API_KEYS.md) are in place. One minor code-quality issue was found in the tests but does not block approval.
