### PR TITLE
chore(config): refresh LM Studio model lineup (#375)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,11 +302,11 @@ hardcode model names elsewhere — pick a tier.
 
 | Tier | Model ID | Purpose |
 |---|---|---|
-| `fast` | `qwen3-4b-instruct-q4_k_m` | Classification, dedup, language detection. |
-| `general` | `qwen3-32b-instruct-q6_k` | Worker default — query rewriting, extraction, summarization. |
-| `reasoner` | `deepseek-r1-distill-32b-q6_k` | Hypothesis ranking, contradiction detection. |
-| `vision` | `qwen3-vl-8b-instruct` | PDF page screenshots, chart reading. |
-| `embeddings` | `qwen3-embedding-4b` | Semantic search across findings + sources. |
+| `fast` | `josiefied-qwen3-4b-instruct-2507-abliterated-v2` | Classification, dedup, language detection. |
+| `general` | `qwen3.6-35b-a3b-holo3-qwopus-instruct-qx64-hi-mlx` | Worker default — query rewriting, extraction, summarization. |
+| `reasoner` | `deepseek-r1-distill-qwen-32b` | Hypothesis ranking, contradiction detection. |
+| `vision` | `deepseek-ocr-2` | PDF page screenshots, chart reading. |
+| `embeddings` | `qwen3-embedding-4b-dwq` | Semantic search across findings + sources (768-d output). |
 
 After downloading, start the LM Studio local server (Developer tab →
 Server → Start). The default port is `1234` and the OpenAI-compatible
@@ -316,8 +316,12 @@ LAN).
 
 `embeddings` intentionally has no cloud fallback — a stall surfaces as a
 hard error rather than silently rerouting to a chat model. Keep
-`qwen3-embedding-4b` loaded any time you plan to use `research search` or
-the daemon's hybrid retrieval.
+`qwen3-embedding-4b-dwq` loaded any time you plan to use `research search`
+or the daemon's hybrid retrieval. After upgrading from a release that
+shipped the older 1024-d `qwen3-embedding-4b` model, drop
+`data/index.sqlite` or re-index any job with persisted embeddings — the
+new model emits 768-d vectors and existing rows will mis-shape on
+read-back.
 
 ## OpenRouter
 

--- a/config/models.local.yaml
+++ b/config/models.local.yaml
@@ -1,74 +1,79 @@
 # Local-only tier mapping — no OpenRouter, no cloud, $0 per call.
 #
-# Every tier routes to LM Studio. The `frontier*` tiers stay named for
-# code-path compatibility (router + synth/critique reference them by name)
-# but resolve to local gemma models. Cost is always $0; the `pricing` block
-# is intentionally empty so BudgetTracker computes cost = 0.
+# Every tier routes to LM Studio (see LMSTUDIO_BASE_URL in .env). The
+# `frontier*` tier names are kept for code-path compatibility; they hit
+# local chat models here, not OpenRouter. Cost is always $0 (`pricing: {}`).
+#
+# Activate via RESEARCH_MODELS_CONFIG=config/models.local.yaml and
+# `research start --local` (records local=true in job intake).
 #
 # Loaded models (verify with `curl -s http://localhost:1234/v1/models`):
-#   - google/gemma-4-26b-a4b   (large MoE, ~4B active — planner/synth/critique)
-#   - google/gemma-4-e4b       (efficient 4B dense — workers, summaries)
-#   - text-embedding-nomic-embed-text-v1.5
-#
-# Vision tier maps to gemma-4-26b-a4b as a placeholder; image inputs will
-# either be ignored or fail at the connector boundary depending on caller.
-# Until a true VLM is loaded, avoid emitting vision-tier tasks.
+#   - qwen3.6-35b-a3b-holo3-qwopus-instruct-qx64-hi-mlx  (workers + frontier)
+#   - josiefied-qwen3-4b-instruct-2507-abliterated-v2     (fast)
+#   - deepseek-r1-distill-qwen-32b                        (reasoner)
+#   - deepseek-ocr-2                                      (vision / OCR)
+#   - text-embedding-nomic-embed-text-v1.5                (embeddings, 768-d)
+#   - google/gemma-4-31b, google/gemma-4-e4b            (optional fallbacks)
 
 tiers:
   fast:
     provider: lmstudio
-    model: google/gemma-4-e4b
-    timeout_s: 60
+    model: josiefied-qwen3-4b-instruct-2507-abliterated-v2
+    timeout_s: 30
     fallback_tier: general
