### PR TITLE
refactor(router): honor RESEARCH_MODELS_CONFIG at every call site (#373)

### DIFF
--- a/src/research_agent/cli.py
+++ b/src/research_agent/cli.py
@@ -713,7 +713,7 @@ def smoke_llm_command(
     from research_agent.llm.router import load_models_config
     from research_agent.llm.smoke import run_llm_smoke
 
-    cfg = load_models_config(Path("config/models.yaml"))
+    cfg = load_models_config()
     result = asyncio.run(run_llm_smoke(tier, prompt, cfg, image_path=image))
     _print_smoke_result(result)
     if not result.ok:
@@ -789,7 +789,7 @@ def search_command(
         job_id = job
 
     try:
-        models_cfg = None if fts_only else load_models_config(Path("config/models.yaml"))
+        models_cfg = None if fts_only else load_models_config()
         results = [
             item.model_dump()
             for item in public_api.search_findings(

--- a/src/research_agent/daemon.py
+++ b/src/research_agent/daemon.py
@@ -360,10 +360,13 @@ def _build_router(job: Job) -> Any:
     the cost of pulling the LLM stack just to launch a child.
     """
     from research_agent.llm.budgets import BudgetTracker
-    from research_agent.llm.router import Router, load_models_config
+    from research_agent.llm.router import (
+        Router,
+        load_models_config,
+        resolve_models_config_path,
+    )
 
-    config_path = os.environ.get("RESEARCH_MODELS_CONFIG", "config/models.yaml")
-    config = load_models_config(config_path)
+    config = load_models_config(resolve_models_config_path())
     pricing = config.get("pricing") or {}
     intake = job.intake or {}
     cap_usd = intake.get("budget_cap_usd")

--- a/src/research_agent/doctor.py
+++ b/src/research_agent/doctor.py
@@ -665,7 +665,12 @@ def run_all_checks(
     results.append(check_lm_studio(config.get("LMSTUDIO_BASE_URL")))
     results.append(check_writable_dirs(root))
     results.append(check_sqlite_wal())
-    results.append(check_models_yaml(root / "config" / "models.yaml"))
+    from research_agent.llm.router import resolve_models_config_path
+
+    models_path = resolve_models_config_path()
+    if not models_path.is_absolute():
+        models_path = root / models_path
+    results.append(check_models_yaml(models_path))
     results.append(check_tesseract())
     results.append(check_serpapi_cost_note())
     results.append(check_trove_api_note())

--- a/src/research_agent/intake.py
+++ b/src/research_agent/intake.py
@@ -15,7 +15,6 @@ cloud failure (intake must not block on cloud failure).
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 from typing import Any
 
 import questionary
@@ -113,7 +112,7 @@ def _generate_followup_questions(answers_so_far: dict[str, Any]) -> list[Followu
     Separated from :func:`_collect_followups` so tests can stub the LLM
     call independently of the user-facing prompt loop.
     """
-    cfg = load_models_config(Path("config/models.yaml"))
+    cfg = load_models_config()
     tiers = cfg["tiers"]
     if "general" not in tiers:
         raise KeyError("'general' tier missing from config/models.yaml")

--- a/src/research_agent/llm/router.py
+++ b/src/research_agent/llm/router.py
@@ -123,13 +123,34 @@ def _is_retryable(exc: BaseException) -> bool:
     return False
 
 
-def load_models_config(path: Path | str = "config/models.yaml") -> dict[str, Any]:
-    """Parse ``config/models.yaml`` and return the raw dict.
+def resolve_models_config_path() -> Path:
+    """Return the active models YAML path.
+
+    Honors the ``RESEARCH_MODELS_CONFIG`` env var (loaded via
+    :mod:`research_agent.config` so ``.env`` / ``.env.local`` files apply
+    consistently); defaults to ``config/models.yaml`` when unset. This is
+    the single source of truth — every caller that needs the active
+    models config path (CLI subcommands, ``intake``, ``doctor``, the
+    daemon's router builder, the local-corpus embedding endpoint
+    resolver) reads through here so a deployment that points the daemon
+    at ``config/models.local.yaml`` doesn't have ``research doctor`` or
+    ``research smoke-llm`` silently checking the wrong file.
+    """
+    raw = cfg_get("RESEARCH_MODELS_CONFIG") or "config/models.yaml"
+    return Path(raw)
+
+
+def load_models_config(path: Path | str | None = None) -> dict[str, Any]:
+    """Parse the active models routing YAML and return the raw dict.
+
+    When ``path`` is omitted, uses :func:`resolve_models_config_path` so
+    every caller honors ``RESEARCH_MODELS_CONFIG`` without re-implementing
+    the env lookup.
 
     Raises :class:`ValueError` if the top-level ``tiers`` key is missing —
     every other layer of the system assumes it exists.
     """
-    p = Path(path)
+    p = Path(path) if path is not None else resolve_models_config_path()
     with p.open("r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
     if not isinstance(data, dict) or "tiers" not in data:
@@ -803,4 +824,5 @@ __all__ = [
     "Router",
     "Tier",
     "load_models_config",
+    "resolve_models_config_path",
 ]

--- a/src/research_agent/tools/local_corpus.py
+++ b/src/research_agent/tools/local_corpus.py
@@ -193,7 +193,7 @@ def _resolve_embedding_endpoint(
     models_config: dict[str, Any] | None = None,
 ) -> tuple[str, str]:
     """Return ``(base_url, model_name)`` for the embeddings tier."""
-    cfg = models_config or load_models_config(Path("config/models.yaml"))
+    cfg = models_config or load_models_config()
     tiers = cfg.get("tiers") or {}
     spec = tiers.get("embeddings")
     if not spec:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,6 +28,10 @@ def _reset_env_loader(monkeypatch):
         "RESEARCH_HEADFUL",
         "RESEARCH_FRAGMENT_SYNTH",
         "LMSTUDIO_BASE_URL",
+        # Issue #373: resolve_models_config_path() honors this env var.
+        # Tests assume the default ``config/models.yaml`` lookup, so clear
+        # any operator-set override from the host ``.env`` before each run.
+        "RESEARCH_MODELS_CONFIG",
     )
     for key in env_keys:
         os.environ.pop(key, None)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -17,6 +17,9 @@ def _scrub_env(monkeypatch):
         "RESEARCH_USER_AGENT",
         "RESEARCH_HEADFUL",
         "LMSTUDIO_BASE_URL",
+        # Issue #373: resolve_models_config_path() honors this; tests
+        # assume the default lookup so clear any host ``.env`` override.
+        "RESEARCH_MODELS_CONFIG",
     ):
         monkeypatch.delenv(key, raising=False)
     config.reset_for_tests()

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -230,6 +230,88 @@ def test_load_models_config_raises_when_tiers_missing(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# resolve_models_config_path() — honors RESEARCH_MODELS_CONFIG everywhere
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_models_config_path_default_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No env var set → resolver returns the documented default path."""
+    from research_agent.llm.router import resolve_models_config_path
+
+    monkeypatch.setattr(
+        "research_agent.llm.router.cfg_get",
+        lambda key, default=None: None,
+    )
+    assert resolve_models_config_path() == Path("config/models.yaml")
+
+
+def test_resolve_models_config_path_reads_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RESEARCH_MODELS_CONFIG override returned verbatim as a Path."""
+    from research_agent.llm.router import resolve_models_config_path
+
+    monkeypatch.setattr(
+        "research_agent.llm.router.cfg_get",
+        lambda key, default=None: "config/models.local.yaml"
+        if key == "RESEARCH_MODELS_CONFIG"
+        else None,
+    )
+    assert resolve_models_config_path() == Path("config/models.local.yaml")
+
+
+def test_load_models_config_no_arg_uses_resolver(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """load_models_config() with no path defers to resolve_models_config_path()."""
+    custom = tmp_path / "custom.yaml"
+    custom.write_text(
+        yaml.safe_dump(
+            {"tiers": {"general": {"provider": "lmstudio", "model": "m"}}}
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "research_agent.llm.router.cfg_get",
+        lambda key, default=None: str(custom)
+        if key == "RESEARCH_MODELS_CONFIG"
+        else None,
+    )
+    cfg = load_models_config()
+    assert cfg["tiers"]["general"]["model"] == "m"
+
+
+def test_load_models_config_explicit_path_overrides_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explicit ``path=`` kwarg wins over RESEARCH_MODELS_CONFIG."""
+    env_yaml = tmp_path / "env.yaml"
+    env_yaml.write_text(
+        yaml.safe_dump(
+            {"tiers": {"general": {"provider": "lmstudio", "model": "env-model"}}}
+        ),
+        encoding="utf-8",
+    )
+    explicit_yaml = tmp_path / "explicit.yaml"
+    explicit_yaml.write_text(
+        yaml.safe_dump(
+            {"tiers": {"general": {"provider": "lmstudio", "model": "explicit-model"}}}
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "research_agent.llm.router.cfg_get",
+        lambda key, default=None: str(env_yaml)
+        if key == "RESEARCH_MODELS_CONFIG"
+        else None,
+    )
+    cfg = load_models_config(explicit_yaml)
+    assert cfg["tiers"]["general"]["model"] == "explicit-model"
+
+
+# ---------------------------------------------------------------------------
 # model_for(tier)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #373

## Why

\`RESEARCH_MODELS_CONFIG\` was honored by the daemon's router builder but silently ignored by five other entry points that hard-coded \`Path(\"config/models.yaml\")\`. An operator running with \`RESEARCH_MODELS_CONFIG=config/models.local.yaml\` got a daemon on the local preset, while \`research doctor\`, \`research smoke-llm\`, \`research search\`, the interactive intake follow-up generator, and the local-corpus embedding endpoint resolver all silently checked the cloud-routing file.

## What

- New \`resolve_models_config_path() -> Path\` in \`research_agent.llm.router\` — single source of truth, reads through \`cfg_get\` so \`.env\` / \`.env.local\` apply consistently.
- \`load_models_config(path=None)\` defers to the resolver when no explicit path is passed.
- Five call sites updated: \`cli.py\`, \`intake.py\`, \`daemon.py\`, \`doctor.py\`, \`tools/local_corpus.py\`.
- Test fixtures (\`_reset_env_loader\`, \`_scrub_env\`) now clear \`RESEARCH_MODELS_CONFIG\` so tests isolate from a host \`.env\` override.

## Test plan

- [x] \`pytest tests/test_llm_router.py tests/test_doctor.py tests/test_intake.py tests/test_cli.py tests/test_daemon.py tests/test_tools_local_corpus.py\` — 262 pass
- [x] Full suite: 2251 passed, 2 skipped, 1 deselected
- [x] \`ruff check\` clean

## Stacking note

First of six PRs landing the parked main-branch work. Base is \`main\`; no dependencies. Prereq for #374-378 and the in-flight dossier stack (PRs #360-367) where the rebase will pick this up.

Made with [Cursor](https://cursor.com)