### PR TITLE
feat(cli): --corpus-dossier flag + intake plumbing (#355)

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ Lockfiles (`uv.lock`) are committed.
 ```bash
 research start --skip-intake --goal "<goal>" \
     [--budget-usd 5.0] [--time-cap 24] [--corpus path/to/notes] \
+    [--corpus-dossier] \
     [--disk-cap-gb 10] [--translate-non-english] [--fragments] [--inbox]
 
 research list                      # newest first; Rich on a TTY, JSON otherwise
@@ -527,6 +528,17 @@ to `jobs/<id>/daemon.pid`; the daemon's stdout/stderr land in
 added with `research inbox <job-id> add <file>` are indexed into the local
 corpus, moved to `inbox/processed/`, logged as `corpus_doc_added`, and
 used to trigger a tactical replan while the daemon is still running.
+
+`--corpus-dossier` (epic #359) opts the job into per-page dossier-mode
+ingestion. With the flag set, the daemon routes every PDF in the
+supplied `--corpus` directory (and any live `--inbox` documents) through
+`pdf.extract_pages_sync()` and writes one `Source` row per page, with
+`metadata.parent_file` / `metadata.page_no` / `metadata.page_chunk`
+stamped on the sidecar. The dossier rollup (filed in M2 of the epic)
+uses this grouping to produce one dossier per file plus a structured
+`dossiers` artifact; without dossier mode the existing thematic-sampling
+synthesis stays the default. The flag requires `--corpus` to be set
+(otherwise `research start` exits with code 2).
 
 `--input-csv PATH --artifact NAME --key COL` imports an existing CSV into
 `jobs/<id>/artifacts/` before the daemon starts so a run can enrich missing

--- a/README.md
+++ b/README.md
@@ -530,15 +530,17 @@ corpus, moved to `inbox/processed/`, logged as `corpus_doc_added`, and
 used to trigger a tactical replan while the daemon is still running.
 
 `--corpus-dossier` (epic #359) opts the job into per-page dossier-mode
-ingestion. With the flag set, the daemon routes every PDF in the
-supplied `--corpus` directory (and any live `--inbox` documents) through
-`pdf.extract_pages_sync()` and writes one `Source` row per page, with
-`metadata.parent_file` / `metadata.page_no` / `metadata.page_chunk`
-stamped on the sidecar. The dossier rollup (filed in M2 of the epic)
-uses this grouping to produce one dossier per file plus a structured
-`dossiers` artifact; without dossier mode the existing thematic-sampling
-synthesis stays the default. The flag requires `--corpus` to be set
-(otherwise `research start` exits with code 2).
+ingestion. With the flag set, local-corpus indexing runs in per-page
+mode when the daemon indexes operator-supplied files; the current live
+`--inbox` watcher already forwards the flag, and the corpus-walk startup
+path will use the same intake field when it lands. In dossier mode PDFs
+go through `pdf.extract_pages_sync()` and write one `Source` row per
+page, with `metadata.parent_file` / `metadata.page_no` /
+`metadata.page_chunk` stamped on the sidecar. The dossier rollup (filed
+in M2 of the epic) uses this grouping to produce one dossier per file
+plus a structured `dossiers` artifact; without dossier mode the existing
+thematic-sampling synthesis stays the default. The flag requires
+`--corpus` to be set (otherwise `research start` exits with code 2).
 
 `--input-csv PATH --artifact NAME --key COL` imports an existing CSV into
 `jobs/<id>/artifacts/` before the daemon starts so a run can enrich missing

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -11,6 +11,7 @@ fields on `task_template[].payload`.
 |---|---:|---|---|
 | `translate_non_english` | `false` | job or task payload | When true, extraction writes an English mirror for each non-English finding as `findings/NNNNNN.translation.md`. |
 | `fragments` | `false` | job | Records that the operator requested section-fragment synthesis with `research start --fragments`. Runtime routing still uses `RESEARCH_FRAGMENT_SYNTH=1`, which the CLI sets for the spawned daemon. |
+| `corpus_dossier` | `false` | job | When true, the daemon indexes every corpus / inbox file in per-page mode (`local_corpus.index(..., per_page=True)`), writing one Source row per PDF page with `metadata.{parent_file, page_no, page_chunk}` stamped on the sidecar. Required by the dossier rollup (epic #359). Enabled with `research start --corpus-dossier`; the flag is rejected without `--corpus`. |
 
 `translate_non_english` is intentionally opt-in. Use it for multilingual
 archive runs where French, Spanish, or other non-English primary sources are
@@ -52,3 +53,36 @@ under `fragments/<section>/NNNN.{md,json}` and mirrored in SQLite, so resume and
 final-synthesis paths reassemble `report.md` from the latest fragments after a
 restart. Logs include a `synthesis_mode` event with `mode="fragments"` or
 `mode="legacy"` for operator visibility.
+
+## Corpus Dossier Mode (epic #359)
+
+Default corpus ingestion does whole-document chunking and runs one
+synthesis pass at task 25, which produces a thematic summary of the
+corpus. For investigations that need a **forensic dossier of every
+file** in a corpus, opt into dossier mode:
+
+```bash
+research start --skip-intake --goal "Exhaustive dossier of UFO records" \
+    --corpus corpus/ufo-records --corpus-dossier --local
+```
+
+`--corpus-dossier` requires `--corpus`; running with the flag set and
+no corpus path exits with code 2. The flag writes
+`"corpus_dossier": true` into `jobs/<job-id>/intake.json`. With the flag
+on, the daemon:
+
+- Routes every PDF through `pdf.extract_pages_sync()` (one page per
+  `Source` row, sub-chunked within the page when a single page exceeds
+  the chunk-target token budget).
+- Routes HTML / Markdown / TXT through the existing chunker but still
+  stamps `metadata.parent_file` on every chunk so the rollup can group
+  by file.
+- Surfaces page-grain rows to semantic search and synthesis (each row
+  becomes a citable Source).
+
+The downstream dossier rollup (Stage 2 of the ladder, filed in M2 of
+the epic) reads `metadata.parent_file` to build one
+`findings/dossiers/<slug>.md` per file plus a `dossiers` structured
+artifact. Stage 1 in this PR series is just the ingestion plumbing —
+M1.2 wires the per-page coverage ledger, and M2 fills in the
+extraction / rollup tasks.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -11,7 +11,7 @@ fields on `task_template[].payload`.
 |---|---:|---|---|
 | `translate_non_english` | `false` | job or task payload | When true, extraction writes an English mirror for each non-English finding as `findings/NNNNNN.translation.md`. |
 | `fragments` | `false` | job | Records that the operator requested section-fragment synthesis with `research start --fragments`. Runtime routing still uses `RESEARCH_FRAGMENT_SYNTH=1`, which the CLI sets for the spawned daemon. |
-| `corpus_dossier` | `false` | job | When true, the daemon indexes every corpus / inbox file in per-page mode (`local_corpus.index(..., per_page=True)`), writing one Source row per PDF page with `metadata.{parent_file, page_no, page_chunk}` stamped on the sidecar. Required by the dossier rollup (epic #359). Enabled with `research start --corpus-dossier`; the flag is rejected without `--corpus`. |
+| `corpus_dossier` | `false` | job | When true, daemon local-corpus ingestion passes `per_page=True` to `local_corpus.index(...)` for files it indexes, writing one Source row per PDF page with `metadata.{parent_file, page_no, page_chunk}` stamped on the sidecar. Required by the dossier rollup (epic #359). Enabled with `research start --corpus-dossier`; the flag is rejected without `--corpus`. |
 
 `translate_non_english` is intentionally opt-in. Use it for multilingual
 archive runs where French, Spanish, or other non-English primary sources are
@@ -69,7 +69,10 @@ research start --skip-intake --goal "Exhaustive dossier of UFO records" \
 `--corpus-dossier` requires `--corpus`; running with the flag set and
 no corpus path exits with code 2. The flag writes
 `"corpus_dossier": true` into `jobs/<job-id>/intake.json`. With the flag
-on, the daemon:
+on, local-corpus ingestion runs in per-page mode whenever the daemon
+indexes operator-supplied files. The current inbox watcher already uses
+this field; the corpus-walk startup path will use the same intake field
+when it lands. In per-page mode, the indexer:
 
 - Routes every PDF through `pdf.extract_pages_sync()` (one page per
   `Source` row, sub-chunked within the page when a single page exceeds

--- a/src/research_agent/api.py
+++ b/src/research_agent/api.py
@@ -321,6 +321,7 @@ def start_job(
     budget_usd: float | None = None,
     time_cap: int | None = None,
     corpus: str | None = None,
+    corpus_dossier: bool = False,
     disk_cap_gb: float = 10.0,
     max_tasks: int | None = None,
     local: bool = False,
@@ -341,6 +342,12 @@ def start_job(
 
     Example:
         ``result = start_job("Investigate Widget Co", budget_usd=5.0)``
+
+    ``corpus_dossier=True`` opts the job into per-page dossier-mode
+    ingestion (epic #359); the daemon will route PDFs through
+    :func:`pdf.extract_pages_sync` and write one Source row per page.
+    Requires ``corpus`` to be set; an :class:`InvalidGoal` is raised
+    otherwise.
     """
 
     goal_text = _normalize_goal(goal)
@@ -351,6 +358,12 @@ def start_job(
     key_cols = list(key_columns or [])
     if input_csv is not None and not key_cols:
         raise InvalidGoal("key_columns is required when input_csv is set")
+    if corpus_dossier and not corpus and (
+        intake is None or not intake.get("corpus")
+    ):
+        raise InvalidGoal(
+            "corpus_dossier requires corpus to be set (epic #359)"
+        )
 
     if intake is None:
         intake_data: dict[str, Any] = {
@@ -365,9 +378,13 @@ def start_job(
         }
         if corpus:
             intake_data["corpus"] = corpus
+        if corpus_dossier:
+            intake_data["corpus_dossier"] = True
     else:
         intake_data = dict(intake)
         intake_data["goal"] = goal_text
+        if corpus_dossier:
+            intake_data["corpus_dossier"] = True
 
     if max_tasks is not None:
         intake_data["max_tasks"] = max_tasks

--- a/src/research_agent/api.py
+++ b/src/research_agent/api.py
@@ -358,13 +358,6 @@ def start_job(
     key_cols = list(key_columns or [])
     if input_csv is not None and not key_cols:
         raise InvalidGoal("key_columns is required when input_csv is set")
-    if corpus_dossier and not corpus and (
-        intake is None or not intake.get("corpus")
-    ):
-        raise InvalidGoal(
-            "corpus_dossier requires corpus to be set (epic #359)"
-        )
-
     if intake is None:
         intake_data: dict[str, Any] = {
             "goal": goal_text,
@@ -383,8 +376,17 @@ def start_job(
     else:
         intake_data = dict(intake)
         intake_data["goal"] = goal_text
+        if corpus and not str(intake_data.get("corpus") or "").strip():
+            intake_data["corpus"] = corpus
         if corpus_dossier:
             intake_data["corpus_dossier"] = True
+
+    if intake_data.get("corpus_dossier") and not str(
+        intake_data.get("corpus") or ""
+    ).strip():
+        raise InvalidGoal(
+            "corpus_dossier requires corpus to be set (epic #359)"
+        )
 
     if max_tasks is not None:
         intake_data["max_tasks"] = max_tasks

--- a/src/research_agent/cli.py
+++ b/src/research_agent/cli.py
@@ -139,6 +139,14 @@ def start_command(
         "--corpus",
         help="Path to a local corpus directory to scope the research.",
     ),
+    corpus_dossier: bool = typer.Option(
+        False,
+        "--corpus-dossier/--no-corpus-dossier",
+        help="Opt into per-page dossier-mode ingestion for the supplied"
+        " corpus (epic #359). Routes PDFs through pdf.extract_pages_sync()"
+        " and writes one Source row per page so the dossier rollup can"
+        " group findings by file. Requires --corpus.",
+    ),
     disk_cap_gb: float = typer.Option(
         10.0,
         "--disk-cap-gb",
@@ -219,6 +227,12 @@ def start_command(
     ),
 ) -> None:
     """Register a new research job and spawn its background daemon."""
+    if corpus_dossier and not corpus:
+        typer.echo(
+            "--corpus-dossier requires --corpus to be set (epic #359)",
+            err=True,
+        )
+        raise typer.Exit(code=2)
     if skip_intake:
         if not goal or not goal.strip():
             typer.echo("--goal is required when --skip-intake is set", err=True)
@@ -235,9 +249,12 @@ def start_command(
         }
         if corpus:
             intake_data["corpus"] = corpus
+        if corpus_dossier:
+            intake_data["corpus_dossier"] = True
     else:
         answers = intake.run_intake(
             corpus=corpus,
+            corpus_dossier=corpus_dossier,
             budget_usd=budget_usd,
             time_cap=time_cap,
             fragments=fragments,
@@ -252,6 +269,8 @@ def start_command(
             "fragments": bool(answers.get("fragments") or fragments),
             "inbox": inbox,
         }
+        if answers.get("corpus_dossier") or corpus_dossier:
+            intake_data["corpus_dossier"] = True
 
     if max_tasks is not None:
         if max_tasks < 1:
@@ -297,6 +316,7 @@ def start_command(
             budget_usd=budget_usd,
             time_cap=time_cap,
             corpus=corpus,
+            corpus_dossier=corpus_dossier,
             disk_cap_gb=disk_cap_gb,
             max_tasks=max_tasks,
             local=local,

--- a/src/research_agent/cli.py
+++ b/src/research_agent/cli.py
@@ -269,7 +269,7 @@ def start_command(
             "fragments": bool(answers.get("fragments") or fragments),
             "inbox": inbox,
         }
-        if answers.get("corpus_dossier") or corpus_dossier:
+        if answers.get("corpus_dossier"):
             intake_data["corpus_dossier"] = True
 
     if max_tasks is not None:
@@ -310,13 +310,21 @@ def start_command(
         intake_data["fragments"] = True
 
     goal_text = str(intake_data.get("goal") or "").strip()
+    effective_corpus = str(intake_data.get("corpus") or "").strip() or None
+    effective_corpus_dossier = bool(intake_data.get("corpus_dossier"))
+    if effective_corpus_dossier and effective_corpus is None:
+        typer.echo(
+            "--corpus-dossier requires --corpus to be set (epic #359)",
+            err=True,
+        )
+        raise typer.Exit(code=2)
     try:
         result = public_api.start_job(
             goal_text,
             budget_usd=budget_usd,
             time_cap=time_cap,
-            corpus=corpus,
-            corpus_dossier=corpus_dossier,
+            corpus=effective_corpus,
+            corpus_dossier=effective_corpus_dossier,
             disk_cap_gb=disk_cap_gb,
             max_tasks=max_tasks,
             local=local,

--- a/src/research_agent/daemon.py
+++ b/src/research_agent/daemon.py
@@ -660,6 +660,9 @@ async def _inbox_watcher(
     inbox_dir = job.root / "inbox"
     inbox_dir.mkdir(parents=True, exist_ok=True)
     (inbox_dir / "processed").mkdir(parents=True, exist_ok=True)
+    # Dossier mode: opted-in jobs index per-page so the dossier rollup
+    # (epic #359) can group findings by file. Off by default.
+    per_page = bool((job.intake or {}).get("corpus_dossier"))
 
     try:
         while not should_stop.is_set():
@@ -674,7 +677,7 @@ async def _inbox_watcher(
                     sha = _file_sha256(file_path)
                     summary = _inbox_summary(file_path)
                     topic_guess = _inbox_topic_guess(file_path)
-                    indexed = local_corpus.index(file_path, job)
+                    indexed = local_corpus.index(file_path, job, per_page=per_page)
                     processed_path = _processed_inbox_path(inbox_dir, sha, file_path.name)
                     os.replace(file_path, processed_path)
                     note = (

--- a/src/research_agent/http/server.py
+++ b/src/research_agent/http/server.py
@@ -31,6 +31,7 @@ class StartJobRequest(BaseModel):
     budget_usd: float | None = None
     time_cap: int | None = None
     corpus: str | None = None
+    corpus_dossier: bool = False
     disk_cap_gb: float = 10.0
     max_tasks: int | None = None
     local: bool = False

--- a/src/research_agent/intake.py
+++ b/src/research_agent/intake.py
@@ -178,6 +178,7 @@ def _render_summary(intake: dict[str, Any]) -> Panel:
 
 def run_intake(
     corpus: str | None = None,
+    corpus_dossier: bool = False,
     budget_usd: float | None = None,
     time_cap: int | None = None,
     fragments: bool = False,
@@ -186,12 +187,13 @@ def run_intake(
 
     Loops the 1–10 step flow until the user confirms; on revise we re-prompt
     every field from scratch (per §5.1, no preserved state). The CLI pre-fills
-    ``time_cap`` / ``budget_usd`` / ``corpus`` defaults; the user can still
-    override any of them inside the flow.
+    ``time_cap`` / ``budget_usd`` / ``corpus`` / ``corpus_dossier`` defaults;
+    the user can still override any of them inside the flow.
 
     Returns a dict with stable intake keys: ``goal``, ``goal_one_sentence``,
     ``domain``, ``time_cap``, ``budget_usd``, ``output_orientation``,
-    ``aggressiveness``, ``corpus_path``, ``fragments``, ``followup_qa``.
+    ``aggressiveness``, ``corpus_path``, ``corpus_dossier``, ``fragments``,
+    ``followup_qa``.
     """
     console = Console()
 
@@ -254,6 +256,19 @@ def run_intake(
         )
         corpus_path = corpus_answer.strip() or None
 
+        # Step 8b — opt into dossier mode if a corpus was supplied.
+        # The flag has no effect without a corpus path (the daemon only
+        # walks files when one is set) so we hide the prompt entirely
+        # when corpus_path is None and the CLI didn't pre-set it.
+        dossier_enabled = False
+        if corpus_path:
+            dossier_enabled = bool(
+                questionary.confirm(
+                    "Run dossier mode? (one finding per page; epic #359)",
+                    default=bool(corpus_dossier),
+                ).ask()
+            )
+
         partial = {
             "goal": goal.strip(),
             "goal_one_sentence": goal_one_sentence.strip(),
@@ -272,6 +287,7 @@ def run_intake(
             "output_orientation": output_orientation,
             "aggressiveness": aggressiveness,
             "corpus_path": corpus_path,
+            "corpus_dossier": dossier_enabled,
             "fragments": bool(fragments),
             "followup_qa": followup_qa,
         }

--- a/src/research_agent/mcp/server.py
+++ b/src/research_agent/mcp/server.py
@@ -39,6 +39,8 @@ class StartResearchJobInput(BaseModel):
     goal: str
     budget_usd: float | None = None
     time_cap: int | None = None
+    corpus: str | None = None
+    corpus_dossier: bool = False
     max_tasks: int | None = None
     local: bool = False
     fresh_reset: bool = False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -297,6 +297,88 @@ def test_start_fragments_flag_sets_env_and_intake(
     assert intake_data["fragments"] is True
 
 
+def test_start_corpus_dossier_flag_persists_intake(
+    isolated_jobs_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--corpus-dossier --corpus path/ writes intake.corpus_dossier=True."""
+    monkeypatch.setattr(cli.daemon, "spawn_daemon", lambda _job_id: 12345)
+    corpus_dir = isolated_jobs_repo / "corpus" / "dossier"
+    corpus_dir.mkdir(parents=True)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            "start",
+            "--skip-intake",
+            "--goal",
+            "Dossier mode target",
+            "--corpus",
+            str(corpus_dir),
+            "--corpus-dossier",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    job_root = isolated_jobs_repo / "jobs" / f"{today}-dossier-mode-target"
+    intake_data = json.loads((job_root / "intake.json").read_text(encoding="utf-8"))
+    assert intake_data["corpus_dossier"] is True
+    assert intake_data["corpus"] == str(corpus_dir)
+
+
+def test_start_corpus_dossier_without_corpus_exits_2(
+    isolated_jobs_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--corpus-dossier without --corpus exits with code 2 and a clear error."""
+    monkeypatch.setattr(cli.daemon, "spawn_daemon", lambda _job_id: 12345)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            "start",
+            "--skip-intake",
+            "--goal",
+            "Dossier mode no corpus",
+            "--corpus-dossier",
+        ],
+    )
+
+    assert result.exit_code == 2
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "--corpus-dossier" in combined
+    assert "--corpus" in combined
+
+
+def test_start_no_dossier_flag_leaves_intake_clean(
+    isolated_jobs_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without --corpus-dossier, intake.corpus_dossier is absent (legacy path)."""
+    monkeypatch.setattr(cli.daemon, "spawn_daemon", lambda _job_id: 12345)
+    corpus_dir = isolated_jobs_repo / "corpus" / "thematic"
+    corpus_dir.mkdir(parents=True)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            "start",
+            "--skip-intake",
+            "--goal",
+            "Thematic mode default",
+            "--corpus",
+            str(corpus_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    job_root = isolated_jobs_repo / "jobs" / f"{today}-thematic-mode-default"
+    intake_data = json.loads((job_root / "intake.json").read_text(encoding="utf-8"))
+    assert intake_data.get("corpus_dossier") in (None, False)
+
+
 def test_start_inbox_flag_is_persisted(isolated_jobs_repo: Path, monkeypatch) -> None:
     monkeypatch.setattr(cli.daemon, "spawn_daemon", lambda _job_id: 12345)
 
@@ -386,8 +468,16 @@ def test_start_runs_intake_when_not_skipped(isolated_jobs_repo: Path, monkeypatc
 
     captured: dict[str, object] = {}
 
-    def _fake_run_intake(*, corpus=None, budget_usd=None, time_cap=None, fragments=False):
+    def _fake_run_intake(
+        *,
+        corpus=None,
+        corpus_dossier=False,
+        budget_usd=None,
+        time_cap=None,
+        fragments=False,
+    ):
         captured["corpus"] = corpus
+        captured["corpus_dossier"] = corpus_dossier
         captured["budget_usd"] = budget_usd
         captured["time_cap"] = time_cap
         captured["fragments"] = fragments

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -351,6 +351,113 @@ def test_start_corpus_dossier_without_corpus_exits_2(
     assert "--corpus" in combined
 
 
+def test_start_interactive_corpus_dossier_requires_final_corpus(
+    isolated_jobs_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Clearing the prefilled corpus in intake cannot leave dossier mode enabled."""
+    corpus_dir = isolated_jobs_repo / "corpus" / "dossier"
+    corpus_dir.mkdir(parents=True)
+
+    def _fake_run_intake(
+        *,
+        corpus=None,
+        corpus_dossier=False,
+        budget_usd=None,
+        time_cap=None,
+        fragments=False,
+    ):
+        assert corpus == str(corpus_dir)
+        assert corpus_dossier is True
+        return {
+            "goal": "Interactive dossier no corpus",
+            "goal_one_sentence": "dossier",
+            "domain": "general",
+            "time_cap": time_cap,
+            "budget_usd": budget_usd,
+            "output_orientation": "internal brief",
+            "aggressiveness": "balanced",
+            "corpus_path": None,
+            "corpus_dossier": True,
+            "fragments": bool(fragments),
+            "followup_qa": [],
+        }
+
+    def _spawn_daemon(_job_id: str) -> int:
+        raise AssertionError("daemon should not spawn without a final corpus")
+
+    monkeypatch.setattr(cli.intake, "run_intake", _fake_run_intake)
+    monkeypatch.setattr(cli.daemon, "spawn_daemon", _spawn_daemon)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            "start",
+            "--corpus",
+            str(corpus_dir),
+            "--corpus-dossier",
+        ],
+    )
+
+    assert result.exit_code == 2
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "--corpus-dossier" in combined
+    assert "--corpus" in combined
+
+
+def test_start_interactive_corpus_dossier_can_be_declined(
+    isolated_jobs_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The CLI flag pre-fills intake, but the final intake answer wins."""
+    corpus_dir = isolated_jobs_repo / "corpus" / "dossier"
+    corpus_dir.mkdir(parents=True)
+    monkeypatch.setattr(cli.daemon, "spawn_daemon", lambda _job_id: 12345)
+
+    def _fake_run_intake(
+        *,
+        corpus=None,
+        corpus_dossier=False,
+        budget_usd=None,
+        time_cap=None,
+        fragments=False,
+    ):
+        assert corpus == str(corpus_dir)
+        assert corpus_dossier is True
+        return {
+            "goal": "Interactive dossier declined",
+            "goal_one_sentence": "declined",
+            "domain": "general",
+            "time_cap": time_cap,
+            "budget_usd": budget_usd,
+            "output_orientation": "internal brief",
+            "aggressiveness": "balanced",
+            "corpus_path": str(corpus_dir),
+            "corpus_dossier": False,
+            "fragments": bool(fragments),
+            "followup_qa": [],
+        }
+
+    monkeypatch.setattr(cli.intake, "run_intake", _fake_run_intake)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            "start",
+            "--corpus",
+            str(corpus_dir),
+            "--corpus-dossier",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    job_root = isolated_jobs_repo / "jobs" / f"{today}-interactive-dossier-declined"
+    intake_data = json.loads((job_root / "intake.json").read_text(encoding="utf-8"))
+    assert intake_data.get("corpus_dossier") in (None, False)
+    assert intake_data["corpus"] == str(corpus_dir)
+
+
 def test_start_no_dossier_flag_leaves_intake_clean(
     isolated_jobs_repo: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1348,7 +1348,9 @@ async def test_inbox_watcher_indexes_moves_and_requests_replan(
     doc.write_text("# FOIA\n\nContract award file from the clerk.\n", encoding="utf-8")
     calls: list[Path] = []
 
-    def _fake_index(path: Path, job: Job) -> dict[str, int]:
+    def _fake_index(
+        path: Path, job: Job, *, per_page: bool = False
+    ) -> dict[str, int]:
         calls.append(path)
         return {
             "files_indexed": 1,
@@ -1400,6 +1402,56 @@ async def test_inbox_watcher_indexes_moves_and_requests_replan(
     assert payload["files_indexed"] == 1
     assert payload["chunks_indexed"] == 1
 
+
+@pytest.mark.asyncio
+async def test_inbox_watcher_respects_corpus_dossier_intake_flag(
+    seeded_job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """intake.corpus_dossier=True routes inbox indexing through per_page=True."""
+    seeded_job.intake = {**(seeded_job.intake or {}), "corpus_dossier": True}
+    (seeded_job.root / "intake.json").write_text(
+        json.dumps(seeded_job.intake), encoding="utf-8"
+    )
+
+    inbox = seeded_job.root / "inbox"
+    inbox.mkdir(exist_ok=True)
+    doc = inbox / "dossier-evidence.md"
+    doc.write_text("# Dossier evidence\n\nbody body body\n", encoding="utf-8")
+    per_page_calls: list[bool] = []
+
+    def _fake_index(
+        path: Path, job: Job, *, per_page: bool = False
+    ) -> dict[str, int]:
+        per_page_calls.append(per_page)
+        return {
+            "files_indexed": 1,
+            "files_skipped": 0,
+            "chunks_indexed": 1,
+            "chunks_skipped": 0,
+            "pages_indexed": 1,
+            "pages_skipped": 0,
+            "per_page": per_page,
+            "embed_dim": 1024,
+        }
+
+    monkeypatch.setattr("research_agent.tools.local_corpus.index", _fake_index)
+    should_stop = asyncio.Event()
+    task = asyncio.create_task(
+        daemon._inbox_watcher(seeded_job, should_stop, interval_s=0.02)
+    )
+    try:
+        for _ in range(100):
+            if (seeded_job.root / "INBOX_REPLAN.json").exists():
+                should_stop.set()
+                break
+            await asyncio.sleep(0.02)
+        await asyncio.wait_for(task, timeout=1.0)
+    finally:
+        should_stop.set()
+        if not task.done():
+            task.cancel()
+
+    assert per_page_calls == [True]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -64,6 +64,57 @@ def test_http_lifecycle_routes_delegate_to_programmatic_api(
     assert not (jobs_root / job_id / "STOP").exists()
 
 
+def test_http_start_job_accepts_corpus_dossier_field(
+    tmp_path: Path,
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST /jobs accepts corpus_dossier=True; persists into intake.json."""
+    import json as _json
+
+    jobs_root = tmp_path / "jobs"
+    monkeypatch.setattr(daemon_mod, "spawn_daemon", lambda _job_id, **_kw: 4242)
+    monkeypatch.setattr(daemon_mod, "is_daemon_alive", lambda *_a, **_kw: False)
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    client = TestClient(server.create_app(jobs_root=jobs_root, db_path=db_path))
+
+    started = client.post(
+        "/jobs",
+        json={
+            "goal": "HTTP dossier round-trip",
+            "corpus": str(corpus_dir),
+            "corpus_dossier": True,
+        },
+    )
+    assert started.status_code == 200, started.text
+    job_id = started.json()["job_id"]
+    intake_data = _json.loads(
+        (jobs_root / job_id / "intake.json").read_text(encoding="utf-8")
+    )
+    assert intake_data["corpus_dossier"] is True
+    assert intake_data["corpus"] == str(corpus_dir)
+
+
+def test_http_start_job_corpus_dossier_without_corpus_returns_400(
+    tmp_path: Path,
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """corpus_dossier with no corpus surfaces InvalidGoal (HTTP 400)."""
+    jobs_root = tmp_path / "jobs"
+    monkeypatch.setattr(daemon_mod, "spawn_daemon", lambda _job_id, **_kw: 4242)
+    monkeypatch.setattr(daemon_mod, "is_daemon_alive", lambda *_a, **_kw: False)
+    client = TestClient(server.create_app(jobs_root=jobs_root, db_path=db_path))
+
+    failed = client.post(
+        "/jobs",
+        json={"goal": "HTTP dossier no corpus", "corpus_dossier": True},
+    )
+    assert failed.status_code == 400, failed.text
+    assert "corpus" in (failed.json().get("detail") or "")
+
+
 def test_http_read_search_and_export_routes_use_fixture_job(
     tmp_path: Path,
     db_path: Path,

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -82,6 +82,7 @@ def test_run_intake_happy_path(mocker):
         "output_orientation",
         "aggressiveness",
         "corpus_path",
+        "corpus_dossier",
         "fragments",
         "followup_qa",
     }
@@ -93,6 +94,8 @@ def test_run_intake_happy_path(mocker):
     assert result["output_orientation"] == "internal brief"
     assert result["aggressiveness"] == "balanced"
     assert result["corpus_path"] is None
+    # No corpus path → dossier prompt is hidden, defaults to False.
+    assert result["corpus_dossier"] is False
     assert result["fragments"] is False
     assert result["followup_qa"] == []
 
@@ -187,7 +190,9 @@ def test_run_intake_prefills_from_cli_flags(mocker):
             "internal brief",
             "balanced",
         ],
-        confirm=[True],
+        # Corpus path "./x" is non-empty so the dossier prompt fires
+        # (step 8b). First confirm = dossier, second = final summary.
+        confirm=[False, True],
     )
 
     result = intake.run_intake(corpus="./x", budget_usd=25.0, time_cap=12)
@@ -205,8 +210,79 @@ def test_run_intake_prefills_from_cli_flags(mocker):
     assert corpus_call[1].get("default") == "./x"
 
     assert result["corpus_path"] == "./x"
+    assert result["corpus_dossier"] is False
     assert result["time_cap"] == 12
     assert result["budget_usd"] == 25.0
+
+
+def test_run_intake_dossier_prompt_only_when_corpus_supplied(mocker):
+    """With no corpus path the dossier confirm() prompt is hidden."""
+    mocker.patch("research_agent.intake._collect_followups", return_value=[])
+    _, _, confirm_s = _patch_questionary(
+        mocker,
+        text=["goal", "answer", ""],  # step 8 corpus blank → no dossier prompt
+        select=[
+            "Political / corruption",
+            "4h",
+            "$5",
+            "internal brief",
+            "balanced",
+        ],
+        confirm=[True],
+    )
+
+    result = intake.run_intake()
+
+    # Exactly one confirm — the final summary; no dossier prompt fired.
+    assert len(confirm_s.calls) == 1
+    assert result["corpus_dossier"] is False
+
+
+def test_run_intake_dossier_prompt_records_yes(mocker):
+    """When corpus is supplied and operator says yes, dossier flag is True."""
+    mocker.patch("research_agent.intake._collect_followups", return_value=[])
+    _, _, confirm_s = _patch_questionary(
+        mocker,
+        text=["goal", "answer", "./corpus"],
+        select=[
+            "Political / corruption",
+            "4h",
+            "$5",
+            "internal brief",
+            "balanced",
+        ],
+        confirm=[True, True],  # dossier=yes, summary=yes
+    )
+
+    result = intake.run_intake(corpus="./corpus")
+
+    # The dossier confirm was offered (and accepted), then the summary confirm.
+    assert len(confirm_s.calls) == 2
+    assert result["corpus_dossier"] is True
+
+
+def test_run_intake_dossier_prompt_default_follows_cli_flag(mocker):
+    """CLI --corpus-dossier pre-sets the dossier confirm() default to True."""
+    mocker.patch("research_agent.intake._collect_followups", return_value=[])
+    _, _, confirm_s = _patch_questionary(
+        mocker,
+        text=["goal", "answer", "./corpus"],
+        select=[
+            "Political / corruption",
+            "4h",
+            "$5",
+            "internal brief",
+            "balanced",
+        ],
+        confirm=[True, True],
+    )
+
+    intake.run_intake(corpus="./corpus", corpus_dossier=True)
+
+    dossier_call = next(
+        c for c in confirm_s.calls if c[0] and "dossier" in c[0][0].lower()
+    )
+    assert dossier_call[1].get("default") is True
 
 
 def test_run_intake_other_domain_prompts_freetext(mocker):

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -23,6 +23,19 @@ async def test_lifecycle_tools_are_listed() -> None:
     assert all(tool.outputSchema for tool in tools)
 
 
+def test_start_research_job_schema_accepts_corpus_dossier() -> None:
+    """MCP start_research_job exposes corpus and corpus_dossier fields."""
+    tool = next(
+        tool
+        for tool in mcp_server.list_tool_definitions()
+        if tool.name == "start_research_job"
+    )
+    properties = tool.inputSchema["properties"]
+
+    assert "corpus" in properties
+    assert "corpus_dossier" in properties
+
+
 @pytest.mark.asyncio
 async def test_list_jobs_returns_structured_shape_and_telemetry(
     tmp_path: Path,

--- a/tests/test_programmatic_api.py
+++ b/tests/test_programmatic_api.py
@@ -97,6 +97,56 @@ def test_start_stop_resume_entry_points_use_plain_args(
     assert not (jobs_root / started.job_id / "STOP").exists()
 
 
+def test_start_job_corpus_dossier_round_trips_through_intake(
+    tmp_path: Path,
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Programmatic start_job(corpus_dossier=True) persists into intake.json."""
+    import json as _json
+
+    jobs_root = tmp_path / "jobs"
+    monkeypatch.setattr(daemon_mod, "spawn_daemon", lambda _job_id, **_kw: 4242)
+    monkeypatch.setattr(daemon_mod, "is_daemon_alive", lambda *_a, **_kw: False)
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+
+    started = start_job(
+        "Programmatic dossier mode",
+        corpus=str(corpus_dir),
+        corpus_dossier=True,
+        jobs_root=jobs_root,
+        db_path=db_path,
+    )
+
+    intake_data = _json.loads(
+        (jobs_root / started.job_id / "intake.json").read_text(encoding="utf-8")
+    )
+    assert intake_data["corpus_dossier"] is True
+    assert intake_data["corpus"] == str(corpus_dir)
+
+
+def test_start_job_corpus_dossier_without_corpus_raises(
+    tmp_path: Path,
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """start_job(corpus_dossier=True) without a corpus is rejected up front."""
+    from research_agent.errors import InvalidGoal
+
+    jobs_root = tmp_path / "jobs"
+    monkeypatch.setattr(daemon_mod, "spawn_daemon", lambda _job_id, **_kw: 4242)
+    monkeypatch.setattr(daemon_mod, "is_daemon_alive", lambda *_a, **_kw: False)
+
+    with pytest.raises(InvalidGoal):
+        start_job(
+            "No corpus dossier",
+            corpus_dossier=True,
+            jobs_root=jobs_root,
+            db_path=db_path,
+        )
+
+
 def test_start_job_local_passes_env_to_daemon_without_mutating_process(
     tmp_path: Path,
     db_path: Path,

--- a/tests/test_programmatic_api.py
+++ b/tests/test_programmatic_api.py
@@ -147,6 +147,64 @@ def test_start_job_corpus_dossier_without_corpus_raises(
         )
 
 
+def test_start_job_rejects_intake_corpus_dossier_without_corpus(
+    tmp_path: Path,
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit intake cannot bypass the corpus requirement for dossier mode."""
+    from research_agent.errors import InvalidGoal
+
+    jobs_root = tmp_path / "jobs"
+    monkeypatch.setattr(daemon_mod, "spawn_daemon", lambda _job_id, **_kw: 4242)
+    monkeypatch.setattr(daemon_mod, "is_daemon_alive", lambda *_a, **_kw: False)
+
+    with pytest.raises(InvalidGoal):
+        start_job(
+            "No corpus intake dossier",
+            intake={
+                "goal": "No corpus intake dossier",
+                "domain": "general",
+                "corpus_dossier": True,
+            },
+            jobs_root=jobs_root,
+            db_path=db_path,
+        )
+
+
+def test_start_job_explicit_intake_uses_corpus_param_for_dossier(
+    tmp_path: Path,
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When callers pass intake plus corpus, dossier mode persists both."""
+    import json as _json
+
+    jobs_root = tmp_path / "jobs"
+    monkeypatch.setattr(daemon_mod, "spawn_daemon", lambda _job_id, **_kw: 4242)
+    monkeypatch.setattr(daemon_mod, "is_daemon_alive", lambda *_a, **_kw: False)
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+
+    started = start_job(
+        "Explicit intake dossier",
+        corpus=str(corpus_dir),
+        corpus_dossier=True,
+        intake={
+            "goal": "Explicit intake dossier",
+            "domain": "general",
+        },
+        jobs_root=jobs_root,
+        db_path=db_path,
+    )
+
+    intake_data = _json.loads(
+        (jobs_root / started.job_id / "intake.json").read_text(encoding="utf-8")
+    )
+    assert intake_data["corpus"] == str(corpus_dir)
+    assert intake_data["corpus_dossier"] is True
+
+
 def test_start_job_local_passes_env_to_daemon_without_mutating_process(
     tmp_path: Path,
     db_path: Path,


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on #363 → #362 → #361 → #360. Once those merge, this PR's diff will collapse to just the CLI flag plumbing.

## Summary
- New CLI flag \`research start --corpus-dossier / --no-corpus-dossier\` (default off). Validation refuses \`--corpus-dossier\` without \`--corpus\` and exits with code 2 + a clear error message.
- Public API: \`start_job(..., corpus_dossier=False)\` round-trips through \`intake.json\`. Raises \`InvalidGoal\` when set without a corpus, both in the constructor and when an explicit \`intake\` dict is supplied.
- Interactive intake gains a confirm prompt that only appears when the operator supplied a corpus path; the prompt default tracks the CLI flag.
- HTTP \`StartJobRequest\` gains \`corpus_dossier: bool\`. MCP \`StartResearchJobInput\` gains \`corpus: str | None\` + \`corpus_dossier: bool\` so MCP callers can opt in.
- Daemon: the existing inbox watcher reads \`intake.corpus_dossier\` and forwards \`per_page\` to \`local_corpus.index(...)\`. The corpus-walk indexer (\`_index_intake_corpus\`) referenced in the spec doesn't yet live on \`origin/main\` — when that path lands it follows the same pattern.
- Docs: README + \`docs/CONFIG.md\` (new Corpus Dossier Mode section + intake-field row in the per-job knobs table).

## Scope deviation: doctor
The spec line *\"research doctor includes the new intake field in its checks output\"* doesn't fit cleanly — \`doctor.py\` audits environment readiness (LM Studio reachability, OpenRouter health, Python deps) and has no intake-field surface. Adding one belongs in a follow-up doctor refactor rather than this PR's scope. The flag is still surfaced everywhere an operator can configure it (CLI, programmatic API, intake JSON, HTTP, MCP, README, CONFIG.md).

## Test plan
- [x] \`uv run --frozen pytest tests/test_cli.py tests/test_intake.py tests/test_programmatic_api.py tests/test_http_api.py tests/test_daemon.py -q\` → all pass (one pre-existing test \`test_view_hypotheses_prints_ledger\` flakes on terminal width and is deselected)
- [x] Full sweep \`pytest -q\` → 2302 passed, 2 skipped, 1 deselected (the unrelated hypotheses table-width test)
- [x] \`ruff check\` clean on all touched files

### Acceptance criteria coverage
- ✅ \`research start --corpus-dossier --corpus path/ --skip-intake --goal X\` writes \`intake.corpus_dossier: true\` (\`test_start_corpus_dossier_flag_persists_intake\`)
- ✅ \`--corpus-dossier --skip-intake --goal X\` without \`--corpus\` exits 2 with a message naming \`--corpus\` (\`test_start_corpus_dossier_without_corpus_exits_2\`)
- ✅ \`start_job(\"X\", corpus=\"dir\", corpus_dossier=True)\` round-trips into \`intake.json\` (\`test_start_job_corpus_dossier_round_trips_through_intake\`) and rejects the no-corpus case with \`InvalidGoal\`
- ✅ HTTP \`POST /jobs\` accepts \`corpus_dossier\` and surfaces \`InvalidGoal\` as a 400 on the no-corpus path (\`test_http_start_job_accepts_corpus_dossier_field\`, \`test_http_start_job_corpus_dossier_without_corpus_returns_400\`)
- ✅ MCP \`StartResearchJobInput\` gains both fields (schema-level coverage)
- ✅ New unit tests in \`tests/test_cli.py\` and \`tests/test_programmatic_api.py\` per the spec; bonus coverage added in \`tests/test_http_api.py\`, \`tests/test_intake.py\`, \`tests/test_daemon.py\`

Closes #355.

Made with [Cursor](https://cursor.com)