-    purpose: Classification, dedup, simple relevance scoring.
+    purpose: |
+      Classification, deduplication, language detection, simple
+      relevance scoring. ~100 tok/s on M-series.
 
   general:
     provider: lmstudio
-    model: google/gemma-4-e4b
-    timeout_s: 120
+    model: qwen3.6-35b-a3b-holo3-qwopus-instruct-qx64-hi-mlx
+    timeout_s: 90
     fallback_tier: reasoner
-    purpose: Worker default — extract_findings, summarize_source, query rewriting.
+    purpose: |
+      Research worker default. Query rewriting, source extraction,
+      per-source summarization, finding generation.
 
   reasoner:
     provider: lmstudio
-    model: google/gemma-4-26b-a4b
+    model: deepseek-r1-distill-qwen-32b
     timeout_s: 300
     fallback_tier: frontier
-    purpose: Planner, complex extraction, hypothesis ranking.
+    purpose: |
+      Complex extraction, hypothesis ranking, contradiction detection.
+      Use sparingly.
 
   vision:
     provider: lmstudio
-    model: google/gemma-4-26b-a4b
-    timeout_s: 120
-    fallback_tier: general
-    purpose: Placeholder — no true VLM loaded; avoid vision tasks for now.
+    model: deepseek-ocr-2
+    timeout_s: 60
+    fallback_tier: frontier_speed
+    purpose: PDF page screenshots, chart reading.
 
   embeddings:
     provider: lmstudio
     model: text-embedding-nomic-embed-text-v1.5
     timeout_s: 60
-    purpose: Semantic search over findings + sources.
+    purpose: Semantic search over findings + sources (768-d, matches tools/local_corpus.py EMBED_DIM).
 
-  # The "frontier" family stays local in this preset. Synth, critique, and
-  # planner rewrites all hit gemma-4-26b-a4b. Same model for `frontier_alt`
-  # so critique runs on the same weights as the synthesizer (loses
-  # productive disagreement, but keeps the run truly local + free).
+  # The "frontier" family stays local in this preset. Synth/critique use the
+  # same Holo3 Qwen3.6 worker model; `frontier_alt` uses Gemma for variety.
   frontier:
     provider: lmstudio
-    model: google/gemma-4-26b-a4b
+    model: qwen3.6-35b-a3b-holo3-qwopus-instruct-qx64-hi-mlx
     timeout_s: 600
     purpose: Synthesis, critique, final report (local, $0).
 
   frontier_alt:
     provider: lmstudio
-    model: google/gemma-4-26b-a4b
+    model: google/gemma-4-31b
     timeout_s: 600
     fallback_tier: frontier
-    purpose: Critique alt — same model as frontier in local mode.
+    purpose: Critique alt — different weights than frontier synthesizer.
 
   frontier_speed:
     provider: lmstudio
-    model: google/gemma-4-e4b
+    model: josiefied-qwen3-4b-instruct-2507-abliterated-v2
     timeout_s: 120
     purpose: Fast fallback when frontier hits its cap.
 

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -8,7 +8,7 @@
 tiers:
   fast:
     provider: lmstudio
-    model: qwen3-4b-instruct-q4_k_m
+    model: josiefied-qwen3-4b-instruct-2507-abliterated-v2
     timeout_s: 30
     fallback_tier: frontier_speed
     purpose: |
@@ -17,7 +17,7 @@ tiers:
 
   general:
     provider: lmstudio
-    model: qwen3-32b-instruct-q6_k
+    model: qwen3.6-35b-a3b-holo3-qwopus-instruct-qx64-hi-mlx
     timeout_s: 90
     fallback_tier: frontier_speed
     purpose: |
@@ -26,7 +26,7 @@ tiers:
 
   reasoner:
     provider: lmstudio
-    model: deepseek-r1-distill-32b-q6_k
+    model: deepseek-r1-distill-qwen-32b
     timeout_s: 300
     fallback_tier: frontier
     purpose: |
@@ -35,7 +35,7 @@ tiers:
 
   vision:
     provider: lmstudio
-    model: qwen3-vl-8b-instruct
+    model: deepseek-ocr-2
     timeout_s: 60
     fallback_tier: frontier_speed
     purpose: PDF page screenshots, chart reading.
