### PR TITLE
feat(coverage): declare file + page coverage units after corpus indexing (#356)

### DIFF
--- a/src/research_agent/daemon.py
+++ b/src/research_agent/daemon.py
@@ -647,6 +647,38 @@ def _processed_inbox_path(inbox_dir: Path, sha: str, filename: str) -> Path:
     return processed_dir / f"{sha}-{safe_name}"
 
 
+def _declare_dossier_coverage_units(job: Job, *, trigger: str) -> None:
+    """Declare per-page coverage units after a dossier-mode index pass.
+
+    Walks the ``sources`` rows already linked to the job and stamps one
+    coverage unit per page (or per non-paginated chunk) via
+    :func:`coverage.declare_corpus_units`. Idempotent — re-running on a
+    job with existing units preserves their statuses; only newly-added
+    rows produce new units. Emits a ``coverage_declared`` event with
+    file_count + page_count so operators see when gating kicks in.
+
+    ``trigger`` is the high-level event source (``"inbox"`` today;
+    ``"corpus_walk"`` when the daemon's intake-corpus indexer lands).
+    """
+    from research_agent.storage import coverage
+
+    units = coverage.declare_corpus_units(job)
+    files = {unit.dimensions.get("file") for unit in units if unit.dimensions.get("file")}
+    page_count = sum(1 for unit in units if "page" in unit.dimensions)
+    emit(
+        job,
+        "INFO",
+        "daemon",
+        "coverage_declared",
+        {
+            "trigger": trigger,
+            "file_count": len(files),
+            "page_count": page_count,
+            "total_units": len(units),
+        },
+    )
+
+
 async def _inbox_watcher(
     job: Job,
     should_stop: asyncio.Event,
@@ -713,6 +745,8 @@ async def _inbox_watcher(
                             **indexed,
                         },
                     )
+                    if per_page:
+                        _declare_dossier_coverage_units(job, trigger="inbox")
                 except Exception as exc:  # noqa: BLE001 — keep watcher alive
                     logger.exception("inbox watcher failed for %s", file_path)
                     try:

--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -63,6 +63,7 @@ EventKind = Literal[
     "low_yield_connector",
     "hypothesis_updated",
     "corpus_doc_added",
+    "coverage_declared",
     "llm_call",
     "lmstudio_degraded",
     "lmstudio_recovered",

--- a/src/research_agent/storage/coverage.py
+++ b/src/research_agent/storage/coverage.py
@@ -485,6 +485,122 @@ def mark_task_failed(job: Job, task: dict[str, Any], reason: str) -> None:
     )
 
 
+def declare_corpus_units(job: Job) -> list[CoverageUnit]:
+    """Declare one coverage unit per indexed corpus Source row (issue #356).
+
+    Reads every ``sources`` row linked to ``job`` whose ``kind='local'``
+    and whose JSON sidecar carries ``metadata.parent_file``, then
+    declares one unit per row with dimensions
+    ``{"file": parent_file, "page": page_no, "page_chunk": page_chunk}``.
+
+    Page-grain units (``page_no`` set) are the source of truth for
+    completion gating; HTML / MD / TXT rows ingest as a single unit per
+    chunk with ``page=null`` so :func:`file_status` still recognises
+    them. Rows with no sidecar metadata (legacy thematic-mode ingests
+    that pre-date dossier mode) are skipped — those jobs should not
+    have coverage units in the first place.
+
+    Idempotent via :func:`declare_coverage` upserts: existing statuses
+    and attempt histories are preserved, so a resume path can replay
+    this without clobbering progress.
+
+    Returns the full list of units now stored on the job (not just the
+    delta), matching :func:`declare_coverage` semantics.
+    """
+    from research_agent.storage.sources import read_source_metadata
+
+    conn = db.connect(job.db_path)
+    try:
+        rows = conn.execute(
+            """
+            SELECT s.sha256 AS sha, s.url AS url
+            FROM sources s
+            JOIN job_sources js ON js.source_id = s.id
+            WHERE js.job_id = ? AND s.kind = ?
+            ORDER BY s.id ASC
+            """,
+            (job.id, "local"),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    new_units: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            meta = read_source_metadata(job, row["sha"])
+        except FileNotFoundError:
+            continue
+        parent = meta.get("parent_file")
+        if not parent:
+            continue
+        page_no = meta.get("page_no")
+        page_chunk = meta.get("page_chunk")
+        dims: dict[str, Any] = {"file": parent}
+        if page_no is not None:
+            dims["page"] = int(page_no)
+        if page_chunk is not None:
+            dims["page_chunk"] = int(page_chunk)
+        new_units.append({"dimensions": dims, "status": "pending"})
+
+    if not new_units:
+        return list_units(job)
+    return declare_coverage(job, new_units)
+
+
+def file_status(job: Job, file_url: str) -> CoverageStatus:
+    """Roll up per-page unit statuses into a per-file coverage status.
+
+    File status is derived from the page units sharing the same
+    ``dims.file`` value. Rules (in evaluation order):
+
+    - No matching units → ``pending`` (caller may have declared the
+      file before any pages were declared).
+    - All page units :data:`TERMINAL_STATUSES`:
+
+      - all ``complete`` → ``complete``.
+      - all ``confirmed_gap`` → ``confirmed_gap``.
+      - all ``not_yet_public`` → ``not_yet_public``.
+      - mixed terminal statuses → ``complete`` (the file landed
+        something; gap pages stay visible as their own units).
+    - Any page in :data:`BLOCKING_STATUSES` with at least one other
+      page already terminal-complete / -gap / -not-yet-public, or with
+      any unit explicitly in ``in_progress``, or with attempt history
+      → ``in_progress``.
+    - Otherwise (every page still pending, no attempts) → ``pending``.
+    """
+    if not isinstance(file_url, str) or not file_url:
+        raise ValueError("file_url must be a non-empty string")
+
+    matching: list[CoverageUnit] = []
+    for unit in list_units(job):
+        if unit.dimensions.get("file") == file_url:
+            matching.append(unit)
+
+    if not matching:
+        return "pending"
+
+    statuses = {unit.status for unit in matching}
+    terminal_set = statuses & TERMINAL_STATUSES
+    blocking_set = statuses & BLOCKING_STATUSES
+
+    if not blocking_set:
+        if statuses == {"complete"}:
+            return "complete"
+        if statuses == {"confirmed_gap"}:
+            return "confirmed_gap"
+        if statuses == {"not_yet_public"}:
+            return "not_yet_public"
+        return "complete"
+
+    if (
+        terminal_set
+        or "in_progress" in statuses
+        or any(unit.recent_attempts for unit in matching)
+    ):
+        return "in_progress"
+    return "pending"
+
+
 def replan_context(job: Job) -> dict[str, Any] | None:
     if not has_coverage(job):
         return None
@@ -508,10 +624,12 @@ __all__ = [
     "CoverageStatus",
     "CoverageUnit",
     "blocking_units",
+    "declare_corpus_units",
     "declare_coverage",
     "declare_from_intake",
     "dim_key_for",
     "dimensions_from_task_and_row",
+    "file_status",
     "has_coverage",
     "is_coverage_complete",
     "list_units",

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1454,6 +1454,92 @@ async def test_inbox_watcher_respects_corpus_dossier_intake_flag(
     assert per_page_calls == [True]
 
 
+@pytest.mark.asyncio
+async def test_inbox_watcher_declares_coverage_units_after_dossier_index(
+    seeded_job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Dossier-mode inbox runs declare per-page coverage + emit coverage_declared."""
+    from research_agent.storage import coverage
+    from research_agent.storage.sources import write_source
+
+    seeded_job.intake = {**(seeded_job.intake or {}), "corpus_dossier": True}
+    (seeded_job.root / "intake.json").write_text(
+        json.dumps(seeded_job.intake), encoding="utf-8"
+    )
+
+    inbox = seeded_job.root / "inbox"
+    inbox.mkdir(exist_ok=True)
+    doc = inbox / "page-evidence.pdf"
+    doc.write_bytes(b"%PDF-1.4 stub")
+
+    def _fake_index(
+        path: Path, job: Job, *, per_page: bool = False
+    ) -> dict[str, int]:
+        # Simulate the M0.2 per-page path: write three page sources
+        # with dossier-mode metadata.
+        for page_no in (1, 2, 3):
+            write_source(
+                job,
+                url=f"file://{path}",
+                title=path.name,
+                raw_content=f"page {page_no} body content",
+                kind="local",
+                metadata={
+                    "parent_file": f"file://{path}",
+                    "page_no": page_no,
+                    "page_chunk": None,
+                },
+            )
+        return {
+            "files_indexed": 1,
+            "files_skipped": 0,
+            "chunks_indexed": 3,
+            "chunks_skipped": 0,
+            "pages_indexed": 3,
+            "pages_skipped": 0,
+            "per_page": per_page,
+            "embed_dim": 1024,
+        }
+
+    monkeypatch.setattr("research_agent.tools.local_corpus.index", _fake_index)
+    should_stop = asyncio.Event()
+    task = asyncio.create_task(
+        daemon._inbox_watcher(seeded_job, should_stop, interval_s=0.02)
+    )
+    try:
+        for _ in range(100):
+            if (seeded_job.root / "INBOX_REPLAN.json").exists():
+                should_stop.set()
+                break
+            await asyncio.sleep(0.02)
+        await asyncio.wait_for(task, timeout=1.0)
+    finally:
+        should_stop.set()
+        if not task.done():
+            task.cancel()
+
+    # 3 page units declared and gating active.
+    units = coverage.list_units(seeded_job)
+    assert len(units) == 3
+    assert coverage.is_coverage_complete(seeded_job) is False
+
+    # coverage_declared event emitted with file_count + page_count.
+    conn = db.connect(seeded_job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT payload_json FROM events WHERE job_id = ? AND kind = ?",
+            (seeded_job.id, "coverage_declared"),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    payload = json.loads(rows[0]["payload_json"])
+    assert payload["trigger"] == "inbox"
+    assert payload["file_count"] == 1
+    assert payload["page_count"] == 3
+    assert payload["total_units"] == 3
+
+
 # ---------------------------------------------------------------------------
 # _cancel_with_timeout — bounds daemon teardown so a hung watcher can't block exit
 # ---------------------------------------------------------------------------

--- a/tests/test_storage_coverage.py
+++ b/tests/test_storage_coverage.py
@@ -138,6 +138,245 @@ def test_fec_enum_row_matches_full_chamber_name_declaration(tmp_path: Path) -> N
     assert reloaded.status == "complete"
 
 
+# ---------------------------------------------------------------------------
+# Corpus dossier coverage (issue #356)
+# ---------------------------------------------------------------------------
+
+
+def _dossier_job(tmp_path: Path) -> Job:
+    db_path = tmp_path / "index.sqlite"
+    db.migrate(path=db_path).close()
+    return Job.create(
+        {
+            "goal": "Exhaustive dossier of UFO records",
+            "domain": "general",
+            "corpus_dossier": True,
+        },
+        jobs_root=tmp_path / "jobs",
+        db_path=db_path,
+        today=date(2026, 5, 19),
+    )
+
+
+def _seed_page_source(
+    job: Job, *, parent_file: str, page_no: int | None, page_chunk: int | None
+) -> None:
+    """Write a Source row + sidecar mimicking dossier-mode per-page ingest."""
+    from research_agent.storage.sources import write_source
+
+    body = f"{parent_file} page {page_no} chunk {page_chunk} body content"
+    write_source(
+        job,
+        url=parent_file,
+        title=Path(parent_file).name,
+        raw_content=body,
+        kind="local",
+        metadata={
+            "parent_file": parent_file,
+            "page_no": page_no,
+            "page_chunk": page_chunk,
+        },
+    )
+
+
+def test_declare_corpus_units_emits_one_unit_per_page(tmp_path: Path) -> None:
+    """5 PDFs × 6 pages each → 30 page units, all pending after declaration."""
+    job = _dossier_job(tmp_path)
+    pdf_uris = [f"file:///pdf{i}.pdf" for i in range(1, 6)]
+    for uri in pdf_uris:
+        for page_no in range(1, 7):
+            _seed_page_source(job, parent_file=uri, page_no=page_no, page_chunk=None)
+
+    units = coverage.declare_corpus_units(job)
+
+    assert len(units) == 30
+    assert all(unit.status == "pending" for unit in units)
+    keys = {(u.dimensions["file"], u.dimensions["page"]) for u in units}
+    expected = {(uri, str(p)) for uri in pdf_uris for p in range(1, 7)}
+    # dim_key normalises ints to strings; just confirm the (file, page) pairs.
+    pairs = {(u.dimensions["file"], u.dimensions["page"]) for u in units}
+    assert {(uri, str(p)) for uri, p in pairs} == expected
+    assert len(keys) == 30
+
+
+def test_declare_corpus_units_is_idempotent(tmp_path: Path) -> None:
+    """Re-running declare_corpus_units preserves statuses + does not duplicate."""
+    job = _dossier_job(tmp_path)
+    parent = "file:///doc.pdf"
+    for page_no in (1, 2, 3):
+        _seed_page_source(job, parent_file=parent, page_no=page_no, page_chunk=None)
+
+    first = coverage.declare_corpus_units(job)
+    assert len(first) == 3
+
+    middle = next(u for u in first if u.dimensions["page"] == "2")
+    coverage.upsert_unit_status(job, middle.dim_key, "complete")
+
+    second = coverage.declare_corpus_units(job)
+    assert len(second) == 3
+    statuses = {u.dimensions["page"]: u.status for u in second}
+    assert statuses == {"1": "pending", "2": "complete", "3": "pending"}
+
+
+def test_declare_corpus_units_skips_legacy_sources_without_metadata(
+    tmp_path: Path,
+) -> None:
+    """Sources without parent_file metadata (legacy thematic ingests) are skipped."""
+    from research_agent.storage.sources import write_source
+
+    job = _dossier_job(tmp_path)
+    _seed_page_source(
+        job, parent_file="file:///dossier.pdf", page_no=1, page_chunk=None
+    )
+    write_source(
+        job,
+        url="file:///legacy.pdf",
+        title="legacy.pdf",
+        raw_content="legacy body without metadata",
+        kind="local",
+    )
+
+    units = coverage.declare_corpus_units(job)
+
+    files = {u.dimensions.get("file") for u in units}
+    assert files == {"file:///dossier.pdf"}
+    assert len(units) == 1
+
+
+def test_declare_corpus_units_blocks_is_coverage_complete(tmp_path: Path) -> None:
+    """A dossier job with open page units is NOT coverage-complete."""
+    job = _dossier_job(tmp_path)
+    for page_no in (1, 2, 3):
+        _seed_page_source(
+            job, parent_file="file:///x.pdf", page_no=page_no, page_chunk=None
+        )
+
+    coverage.declare_corpus_units(job)
+
+    assert coverage.is_coverage_complete(job) is False
+
+
+def test_declare_corpus_units_handles_non_paginated_chunks(tmp_path: Path) -> None:
+    """HTML/MD sources stamp page=None and still register as units."""
+    job = _dossier_job(tmp_path)
+    _seed_page_source(
+        job, parent_file="file:///notes.html", page_no=None, page_chunk=None
+    )
+    _seed_page_source(
+        job, parent_file="file:///notes.md", page_no=None, page_chunk=None
+    )
+
+    units = coverage.declare_corpus_units(job)
+
+    files = {u.dimensions["file"] for u in units}
+    assert files == {"file:///notes.html", "file:///notes.md"}
+    for unit in units:
+        assert "page" not in unit.dimensions
+
+
+def test_file_status_rolls_up_page_units(tmp_path: Path) -> None:
+    """File status derives from the union of page-unit statuses."""
+    job = _dossier_job(tmp_path)
+    pdf = "file:///rollup.pdf"
+    for page_no in (1, 2, 3, 4):
+        _seed_page_source(job, parent_file=pdf, page_no=page_no, page_chunk=None)
+    units = coverage.declare_corpus_units(job)
+    keyed = {u.dimensions["page"]: u for u in units}
+
+    assert coverage.file_status(job, pdf) == "pending"
+
+    coverage.upsert_unit_status(job, keyed["1"].dim_key, "complete")
+    coverage.upsert_unit_status(job, keyed["2"].dim_key, "complete")
+    assert coverage.file_status(job, pdf) == "in_progress"
+
+    coverage.upsert_unit_status(job, keyed["3"].dim_key, "complete")
+    coverage.upsert_unit_status(job, keyed["4"].dim_key, "complete")
+    assert coverage.file_status(job, pdf) == "complete"
+
+
+def test_file_status_confirmed_gap_when_all_pages_gap(tmp_path: Path) -> None:
+    job = _dossier_job(tmp_path)
+    pdf = "file:///allgap.pdf"
+    for page_no in (1, 2):
+        _seed_page_source(job, parent_file=pdf, page_no=page_no, page_chunk=None)
+    units = coverage.declare_corpus_units(job)
+    for unit in units:
+        coverage.upsert_unit_status(job, unit.dim_key, "confirmed_gap")
+
+    assert coverage.file_status(job, pdf) == "confirmed_gap"
+
+
+def test_file_status_mixed_terminal_is_complete(tmp_path: Path) -> None:
+    """Some pages complete, others confirmed_gap → file is 'complete' overall."""
+    job = _dossier_job(tmp_path)
+    pdf = "file:///mixed.pdf"
+    for page_no in (1, 2, 3):
+        _seed_page_source(job, parent_file=pdf, page_no=page_no, page_chunk=None)
+    units = coverage.declare_corpus_units(job)
+    keyed = {u.dimensions["page"]: u for u in units}
+    coverage.upsert_unit_status(job, keyed["1"].dim_key, "complete")
+    coverage.upsert_unit_status(job, keyed["2"].dim_key, "complete")
+    coverage.upsert_unit_status(job, keyed["3"].dim_key, "confirmed_gap")
+
+    assert coverage.file_status(job, pdf) == "complete"
+
+
+def test_file_status_unknown_file_is_pending(tmp_path: Path) -> None:
+    job = _dossier_job(tmp_path)
+    _seed_page_source(
+        job, parent_file="file:///known.pdf", page_no=1, page_chunk=None
+    )
+    coverage.declare_corpus_units(job)
+
+    assert coverage.file_status(job, "file:///missing.pdf") == "pending"
+
+
+def test_file_status_rejects_empty_url(tmp_path: Path) -> None:
+    import pytest
+
+    job = _dossier_job(tmp_path)
+    with pytest.raises(ValueError):
+        coverage.file_status(job, "")
+
+
+def test_goal_complete_gated_by_dossier_page_units(tmp_path: Path) -> None:
+    """_is_goal_complete must return False while any page unit is open."""
+    from research_agent.orchestrator.loop import _is_goal_complete
+    from research_agent.orchestrator.plan import Plan, Subgoal, TaskSpec
+
+    job = _dossier_job(tmp_path)
+    for page_no in (1, 2):
+        _seed_page_source(
+            job, parent_file="file:///gate.pdf", page_no=page_no, page_chunk=None
+        )
+    units = coverage.declare_corpus_units(job)
+    assert len(units) == 2
+
+    # Minimal valid plan whose subgoals are all done — without coverage
+    # gating, plan.is_complete() would return True. Coverage must hold
+    # _is_goal_complete at False.
+    plan = Plan(
+        version=1,
+        objective="Exhaustive dossier of UFO records",
+        subgoals=[
+            Subgoal(id=1, description="ingest all pages", done=True),
+        ],
+        task_template=[
+            TaskSpec(kind="local_corpus_query", payload={"query": "ingest pages"}),
+        ],
+        expected_iterations=1,
+    )
+
+    assert _is_goal_complete(job, plan) is False
+
+    # Flip every page unit terminal-complete → coverage closes, plan
+    # is already done, _is_goal_complete is now True.
+    for unit in coverage.list_units(job):
+        coverage.upsert_unit_status(job, unit.dim_key, "complete")
+
+    assert _is_goal_complete(job, plan) is True
+
+
 def test_state_election_row_carries_state_ballot_qualified_source_type(tmp_path: Path) -> None:
     """state_election rows must emit source_type='state-ballot-qualified' so
     declared coverage with that source_type is matched. File-format details


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on #364 → #363 → #362 → #361 → #360. Once those merge, this PR's diff will collapse to just the coverage declarer + rollup + daemon hook.

## Summary
- \`coverage.declare_corpus_units(job)\` walks every \`sources\` row linked to the job with \`kind='local'\` and \`metadata.parent_file\` set, then upserts one \`CoverageUnit\` per row with dimensions \`{file, page, page_chunk}\`. Page units are the source of truth; HTML / MD chunks land with \`page=None\` so they participate in the ledger. Rows without sidecar metadata (legacy thematic ingests) are skipped.
- \`coverage.file_status(job, file_url)\` rolls up page units into a per-file status: \`complete\` / \`confirmed_gap\` / \`not_yet_public\` / \`in_progress\` / \`pending\`. Mixed terminal statuses roll up to \`complete\` so a file with some gap pages still reads as \"landed\" while individual gaps stay visible.
- New \`EventKind\` \`coverage_declared\` — emitted by the daemon after a dossier-mode index pass with \`{trigger, file_count, page_count, total_units}\`.
- Daemon: \`_declare_dossier_coverage_units(job, trigger)\` is the call site; the inbox watcher invokes it whenever \`per_page=True\`. When the corpus-walk indexer lands (still absent from \`origin/main\`) it'll call the same helper with \`trigger=\"corpus_walk\"\`.

## Test plan
- [x] \`uv run --frozen pytest tests/test_storage_coverage.py tests/test_daemon.py -q -k 'dossier or coverage'\` → 18 passed
- [x] Full sweep \`pytest -q\` → 2314 passed, 2 skipped, 1 deselected (pre-existing hypotheses table-width test)
- [x] \`ruff check\` clean on every touched file

### Acceptance criteria coverage
- ✅ 5-PDF × 6-page fixture → 30 page units, all \`pending\` post-declaration (\`test_declare_corpus_units_emits_one_unit_per_page\`).
- ✅ \`file_status\` rolls up the four required states across the page lifecycle (\`test_file_status_rolls_up_page_units\`, \`test_file_status_confirmed_gap_when_all_pages_gap\`, \`test_file_status_mixed_terminal_is_complete\`, \`test_file_status_unknown_file_is_pending\`).
- ✅ \`_is_goal_complete()\` returns False while any page unit is open (\`test_goal_complete_gated_by_dossier_page_units\`) — proves the loop physically can't exit while the ledger has work to do.
- ✅ Idempotent on re-invocation (\`test_declare_corpus_units_is_idempotent\`) — statuses preserved, no duplicate units.
- ✅ New unit + integration tests in \`tests/test_storage_coverage.py\`; daemon-level smoke in \`tests/test_daemon.py\`.

Closes #356.

Made with [Cursor](https://cursor.com)