### PR TITLE
feat(coverage): record extraction failures as confirmed_gap units (#357)

### DIFF
--- a/src/research_agent/daemon.py
+++ b/src/research_agent/daemon.py
@@ -647,7 +647,12 @@ def _processed_inbox_path(inbox_dir: Path, sha: str, filename: str) -> Path:
     return processed_dir / f"{sha}-{safe_name}"
 
 
-def _declare_dossier_coverage_units(job: Job, *, trigger: str) -> None:
+def _declare_dossier_coverage_units(
+    job: Job,
+    *,
+    trigger: str,
+    skipped: list[dict[str, str]] | None = None,
+) -> int:
     """Declare per-page coverage units after a dossier-mode index pass.
 
     Walks the ``sources`` rows already linked to the job and stamps one
@@ -655,16 +660,45 @@ def _declare_dossier_coverage_units(job: Job, *, trigger: str) -> None:
     :func:`coverage.declare_corpus_units`. Idempotent — re-running on a
     job with existing units preserves their statuses; only newly-added
     rows produce new units. Emits a ``coverage_declared`` event with
-    file_count + page_count so operators see when gating kicks in.
+    file_count + page_count + files_confirmed_gap so operators see
+    when gating kicks in and how many files were unreadable.
 
     ``trigger`` is the high-level event source (``"inbox"`` today;
     ``"corpus_walk"`` when the daemon's intake-corpus indexer lands).
+
+    ``skipped`` is the ``index()`` summary's ``skipped`` list — each
+    entry becomes a ``confirmed_gap`` coverage unit so the
+    extraction-failed PDF doesn't block ``goal_complete`` forever
+    (issue #357). Returns the number of confirmed-gap units declared.
     """
     from research_agent.storage import coverage
 
     units = coverage.declare_corpus_units(job)
     files = {unit.dimensions.get("file") for unit in units if unit.dimensions.get("file")}
     page_count = sum(1 for unit in units if "page" in unit.dimensions)
+
+    confirmed_gap_count = 0
+    for record in skipped or []:
+        file_url = record.get("file_url")
+        reason = record.get("reason") or "extraction_failed"
+        if not isinstance(file_url, str) or not file_url:
+            continue
+        try:
+            coverage.declare_file_gap(job, file_url, reason)
+        except Exception as exc:  # noqa: BLE001 — keep watcher alive on a bad row
+            logger.warning(
+                "failed to declare confirmed_gap for %s: %s", file_url, exc
+            )
+            continue
+        confirmed_gap_count += 1
+        emit(
+            job,
+            "WARN",
+            "daemon",
+            "corpus_file_gap",
+            {"file_url": file_url, "reason": reason, "trigger": trigger},
+        )
+
     emit(
         job,
         "INFO",
@@ -674,9 +708,11 @@ def _declare_dossier_coverage_units(job: Job, *, trigger: str) -> None:
             "trigger": trigger,
             "file_count": len(files),
             "page_count": page_count,
-            "total_units": len(units),
+            "total_units": len(units) + confirmed_gap_count,
+            "files_confirmed_gap": confirmed_gap_count,
         },
     )
+    return confirmed_gap_count
 
 
 async def _inbox_watcher(
@@ -731,6 +767,24 @@ async def _inbox_watcher(
                         )
                         + "\n",
                     )
+                    confirmed_gap_count = 0
+                    if per_page:
+                        confirmed_gap_count = _declare_dossier_coverage_units(
+                            job,
+                            trigger="inbox",
+                            skipped=indexed.get("skipped") or [],
+                        )
+                    # Strip the skipped detail list before fanning the
+                    # summary into the doc-added event — operators see
+                    # the per-file gap events separately and event
+                    # payloads should stay terse.
+                    doc_added_payload = {
+                        k: v for k, v in indexed.items() if k != "skipped"
+                    }
+                    if per_page:
+                        doc_added_payload["files_confirmed_gap"] = (
+                            confirmed_gap_count
+                        )
                     emit(
                         job,
                         "INFO",
@@ -742,11 +796,9 @@ async def _inbox_watcher(
                             "processed_path": str(processed_path.relative_to(job.root)),
                             "topic_guess": topic_guess,
                             "summary_chars": len(summary),
-                            **indexed,
+                            **doc_added_payload,
                         },
                     )
