### PR TITLE
feat(local_corpus): per-page ingestion path for dossier mode (#352)

### DIFF
--- a/src/research_agent/tools/local_corpus.py
+++ b/src/research_agent/tools/local_corpus.py
@@ -261,13 +261,30 @@ def index(
     job: Job,
     *,
     models_config: dict[str, Any] | None = None,
-) -> dict[str, int]:
+    per_page: bool = False,
+) -> dict[str, Any]:
     """Index every supported file under ``corpus_path`` into ``job``.
 
     Returns a summary dict with ``files_indexed``, ``files_skipped``,
-    ``chunks_indexed``, ``chunks_skipped``, and ``embed_dim``. Idempotent —
+    ``chunks_indexed``, ``chunks_skipped``, ``pages_indexed``,
+    ``pages_skipped``, ``per_page``, and ``embed_dim``. Idempotent —
     chunks already present in ``sources`` (matched by sha256) are linked
     to the job without re-embedding.
+
+    When ``per_page=True``, PDFs use :func:`pdf.extract_pages_sync` and
+    write one :class:`Source` row per page so the dossier extractor
+    (issue #353 / epic #359) can record per-page findings without the
+    legacy chunker straddling page boundaries. A page that exceeds the
+    chunk-target token budget is sub-chunked **within that page only**
+    and the sub-chunk index is recorded as ``metadata.page_chunk``;
+    sub-chunking never crosses pages. HTML / MD / TXT files have no
+    page concept, so each chunk records ``metadata.page_no = None`` but
+    keeps the same ``metadata.parent_file`` so coverage rollup can group
+    chunks by their source file.
+
+    When ``per_page=False`` (default), behaviour is unchanged: one
+    embedding batch per file, no metadata stamping, ``pages_indexed`` /
+    ``pages_skipped`` are zero.
     """
     root = Path(corpus_path)
     base_url, model_name = _resolve_embedding_endpoint(models_config)