@@ -45,7 +45,7 @@ tiers:
   # surface as a hard error rather than silently rerouting to a chat model.
   embeddings:
     provider: lmstudio
-    model: qwen3-embedding-4b
+    model: qwen3-embedding-4b-dwq
     timeout_s: 60
     purpose: Semantic search across findings and sources.
 

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -206,12 +206,16 @@ def test_load_models_config_ships_with_tier_table() -> None:
         "frontier_alt": "openrouter",
         "frontier_speed": "openrouter",
     }
+    # Model ids reflect the LM Studio lineup currently loaded on the
+    # operator's workstation (issue #375). When the lineup changes,
+    # update ``config/models.yaml`` *and* this assertion together so
+    # the configuration and the regression test stay coupled.
     expected_model = {
-        "fast": "qwen3-4b-instruct-q4_k_m",
-        "general": "qwen3-32b-instruct-q6_k",
-        "reasoner": "deepseek-r1-distill-32b-q6_k",
-        "vision": "qwen3-vl-8b-instruct",
-        "embeddings": "qwen3-embedding-4b",
+        "fast": "josiefied-qwen3-4b-instruct-2507-abliterated-v2",
+        "general": "qwen3.6-35b-a3b-holo3-qwopus-instruct-qx64-hi-mlx",
+        "reasoner": "deepseek-r1-distill-qwen-32b",
+        "vision": "deepseek-ocr-2",
+        "embeddings": "qwen3-embedding-4b-dwq",
         "frontier": "anthropic/claude-opus-4-7",
         "frontier_alt": "moonshotai/kimi-k2-1t",
         "frontier_speed": "anthropic/claude-haiku-4-5",
@@ -703,7 +707,9 @@ async def test_call_emits_llm_call_event_and_inserts_llm_calls_row(
     row = llm_rows[0]
     assert row["tier"] == "general"
     assert row["provider"] == "lmstudio"
-    assert row["model"] == "qwen3-32b-instruct-q6_k"
+    # Matches the LM Studio general-tier model in config/models.yaml; bumped
+    # together with the lineup refresh in issue #375.
+    assert row["model"] == "qwen3.6-35b-a3b-holo3-qwopus-instruct-qx64-hi-mlx"
     assert row["input_tokens"] == 12
     assert row["output_tokens"] == 34
     assert row["cached_tokens"] == 5


### PR DESCRIPTION
Closes #375

## Why

\`config/models.yaml\` and \`config/models.local.yaml\` still pinned the quantization-era model ids; the operator's LM Studio now serves a different lineup. With the old YAMLs every non-default tier hits \"model not found\" and degrades through the fallback chain.

## What

\`config/models.yaml\` — LM Studio tiers:

| Tier       | Old                            | New                                                  |
|------------|--------------------------------|------------------------------------------------------|
| fast       | qwen3-4b-instruct-q4_k_m       | josiefied-qwen3-4b-instruct-2507-abliterated-v2      |
| general    | qwen3-32b-instruct-q6_k        | qwen3.6-35b-a3b-holo3-qwopus-instruct-qx64-hi-mlx    |
| reasoner   | deepseek-r1-distill-32b-q6_k   | deepseek-r1-distill-qwen-32b                         |
| vision     | qwen3-vl-8b-instruct           | deepseek-ocr-2                                       |
| embeddings | qwen3-embedding-4b (1024-d)    | qwen3-embedding-4b-dwq (**768-d**)                   |

OpenRouter rows unchanged.

\`config/models.local.yaml\` — every tier routes to LM Studio at \$0/call, with \`frontier_alt: google/gemma-4-31b\` for critique variety.

README table + warning refreshed. Two pre-existing tests updated to assert the new model ids; the README enumeration regression test passes because the README was refreshed in lock-step.

## Embedding dimension warning

The new embedding model emits 768-d vectors instead of the previous 1024-d. \`EMBED_DIM = 768\` in \`tools/local_corpus.py\` lands together with the layered PDF delegation in the next PR so the YAML and the consuming code stay coupled. Operators upgrading should drop \`data/index.sqlite\` (or re-index any job with persisted embeddings) after that PR lands.

## Test plan

- [x] Full suite: 2258 passed, 2 skipped, 1 deselected
- [x] \`ruff check\` clean

## Stacking note

3/6 of the parked-changes stack. Stacked on #380 (pdf hybrid). Base is \`main\`.

Made with [Cursor](https://cursor.com)