### PR TITLE
feat(plan): add Subgoal.stage int field + plan migration (#358)

### DIFF
--- a/docs/JOB_FOLDER_CONTRACT.md
+++ b/docs/JOB_FOLDER_CONTRACT.md
@@ -5,8 +5,16 @@ consumers such as MCP servers, Python embedders, and future UIs should read
 from this folder through `research_agent.contract` and must not infer state
 from daemon internals.
 
-`job.json` has `schema_version: 1`. Any incompatible change to stable files
+`job.json` has `schema_version: 2`. Any incompatible change to stable files
 below requires bumping that version in the same PR.
+
+Schema version history:
+
+- `2` — issue #358: `plan/NNNN.json` subgoals now carry an integer
+  `stage` field (default `1`) so the dossier stage ladder can detect
+  premature subgoal closure. Plans written under schema 1 deserialise
+  unchanged (every subgoal becomes `stage=1`).
+- `1` — initial stable contract.
 
 ## Stability
 
@@ -76,7 +84,7 @@ Canonical disk metadata for one job.
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "id": "2026-05-16-investigate-widget-co",
   "goal": "Investigate Widget Co",
   "domain": "general",
@@ -141,6 +149,18 @@ Raw planner payload. Current top-level fields are planner-defined and may
 include `tasks`, `subgoals`, `scope_class`, `active_strategies`, and
 `cornerstone_url`. Consumers should treat the JSON sidecar as structured
 planner state and the markdown as display text.
+
+Each entry in `subgoals` carries (schema 2+):
+
+- `id` integer.
+- `description` string.
+- `done` boolean.
+- `gap_reason`, `gap_status` optional strings (planner-documented gaps).
+- `stage` integer ≥ 1 (default `1`). Groups subgoals into ordered phases
+  for the dossier stage ladder; the synth guard refuses to close a
+  stage `N+k` subgoal while any stage `N` subgoal is still open. Plans
+  loaded from schema 1 jobs deserialise with `stage=1` for every
+  subgoal.
 
 ### `findings/NNNNNN.md`
 

--- a/docs/JOB_FOLDER_CONTRACT.md
+++ b/docs/JOB_FOLDER_CONTRACT.md
@@ -157,10 +157,10 @@ Each entry in `subgoals` carries (schema 2+):
 - `done` boolean.
 - `gap_reason`, `gap_status` optional strings (planner-documented gaps).
 - `stage` integer ≥ 1 (default `1`). Groups subgoals into ordered phases
-  for the dossier stage ladder; the synth guard refuses to close a
-  stage `N+k` subgoal while any stage `N` subgoal is still open. Plans
-  loaded from schema 1 jobs deserialise with `stage=1` for every
-  subgoal.
+  for the dossier stage ladder; planned synth guards can use it to avoid
+  closing a stage `N+k` subgoal while any stage `N` subgoal is still
+  open. Plans loaded from schema 1 jobs deserialise with `stage=1` for
+  every subgoal.
 
 ### `findings/NNNNNN.md`
 

--- a/src/research_agent/orchestrator/plan.py
+++ b/src/research_agent/orchestrator/plan.py
@@ -145,7 +145,18 @@ ScopeClass = Literal["narrow", "medium", "broad", "comprehensive"]
 
 
 class Subgoal(BaseModel):
-    """A single subgoal within a Plan. ``done=True`` retires it from the loop."""
+    """A single subgoal within a Plan. ``done=True`` retires it from the loop.
+
+    ``stage`` (issue #358) groups subgoals into ordered phases for the
+    dossier ladder — e.g. ``stage=1`` per-file extraction, ``stage=2``
+    entity rollup, ``stage=3`` geo/temporal, ``stage=4`` contradictions,
+    ``stage=5`` narrative. Plans written before this field existed (or
+    written by a planner that omits it) default to ``stage=1`` so legacy
+    plan rows continue to round-trip cleanly through ``model_validate``.
+    The M3 synth guard will consult this field to refuse closing a
+    stage N+k subgoal while a stage N subgoal is still open; this PR
+    only lands the field + persistence + migration.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
@@ -154,6 +165,7 @@ class Subgoal(BaseModel):
     done: bool = False
     gap_reason: str | None = None
     gap_status: str | None = None
+    stage: int = Field(default=1, ge=1)
 
 
 class TaskSpec(BaseModel):

--- a/src/research_agent/storage/jobs.py
+++ b/src/research_agent/storage/jobs.py
@@ -36,7 +36,11 @@ from typing import Any
 from research_agent.storage import db
 
 DEFAULT_JOBS_ROOT = Path("jobs")
-JOB_SCHEMA_VERSION = 1
+JOB_SCHEMA_VERSION = 2
+"""Bumped to 2 for issue #358: ``Subgoal.stage`` field added to plan
+documents. Backward compatible — plans written under schema 1 deserialise
+with ``stage=1`` for every subgoal — but new jobs declare 2 so the rest
+of the stack can detect when a plan can be expected to carry stages."""
 RESUME_REPLAN_FILE = "RESUME_REPLAN.json"
 INBOX_REPLAN_FILE = "INBOX_REPLAN.json"
 

--- a/tests/test_orchestrator_plan.py
+++ b/tests/test_orchestrator_plan.py
@@ -186,6 +186,53 @@ def test_subgoal_forbids_extra_keys() -> None:
         Subgoal.model_validate({"id": 1, "description": "do thing", "extra": True})
 
 
+def test_subgoal_stage_defaults_to_one() -> None:
+    """No-stage Subgoals (legacy plans) deserialise as stage=1 (issue #358)."""
+    sg = Subgoal(id=1, description="do thing")
+    assert sg.stage == 1
+
+
+def test_subgoal_stage_round_trips_explicit_value() -> None:
+    sg = Subgoal(id=2, description="entity rollup", stage=3)
+    assert sg.stage == 3
+    dumped = sg.model_dump()
+    assert dumped["stage"] == 3
+    assert Subgoal.model_validate(dumped) == sg
+
+
+def test_subgoal_stage_legacy_payload_backward_compat() -> None:
+    """A pre-#358 plan payload (no stage key) loads with stage=1."""
+    legacy_payload = {"id": 7, "description": "before stages existed"}
+    sg = Subgoal.model_validate(legacy_payload)
+    assert sg.stage == 1
+
+
+def test_subgoal_stage_rejects_zero_and_negative() -> None:
+    with pytest.raises(ValidationError):
+        Subgoal(id=1, description="x", stage=0)
+    with pytest.raises(ValidationError):
+        Subgoal(id=1, description="x", stage=-2)
+
+
+def test_subgoal_stage_yaml_round_trip_via_plan() -> None:
+    """A Plan that carries staged subgoals round-trips through model_dump."""
+    plan = Plan(
+        version=1,
+        objective="dossier ladder",
+        subgoals=[
+            Subgoal(id=1, description="per-file extract", stage=1),
+            Subgoal(id=2, description="entity rollup", stage=2),
+            Subgoal(id=3, description="narrative", stage=5),
+        ],
+        task_template=[
+            TaskSpec(kind="local_corpus_query", payload={"q": "intake"}),
+        ],
+        expected_iterations=4,
+    )
+    rebuilt = Plan.model_validate(plan.model_dump())
+    assert [sg.stage for sg in rebuilt.subgoals] == [1, 2, 5]
+
+
 # ---------------------------------------------------------------------------
 # Plan
 # ---------------------------------------------------------------------------

--- a/tests/test_storage_jobs.py
+++ b/tests/test_storage_jobs.py
@@ -17,6 +17,7 @@ import pytest
 from research_agent.storage import db, jobs
 from research_agent.storage.jobs import (
     DEFAULT_JOBS_ROOT,
+    JOB_SCHEMA_VERSION,
     Job,
     _atomic_write_text,
     _slugify,
@@ -184,6 +185,7 @@ def test_create_writes_full_folder_layout(
     assert job_meta["goal"] == sample_intake["goal"]
     assert job_meta["status"] == "pending"
     assert job_meta["intake"] == sample_intake
+    assert job_meta["schema_version"] == JOB_SCHEMA_VERSION
 
 
 def test_create_inserts_db_row(sample_intake: dict, jobs_root: Path, db_path: Path) -> None:


### PR DESCRIPTION
Closes #358

## Why

The dossier stage ladder (per-file → entity rollup → geo/temporal →
contradictions → narrative) needs each subgoal to declare which phase
it belongs to so the M3 synth guard can refuse to close a stage N+k
subgoal while a stage N subgoal is still open. This PR lands the
field, persistence, and schema bump so plans written today already
carry it; the guard logic is M3 scope.

## What

- ``Subgoal`` gains ``stage: int = Field(default=1, ge=1)``.
- Plans written before #358 (no ``stage`` key) load with ``stage=1``
  for every subgoal — confirmed by a new backward-compat test.
- ``JOB_SCHEMA_VERSION`` bumped 1 → 2 per AGENTS.md per-job contract
  rule. New jobs declare 2; existing fixture data with
  ``schema_version: 1`` continues to read clean.
- ``docs/JOB_FOLDER_CONTRACT.md`` documents the version history and
  the new ``stage`` field on ``plan/NNNN.json``.

The plan markdown writer dumps the full ``model_dump()`` payload, so
the new field flows into ``plan/NNNN.{md,json}`` automatically.

## Stacking note

Stacked on ``issue-357-extraction-gaps``. Base is ``main`` (consistent
with PRs #360-366); diff currently includes prior commits and will
resolve once they land.

## Test plan

- [x] ``pytest tests/test_orchestrator_plan.py tests/test_contract.py tests/test_storage_jobs.py`` (254 pass)
- [x] Full suite ``pytest tests/`` (2329 passed, 2 skipped, 1 deselected)
- [x] ``ruff check`` on modified files (clean)

Made with [Cursor](https://cursor.com)