-                    if per_page:
-                        _declare_dossier_coverage_units(job, trigger="inbox")
                 except Exception as exc:  # noqa: BLE001 — keep watcher alive
                     logger.exception("inbox watcher failed for %s", file_path)
                     try:

--- a/src/research_agent/daemon.py
+++ b/src/research_agent/daemon.py
@@ -673,11 +673,8 @@ def _declare_dossier_coverage_units(
     """
     from research_agent.storage import coverage
 
-    units = coverage.declare_corpus_units(job)
-    files = {unit.dimensions.get("file") for unit in units if unit.dimensions.get("file")}
-    page_count = sum(1 for unit in units if "page" in unit.dimensions)
-
-    confirmed_gap_count = 0
+    coverage.declare_corpus_units(job)
+    confirmed_gap_files: set[str] = set()
     for record in skipped or []:
         file_url = record.get("file_url")
         reason = record.get("reason") or "extraction_failed"
@@ -690,7 +687,7 @@ def _declare_dossier_coverage_units(
                 "failed to declare confirmed_gap for %s: %s", file_url, exc
             )
             continue
-        confirmed_gap_count += 1
+        confirmed_gap_files.add(file_url)
         emit(
             job,
             "WARN",
@@ -699,6 +696,10 @@ def _declare_dossier_coverage_units(
             {"file_url": file_url, "reason": reason, "trigger": trigger},
         )
 
+    units = coverage.list_units(job)
+    files = {unit.dimensions.get("file") for unit in units if unit.dimensions.get("file")}
+    page_count = sum(1 for unit in units if "page" in unit.dimensions)
+    confirmed_gap_count = len(confirmed_gap_files)
     emit(
         job,
         "INFO",
@@ -708,7 +709,7 @@ def _declare_dossier_coverage_units(
             "trigger": trigger,
             "file_count": len(files),
             "page_count": page_count,
-            "total_units": len(units) + confirmed_gap_count,
+            "total_units": len(units),
             "files_confirmed_gap": confirmed_gap_count,
         },
     )

--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -63,6 +63,7 @@ EventKind = Literal[
     "low_yield_connector",
     "hypothesis_updated",
     "corpus_doc_added",
+    "corpus_file_gap",
     "coverage_declared",
     "llm_call",
     "lmstudio_degraded",

--- a/src/research_agent/storage/coverage.py
+++ b/src/research_agent/storage/coverage.py
@@ -547,6 +547,71 @@ def declare_corpus_units(job: Job) -> list[CoverageUnit]:
     return declare_coverage(job, new_units)
 
 
+def declare_file_gap(
+    job: Job,
+    file_url: str,
+    reason: str,
+    *,
+    unblocker: str | None = None,
+) -> CoverageUnit:
+    """Declare a single ``confirmed_gap`` unit for an unreadable file.
+
+    Used by the dossier-mode indexer (issue #357) when
+    :func:`local_corpus.index` can't extract text from a corpus file —
+    e.g. a corrupt PDF, a truncated upload, an image-only scan with no
+    OCR yield. The unit dimensions are ``{"file": file_url}``; no page
+    dimension because the file produced zero pages.
+
+    The reason is recorded on the unit's ``recent_attempts`` so
+    ``research status`` can show *why* the gap was confirmed.
+    Idempotent: re-running on a job that already has a unit for the
+    same file flips its status to ``confirmed_gap`` (with the latest
+    reason) rather than duplicating it.
+
+    Returns the resulting :class:`CoverageUnit`.
+    """
+    if not isinstance(file_url, str) or not file_url:
+        raise ValueError("file_url must be a non-empty string")
+    reason_text = str(reason or "extraction_failed")
+
+    attempt = CoverageAttempt(
+        task_kind="local_corpus_index",
+        status="confirmed_gap",
+        reason=reason_text,
+    )
+
+    # Reuse declare_coverage's upsert path so existing units (and their
+    # attempt history) survive an idempotent rerun.
+    declared = declare_coverage(
+        job,
+        [
+            {
+                "dimensions": {"file": file_url},
+                "status": "confirmed_gap",
+                "recent_attempts": [attempt.model_dump(mode="json")],
+                "unblocker": unblocker,
+            }
+        ],
+    )
+    matching = [u for u in declared if u.dimensions.get("file") == file_url]
+    if not matching:
+        raise RuntimeError(
+            f"declare_file_gap did not write a unit for {file_url!r}"
+        )
+
+    # declare_coverage preserves prior status on conflict; force the gap
+    # by flipping the unit through upsert_unit_status, which also
+    # records the attempt.
+    target = matching[0]
+    return upsert_unit_status(
+        job,
+        target.dim_key,
+        "confirmed_gap",
+        attempt=attempt,
+        unblocker=unblocker,
+    )
+
+
 def file_status(job: Job, file_url: str) -> CoverageStatus:
     """Roll up per-page unit statuses into a per-file coverage status.
 
@@ -626,6 +691,7 @@ __all__ = [
     "blocking_units",
     "declare_corpus_units",
     "declare_coverage",
+    "declare_file_gap",
     "declare_from_intake",
     "dim_key_for",
     "dimensions_from_task_and_row",

--- a/src/research_agent/tools/local_corpus.py
+++ b/src/research_agent/tools/local_corpus.py
@@ -408,7 +408,7 @@ def _index_pdf_per_page(
     *,
     base_url: str,
     model_name: str,
-) -> dict[str, int]:
+) -> dict[str, Any]:
     """Index one PDF as one :class:`Source` row per page (dossier mode).
 
     Calls :func:`pdf.extract_pages_sync` to get ``[(page_no, text), ...]``
@@ -418,7 +418,8 @@ def _index_pdf_per_page(
     in ``metadata``. The chunker never crosses page boundaries.
 
     Returns the same shape as :func:`index`'s per-file accumulator so
-    the outer loop can fold the counters in unchanged.
+    the outer loop can fold the counters and skipped-file details in
+    unchanged.
     """
     from research_agent.tools import pdf as pdf_mod  # lazy
 

--- a/src/research_agent/tools/local_corpus.py
+++ b/src/research_agent/tools/local_corpus.py
@@ -267,9 +267,13 @@ def index(
 
     Returns a summary dict with ``files_indexed``, ``files_skipped``,
     ``chunks_indexed``, ``chunks_skipped``, ``pages_indexed``,
-    ``pages_skipped``, ``per_page``, and ``embed_dim``. Idempotent —
-    chunks already present in ``sources`` (matched by sha256) are linked
-    to the job without re-embedding.
+    ``pages_skipped``, ``per_page``, ``embed_dim``, and ``skipped``
+    (a list of ``{"file_url": str, "reason": str}`` records, one per
+    skipped file — issue #357). The daemon's dossier path turns each
+    skipped record into a ``confirmed_gap`` coverage unit so an
+    unreadable PDF doesn't block ``goal_complete`` forever.
+    Idempotent — chunks already present in ``sources`` (matched by
+    sha256) are linked to the job without re-embedding.
 
     When ``per_page=True``, PDFs use :func:`pdf.extract_pages_sync` and
     write one :class:`Source` row per page so the dossier extractor
@@ -295,6 +299,7 @@ def index(
     chunks_skipped = 0
     pages_indexed = 0
     pages_skipped = 0
+    skipped: list[dict[str, str]] = []
 
     for file_path in _walk_corpus(root):
         if per_page and file_path.suffix.lower() == ".pdf":
@@ -310,24 +315,31 @@ def index(
             chunks_skipped += stats["chunks_skipped"]
             pages_indexed += stats["pages_indexed"]
             pages_skipped += stats["pages_skipped"]
+            skipped.extend(stats.get("skipped", []))
             continue
 
+        file_url = file_path.as_uri()
         try:
             raw_text, _kind_hint = _extract_text(file_path)
         except Exception as exc:  # noqa: BLE001
             logger.warning("failed to extract %s: %s", file_path, exc)
             files_skipped += 1
+            skipped.append(
+                {"file_url": file_url, "reason": f"extraction_failed: {exc}"}
+            )
             continue
 
         cleaned_full = clean_content(raw_text) if raw_text else ""
         if not cleaned_full:
             logger.info("skipping empty file: %s", file_path)
             files_skipped += 1
+            skipped.append({"file_url": file_url, "reason": "empty_content"})
             continue
 
         chunks = _chunk_text(cleaned_full)
         if not chunks:
             files_skipped += 1
+            skipped.append({"file_url": file_url, "reason": "empty_content"})
             continue
 
         # Pre-check existing sources to avoid re-embedding what we already have.
@@ -347,7 +359,6 @@ def index(
             for chunk_idx, vec in zip(to_embed_idx, vectors, strict=True)
         }
 
-        file_url = file_path.as_uri()
         # Default path also stamps `parent_file` when per_page=True so
         # callers walking the coverage ledger can group HTML / MD / TXT
         # chunks under a single file unit. page_no stays None because
@@ -387,6 +398,7 @@ def index(
         "pages_skipped": pages_skipped,
         "per_page": per_page,
         "embed_dim": EMBED_DIM,
+        "skipped": skipped,
     }
 
 
@@ -410,27 +422,37 @@ def _index_pdf_per_page(
     """
     from research_agent.tools import pdf as pdf_mod  # lazy
 
-    empty_summary = {
+    empty_summary: dict[str, Any] = {
         "files_indexed": 0,
         "files_skipped": 0,
         "chunks_indexed": 0,
         "chunks_skipped": 0,
         "pages_indexed": 0,
         "pages_skipped": 0,
+        "skipped": [],
     }
 
+    file_url = file_path.as_uri()
     try:
         pages = pdf_mod.extract_pages_sync(file_path)
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "pdf per-page extract failed for %s: %s", file_path, exc
         )
-        return {**empty_summary, "files_skipped": 1}
+        return {
+            **empty_summary,
+            "files_skipped": 1,
+            "skipped": [
+                {"file_url": file_url, "reason": f"extraction_failed: {exc}"}
+            ],
+        }
 
     if not pages:
-        return {**empty_summary, "files_skipped": 1}
-
-    file_url = file_path.as_uri()
+        return {
+            **empty_summary,
+            "files_skipped": 1,
+            "skipped": [{"file_url": file_url, "reason": "empty_content"}],
+        }
 
     # Materialise per-page sub-chunks first so we can batch-embed every
     # row produced by this file in a single embeddings call. Each entry
@@ -487,6 +509,7 @@ def _index_pdf_per_page(
             "files_skipped": 1,
             "pages_indexed": pages_indexed,
             "pages_skipped": pages_skipped,
+            "skipped": [{"file_url": file_url, "reason": "empty_content"}],
         }
 
     chunk_shas = [content_sha256(clean_content(c)) for _, _, _, c in page_chunks]
@@ -537,6 +560,7 @@ def _index_pdf_per_page(
         "chunks_skipped": chunks_skipped,
         "pages_indexed": pages_indexed,
         "pages_skipped": pages_skipped,
+        "skipped": [],
     }
 
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1538,6 +1538,94 @@ async def test_inbox_watcher_declares_coverage_units_after_dossier_index(
     assert payload["file_count"] == 1
     assert payload["page_count"] == 3
     assert payload["total_units"] == 3
+    assert payload.get("files_confirmed_gap", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_inbox_watcher_dossier_records_confirmed_gap_for_skipped_file(
+    seeded_job: Job, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Dossier-mode inbox runs with skipped file -> confirmed_gap unit + event."""
+    from research_agent.storage import coverage
+
+    seeded_job.intake = {**(seeded_job.intake or {}), "corpus_dossier": True}
+    (seeded_job.root / "intake.json").write_text(
+        json.dumps(seeded_job.intake), encoding="utf-8"
+    )
+
+    inbox = seeded_job.root / "inbox"
+    inbox.mkdir(exist_ok=True)
+    doc = inbox / "broken-scan.pdf"
+    doc.write_bytes(b"%PDF-corrupt")
+
+    def _fake_index(
+        path: Path, job: Job, *, per_page: bool = False
+    ) -> dict[str, object]:
+        return {
+            "files_indexed": 0,
+            "files_skipped": 1,
+            "chunks_indexed": 0,
+            "chunks_skipped": 0,
+            "pages_indexed": 0,
+            "pages_skipped": 0,
+            "per_page": per_page,
+            "embed_dim": 1024,
+            "skipped": [
+                {
+                    "file_url": f"file://{path}",
+                    "reason": "extraction_failed: pdf parse error",
+                }
+            ],
+        }
+
+    monkeypatch.setattr("research_agent.tools.local_corpus.index", _fake_index)
+    should_stop = asyncio.Event()
+    task = asyncio.create_task(
+        daemon._inbox_watcher(seeded_job, should_stop, interval_s=0.02)
+    )
+    try:
+        for _ in range(100):
+            if (seeded_job.root / "INBOX_REPLAN.json").exists():
+                should_stop.set()
+                break
+            await asyncio.sleep(0.02)
+        await asyncio.wait_for(task, timeout=1.0)
+    finally:
+        should_stop.set()
+        if not task.done():
+            task.cancel()
+
+    units = coverage.list_units(seeded_job)
+    assert len(units) == 1
+    assert units[0].status == "confirmed_gap"
+    assert units[0].dimensions.get("file", "").endswith("broken-scan.pdf")
+    # Pure-gap dossier is coverage-complete by design (issue #357).
+    assert coverage.is_coverage_complete(seeded_job) is True
+
+    conn = db.connect(seeded_job.db_path)
+    try:
+        gap_rows = conn.execute(
+            "SELECT payload_json FROM events WHERE job_id = ? AND kind = ?",
+            (seeded_job.id, "corpus_file_gap"),
+        ).fetchall()
+        coverage_rows = conn.execute(
+            "SELECT payload_json FROM events WHERE job_id = ? AND kind = ?",
+            (seeded_job.id, "coverage_declared"),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert len(gap_rows) == 1
+    gap_payload = json.loads(gap_rows[0]["payload_json"])
+    assert gap_payload["reason"].startswith("extraction_failed")
+    assert gap_payload["trigger"] == "inbox"
+    assert gap_payload["file_url"].endswith("broken-scan.pdf")
+
+    assert len(coverage_rows) == 1
+    cov_payload = json.loads(coverage_rows[0]["payload_json"])
+    assert cov_payload["files_confirmed_gap"] == 1
+    assert cov_payload["page_count"] == 0
+    assert cov_payload["total_units"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1628,6 +1628,46 @@ async def test_inbox_watcher_dossier_records_confirmed_gap_for_skipped_file(
     assert cov_payload["total_units"] == 1
 
 
+def test_declare_dossier_coverage_units_gap_rerun_reports_actual_total(
+    seeded_job: Job,
+) -> None:
+    """Idempotent gap reruns should not inflate coverage_declared.total_units."""
+    from research_agent.storage import coverage
+
+    skipped = [
+        {
+            "file_url": "file:///rerun-broken.pdf",
+            "reason": "empty_content",
+        }
+    ]
+
+    first = daemon._declare_dossier_coverage_units(
+        seeded_job, trigger="inbox", skipped=skipped
+    )
+    second = daemon._declare_dossier_coverage_units(
+        seeded_job, trigger="inbox", skipped=skipped
+    )
+
+    assert first == 1
+    assert second == 1
+    units = coverage.list_units(seeded_job)
+    assert len(units) == 1
+    assert units[0].status == "confirmed_gap"
+
+    conn = db.connect(seeded_job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT payload_json FROM events WHERE job_id = ? AND kind = ?",
+            (seeded_job.id, "coverage_declared"),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    payloads = [json.loads(row["payload_json"]) for row in rows]
+    assert [payload["total_units"] for payload in payloads] == [1, 1]
+    assert [payload["files_confirmed_gap"] for payload in payloads] == [1, 1]
+
+
 # ---------------------------------------------------------------------------
 # _cancel_with_timeout — bounds daemon teardown so a hung watcher can't block exit
 # ---------------------------------------------------------------------------

--- a/tests/test_storage_coverage.py
+++ b/tests/test_storage_coverage.py
@@ -339,6 +339,85 @@ def test_file_status_rejects_empty_url(tmp_path: Path) -> None:
         coverage.file_status(job, "")
 
 
+# ---------------------------------------------------------------------------
+# declare_file_gap (issue #357)
+# ---------------------------------------------------------------------------
+
+
+def test_declare_file_gap_marks_file_confirmed_gap(tmp_path: Path) -> None:
+    """An unreadable file becomes a confirmed_gap unit, no page dimension."""
+    job = _dossier_job(tmp_path)
+
+    unit = coverage.declare_file_gap(
+        job, "file:///broken.pdf", "extraction_failed: malformed xref"
+    )
+
+    assert unit.status == "confirmed_gap"
+    assert unit.dimensions == {"file": "file:///broken.pdf"}
+    assert "page" not in unit.dimensions
+    assert unit.recent_attempts, "confirmed_gap unit must record an attempt"
+    assert unit.recent_attempts[-1].reason.startswith("extraction_failed")
+
+    listed = coverage.list_units(job)
+    assert len(listed) == 1
+    assert listed[0].status == "confirmed_gap"
+
+
+def test_declare_file_gap_is_idempotent(tmp_path: Path) -> None:
+    """Calling declare_file_gap twice on the same file does not duplicate."""
+    job = _dossier_job(tmp_path)
+
+    coverage.declare_file_gap(job, "file:///a.pdf", "extraction_failed: x")
+    coverage.declare_file_gap(job, "file:///a.pdf", "empty_content")
+
+    listed = [u for u in coverage.list_units(job) if u.dimensions == {"file": "file:///a.pdf"}]
+    assert len(listed) == 1
+    assert listed[0].status == "confirmed_gap"
+    # Latest attempt wins.
+    assert listed[0].recent_attempts[-1].reason == "empty_content"
+
+
+def test_declare_file_gap_does_not_block_coverage(tmp_path: Path) -> None:
+    """A pure-gap dossier (no page units) is coverage-complete (issue #357)."""
+    job = _dossier_job(tmp_path)
+
+    coverage.declare_file_gap(
+        job, "file:///broken1.pdf", "extraction_failed: foo"
+    )
+    coverage.declare_file_gap(job, "file:///broken2.pdf", "empty_content")
+
+    assert coverage.is_coverage_complete(job) is True
+
+
+def test_declare_file_gap_coexists_with_pending_pages(tmp_path: Path) -> None:
+    """A mix of gap + open page units stays not-complete until pages close."""
+    job = _dossier_job(tmp_path)
+
+    _seed_page_source(
+        job, parent_file="file:///good.pdf", page_no=1, page_chunk=None
+    )
+    coverage.declare_corpus_units(job)
+    coverage.declare_file_gap(
+        job, "file:///bad.pdf", "extraction_failed: corrupt"
+    )
+
+    assert coverage.is_coverage_complete(job) is False
+
+    page_units = [u for u in coverage.list_units(job) if "page" in u.dimensions]
+    for unit in page_units:
+        coverage.upsert_unit_status(job, unit.dim_key, "complete")
+
+    assert coverage.is_coverage_complete(job) is True
+
+
+def test_declare_file_gap_rejects_empty_url(tmp_path: Path) -> None:
+    import pytest
+
+    job = _dossier_job(tmp_path)
+    with pytest.raises(ValueError):
+        coverage.declare_file_gap(job, "", "reason")
+
+
 def test_goal_complete_gated_by_dossier_page_units(tmp_path: Path) -> None:
     """_is_goal_complete must return False while any page unit is open."""
     from research_agent.orchestrator.loop import _is_goal_complete

--- a/tests/test_tools_local_corpus.py
+++ b/tests/test_tools_local_corpus.py
@@ -292,6 +292,49 @@ def test_index_handles_empty_file(
     summary = local_corpus.index(corpus, job, models_config=stub_models_config)
     assert summary["files_indexed"] == 1
     assert summary["files_skipped"] == 1
+    skipped = summary["skipped"]
+    assert len(skipped) == 1
+    assert skipped[0]["file_url"] == (corpus / "empty.txt").as_uri()
+    assert skipped[0]["reason"] == "empty_content"
+
+
+def test_index_skipped_field_default_empty(
+    tmp_path: Path, job: Job, monkeypatch, stub_models_config: dict
+) -> None:
+    """Healthy corpus -> ``skipped`` is present and empty (issue #357)."""
+    _stub_embed(monkeypatch)
+    corpus = tmp_path / "clean"
+    corpus.mkdir()
+    (corpus / "ok.txt").write_text("alpha beta gamma " * 40)
+
+    summary = local_corpus.index(corpus, job, models_config=stub_models_config)
+    assert summary["files_skipped"] == 0
+    assert summary["skipped"] == []
+
+
+def test_index_extraction_failure_records_reason(
+    tmp_path: Path, job: Job, monkeypatch, stub_models_config: dict
+) -> None:
+    """A raising ``_extract_text`` -> ``extraction_failed: <exc>`` in skipped."""
+    _stub_embed(monkeypatch)
+    corpus = tmp_path / "broken"
+    corpus.mkdir()
+    target = corpus / "broken.txt"
+    target.write_text("payload")
+
+    def _boom(path: Path):
+        raise RuntimeError("synthetic extract failure")
+
+    monkeypatch.setattr(local_corpus, "_extract_text", _boom)
+
+    summary = local_corpus.index(corpus, job, models_config=stub_models_config)
+    assert summary["files_indexed"] == 0
+    assert summary["files_skipped"] == 1
+    skipped = summary["skipped"]
+    assert len(skipped) == 1
+    assert skipped[0]["file_url"] == target.as_uri()
+    assert "extraction_failed" in skipped[0]["reason"]
+    assert "synthetic extract failure" in skipped[0]["reason"]
 
 
 # ---------------------------------------------------------------------------
@@ -686,7 +729,8 @@ def test_index_per_page_unopenable_pdf_skips_file(
     _stub_embed(monkeypatch)
     corpus = tmp_path / "broken_pdf"
     corpus.mkdir()
-    (corpus / "broken.pdf").write_bytes(b"not actually a pdf")
+    pdf_path = corpus / "broken.pdf"
+    pdf_path.write_bytes(b"not actually a pdf")
 
     from research_agent.tools import pdf as pdf_mod
 
@@ -700,6 +744,64 @@ def test_index_per_page_unopenable_pdf_skips_file(
     assert summary["pages_indexed"] == 0
     assert summary["pages_skipped"] == 0
     assert summary["chunks_indexed"] == 0
+    skipped = summary["skipped"]
+    assert len(skipped) == 1
+    assert skipped[0]["file_url"] == pdf_path.as_uri()
+    assert skipped[0]["reason"] == "empty_content"
+
+
+def test_index_per_page_pdf_extract_raises_records_reason(
+    tmp_path: Path, job: Job, monkeypatch, stub_models_config: dict
+) -> None:
+    """extract_pages_sync raising -> ``extraction_failed: <exc>`` (issue #357)."""
+    _stub_embed(monkeypatch)
+    corpus = tmp_path / "raising_pdf"
+    corpus.mkdir()
+    pdf_path = corpus / "raises.pdf"
+    pdf_path.write_bytes(b"%PDF-fake")
+
+    from research_agent.tools import pdf as pdf_mod
+
+    def _boom(*a, **k):
+        raise RuntimeError("malformed xref table")
+
+    monkeypatch.setattr(pdf_mod, "extract_pages_sync", _boom)
+
+    summary = local_corpus.index(
+        corpus, job, models_config=stub_models_config, per_page=True
+    )
+    assert summary["files_skipped"] == 1
+    skipped = summary["skipped"]
+    assert len(skipped) == 1
+    assert skipped[0]["file_url"] == pdf_path.as_uri()
+    assert "extraction_failed" in skipped[0]["reason"]
+    assert "malformed xref" in skipped[0]["reason"]
+
+
+def test_index_per_page_pdf_all_pages_empty_records_gap(
+    tmp_path: Path, job: Job, monkeypatch, stub_models_config: dict
+) -> None:
+    """Every page empty -> file-level ``empty_content`` gap (issue #357)."""
+    _stub_embed(monkeypatch)
+    corpus = tmp_path / "blank_pages"
+    corpus.mkdir()
+    pdf_path = corpus / "blank.pdf"
+    pdf_path.write_bytes(b"%PDF-fake")
+
+    from research_agent.tools import pdf as pdf_mod
+
+    monkeypatch.setattr(
+        pdf_mod, "extract_pages_sync", lambda *a, **k: [(1, ""), (2, "")]
+    )
+
+    summary = local_corpus.index(
+        corpus, job, models_config=stub_models_config, per_page=True
+    )
+    assert summary["files_skipped"] == 1
+    skipped = summary["skipped"]
+    assert len(skipped) == 1
+    assert skipped[0]["file_url"] == pdf_path.as_uri()
+    assert skipped[0]["reason"] == "empty_content"
 
 
 def test_index_per_page_html_stamps_parent_file_and_null_page(


### PR DESCRIPTION
Closes #357

## Why

Dossier-mode jobs need an explicit way to mark unreadable corpus files
as terminal so they don't block `goal_complete` forever. Without this,
a single corrupt PDF in the corpus would keep the coverage ledger open
and the agent would never stop.

## What

- `local_corpus.index(..., per_page=True)` now returns a structured
  `skipped: [{file_url, reason}]` list alongside the counters. Reasons
  are either `extraction_failed: <exc>` or `empty_content`.
- New `coverage.declare_file_gap(job, file_url, reason)` upserts a
  file-dimension `confirmed_gap` unit. Idempotent; latest reason wins.
- Daemon dossier inbox path walks the new `skipped` list, declares one
  gap per file, emits a `corpus_file_gap` event per file with the
  reason, and surfaces the count via `files_confirmed_gap` in both
  `coverage_declared` and `corpus_doc_added` payloads.
- New `corpus_file_gap` event kind in `observability.events`.

## Stacking note

Stacked on `issue-356-coverage-units` (PR #365). Base is `main` so this
PR's diff currently includes the #356 commits — review will resolve
once #365 lands and this rebases.

## Test plan

- [x] `pytest tests/test_tools_local_corpus.py tests/test_storage_coverage.py tests/test_daemon.py` (97 pass)
- [x] `ruff check` on all modified files (clean)
- [ ] Manual smoke once stacked PRs are squashed into main: drop a corrupt PDF in `inbox/`, confirm `coverage_declared.files_confirmed_gap == 1`, `is_coverage_complete()` doesn't stay blocked.

Made with [Cursor](https://cursor.com)