### PR TITLE
feat(pdf): per-page extraction API for dossier mode (#351)

### DIFF
--- a/src/research_agent/tools/pdf.py
+++ b/src/research_agent/tools/pdf.py
@@ -657,6 +657,330 @@ def extract_sync(
 
 
 # ---------------------------------------------------------------------------
+# Per-page extraction (issue #351 — dossier mode)
+# ---------------------------------------------------------------------------
+#
+# Dossier mode (epic #359) needs the LLM grain to be a single page so a
+# downstream extractor never blends content from page 1 and page 30 into the
+# same finding. The existing layer helpers all return one concatenated
+# string per document; the per-page helpers below keep one entry per page
+# (empty string for blank/broken pages) so callers can correlate by index.
+# Existing entry points (``extract``, ``extract_sync``, ``extract_from_bytes``)
+# are untouched — this is purely additive.
+
+
+def _extract_pypdf_pages(path: Path, max_pages: int) -> list[str]:
+    """Per-page pypdf text. One entry per page; ``""`` for empty/broken pages.
+
+    Returns an empty list when pypdf can't open the file at all so the
+    caller can fall through to the next layer.
+    """
+    import pypdf  # lazy
+
+    try:
+        reader = pypdf.PdfReader(str(path))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("pypdf open failed for %s: %s", path, exc)
+        return []
+
+    total_pages = len(reader.pages)
+    page_slice = min(total_pages, max_pages)
+    pages: list[str] = []
+    for idx in range(page_slice):
+        try:
+            text = reader.pages[idx].extract_text() or ""
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("pypdf page %d extract failed: %s", idx, exc)
+            text = ""
+        pages.append(text.strip())
+    return pages
+
+
+def _extract_pdfplumber_pages(path: Path, max_pages: int) -> list[str]:
+    """Per-page pdfplumber text (incl. tables). Empty list on whole-doc failure."""
+    try:
+        import pdfplumber  # lazy
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("pdfplumber import failed: %s", exc)
+        return []
+
+    pages: list[str] = []
+    try:
+        with pdfplumber.open(str(path)) as plumber:
+            for idx, page in enumerate(plumber.pages):
+                if idx >= max_pages:
+                    break
+                text = (page.extract_text() or "").strip()
+                table_blocks: list[str] = []
+                try:
+                    tables = page.extract_tables() or []
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(
+                        "pdfplumber tables failed on page %d: %s", idx, exc
+                    )
+                    tables = []
+                for table in tables:
+                    md_table = _table_to_markdown(table)
+                    if md_table:
+                        table_blocks.append(md_table)
+                merged = "\n\n".join(t for t in (text, *table_blocks) if t)
+                pages.append(merged)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("pdfplumber failed for %s: %s", path, exc)
+        return pages
+    return pages
+
+
+def _extract_tesseract_pages(path: Path, max_pages: int) -> list[str]:
+    """Per-page Tesseract OCR. Empty list when binary missing or rasterisation fails."""
+    if not _tesseract_available():
+        logger.warning("tesseract binary not found on PATH — skipping OCR layer")
+        return []
+
+    try:
+        import pytesseract  # lazy
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("pytesseract import failed: %s", exc)
+        return []
+
+    images = _render_pages_to_images(path, max_pages)
+    if not images:
+        return []
+
+    pages: list[str] = []
+    for idx, image in enumerate(images):
+        try:
+            text = pytesseract.image_to_string(image) or ""
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("pytesseract OCR failed on page %d: %s", idx, exc)
+            text = ""
+        pages.append(text.strip())
+    return pages
+
+
+def _pages_density(pages: list[str]) -> bool:
+    """Aggregate density gate over a per-page list.
+
+    Same threshold as :func:`_text_density` — fewer than
+    ``_DENSITY_MIN_ALPHA_PER_PAGE`` alpha chars on average across the
+    sampled pages counts as "this layer didn't work."
+    """
+    if not pages:
+        return False
+    joined = "\n".join(pages)
+    return _text_density(joined, len(pages))
+
+
+def _best_text_layer_pages(path: Path, max_pages: int) -> list[str]:
+    """Pick whichever of pypdf / pdfplumber yields more alpha text per page.
+
+    Used by the hybrid path so a structured filing that breaks pypdf still
+    contributes a usable text layer to merge with OCR.
+    """
+    pypdf_pages = _extract_pypdf_pages(path, max_pages)
+    plumber_pages = _extract_pdfplumber_pages(path, max_pages)
+    if _alpha_count("".join(plumber_pages)) > _alpha_count("".join(pypdf_pages)):
+        return plumber_pages
+    return pypdf_pages
+
+
+def _hybrid_merge_pages(
+    text_pages: list[str],
+    ocr_pages: list[str],
+) -> list[str]:
+    """Merge text-layer and OCR per-page lists strictly by index.
+
+    Each output entry is the text-layer page followed by an
+    ``[OCR supplement]`` block when *both* layers produced content for
+    that page. When only one layer produced content, that text is the
+    entry. OCR for page N never appears in page M's slot — lists are
+    zipped strictly by index, so the dossier extractor (M2) can rely on
+    "every entry is one page of one file."
+    """
+    max_len = max(len(text_pages), len(ocr_pages))
+    merged: list[str] = []
+    for idx in range(max_len):
+        text = text_pages[idx] if idx < len(text_pages) else ""
+        ocr = ocr_pages[idx] if idx < len(ocr_pages) else ""
+        if text and ocr:
+            merged.append(f"{text}\n\n[OCR supplement]\n{ocr}")
+        else:
+            merged.append(text or ocr)
+    return merged
+
+
+def _select_best_pages(candidates: list[list[str]]) -> list[str]:
+    """Pick whichever candidate produced the most alpha text.
+
+    Used as a no-layer-passed-the-density-gate fallback so callers still
+    see something for files that are only partly readable.
+    """
+    if not candidates:
+        return []
+    return max(candidates, key=lambda pages: _alpha_count("".join(pages)))
+
+
+def _to_indexed_pages(
+    pages: list[str], max_chars: int
+) -> list[tuple[int, str]]:
+    """Wrap a per-page text list in ``(1-based page_no, truncated_text)`` tuples.
+
+    ``max_chars`` is applied **per page** so callers can rely on bounded
+    entries without having to know the total page count.
+    """
+    return [
+        (idx + 1, _truncate(text, max_chars) if text else "")
+        for idx, text in enumerate(pages)
+    ]
+
+
+def _extract_pages(
+    path: Path,
+    *,
+    max_pages: int,
+    max_chars: int,
+    hybrid_pages: bool,
+) -> list[tuple[int, str]]:
+    """Synchronous core of :func:`extract_pages_sync`."""
+    if hybrid_pages:
+        text_pages = _best_text_layer_pages(path, max_pages)
+        ocr_pages = _extract_tesseract_pages(path, max_pages)
+        merged = _hybrid_merge_pages(text_pages, ocr_pages)
+        return _to_indexed_pages(merged, max_chars)
+
+    # Non-hybrid: layered try with aggregate density gate per layer.
+    pypdf_pages = _extract_pypdf_pages(path, max_pages)
+    if _pages_density(pypdf_pages):
+        return _to_indexed_pages(pypdf_pages, max_chars)
+
+    plumber_pages = _extract_pdfplumber_pages(path, max_pages)
+    if _pages_density(plumber_pages):
+        return _to_indexed_pages(plumber_pages, max_chars)
+
+    tesseract_pages = _extract_tesseract_pages(path, max_pages)
+    if _pages_density(tesseract_pages):
+        return _to_indexed_pages(tesseract_pages, max_chars)
+
+    # No layer met the floor — return whichever produced the most text so
+    # downstream callers at least see something to inspect rather than a
+    # confusing empty list when the file *did* have pages.
+    best = _select_best_pages([pypdf_pages, plumber_pages, tesseract_pages])
+    return _to_indexed_pages(best, max_chars)
+
+
+def extract_pages_sync(
+    path_or_url: str | Path,
+    *,
+    max_pages: int = DEFAULT_MAX_PAGES,
+    max_chars: int = DEFAULT_MAX_CHARS,
+    hybrid_pages: bool = False,
+    job: Job | None = None,
+) -> list[tuple[int, str]]:
+    """Per-page PDF extraction. Returns ``[(page_no, text), ...]`` (1-based).
+
+    Layer selection mirrors :func:`extract_sync`: pypdf → pdfplumber →
+    Tesseract; the aggregate density gate per layer decides whether to
+    fall to the next. The first layer that passes wins. When no layer
+    passes, the layer with the most alpha characters wins so callers
+    still see something for files that are partly readable.
+
+    When ``hybrid_pages=True``, every entry is a text-layer page
+    (whichever of pypdf / pdfplumber yields more text) **plus** an OCR
+    supplement for that same page when both layers produced content.
+    OCR for page N never appears in page M's slot — the lists are zipped
+    strictly by index.
+
+    ``max_chars`` is applied per page — each page's text is truncated to
+    that length individually so callers can rely on bounded entries
+    without knowing the total page count.
+
+    Empty / sub-floor pages are emitted as ``(page_no, "")`` rather than
+    being dropped so the dossier rollup can correlate by ``page_no`` and
+    record per-page coverage units (M1.2 / epic #359).
+
+    URLs are fetched synchronously via ``asyncio.run``; this function is
+    safe to call from sync contexts but should not be called from inside
+    a running event loop. Use :func:`extract_pages` for the async path.
+    """
+    raw = str(path_or_url)
+    cleanup_temp: Path | None = None
+    if _looks_like_url(raw):
+        try:
+            data = asyncio.run(fetch_pdf_bytes(raw))
+        except (httpx.HTTPError, OSError) as exc:
+            logger.warning("pdf fetch failed for %s: %s", raw, exc)
+            return []
+        path = _write_temp_pdf(data)
+        cleanup_temp = path
+    else:
+        path = Path(raw)
+        if not path.exists():
+            logger.warning("pdf path does not exist: %s", path)
+            return []
+    try:
+        return _extract_pages(
+            path,
+            max_pages=max_pages,
+            max_chars=max_chars,
+            hybrid_pages=hybrid_pages,
+        )
+    finally:
+        if cleanup_temp is not None:
+            try:
+                cleanup_temp.unlink()
+            except OSError:
+                pass
+
+
+async def extract_pages(
+    path_or_url: str | Path,
+    *,
+    max_pages: int = DEFAULT_MAX_PAGES,
+    max_chars: int = DEFAULT_MAX_CHARS,
+    hybrid_pages: bool = False,
+    job: Job | None = None,
+) -> list[tuple[int, str]]:
+    """Async wrapper around :func:`extract_pages_sync`.
+
+    I/O happens in a thread executor so a 1000-page PDF doesn't stall
+    the event loop while the layers walk pages. URL fetch uses the
+    already-async ``fetch_pdf_bytes`` rather than ``asyncio.run`` so
+    this is safe to call from inside a running loop.
+    """
+    raw = str(path_or_url)
+    cleanup_temp: Path | None = None
+    if _looks_like_url(raw):
+        try:
+            data = await fetch_pdf_bytes(raw)
+        except (httpx.HTTPError, OSError) as exc:
+            logger.warning("pdf fetch failed for %s: %s", raw, exc)
+            return []
+        path = _write_temp_pdf(data)
+        cleanup_temp = path
+    else:
+        path = Path(raw)
+        if not path.exists():
+            logger.warning("pdf path does not exist: %s", path)
+            return []
+    try:
+        return await asyncio.get_running_loop().run_in_executor(
+            None,
+            lambda: _extract_pages(
+                path,
+                max_pages=max_pages,
+                max_chars=max_chars,
+                hybrid_pages=hybrid_pages,
+            ),
+        )
+    finally:
+        if cleanup_temp is not None:
+            try:
+                cleanup_temp.unlink()
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
 # Section walk (issue #206) — structural splitting for cornerstone PDFs
 # ---------------------------------------------------------------------------
 
@@ -1043,6 +1367,8 @@ __all__ = [
     "DEFAULT_MAX_PAGES",
     "extract",
     "extract_from_bytes",
+    "extract_pages",
+    "extract_pages_sync",
     "extract_sections",
     "extract_sections_sync",
     "extract_sync",

--- a/tests/test_tools_pdf.py
+++ b/tests/test_tools_pdf.py
@@ -383,6 +383,284 @@ def test_smoke_pdf_against_local_fixture():
 
 
 # ---------------------------------------------------------------------------
+# Per-page extraction (issue #351 — dossier mode, epic #359)
+# ---------------------------------------------------------------------------
+
+
+def _stub_pypdf_pages(monkeypatch, pages: list[str]):
+    """Install a pypdf stub whose reader returns the supplied per-page texts."""
+
+    class _FakePage:
+        def __init__(self, text: str) -> None:
+            self._text = text
+
+        def extract_text(self) -> str:
+            return self._text
+
+    class _FakeReader:
+        def __init__(self, *_a, **_kw) -> None:
+            self.pages = [_FakePage(t) for t in pages]
+            self.outline = []
+
+    fake_pypdf = type("M", (), {"PdfReader": _FakeReader})
+    monkeypatch.setitem(__import__("sys").modules, "pypdf", fake_pypdf)
+
+
+def test_extract_pages_sync_single_page_fixture():
+    """Real single-page arxiv fixture: returns one tuple with 1-based page_no."""
+    pages = pdf.extract_pages_sync(ARXIV_PDF)
+    assert len(pages) == 1
+    page_no, text = pages[0]
+    assert page_no == 1
+    assert "arxiv research paper text" in text
+
+
+def test_extract_pages_sync_returns_distinct_per_page(monkeypatch):
+    """Multi-page text-layer: every page's text is distinct, in order, no bleed."""
+    _stub_pypdf_pages(
+        monkeypatch,
+        [
+            "First page content about Alpha. " * 20,
+            "Second page covers Beta in detail. " * 20,
+            "Third page mentions Gamma topics. " * 20,
+        ],
+    )
+
+    pages = pdf.extract_pages_sync(ARXIV_PDF)
+    assert [n for n, _ in pages] == [1, 2, 3]
+    assert "Alpha" in pages[0][1]
+    assert "Beta" in pages[1][1]
+    assert "Gamma" in pages[2][1]
+    # Acceptance: per-page boundaries hold, no cross-page bleed.
+    assert "Beta" not in pages[0][1]
+    assert "Alpha" not in pages[1][1]
+    assert "Gamma" not in pages[1][1]
+
+
+def test_extract_pages_sync_respects_max_pages(monkeypatch):
+    _stub_pypdf_pages(monkeypatch, [f"Page {i} body " * 30 for i in range(5)])
+    pages = pdf.extract_pages_sync(ARXIV_PDF, max_pages=2)
+    assert [n for n, _ in pages] == [1, 2]
+
+
+def test_extract_pages_sync_truncates_per_page(monkeypatch):
+    """max_chars is applied per page so callers see bounded entries."""
+    _stub_pypdf_pages(monkeypatch, ["x" * 5_000, "y" * 5_000])
+    monkeypatch.setattr(pdf, "_pages_density", lambda _pages: True)
+
+    pages = pdf.extract_pages_sync(ARXIV_PDF, max_chars=100)
+    assert len(pages) == 2
+    for _, text in pages:
+        body, _, _ = text.partition("…[truncated]")
+        assert len(body.rstrip()) <= 100
+        assert text.endswith("…[truncated]")
+
+
+def test_extract_pages_sync_emits_empty_string_for_blank_pages(monkeypatch):
+    """Sub-floor pages remain in the list so callers can correlate by index."""
+    _stub_pypdf_pages(
+        monkeypatch,
+        ["Real content " * 30, "", "More content " * 30, ""],
+    )
+
+    pages = pdf.extract_pages_sync(ARXIV_PDF)
+    assert [n for n, _ in pages] == [1, 2, 3, 4]
+    assert pages[1][1] == ""
+    assert pages[3][1] == ""
+
+
+def test_extract_pages_sync_falls_through_to_ocr(monkeypatch):
+    """Scanned PDF: pypdf empty, OCR fills every page, distinct per page."""
+    monkeypatch.setattr(pdf, "_extract_pypdf_pages", lambda *a, **k: ["", ""])
+    monkeypatch.setattr(pdf, "_extract_pdfplumber_pages", lambda *a, **k: ["", ""])
+    monkeypatch.setattr(
+        pdf,
+        "_extract_tesseract_pages",
+        lambda *a, **k: [
+            "Scanned filing recovered via OCR " * 20,
+            "Page two OCR distinct content " * 20,
+        ],
+    )
+
+    pages = pdf.extract_pages_sync(SCANNED_PDF)
+    assert len(pages) == 2
+    assert [n for n, _ in pages] == [1, 2]
+    assert "Scanned filing" in pages[0][1]
+    assert "Page two OCR" in pages[1][1]
+    # Cross-page bleed check on the OCR fall-through path too.
+    assert "Page two OCR" not in pages[0][1]
+    assert "Scanned filing" not in pages[1][1]
+
+
+def test_extract_pages_sync_no_density_returns_best_layer(monkeypatch):
+    """No layer meets the floor — return whichever produced the most text."""
+    monkeypatch.setattr(pdf, "_extract_pypdf_pages", lambda *a, **k: [""])
+    monkeypatch.setattr(
+        pdf, "_extract_pdfplumber_pages", lambda *a, **k: ["short"]
+    )
+    monkeypatch.setattr(
+        pdf,
+        "_extract_tesseract_pages",
+        lambda *a, **k: ["a much longer string that beats plumber"],
+    )
+
+    pages = pdf.extract_pages_sync(ARXIV_PDF)
+    assert len(pages) == 1
+    assert "much longer string" in pages[0][1]
+
+
+def test_extract_pages_sync_returns_empty_when_every_layer_yields_nothing(
+    monkeypatch,
+):
+    monkeypatch.setattr(pdf, "_extract_pypdf_pages", lambda *a, **k: [])
+    monkeypatch.setattr(pdf, "_extract_pdfplumber_pages", lambda *a, **k: [])
+    monkeypatch.setattr(pdf, "_extract_tesseract_pages", lambda *a, **k: [])
+
+    assert pdf.extract_pages_sync(ARXIV_PDF) == []
+
+
+def test_extract_pages_sync_hybrid_merges_text_and_ocr(monkeypatch):
+    """Hybrid: text-layer + OCR supplement per page, no cross-page bleed."""
+    monkeypatch.setattr(
+        pdf,
+        "_extract_pypdf_pages",
+        lambda *a, **k: ["Text layer page one.", "Text layer page two."],
+    )
+    monkeypatch.setattr(pdf, "_extract_pdfplumber_pages", lambda *a, **k: [])
+    monkeypatch.setattr(
+        pdf,
+        "_extract_tesseract_pages",
+        lambda *a, **k: ["OCR alpha supplement.", "OCR beta supplement."],
+    )
+
+    pages = pdf.extract_pages_sync(ARXIV_PDF, hybrid_pages=True)
+    assert [n for n, _ in pages] == [1, 2]
+    p1, p2 = pages[0][1], pages[1][1]
+    assert "Text layer page one." in p1
+    assert "OCR alpha supplement." in p1
+    assert "[OCR supplement]" in p1
+    assert "Text layer page two." in p2
+    assert "OCR beta supplement." in p2
+    # The signal acceptance criterion: OCR for page N never appears in
+    # any other page's slot.
+    assert "OCR beta supplement" not in p1
+    assert "OCR alpha supplement" not in p2
+    assert "Text layer page two" not in p1
+    assert "Text layer page one" not in p2
+
+
+def test_extract_pages_sync_hybrid_text_only_when_ocr_unavailable(monkeypatch):
+    """Hybrid with no OCR binary: text-only pages, no supplement marker."""
+    monkeypatch.setattr(
+        pdf,
+        "_extract_pypdf_pages",
+        lambda *a, **k: ["Text layer page one.", "Text layer page two."],
+    )
+    monkeypatch.setattr(pdf, "_extract_pdfplumber_pages", lambda *a, **k: [])
+    monkeypatch.setattr(pdf, "_extract_tesseract_pages", lambda *a, **k: [])
+
+    pages = pdf.extract_pages_sync(ARXIV_PDF, hybrid_pages=True)
+    assert len(pages) == 2
+    assert pages[0][1] == "Text layer page one."
+    assert pages[1][1] == "Text layer page two."
+    assert "[OCR supplement]" not in pages[0][1]
+
+
+def test_extract_pages_sync_hybrid_ocr_only_when_text_blank(monkeypatch):
+    """Hybrid with empty text layer falls back to OCR-only pages."""
+    monkeypatch.setattr(pdf, "_extract_pypdf_pages", lambda *a, **k: ["", ""])
+    monkeypatch.setattr(
+        pdf, "_extract_pdfplumber_pages", lambda *a, **k: ["", ""]
+    )
+    monkeypatch.setattr(
+        pdf,
+        "_extract_tesseract_pages",
+        lambda *a, **k: ["OCR alpha page one.", "OCR beta page two."],
+    )
+
+    pages = pdf.extract_pages_sync(ARXIV_PDF, hybrid_pages=True)
+    assert len(pages) == 2
+    assert pages[0][1] == "OCR alpha page one."
+    assert pages[1][1] == "OCR beta page two."
+    assert "[OCR supplement]" not in pages[0][1]
+
+
+def test_extract_pages_sync_hybrid_prefers_plumber_when_pypdf_thin(monkeypatch):
+    """When pypdf returns thin text but plumber recovers more, hybrid uses plumber."""
+    monkeypatch.setattr(pdf, "_extract_pypdf_pages", lambda *a, **k: ["x", "y"])
+    monkeypatch.setattr(
+        pdf,
+        "_extract_pdfplumber_pages",
+        lambda *a, **k: [
+            "Plumber recovered structured text " * 5,
+            "Plumber page two structured " * 5,
+        ],
+    )
+    monkeypatch.setattr(pdf, "_extract_tesseract_pages", lambda *a, **k: [])
+
+    pages = pdf.extract_pages_sync(ARXIV_PDF, hybrid_pages=True)
+    assert "Plumber recovered structured text" in pages[0][1]
+    assert "Plumber page two structured" in pages[1][1]
+
+
+def test_extract_pages_sync_url_routes_through_fetch(monkeypatch):
+    captured: list[str] = []
+
+    async def _fake_fetch(url, *, timeout=60.0):
+        captured.append(url)
+        return ARXIV_PDF.read_bytes()
+
+    monkeypatch.setattr(pdf, "fetch_pdf_bytes", _fake_fetch)
+
+    pages = pdf.extract_pages_sync("https://example.com/sample.pdf")
+    assert captured == ["https://example.com/sample.pdf"]
+    assert pages
+    assert "arxiv research paper text" in pages[0][1]
+
+
+def test_extract_pages_sync_returns_empty_for_missing_path():
+    assert pdf.extract_pages_sync("/no/such/file.pdf") == []
+
+
+async def test_extract_pages_async_wrapper(monkeypatch):
+    """Async wrapper runs the same core in a thread executor."""
+    _stub_pypdf_pages(monkeypatch, ["Async page body " * 30])
+    pages = await pdf.extract_pages(ARXIV_PDF)
+    assert pages[0][0] == 1
+    assert "Async page body" in pages[0][1]
+
+
+def test_extract_sync_regression_unchanged():
+    """extract_sync() contract must stay green after the additive change."""
+    text = pdf.extract_sync(ARXIV_PDF)
+    assert "## Page 1" in text
+    assert "arxiv research paper text" in text
+
+
+def test_hybrid_merge_pages_zero_length_inputs():
+    """Edge: empty lists merge to empty list."""
+    assert pdf._hybrid_merge_pages([], []) == []
+
+
+def test_hybrid_merge_pages_uneven_lengths():
+    """Edge: when one list is shorter, the longer one's tail is preserved."""
+    merged = pdf._hybrid_merge_pages(["A", "B", "C"], ["x"])
+    assert merged[0] == "A\n\n[OCR supplement]\nx"
+    assert merged[1] == "B"
+    assert merged[2] == "C"
+
+
+def test_pages_density_empty_returns_false():
+    assert pdf._pages_density([]) is False
+    assert pdf._pages_density(["", "", ""]) is False
+
+
+def test_pages_density_passes_when_above_threshold():
+    one_page = "a" * (pdf._DENSITY_MIN_ALPHA_PER_PAGE * 2)
+    assert pdf._pages_density([one_page]) is True
+
+
+# ---------------------------------------------------------------------------
 # Section walk (issue #206)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `pdf.extract_pages_sync()` and async wrapper `pdf.extract_pages()` returning `[(page_no, text), ...]` with 1-based page numbers and one entry per page (empty string for blank/sub-floor pages so callers can correlate by index).
- Mirrors existing layer selection (pypdf -> pdfplumber -> Tesseract) with the same aggregate density gate; first layer that passes wins, otherwise the layer with the most alpha text is returned so callers still see something for partly readable files.
- When `hybrid_pages=True`, every entry is the best text-layer page merged with the matching OCR page; lists are zipped strictly by index so OCR for page N never appears in page M's slot. Falls back gracefully to text-only when the OCR binary is absent, or OCR-only when the text layer is blank.
- Public surface is purely additive: `extract`, `extract_sync`, `extract_from_bytes`, `extract_sections*` keep their current contracts. Regression test on `extract_sync()` stays green.

Backs the corpus dossier mode epic (#359). The dossier extractor (#353) will consume these tuples so a 250-page FOIA file never blends content from page 1 and page 30 into the same finding.

## Test plan
- [x] `uv run --frozen pytest tests/test_tools_pdf.py -q` -> 52 passed
- [x] `uv run --frozen pytest tests/test_tools_pdf.py tests/test_tools_local_corpus.py tests/test_tools_web_fetch.py -q` -> 149 passed
- [x] `uv run --frozen ruff check src/research_agent/tools/pdf.py tests/test_tools_pdf.py` -> clean
- [x] Manual smoke: `pdf.extract_pages_sync(arxiv_paper.pdf)` returns one tuple; `hybrid_pages=True` merges the local OCR supplement into the same page.

### Acceptance criteria coverage
- Multi-page text-layer: every page distinct, ordered by `page_no`, no cross-page bleed (`test_extract_pages_sync_returns_distinct_per_page`).
- Scanned/OCR: every page OCR'd; failed pages yield `""` not exceptions (`test_extract_pages_sync_falls_through_to_ocr`, `_emits_empty_string_for_blank_pages`).
- Hybrid: text-layer + OCR supplement merged per page; OCR of page N never appears in page M (`test_extract_pages_sync_hybrid_merges_text_and_ocr`).
- Existing `extract_sync()` behaviour unchanged (regression test + all pre-existing PDF tests).

Closes #351.

Made with [Cursor](https://cursor.com)