@@ -276,8 +293,25 @@ def index(
     files_skipped = 0
     chunks_indexed = 0
     chunks_skipped = 0
+    pages_indexed = 0
+    pages_skipped = 0
 
     for file_path in _walk_corpus(root):
+        if per_page and file_path.suffix.lower() == ".pdf":
+            stats = _index_pdf_per_page(
+                file_path,
+                job,
+                base_url=base_url,
+                model_name=model_name,
+            )
+            files_indexed += stats["files_indexed"]
+            files_skipped += stats["files_skipped"]
+            chunks_indexed += stats["chunks_indexed"]
+            chunks_skipped += stats["chunks_skipped"]
+            pages_indexed += stats["pages_indexed"]
+            pages_skipped += stats["pages_skipped"]
+            continue
+
         try:
             raw_text, _kind_hint = _extract_text(file_path)
         except Exception as exc:  # noqa: BLE001
@@ -313,6 +347,19 @@ def index(
             for chunk_idx, vec in zip(to_embed_idx, vectors, strict=True)
         }
 
+        file_url = file_path.as_uri()
+        # Default path also stamps `parent_file` when per_page=True so
+        # callers walking the coverage ledger can group HTML / MD / TXT
+        # chunks under a single file unit. page_no stays None because
+        # these formats have no page concept.
+        file_metadata: dict[str, Any] | None = None
+        if per_page:
+            file_metadata = {
+                "parent_file": file_url,
+                "page_no": None,
+                "page_chunk": None,
+            }
+
         for i, chunk in enumerate(chunks):
             embedding_blob = new_blobs.get(i)
             if embedding_blob is None:
@@ -321,11 +368,12 @@ def index(
                 chunks_indexed += 1
             write_source(
                 job,
-                url=file_path.as_uri(),
+                url=file_url,
                 title=file_path.name,
                 raw_content=chunk,
                 kind="local",
                 embedding=embedding_blob,
+                metadata=file_metadata,
             )
 
         files_indexed += 1
@@ -335,7 +383,133 @@ def index(
         "files_skipped": files_skipped,
         "chunks_indexed": chunks_indexed,
         "chunks_skipped": chunks_skipped,
+        "pages_indexed": pages_indexed,
+        "pages_skipped": pages_skipped,
+        "per_page": per_page,
         "embed_dim": EMBED_DIM,
+    }
+
+
+def _index_pdf_per_page(
+    file_path: Path,
+    job: Job,
+    *,
+    base_url: str,
+    model_name: str,
+) -> dict[str, int]:
+    """Index one PDF as one :class:`Source` row per page (dossier mode).
+
+    Calls :func:`pdf.extract_pages_sync` to get ``[(page_no, text), ...]``
+    and writes one row per page. A page whose text exceeds the chunk
+    target is sub-chunked **inside that page only**; each sub-chunk
+    records the same ``page_no`` and a distinct 1-based ``page_chunk``
+    in ``metadata``. The chunker never crosses page boundaries.
+
+    Returns the same shape as :func:`index`'s per-file accumulator so
+    the outer loop can fold the counters in unchanged.
+    """
+    from research_agent.tools import pdf as pdf_mod  # lazy
+
+    empty_summary = {
+        "files_indexed": 0,
+        "files_skipped": 0,
+        "chunks_indexed": 0,
+        "chunks_skipped": 0,
+        "pages_indexed": 0,
+        "pages_skipped": 0,
+    }
+
+    try:
+        pages = pdf_mod.extract_pages_sync(file_path)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "pdf per-page extract failed for %s: %s", file_path, exc
+        )
+        return {**empty_summary, "files_skipped": 1}
+
+    if not pages:
+        return {**empty_summary, "files_skipped": 1}
+
+    file_url = file_path.as_uri()
+
+    # Materialise per-page sub-chunks first so we can batch-embed every
+    # row produced by this file in a single embeddings call. Each entry
+    # is ``(page_no, page_chunk_no_or_None, cleaned_chunk_text)``; an
+    # empty page contributes no entries (and is counted as a skipped
+    # page so coverage rollup can see the gap).
+    page_chunks: list[tuple[int, int | None, str]] = []
+    pages_indexed = 0
+    pages_skipped = 0
+    for page_no, page_text in pages:
+        cleaned = clean_content(page_text) if page_text else ""
+        if not cleaned:
+            pages_skipped += 1
+            continue
+        within_page = _chunk_text(cleaned)
+        if not within_page:
+            pages_skipped += 1
+            continue
+        pages_indexed += 1
+        if len(within_page) == 1:
+            page_chunks.append((page_no, None, within_page[0]))
+        else:
+            for idx, sub in enumerate(within_page, start=1):
+                page_chunks.append((page_no, idx, sub))
+
+    if not page_chunks:
+        return {
+            **empty_summary,
+            "files_skipped": 1,
+            "pages_indexed": pages_indexed,
+            "pages_skipped": pages_skipped,
+        }
+
+    chunk_shas = [content_sha256(clean_content(c)) for _, _, c in page_chunks]
+    existing = _existing_shas(job.db_path, chunk_shas)
+    to_embed_idx = [
+        i for i, sha in enumerate(chunk_shas) if sha not in existing
+    ]
+    embed_inputs = [page_chunks[i][2] for i in to_embed_idx]
+
+    if embed_inputs:
+        vectors = _embed_chunks_sync(embed_inputs, base_url, model_name)
+    else:
+        vectors = []
+
+    new_blobs: dict[int, bytes] = {
+        chunk_idx: _pack_embedding(vec)
+        for chunk_idx, vec in zip(to_embed_idx, vectors, strict=True)
+    }
+
+    chunks_indexed = 0
+    chunks_skipped = 0
+    for i, (page_no, page_chunk_no, chunk_text) in enumerate(page_chunks):
+        embedding_blob = new_blobs.get(i)
+        if embedding_blob is None:
+            chunks_skipped += 1
+        else:
+            chunks_indexed += 1
+        write_source(
+            job,
+            url=file_url,
+            title=file_path.name,
+            raw_content=chunk_text,
+            kind="local",
+            embedding=embedding_blob,
+            metadata={
+                "parent_file": file_url,
+                "page_no": page_no,
+                "page_chunk": page_chunk_no,
+            },
+        )
+
+    return {
+        "files_indexed": 1,
+        "files_skipped": 0,
+        "chunks_indexed": chunks_indexed,
+        "chunks_skipped": chunks_skipped,
+        "pages_indexed": pages_indexed,
+        "pages_skipped": pages_skipped,
     }
 
 

--- a/src/research_agent/tools/local_corpus.py
+++ b/src/research_agent/tools/local_corpus.py
@@ -434,10 +434,10 @@ def _index_pdf_per_page(
 
     # Materialise per-page sub-chunks first so we can batch-embed every
     # row produced by this file in a single embeddings call. Each entry
-    # is ``(page_no, page_chunk_no_or_None, cleaned_chunk_text)``; an
-    # empty page contributes no entries (and is counted as a skipped
-    # page so coverage rollup can see the gap).
-    page_chunks: list[tuple[int, int | None, str]] = []
+    # is ``(page_no, page_chunk_no_or_None, cleaned_chunk_text,
+    # source_text_with_identity)``; an empty page contributes no entries
+    # (and is counted as a skipped page so coverage rollup can see the gap).
+    page_chunks: list[tuple[int, int | None, str, str]] = []
     pages_indexed = 0
     pages_skipped = 0
     for page_no, page_text in pages:
@@ -451,10 +451,35 @@ def _index_pdf_per_page(
             continue
         pages_indexed += 1
         if len(within_page) == 1:
-            page_chunks.append((page_no, None, within_page[0]))
+            chunk_text = within_page[0]
+            page_chunks.append(
+                (
+                    page_no,
+                    None,
+                    chunk_text,
+                    _per_page_source_text(
+                        chunk_text,
+                        parent_file=file_url,
+                        page_no=page_no,
+                        page_chunk=None,
+                    ),
+                )
+            )
         else:
             for idx, sub in enumerate(within_page, start=1):
-                page_chunks.append((page_no, idx, sub))
+                page_chunks.append(
+                    (
+                        page_no,
+                        idx,
+                        sub,
+                        _per_page_source_text(
+                            sub,
+                            parent_file=file_url,
+                            page_no=page_no,
+                            page_chunk=idx,
+                        ),
+                    )
+                )
 
     if not page_chunks:
         return {
@@ -464,7 +489,7 @@ def _index_pdf_per_page(
             "pages_skipped": pages_skipped,
         }
 
-    chunk_shas = [content_sha256(clean_content(c)) for _, _, c in page_chunks]
+    chunk_shas = [content_sha256(clean_content(c)) for _, _, _, c in page_chunks]
     existing = _existing_shas(job.db_path, chunk_shas)
     to_embed_idx = [
         i for i, sha in enumerate(chunk_shas) if sha not in existing
@@ -483,7 +508,9 @@ def _index_pdf_per_page(
 
     chunks_indexed = 0
     chunks_skipped = 0
-    for i, (page_no, page_chunk_no, chunk_text) in enumerate(page_chunks):
+    for i, (page_no, page_chunk_no, _chunk_text_for_embedding, source_text) in enumerate(
+        page_chunks
+    ):
         embedding_blob = new_blobs.get(i)
         if embedding_blob is None:
             chunks_skipped += 1
@@ -493,7 +520,7 @@ def _index_pdf_per_page(
             job,
             url=file_url,
             title=file_path.name,
-            raw_content=chunk_text,
+            raw_content=source_text,
             kind="local",
             embedding=embedding_blob,
             metadata={
@@ -511,6 +538,33 @@ def _index_pdf_per_page(
         "pages_indexed": pages_indexed,
         "pages_skipped": pages_skipped,
     }
+
+
+def _per_page_source_text(
+    chunk_text: str,
+    *,
+    parent_file: str,
+    page_no: int,
+    page_chunk: int | None,
+) -> str:
+    """Return persisted text with deterministic page identity metadata.
+
+    ``write_source`` dedupes by cleaned content hash, but dossier mode needs
+    two pages with identical visible text to remain two distinct Source rows
+    with different ``metadata.page_no`` values. The HTML comment is stable,
+    human-inspectable in raw markdown, and does not affect the embedding
+    input because callers embed ``chunk_text`` before passing this persisted
+    source text to storage.
+    """
+    page_chunk_text = "" if page_chunk is None else str(page_chunk)
+    return (
+        "<!-- local_corpus_page_identity\n"
+        f"parent_file: {parent_file}\n"
+        f"page_no: {page_no}\n"
+        f"page_chunk: {page_chunk_text}\n"
+        "-->\n\n"
+        f"{chunk_text}"
+    )
 
 
 def _existing_shas(db_path: Path, shas: list[str]) -> set[str]:

--- a/src/research_agent/tools/pdf.py
+++ b/src/research_agent/tools/pdf.py
@@ -657,6 +657,330 @@ def extract_sync(
 
 
 # ---------------------------------------------------------------------------
+# Per-page extraction (issue #351 — dossier mode)
+# ---------------------------------------------------------------------------
+#
+# Dossier mode (epic #359) needs the LLM grain to be a single page so a
+# downstream extractor never blends content from page 1 and page 30 into the
+# same finding. The existing layer helpers all return one concatenated
+# string per document; the per-page helpers below keep one entry per page
+# (empty string for blank/broken pages) so callers can correlate by index.
+# Existing entry points (``extract``, ``extract_sync``, ``extract_from_bytes``)
+# are untouched — this is purely additive.
+
+
+def _extract_pypdf_pages(path: Path, max_pages: int) -> list[str]:
+    """Per-page pypdf text. One entry per page; ``""`` for empty/broken pages.
+
+    Returns an empty list when pypdf can't open the file at all so the
+    caller can fall through to the next layer.
+    """
+    import pypdf  # lazy
+
+    try:
+        reader = pypdf.PdfReader(str(path))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("pypdf open failed for %s: %s", path, exc)
+        return []
+
+    total_pages = len(reader.pages)
+    page_slice = min(total_pages, max_pages)
+    pages: list[str] = []
+    for idx in range(page_slice):
+        try:
+            text = reader.pages[idx].extract_text() or ""
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("pypdf page %d extract failed: %s", idx, exc)
+            text = ""
+        pages.append(text.strip())
+    return pages
+
+
+def _extract_pdfplumber_pages(path: Path, max_pages: int) -> list[str]:
+    """Per-page pdfplumber text (incl. tables). Empty list on whole-doc failure."""
+    try:
+        import pdfplumber  # lazy
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("pdfplumber import failed: %s", exc)
+        return []
+
+    pages: list[str] = []
+    try:
+        with pdfplumber.open(str(path)) as plumber:
+            for idx, page in enumerate(plumber.pages):
+                if idx >= max_pages:
+                    break
+                text = (page.extract_text() or "").strip()
+                table_blocks: list[str] = []
+                try:
+                    tables = page.extract_tables() or []
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(
+                        "pdfplumber tables failed on page %d: %s", idx, exc
+                    )
+                    tables = []
+                for table in tables:
+                    md_table = _table_to_markdown(table)
+                    if md_table:
+                        table_blocks.append(md_table)
+                merged = "\n\n".join(t for t in (text, *table_blocks) if t)
+                pages.append(merged)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("pdfplumber failed for %s: %s", path, exc)
+        return pages
+    return pages
+
+
+def _extract_tesseract_pages(path: Path, max_pages: int) -> list[str]:
+    """Per-page Tesseract OCR. Empty list when binary missing or rasterisation fails."""
+    if not _tesseract_available():
+        logger.warning("tesseract binary not found on PATH — skipping OCR layer")
+        return []
+
+    try:
+        import pytesseract  # lazy
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("pytesseract import failed: %s", exc)
+        return []
+
+    images = _render_pages_to_images(path, max_pages)
+    if not images:
+        return []
+
+    pages: list[str] = []
+    for idx, image in enumerate(images):
+        try:
+            text = pytesseract.image_to_string(image) or ""
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("pytesseract OCR failed on page %d: %s", idx, exc)
+            text = ""
+        pages.append(text.strip())
+    return pages
+
+
+def _pages_density(pages: list[str]) -> bool:
+    """Aggregate density gate over a per-page list.
+
+    Same threshold as :func:`_text_density` — fewer than
+    ``_DENSITY_MIN_ALPHA_PER_PAGE`` alpha chars on average across the
+    sampled pages counts as "this layer didn't work."
+    """
+    if not pages:
+        return False
+    joined = "\n".join(pages)
+    return _text_density(joined, len(pages))
+
+
+def _best_text_layer_pages(path: Path, max_pages: int) -> list[str]:
+    """Pick whichever of pypdf / pdfplumber yields more alpha text per page.
+
+    Used by the hybrid path so a structured filing that breaks pypdf still
+    contributes a usable text layer to merge with OCR.
+    """
+    pypdf_pages = _extract_pypdf_pages(path, max_pages)
+    plumber_pages = _extract_pdfplumber_pages(path, max_pages)
+    if _alpha_count("".join(plumber_pages)) > _alpha_count("".join(pypdf_pages)):
+        return plumber_pages
+    return pypdf_pages
+
+
+def _hybrid_merge_pages(
+    text_pages: list[str],
+    ocr_pages: list[str],
+) -> list[str]:
+    """Merge text-layer and OCR per-page lists strictly by index.
+
+    Each output entry is the text-layer page followed by an
+    ``[OCR supplement]`` block when *both* layers produced content for
+    that page. When only one layer produced content, that text is the
+    entry. OCR for page N never appears in page M's slot — lists are
+    zipped strictly by index, so the dossier extractor (M2) can rely on
+    "every entry is one page of one file."
+    """
+    max_len = max(len(text_pages), len(ocr_pages))
+    merged: list[str] = []
+    for idx in range(max_len):
+        text = text_pages[idx] if idx < len(text_pages) else ""
+        ocr = ocr_pages[idx] if idx < len(ocr_pages) else ""
+        if text and ocr:
+            merged.append(f"{text}\n\n[OCR supplement]\n{ocr}")
+        else:
+            merged.append(text or ocr)
+    return merged
+
+
+def _select_best_pages(candidates: list[list[str]]) -> list[str]:
+    """Pick whichever candidate produced the most alpha text.
+
+    Used as a no-layer-passed-the-density-gate fallback so callers still
+    see something for files that are only partly readable.
+    """
+    if not candidates:
+        return []
+    return max(candidates, key=lambda pages: _alpha_count("".join(pages)))
+
+
+def _to_indexed_pages(
+    pages: list[str], max_chars: int
+) -> list[tuple[int, str]]:
+    """Wrap a per-page text list in ``(1-based page_no, truncated_text)`` tuples.
+
+    ``max_chars`` is applied **per page** so callers can rely on bounded
+    entries without having to know the total page count.
+    """
+    return [
+        (idx + 1, _truncate(text, max_chars) if text else "")
+        for idx, text in enumerate(pages)
+    ]
+
+
+def _extract_pages(
+    path: Path,
+    *,
+    max_pages: int,
+    max_chars: int,
+    hybrid_pages: bool,
+) -> list[tuple[int, str]]:
+    """Synchronous core of :func:`extract_pages_sync`."""
+    if hybrid_pages:
+        text_pages = _best_text_layer_pages(path, max_pages)
+        ocr_pages = _extract_tesseract_pages(path, max_pages)
+        merged = _hybrid_merge_pages(text_pages, ocr_pages)
+        return _to_indexed_pages(merged, max_chars)
+
+    # Non-hybrid: layered try with aggregate density gate per layer.
+    pypdf_pages = _extract_pypdf_pages(path, max_pages)
+    if _pages_density(pypdf_pages):
+        return _to_indexed_pages(pypdf_pages, max_chars)
+
+    plumber_pages = _extract_pdfplumber_pages(path, max_pages)
+    if _pages_density(plumber_pages):
+        return _to_indexed_pages(plumber_pages, max_chars)
+
+    tesseract_pages = _extract_tesseract_pages(path, max_pages)
+    if _pages_density(tesseract_pages):
+        return _to_indexed_pages(tesseract_pages, max_chars)
+
+    # No layer met the floor — return whichever produced the most text so
+    # downstream callers at least see something to inspect rather than a
+    # confusing empty list when the file *did* have pages.
+    best = _select_best_pages([pypdf_pages, plumber_pages, tesseract_pages])
+    return _to_indexed_pages(best, max_chars)
+
+
+def extract_pages_sync(
+    path_or_url: str | Path,
+    *,
+    max_pages: int = DEFAULT_MAX_PAGES,
+    max_chars: int = DEFAULT_MAX_CHARS,
+    hybrid_pages: bool = False,
+    job: Job | None = None,
+) -> list[tuple[int, str]]:
+    """Per-page PDF extraction. Returns ``[(page_no, text), ...]`` (1-based).
+
+    Layer selection mirrors :func:`extract_sync`: pypdf → pdfplumber →
+    Tesseract; the aggregate density gate per layer decides whether to
+    fall to the next. The first layer that passes wins. When no layer
+    passes, the layer with the most alpha characters wins so callers
+    still see something for files that are partly readable.
+
+    When ``hybrid_pages=True``, every entry is a text-layer page
+    (whichever of pypdf / pdfplumber yields more text) **plus** an OCR
+    supplement for that same page when both layers produced content.
+    OCR for page N never appears in page M's slot — the lists are zipped
+    strictly by index.
+
+    ``max_chars`` is applied per page — each page's text is truncated to
+    that length individually so callers can rely on bounded entries
+    without knowing the total page count.
+
+    Empty / sub-floor pages are emitted as ``(page_no, "")`` rather than
+    being dropped so the dossier rollup can correlate by ``page_no`` and
+    record per-page coverage units (M1.2 / epic #359).
+
+    URLs are fetched synchronously via ``asyncio.run``; this function is
+    safe to call from sync contexts but should not be called from inside
+    a running event loop. Use :func:`extract_pages` for the async path.
+    """
+    raw = str(path_or_url)
+    cleanup_temp: Path | None = None
+    if _looks_like_url(raw):
+        try:
+            data = asyncio.run(fetch_pdf_bytes(raw))
+        except (httpx.HTTPError, OSError) as exc:
+            logger.warning("pdf fetch failed for %s: %s", raw, exc)
+            return []
+        path = _write_temp_pdf(data)
+        cleanup_temp = path
+    else:
+        path = Path(raw)
+        if not path.exists():
+            logger.warning("pdf path does not exist: %s", path)
+            return []
+    try:
+        return _extract_pages(
+            path,
+            max_pages=max_pages,
+            max_chars=max_chars,
+            hybrid_pages=hybrid_pages,
+        )
+    finally:
+        if cleanup_temp is not None:
+            try:
+                cleanup_temp.unlink()
+            except OSError:
+                pass
+
+
+async def extract_pages(
+    path_or_url: str | Path,
+    *,
+    max_pages: int = DEFAULT_MAX_PAGES,
+    max_chars: int = DEFAULT_MAX_CHARS,
+    hybrid_pages: bool = False,
+    job: Job | None = None,
+) -> list[tuple[int, str]]:
+    """Async wrapper around :func:`extract_pages_sync`.
+
+    I/O happens in a thread executor so a 1000-page PDF doesn't stall
+    the event loop while the layers walk pages. URL fetch uses the
+    already-async ``fetch_pdf_bytes`` rather than ``asyncio.run`` so
+    this is safe to call from inside a running loop.
+    """
+    raw = str(path_or_url)
+    cleanup_temp: Path | None = None
+    if _looks_like_url(raw):
+        try:
+            data = await fetch_pdf_bytes(raw)
+        except (httpx.HTTPError, OSError) as exc:
+            logger.warning("pdf fetch failed for %s: %s", raw, exc)
+            return []
+        path = _write_temp_pdf(data)
+        cleanup_temp = path
+    else:
+        path = Path(raw)
+        if not path.exists():
+            logger.warning("pdf path does not exist: %s", path)
+            return []
+    try:
+        return await asyncio.get_running_loop().run_in_executor(
+            None,
+            lambda: _extract_pages(
+                path,
+                max_pages=max_pages,
+                max_chars=max_chars,
+                hybrid_pages=hybrid_pages,
+            ),
+        )
+    finally:
+        if cleanup_temp is not None:
+            try:
+                cleanup_temp.unlink()
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
 # Section walk (issue #206) — structural splitting for cornerstone PDFs
 # ---------------------------------------------------------------------------
 
@@ -1043,6 +1367,8 @@ __all__ = [
     "DEFAULT_MAX_PAGES",
     "extract",
     "extract_from_bytes",
+    "extract_pages",
+    "extract_pages_sync",
     "extract_sections",
     "extract_sections_sync",
     "extract_sync",

--- a/tests/test_tools_local_corpus.py
+++ b/tests/test_tools_local_corpus.py
@@ -420,6 +420,344 @@ def test_write_source_persists_embedding_blob(job: Job) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Per-page ingestion (issue #352 — dossier mode, epic #359)
+# ---------------------------------------------------------------------------
+
+
+def _read_sidecar(job: Job, sha: str) -> dict:
+    """Read the JSON sidecar a `write_source` call materialised under ``job``."""
+    import json
+
+    path = job.root / "sources" / f"{sha}.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_index_per_page_default_is_unchanged(
+    job: Job, monkeypatch, stub_models_config: dict
+) -> None:
+    """per_page omitted/False must keep the legacy behaviour byte-for-byte."""
+    _stub_embed(monkeypatch)
+    baseline = local_corpus.index(
+        FIXTURE_CORPUS, job, models_config=stub_models_config
+    )
+    assert "pages_indexed" in baseline
+    assert "pages_skipped" in baseline
+    assert baseline["pages_indexed"] == 0
+    assert baseline["pages_skipped"] == 0
+    assert baseline["per_page"] is False
+
+
+def test_index_per_page_pdf_writes_one_source_per_page(
+    tmp_path: Path, job: Job, monkeypatch, stub_models_config: dict
+) -> None:
+    """PDF in per_page=True mode: N pages -> N Source rows, page_no stamped."""
+    _stub_embed(monkeypatch)
+    corpus = tmp_path / "pdf_only"
+    corpus.mkdir()
+    pdf_path = corpus / "filing.pdf"
+    pdf_path.write_bytes(b"%PDF-fake")
+
+    fake_pages = [
+        (1, "Page one of the filing about Alpha topics. " * 30),
+        (2, "Page two covers Beta procurement detail. " * 30),
+        (3, "Page three pivots to Gamma incidents. " * 30),
+    ]
+
+    def _fake_extract_pages_sync(path, **_kwargs):
+        return list(fake_pages)
+
+    from research_agent.tools import pdf as pdf_mod
+
+    monkeypatch.setattr(pdf_mod, "extract_pages_sync", _fake_extract_pages_sync)
+
+    summary = local_corpus.index(
+        corpus, job, models_config=stub_models_config, per_page=True
+    )
+
+    assert summary["files_indexed"] == 1
+    assert summary["files_skipped"] == 0
+    assert summary["pages_indexed"] == 3
+    assert summary["pages_skipped"] == 0
+    assert summary["chunks_indexed"] == 3
+    assert summary["per_page"] is True
+
+    conn = db.connect(job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT s.sha256, s.url, s.title FROM sources s"
+            " JOIN job_sources js ON js.source_id = s.id"
+            " WHERE js.job_id = ?"
+            " ORDER BY s.id ASC",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 3
+    page_nos: list[int] = []
+    parent_files: set[str] = set()
+    for row in rows:
+        sidecar = _read_sidecar(job, row["sha256"])
+        meta = sidecar["metadata"]
+        assert meta["parent_file"] == pdf_path.as_uri()
+        assert meta["page_chunk"] is None
+        page_nos.append(meta["page_no"])
+        parent_files.add(meta["parent_file"])
+    assert page_nos == [1, 2, 3]
+    assert parent_files == {pdf_path.as_uri()}
+
+
+def test_index_per_page_oversize_page_subchunks_within_page(
+    tmp_path: Path, job: Job, monkeypatch, stub_models_config: dict
+) -> None:
+    """Page text > chunk target: emit multiple Sources with same page_no, distinct page_chunk."""
+    _stub_embed(monkeypatch)
+    corpus = tmp_path / "big_pdf"
+    corpus.mkdir()
+    pdf_path = corpus / "big.pdf"
+    pdf_path.write_bytes(b"%PDF-fake")
+
+    oversize = " ".join(f"tok{i}" for i in range(local_corpus.CHUNK_TARGET_TOKENS * 2 + 100))
+    fake_pages = [
+        (1, "Small page one body alpha. " * 30),
+        (2, oversize),  # forces sub-chunking
+        (3, "Small page three body gamma. " * 30),
+    ]
+
+    def _fake_extract_pages_sync(path, **_kwargs):
+        return list(fake_pages)
+
+    from research_agent.tools import pdf as pdf_mod
+
+    monkeypatch.setattr(pdf_mod, "extract_pages_sync", _fake_extract_pages_sync)
+
+    summary = local_corpus.index(
+        corpus, job, models_config=stub_models_config, per_page=True
+    )
+    assert summary["pages_indexed"] == 3
+    assert summary["chunks_indexed"] >= 4  # 1 + (>=2 subchunks) + 1
+
+    conn = db.connect(job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT s.sha256 FROM sources s"
+            " JOIN job_sources js ON js.source_id = s.id"
+            " WHERE js.job_id = ?"
+            " ORDER BY s.id ASC",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    by_page: dict[int, list[int | None]] = {}
+    for row in rows:
+        meta = _read_sidecar(job, row["sha256"])["metadata"]
+        by_page.setdefault(meta["page_no"], []).append(meta["page_chunk"])
+
+    assert set(by_page.keys()) == {1, 2, 3}
+    # Pages 1 and 3 fit in one chunk apiece -> page_chunk = None.
+    assert by_page[1] == [None]
+    assert by_page[3] == [None]
+    # Page 2 is sub-chunked: distinct 1-based page_chunk values, all >= 2 chunks.
+    assert all(isinstance(c, int) and c >= 1 for c in by_page[2])
+    assert len(by_page[2]) >= 2
+    assert sorted(by_page[2]) == sorted(set(by_page[2]))  # distinct
+
+
+def test_index_per_page_empty_pages_count_as_skipped(
+    tmp_path: Path, job: Job, monkeypatch, stub_models_config: dict
+) -> None:
+    """Pages whose text is empty are counted under pages_skipped, not pages_indexed."""
+    _stub_embed(monkeypatch)
+    corpus = tmp_path / "sparse_pdf"
+    corpus.mkdir()
+    pdf_path = corpus / "sparse.pdf"
+    pdf_path.write_bytes(b"%PDF-fake")
+
+    fake_pages = [
+        (1, "Real content alpha alpha. " * 30),
+        (2, ""),
+        (3, "Real content gamma gamma. " * 30),
+        (4, ""),
+    ]
+
+    def _fake_extract_pages_sync(path, **_kwargs):
+        return list(fake_pages)
+
+    from research_agent.tools import pdf as pdf_mod
+
+    monkeypatch.setattr(pdf_mod, "extract_pages_sync", _fake_extract_pages_sync)
+
+    summary = local_corpus.index(
+        corpus, job, models_config=stub_models_config, per_page=True
+    )
+    assert summary["pages_indexed"] == 2
+    assert summary["pages_skipped"] == 2
+    assert summary["files_indexed"] == 1
+    assert summary["chunks_indexed"] == 2
+
+
+def test_index_per_page_pdf_with_no_extractable_text_skips_file(
+    tmp_path: Path, job: Job, monkeypatch, stub_models_config: dict
+) -> None:
+    """Every page empty -> the file itself counts as skipped (pages_indexed=0)."""
+    _stub_embed(monkeypatch)
+    corpus = tmp_path / "blank_pdf"
+    corpus.mkdir()
+    pdf_path = corpus / "blank.pdf"
+    pdf_path.write_bytes(b"%PDF-fake")
+
+    def _fake_extract_pages_sync(path, **_kwargs):
+        return [(1, ""), (2, "")]
+
+    from research_agent.tools import pdf as pdf_mod
+
+    monkeypatch.setattr(pdf_mod, "extract_pages_sync", _fake_extract_pages_sync)
+
+    summary = local_corpus.index(
+        corpus, job, models_config=stub_models_config, per_page=True
+    )
+    assert summary["files_indexed"] == 0
+    assert summary["files_skipped"] == 1
+    assert summary["pages_indexed"] == 0
+    assert summary["pages_skipped"] == 2
+
+
+def test_index_per_page_unopenable_pdf_skips_file(
+    tmp_path: Path, job: Job, monkeypatch, stub_models_config: dict
+) -> None:
+    """extract_pages_sync returning [] (unopenable) -> file counted as skipped."""
+    _stub_embed(monkeypatch)
+    corpus = tmp_path / "broken_pdf"
+    corpus.mkdir()
+    (corpus / "broken.pdf").write_bytes(b"not actually a pdf")
+
+    from research_agent.tools import pdf as pdf_mod
+
+    monkeypatch.setattr(pdf_mod, "extract_pages_sync", lambda *a, **k: [])
+
+    summary = local_corpus.index(
+        corpus, job, models_config=stub_models_config, per_page=True
+    )
+    assert summary["files_indexed"] == 0
+    assert summary["files_skipped"] == 1
+    assert summary["pages_indexed"] == 0
+    assert summary["pages_skipped"] == 0
+    assert summary["chunks_indexed"] == 0
+
+
+def test_index_per_page_html_stamps_parent_file_and_null_page(
+    tmp_path: Path, job: Job, monkeypatch, stub_models_config: dict
+) -> None:
+    """HTML in per_page=True: existing chunking, metadata.page_no = None, parent_file set."""
+    _stub_embed(monkeypatch)
+    corpus = tmp_path / "html_only"
+    corpus.mkdir()
+    html_path = corpus / "page.html"
+    body = "html body section " * 80
+    html_path.write_text(f"<html><body><p>{body}</p></body></html>")
+
+    summary = local_corpus.index(
+        corpus, job, models_config=stub_models_config, per_page=True
+    )
+    assert summary["files_indexed"] == 1
+    assert summary["chunks_indexed"] >= 1
+    # HTML has no pages so the page counters stay at zero even in per_page mode.
+    assert summary["pages_indexed"] == 0
+    assert summary["pages_skipped"] == 0
+
+    conn = db.connect(job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT s.sha256 FROM sources s"
+            " JOIN job_sources js ON js.source_id = s.id"
+            " WHERE js.job_id = ?",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    for row in rows:
+        meta = _read_sidecar(job, row["sha256"])["metadata"]
+        assert meta["parent_file"] == html_path.as_uri()
+        assert meta["page_no"] is None
+        assert meta["page_chunk"] is None
+
+
+def test_index_per_page_is_idempotent(
+    tmp_path: Path, job: Job, monkeypatch, stub_models_config: dict
+) -> None:
+    """Re-running per_page=True over the same PDF must skip re-embedding."""
+    _stub_embed(monkeypatch)
+    corpus = tmp_path / "rerun_pdf"
+    corpus.mkdir()
+    pdf_path = corpus / "rerun.pdf"
+    pdf_path.write_bytes(b"%PDF-fake")
+
+    fake_pages = [
+        (1, "Idempotent page one alpha. " * 30),
+        (2, "Idempotent page two beta. " * 30),
+    ]
+
+    from research_agent.tools import pdf as pdf_mod
+
+    monkeypatch.setattr(
+        pdf_mod, "extract_pages_sync", lambda *a, **k: list(fake_pages)
+    )
+
+    first = local_corpus.index(
+        corpus, job, models_config=stub_models_config, per_page=True
+    )
+    assert first["chunks_indexed"] == 2
+
+    # Reject any further embeddings call on the second pass.
+    def _no_embed(chunks, base_url, model):  # noqa: ARG001
+        raise AssertionError("re-embedded an already-indexed page chunk")
+
+    monkeypatch.setattr(local_corpus, "_embed_chunks_sync", _no_embed)
+
+    second = local_corpus.index(
+        corpus, job, models_config=stub_models_config, per_page=True
+    )
+    assert second["chunks_indexed"] == 0
+    assert second["chunks_skipped"] == 2
+    assert second["pages_indexed"] == 2
+
+
+def test_index_per_page_real_pdf_fixture_smoke(
+    tmp_path: Path, job: Job, monkeypatch, stub_models_config: dict
+) -> None:
+    """Integration: a real PDF fixture goes through extract_pages_sync end-to-end."""
+    _stub_embed(monkeypatch)
+    corpus = tmp_path / "real_pdf"
+    corpus.mkdir()
+    fixture = Path(__file__).parent / "fixtures" / "arxiv_paper.pdf"
+    destination = corpus / "arxiv.pdf"
+    destination.write_bytes(fixture.read_bytes())
+
+    summary = local_corpus.index(
+        corpus, job, models_config=stub_models_config, per_page=True
+    )
+    assert summary["files_indexed"] == 1
+    assert summary["pages_indexed"] >= 1
+    assert summary["chunks_indexed"] >= 1
+
+    conn = db.connect(job.db_path)
+    try:
+        sha = conn.execute(
+            "SELECT s.sha256 FROM sources s"
+            " JOIN job_sources js ON js.source_id = s.id"
+            " WHERE js.job_id = ?"
+            " ORDER BY s.id ASC LIMIT 1",
+            (job.id,),
+        ).fetchone()["sha256"]
+    finally:
+        conn.close()
+    meta = _read_sidecar(job, sha)["metadata"]
+    assert meta["parent_file"] == destination.as_uri()
+    assert meta["page_no"] == 1
+
+
+# ---------------------------------------------------------------------------
 # Cornerstone vector index (issue #206)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_tools_local_corpus.py
+++ b/tests/test_tools_local_corpus.py
@@ -506,6 +506,63 @@ def test_index_per_page_pdf_writes_one_source_per_page(
     assert parent_files == {pdf_path.as_uri()}
 
 
+def test_index_per_page_duplicate_pdf_pages_remain_distinct_sources(
+    tmp_path: Path, job: Job, monkeypatch, stub_models_config: dict
+) -> None:
+    """Identical visible page text must still persist one Source per page."""
+    _stub_embed(monkeypatch)
+    corpus = tmp_path / "duplicate_pdf"
+    corpus.mkdir()
+    pdf_path = corpus / "dupe.pdf"
+    pdf_path.write_bytes(b"%PDF-fake")
+
+    duplicate_text = "Same page body alpha. " * 40
+
+    from research_agent.tools import pdf as pdf_mod
+
+    monkeypatch.setattr(
+        pdf_mod,
+        "extract_pages_sync",
+        lambda *a, **k: [(1, duplicate_text), (2, duplicate_text)],
+    )
+
+    summary = local_corpus.index(
+        corpus, job, models_config=stub_models_config, per_page=True
+    )
+
+    assert summary["files_indexed"] == 1
+    assert summary["pages_indexed"] == 2
+    assert summary["chunks_indexed"] == 2
+
+    conn = db.connect(job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT s.sha256 FROM sources s"
+            " JOIN job_sources js ON js.source_id = s.id"
+            " WHERE js.job_id = ?"
+            " ORDER BY s.id ASC",
+            (job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert len(rows) == 2
+    assert len({row["sha256"] for row in rows}) == 2
+    page_nos = [_read_sidecar(job, row["sha256"])["metadata"]["page_no"] for row in rows]
+    assert page_nos == [1, 2]
+
+    def _no_embed(chunks, base_url, model):  # noqa: ARG001
+        raise AssertionError("re-embedded already-indexed duplicate page chunks")
+
+    monkeypatch.setattr(local_corpus, "_embed_chunks_sync", _no_embed)
+    second = local_corpus.index(
+        corpus, job, models_config=stub_models_config, per_page=True
+    )
+    assert second["chunks_indexed"] == 0
+    assert second["chunks_skipped"] == 2
+    assert second["pages_indexed"] == 2
+
+
 def test_index_per_page_oversize_page_subchunks_within_page(
     tmp_path: Path, job: Job, monkeypatch, stub_models_config: dict
 ) -> None:

--- a/tests/test_tools_pdf.py
+++ b/tests/test_tools_pdf.py
@@ -383,6 +383,284 @@ def test_smoke_pdf_against_local_fixture():
 
 
 # ---------------------------------------------------------------------------
+# Per-page extraction (issue #351 — dossier mode, epic #359)
+# ---------------------------------------------------------------------------
+
+
+def _stub_pypdf_pages(monkeypatch, pages: list[str]):
+    """Install a pypdf stub whose reader returns the supplied per-page texts."""
+
+    class _FakePage:
+        def __init__(self, text: str) -> None:
+            self._text = text
+
+        def extract_text(self) -> str:
+            return self._text
+
+    class _FakeReader:
+        def __init__(self, *_a, **_kw) -> None:
+            self.pages = [_FakePage(t) for t in pages]
+            self.outline = []
+
+    fake_pypdf = type("M", (), {"PdfReader": _FakeReader})
+    monkeypatch.setitem(__import__("sys").modules, "pypdf", fake_pypdf)
+
+
+def test_extract_pages_sync_single_page_fixture():
+    """Real single-page arxiv fixture: returns one tuple with 1-based page_no."""
+    pages = pdf.extract_pages_sync(ARXIV_PDF)
+    assert len(pages) == 1
+    page_no, text = pages[0]
+    assert page_no == 1
+    assert "arxiv research paper text" in text
+
+
+def test_extract_pages_sync_returns_distinct_per_page(monkeypatch):
+    """Multi-page text-layer: every page's text is distinct, in order, no bleed."""
+    _stub_pypdf_pages(
+        monkeypatch,
+        [
+            "First page content about Alpha. " * 20,
+            "Second page covers Beta in detail. " * 20,
+            "Third page mentions Gamma topics. " * 20,
+        ],
+    )
+
+    pages = pdf.extract_pages_sync(ARXIV_PDF)
+    assert [n for n, _ in pages] == [1, 2, 3]
+    assert "Alpha" in pages[0][1]
+    assert "Beta" in pages[1][1]
+    assert "Gamma" in pages[2][1]
+    # Acceptance: per-page boundaries hold, no cross-page bleed.
+    assert "Beta" not in pages[0][1]
+    assert "Alpha" not in pages[1][1]
+    assert "Gamma" not in pages[1][1]
+
+
+def test_extract_pages_sync_respects_max_pages(monkeypatch):
+    _stub_pypdf_pages(monkeypatch, [f"Page {i} body " * 30 for i in range(5)])
+    pages = pdf.extract_pages_sync(ARXIV_PDF, max_pages=2)
+    assert [n for n, _ in pages] == [1, 2]
+
+
+def test_extract_pages_sync_truncates_per_page(monkeypatch):
+    """max_chars is applied per page so callers see bounded entries."""
+    _stub_pypdf_pages(monkeypatch, ["x" * 5_000, "y" * 5_000])
+    monkeypatch.setattr(pdf, "_pages_density", lambda _pages: True)
+
+    pages = pdf.extract_pages_sync(ARXIV_PDF, max_chars=100)
+    assert len(pages) == 2
+    for _, text in pages:
+        body, _, _ = text.partition("…[truncated]")
+        assert len(body.rstrip()) <= 100
+        assert text.endswith("…[truncated]")
+
+
+def test_extract_pages_sync_emits_empty_string_for_blank_pages(monkeypatch):
+    """Sub-floor pages remain in the list so callers can correlate by index."""
+    _stub_pypdf_pages(
+        monkeypatch,
+        ["Real content " * 30, "", "More content " * 30, ""],
+    )
+
+    pages = pdf.extract_pages_sync(ARXIV_PDF)
+    assert [n for n, _ in pages] == [1, 2, 3, 4]
+    assert pages[1][1] == ""
+    assert pages[3][1] == ""
+
+
+def test_extract_pages_sync_falls_through_to_ocr(monkeypatch):
+    """Scanned PDF: pypdf empty, OCR fills every page, distinct per page."""
+    monkeypatch.setattr(pdf, "_extract_pypdf_pages", lambda *a, **k: ["", ""])
+    monkeypatch.setattr(pdf, "_extract_pdfplumber_pages", lambda *a, **k: ["", ""])
+    monkeypatch.setattr(
+        pdf,
+        "_extract_tesseract_pages",
+        lambda *a, **k: [
+            "Scanned filing recovered via OCR " * 20,
+            "Page two OCR distinct content " * 20,
+        ],
+    )
+
+    pages = pdf.extract_pages_sync(SCANNED_PDF)
+    assert len(pages) == 2
+    assert [n for n, _ in pages] == [1, 2]
+    assert "Scanned filing" in pages[0][1]
+    assert "Page two OCR" in pages[1][1]
+    # Cross-page bleed check on the OCR fall-through path too.
+    assert "Page two OCR" not in pages[0][1]
+    assert "Scanned filing" not in pages[1][1]
+
+
+def test_extract_pages_sync_no_density_returns_best_layer(monkeypatch):
+    """No layer meets the floor — return whichever produced the most text."""
+    monkeypatch.setattr(pdf, "_extract_pypdf_pages", lambda *a, **k: [""])
+    monkeypatch.setattr(
+        pdf, "_extract_pdfplumber_pages", lambda *a, **k: ["short"]
+    )
+    monkeypatch.setattr(
+        pdf,
+        "_extract_tesseract_pages",
+        lambda *a, **k: ["a much longer string that beats plumber"],
+    )
+
+    pages = pdf.extract_pages_sync(ARXIV_PDF)
+    assert len(pages) == 1
+    assert "much longer string" in pages[0][1]
+
+
+def test_extract_pages_sync_returns_empty_when_every_layer_yields_nothing(
+    monkeypatch,
+):
+    monkeypatch.setattr(pdf, "_extract_pypdf_pages", lambda *a, **k: [])
+    monkeypatch.setattr(pdf, "_extract_pdfplumber_pages", lambda *a, **k: [])
+    monkeypatch.setattr(pdf, "_extract_tesseract_pages", lambda *a, **k: [])
+
+    assert pdf.extract_pages_sync(ARXIV_PDF) == []
+
+
+def test_extract_pages_sync_hybrid_merges_text_and_ocr(monkeypatch):
+    """Hybrid: text-layer + OCR supplement per page, no cross-page bleed."""
+    monkeypatch.setattr(
+        pdf,
+        "_extract_pypdf_pages",
+        lambda *a, **k: ["Text layer page one.", "Text layer page two."],
+    )
+    monkeypatch.setattr(pdf, "_extract_pdfplumber_pages", lambda *a, **k: [])
+    monkeypatch.setattr(
+        pdf,
+        "_extract_tesseract_pages",
+        lambda *a, **k: ["OCR alpha supplement.", "OCR beta supplement."],
+    )
+
+    pages = pdf.extract_pages_sync(ARXIV_PDF, hybrid_pages=True)
+    assert [n for n, _ in pages] == [1, 2]
+    p1, p2 = pages[0][1], pages[1][1]
+    assert "Text layer page one." in p1
+    assert "OCR alpha supplement." in p1
+    assert "[OCR supplement]" in p1
+    assert "Text layer page two." in p2
+    assert "OCR beta supplement." in p2
+    # The signal acceptance criterion: OCR for page N never appears in
+    # any other page's slot.
+    assert "OCR beta supplement" not in p1
+    assert "OCR alpha supplement" not in p2
+    assert "Text layer page two" not in p1
+    assert "Text layer page one" not in p2
+
+
+def test_extract_pages_sync_hybrid_text_only_when_ocr_unavailable(monkeypatch):
+    """Hybrid with no OCR binary: text-only pages, no supplement marker."""
+    monkeypatch.setattr(
+        pdf,
+        "_extract_pypdf_pages",
+        lambda *a, **k: ["Text layer page one.", "Text layer page two."],
+    )
+    monkeypatch.setattr(pdf, "_extract_pdfplumber_pages", lambda *a, **k: [])
+    monkeypatch.setattr(pdf, "_extract_tesseract_pages", lambda *a, **k: [])
+
+    pages = pdf.extract_pages_sync(ARXIV_PDF, hybrid_pages=True)
+    assert len(pages) == 2
+    assert pages[0][1] == "Text layer page one."
+    assert pages[1][1] == "Text layer page two."
+    assert "[OCR supplement]" not in pages[0][1]
+
+
+def test_extract_pages_sync_hybrid_ocr_only_when_text_blank(monkeypatch):
+    """Hybrid with empty text layer falls back to OCR-only pages."""
+    monkeypatch.setattr(pdf, "_extract_pypdf_pages", lambda *a, **k: ["", ""])
+    monkeypatch.setattr(
+        pdf, "_extract_pdfplumber_pages", lambda *a, **k: ["", ""]
+    )
+    monkeypatch.setattr(
+        pdf,
+        "_extract_tesseract_pages",
+        lambda *a, **k: ["OCR alpha page one.", "OCR beta page two."],
+    )
+
+    pages = pdf.extract_pages_sync(ARXIV_PDF, hybrid_pages=True)
+    assert len(pages) == 2
+    assert pages[0][1] == "OCR alpha page one."
+    assert pages[1][1] == "OCR beta page two."
+    assert "[OCR supplement]" not in pages[0][1]
+
+
+def test_extract_pages_sync_hybrid_prefers_plumber_when_pypdf_thin(monkeypatch):
+    """When pypdf returns thin text but plumber recovers more, hybrid uses plumber."""
+    monkeypatch.setattr(pdf, "_extract_pypdf_pages", lambda *a, **k: ["x", "y"])
+    monkeypatch.setattr(
+        pdf,
+        "_extract_pdfplumber_pages",
+        lambda *a, **k: [
+            "Plumber recovered structured text " * 5,
+            "Plumber page two structured " * 5,
+        ],
+    )
+    monkeypatch.setattr(pdf, "_extract_tesseract_pages", lambda *a, **k: [])
+
+    pages = pdf.extract_pages_sync(ARXIV_PDF, hybrid_pages=True)
+    assert "Plumber recovered structured text" in pages[0][1]
+    assert "Plumber page two structured" in pages[1][1]
+
+
+def test_extract_pages_sync_url_routes_through_fetch(monkeypatch):
+    captured: list[str] = []
+
+    async def _fake_fetch(url, *, timeout=60.0):
+        captured.append(url)
+        return ARXIV_PDF.read_bytes()
+
+    monkeypatch.setattr(pdf, "fetch_pdf_bytes", _fake_fetch)
+
+    pages = pdf.extract_pages_sync("https://example.com/sample.pdf")
+    assert captured == ["https://example.com/sample.pdf"]
+    assert pages
+    assert "arxiv research paper text" in pages[0][1]
+
+
+def test_extract_pages_sync_returns_empty_for_missing_path():
+    assert pdf.extract_pages_sync("/no/such/file.pdf") == []
+
+
+async def test_extract_pages_async_wrapper(monkeypatch):
+    """Async wrapper runs the same core in a thread executor."""
+    _stub_pypdf_pages(monkeypatch, ["Async page body " * 30])
+    pages = await pdf.extract_pages(ARXIV_PDF)
+    assert pages[0][0] == 1
+    assert "Async page body" in pages[0][1]
+
+
+def test_extract_sync_regression_unchanged():
+    """extract_sync() contract must stay green after the additive change."""
+    text = pdf.extract_sync(ARXIV_PDF)
+    assert "## Page 1" in text
+    assert "arxiv research paper text" in text
+
+
+def test_hybrid_merge_pages_zero_length_inputs():
+    """Edge: empty lists merge to empty list."""
+    assert pdf._hybrid_merge_pages([], []) == []
+
+
+def test_hybrid_merge_pages_uneven_lengths():
+    """Edge: when one list is shorter, the longer one's tail is preserved."""
+    merged = pdf._hybrid_merge_pages(["A", "B", "C"], ["x"])
+    assert merged[0] == "A\n\n[OCR supplement]\nx"
+    assert merged[1] == "B"
+    assert merged[2] == "C"
+
+
+def test_pages_density_empty_returns_false():
+    assert pdf._pages_density([]) is False
+    assert pdf._pages_density(["", "", ""]) is False
+
+
+def test_pages_density_passes_when_above_threshold():
+    one_page = "a" * (pdf._DENSITY_MIN_ALPHA_PER_PAGE * 2)
+    assert pdf._pages_density([one_page]) is True
+
+
+# ---------------------------------------------------------------------------
 # Section walk (issue #206)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on top of #360 (M0.1 / #351). Once #360 merges, this PR's diff will collapse to just the per-page corpus change.

## Summary
- Adds `per_page=False` default flag to `local_corpus.index(...)`. When set, PDFs route through `pdf.extract_pages_sync()` (M0.1) and write one `Source` row per page; a page that exceeds the chunk-target token budget is sub-chunked **inside that page only**, with the 1-based sub-chunk index recorded as `metadata.page_chunk`. Sub-chunking never crosses page boundaries.
- HTML / MD / TXT have no page concept, so the default chunker still runs but each chunk's metadata records `parent_file` (the file URI) and leaves `page_no` / `page_chunk` null. Coverage rollup (M1.2) can group those chunks by file later.
- Pages with no readable text are counted as `pages_skipped` so the coverage ledger (M1.2) can see gaps. A whole-PDF empty extract counts as `files_skipped` with `pages_skipped` populated; an unopenable PDF counts as `files_skipped` only.
- Summary dict now carries `pages_indexed`, `pages_skipped`, `per_page`. The existing `_inbox_watcher` caller already spreads the summary into the `corpus_doc_added` event payload, so the new counters appear in events for free.
- `per_page=False` (default) keeps the legacy behaviour byte-for-byte; no metadata stamping, page counters stay zero.

## Why
Dossier mode (epic #359) needs the LLM grain to be a single page (PDF) or a chunk within a single file (HTML / MD / TXT) — never cross-file. The current chunker concatenates all page text and then slices by whitespace tokens, so chunks routinely straddle page boundaries. That works for semantic top-K but breaks per-page dossier extraction and the per-page coverage ledger.

## Out of scope (M1+ followups)
- Wiring the flag through CLI / intake → M1.1.
- Page-level coverage declaration → M1.2 (#357).
- Failure → `confirmed_gap` mapping → M1.3.
- Extending the standalone `corpus_indexed` event payload (the daemon's corpus-init path that emits this event isn't on `origin/main` yet — separate PR).

## Test plan
- [x] `uv run --frozen pytest tests/test_tools_local_corpus.py -q` → 30 passed (11 new)
- [x] `uv run --frozen pytest tests/test_tools_pdf.py tests/test_tools_local_corpus.py tests/test_daemon.py -q` → 121 passed
- [x] `uv run --frozen ruff check src/research_agent/tools/local_corpus.py tests/test_tools_local_corpus.py` → clean
- [x] Idempotency test: second pass on the same PDF in per-page mode does **not** call the embeddings API again.

### Acceptance criteria coverage
- ✅ Multi-page PDF: N Sources, each with `metadata.page_no` set and `parent_file` = file URL (`test_index_per_page_pdf_writes_one_source_per_page`).
- ✅ Oversize page → multiple Sources with same `page_no`, distinct `page_chunk` (`test_index_per_page_oversize_page_subchunks_within_page`).
- ✅ HTML fixture → chunks with `parent_file` set and `page_no=None` (`test_index_per_page_html_stamps_parent_file_and_null_page`).
- ✅ Existing default-path tests stay green (`test_index_per_page_default_is_unchanged` + every pre-existing test).
- ✅ Summary dict carries `pages_indexed`, `pages_skipped` (covered by every per-page test).

Closes #352.

Made with [Cursor](https://cursor.com)