### PR TITLE
feat(local_corpus): delegate PDF extraction to layered pipeline + EMBED_DIM=768 (#376)

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -12,6 +12,9 @@ fields on `task_template[].payload`.
 | `translate_non_english` | `false` | job or task payload | When true, extraction writes an English mirror for each non-English finding as `findings/NNNNNN.translation.md`. |
 | `fragments` | `false` | job | Records that the operator requested section-fragment synthesis with `research start --fragments`. Runtime routing still uses `RESEARCH_FRAGMENT_SYNTH=1`, which the CLI sets for the spawned daemon. |
 | `corpus_dossier` | `false` | job | When true, daemon local-corpus ingestion passes `per_page=True` to `local_corpus.index(...)` for files it indexes, writing one Source row per PDF page with `metadata.{parent_file, page_no, page_chunk}` stamped on the sidecar. Required by the dossier rollup (epic #359). Enabled with `research start --corpus-dossier`; the flag is rejected without `--corpus`. |
+| `pdf_hybrid_pages` | `false` | job | When true, local-corpus PDF extraction merges the text layer with Tesseract OCR per page (`tools.pdf` hybrid mode). Use for FOIA / archival corpora that mix typed sections with scanned inserts. |
+| `pdf_max_pages` | `1000` | job | Per-PDF page cap for local-corpus indexing. Clamped to `MAX_PAGES_HARD_CAP = 1000` regardless of intake value. |
+| `pdf_max_chars` | `2_000_000` | job | Per-PDF character cap for local-corpus indexing. |
 
 `translate_non_english` is intentionally opt-in. Use it for multilingual
 archive runs where French, Spanish, or other non-English primary sources are
@@ -37,6 +40,25 @@ Job-level CLI opt-in:
 ```bash
 research start --skip-intake --goal "Algerian war archives" --translate-non-english
 ```
+
+## Embedding Dimension Migration (issue #376)
+
+The local-corpus embedding tier now emits **768-dimensional** vectors
+(model `qwen3-embedding-4b-dwq` in `config/models.yaml`, model
+`text-embedding-nomic-embed-text-v1.5` in `config/models.local.yaml`).
+`tools/local_corpus.py` sets `EMBED_DIM = 768` to match.
+
+Pre-upgrade jobs persisted 1024-d float32 blobs in `sources.embedding`.
+Running `research search` against those rows after upgrading will not search
+them cleanly: current code skips mismatched vectors, and older code paths may
+fail while reading them. Choose one:
+
+- **Drop the index**: `rm data/index.sqlite` and re-run `research start`
+  for any job whose corpus you still need (re-embeds at $0 on local).
+- **Per-job re-index**: delete the affected rows from `sources` and
+  `job_sources` and re-run `research start` for that job.
+
+New jobs created after the upgrade are unaffected.
 
 ## Fragment Synthesis Rollout
 

--- a/src/research_agent/tools/local_corpus.py
+++ b/src/research_agent/tools/local_corpus.py
@@ -11,9 +11,9 @@ Idempotent by design: each chunk is content-addressed by sha256, so re-
 running on the same corpus skips already-indexed chunks (and never re-
 spends embedding tokens on them).
 
-Heavy parsers — ``pypdf``, ``unstructured.*``, ``bs4`` — are lazy-imported
-only inside their extractor helpers so importing this module on startup
-stays cheap.
+PDFs use the layered :mod:`research_agent.tools.pdf` pipeline (pypdf →
+pdfplumber → Tesseract OCR → optional VLM). HTML uses ``bs4`` with an
+``unstructured`` fallback. Imports stay lazy so module load stays cheap.
 
 ``search(query, job, top_k)`` runs a numpy cosine over the job's local
 sources and returns the top-k matches, sorted descending by score.
@@ -43,10 +43,11 @@ logger = logging.getLogger(__name__)
 
 CHUNK_TARGET_TOKENS = 6000
 CHUNK_OVERLAP_TOKENS = 200
-EMBED_DIM = 1024
+EMBED_DIM = 768
 
 _SUPPORTED_SUFFIXES = frozenset({".pdf", ".md", ".txt", ".html", ".htm"})
 _PYPDF_MIN_CHARS = 100
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
 
 
 # ---------------------------------------------------------------------------
@@ -67,34 +68,73 @@ def _walk_corpus(path: Path) -> Iterable[Path]:
             yield candidate
 
 
-def _extract_pdf(path: Path) -> str:
-    """Extract text from a PDF. Pypdf first, ``unstructured`` lazy fallback."""
-    import pypdf  # lazy
+def _resolve_pdf_hybrid_pages(job: Job | None, hybrid_pages: bool | None) -> bool:
+    """Resolve ``hybrid_pages`` from an explicit arg or ``job.intake``."""
+    if hybrid_pages is not None:
+        return hybrid_pages
+    if job is None:
+        return False
+    raw = (job.intake or {}).get("pdf_hybrid_pages")
+    if isinstance(raw, str):
+        return raw.strip().lower() in _TRUTHY
+    return bool(raw)
 
-    try:
-        reader = pypdf.PdfReader(str(path))
-        parts = [page.extract_text() or "" for page in reader.pages]
-        text = "\n\n".join(p for p in parts if p)
-    except Exception as exc:  # noqa: BLE001 — fall through to unstructured
-        logger.debug("pypdf failed for %s: %s", path, exc)
-        text = ""
 
-    if len(text) >= _PYPDF_MIN_CHARS:
-        return text
+def _clamp_pdf_max_pages(value: int) -> int:
+    from research_agent.tools.pdf import MAX_PAGES_HARD_CAP
 
-    # Lazy fallback — only pay the unstructured import when pypdf under-extracts.
-    try:
-        from unstructured.partition.pdf import partition_pdf  # type: ignore[import-untyped]
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("unstructured.partition.pdf import failed: %s", exc)
-        return text
+    return min(max(1, int(value)), MAX_PAGES_HARD_CAP)
 
-    try:
-        elements = partition_pdf(filename=str(path))
-        return "\n\n".join(str(el) for el in elements if str(el).strip())
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("unstructured.partition.pdf failed for %s: %s", path, exc)
-        return text
+
+def _resolve_pdf_max_pages(job: Job | None, max_pages: int | None) -> int:
+    """Resolve per-PDF page cap for corpus indexing (default 1000)."""
+    from research_agent.tools.pdf import CORPUS_MAX_PAGES
+
+    if max_pages is not None:
+        return _clamp_pdf_max_pages(max_pages)
+    if job is not None:
+        intake_pages = (job.intake or {}).get("pdf_max_pages")
+        if intake_pages is not None:
+            return _clamp_pdf_max_pages(int(intake_pages))
+    return CORPUS_MAX_PAGES
+
+
+def _resolve_pdf_max_chars(job: Job | None, max_chars: int | None) -> int:
+    """Resolve per-PDF character cap for corpus indexing."""
+    from research_agent.tools.pdf import CORPUS_MAX_CHARS
+
+    if max_chars is not None:
+        return max(1, int(max_chars))
+    if job is not None:
+        intake_chars = (job.intake or {}).get("pdf_max_chars")
+        if intake_chars is not None:
+            return max(1, int(intake_chars))
+    return CORPUS_MAX_CHARS
+
+
+def _extract_pdf(
+    path: Path,
+    job: Job | None = None,
+    *,
+    hybrid_pages: bool | None = None,
+    max_pages: int | None = None,
+    max_chars: int | None = None,
+) -> str:
+    """Extract text from a PDF via the layered :mod:`pdf` pipeline.
+
+    Scanned documents need the Tesseract OCR layer (``tesseract`` on PATH).
+    When ``hybrid_pages`` is true, each page merges text-layer extraction with
+    an OCR supplement (see :func:`pdf.extract_sync`).
+    """
+    from research_agent.tools import pdf as pdf_mod
+
+    return pdf_mod.extract_sync(
+        path,
+        job=job,
+        hybrid_pages=_resolve_pdf_hybrid_pages(job, hybrid_pages),
+        max_pages=_resolve_pdf_max_pages(job, max_pages),
+        max_chars=_resolve_pdf_max_chars(job, max_chars),
+    )
 
 
 def _extract_html(path: Path) -> str:
@@ -130,7 +170,12 @@ def _extract_html(path: Path) -> str:
         return text
 
 
-def _extract_text(path: Path) -> tuple[str, str]:
+def _extract_text(
+    path: Path,
+    job: Job | None = None,
+    *,
+    hybrid_pages: bool | None = None,
+) -> tuple[str, str]:
     """Return ``(extracted_text, kind_hint)`` for ``path``.
 
     ``kind_hint`` is the file-type label (``pdf``, ``md``, ``txt``, ``html``)
@@ -139,7 +184,7 @@ def _extract_text(path: Path) -> tuple[str, str]:
     """
     suffix = path.suffix.lower()
     if suffix == ".pdf":
-        return _extract_pdf(path), "pdf"
+        return _extract_pdf(path, job=job, hybrid_pages=hybrid_pages), "pdf"
     if suffix in (".html", ".htm"):
         return _extract_html(path), "html"
     if suffix in (".md", ".txt"):
@@ -242,7 +287,7 @@ def _embed_chunks_sync(
 
 
 def _pack_embedding(vec: np.ndarray) -> bytes:
-    """Pack a float32 vector to a little-endian BLOB (1024 * 4 = 4096 bytes)."""
+    """Pack a float32 vector to a little-endian BLOB."""
     arr = np.asarray(vec, dtype="<f4")
     return arr.tobytes()
 
@@ -262,6 +307,7 @@ def index(
     *,
     models_config: dict[str, Any] | None = None,
     per_page: bool = False,
+    hybrid_pages: bool | None = None,
 ) -> dict[str, Any]:
     """Index every supported file under ``corpus_path`` into ``job``.
 
@@ -286,9 +332,15 @@ def index(
     keeps the same ``metadata.parent_file`` so coverage rollup can group
     chunks by their source file.
 
-    When ``per_page=False`` (default), behaviour is unchanged: one
+    The ``hybrid_pages`` arg, or ``job.intake["pdf_hybrid_pages"]`` when
+    the arg is ``None``, enables per-page text-layer + OCR merging for PDF
+    extraction. ``pdf_max_pages`` and ``pdf_max_chars`` intake values are
+    resolved by the PDF helpers.
+
+    When ``per_page=False`` (default), non-PDF behaviour is unchanged: one
     embedding batch per file, no metadata stamping, ``pages_indexed`` /
-    ``pages_skipped`` are zero.
+    ``pages_skipped`` are zero. PDFs use the layered
+    :mod:`research_agent.tools.pdf` pipeline.
     """
     root = Path(corpus_path)
     base_url, model_name = _resolve_embedding_endpoint(models_config)
@@ -300,6 +352,7 @@ def index(
     pages_indexed = 0
     pages_skipped = 0
     skipped: list[dict[str, str]] = []
+    pdf_hybrid = _resolve_pdf_hybrid_pages(job, hybrid_pages)
 
     for file_path in _walk_corpus(root):
         if per_page and file_path.suffix.lower() == ".pdf":
@@ -308,6 +361,7 @@ def index(
                 job,
                 base_url=base_url,
                 model_name=model_name,
+                hybrid_pages=pdf_hybrid,
             )
             files_indexed += stats["files_indexed"]
             files_skipped += stats["files_skipped"]
@@ -320,7 +374,11 @@ def index(
 
         file_url = file_path.as_uri()
         try:
-            raw_text, _kind_hint = _extract_text(file_path)
+            raw_text, _kind_hint = _extract_text(
+                file_path,
+                job=job,
+                hybrid_pages=pdf_hybrid,
+            )
         except Exception as exc:  # noqa: BLE001
             logger.warning("failed to extract %s: %s", file_path, exc)
             files_skipped += 1
@@ -408,6 +466,7 @@ def _index_pdf_per_page(
     *,
     base_url: str,
     model_name: str,
+    hybrid_pages: bool = False,
 ) -> dict[str, Any]:
     """Index one PDF as one :class:`Source` row per page (dossier mode).
 
@@ -435,7 +494,13 @@ def _index_pdf_per_page(
 
     file_url = file_path.as_uri()
     try:
-        pages = pdf_mod.extract_pages_sync(file_path)
+        pages = pdf_mod.extract_pages_sync(
+            file_path,
+            job=job,
+            hybrid_pages=hybrid_pages,
+            max_pages=_resolve_pdf_max_pages(job, None),
+            max_chars=_resolve_pdf_max_chars(job, None),
+        )
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "pdf per-page extract failed for %s: %s", file_path, exc

--- a/tests/test_tools_local_corpus.py
+++ b/tests/test_tools_local_corpus.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -179,6 +180,97 @@ def test_extract_text_html_lazy_unstructured(tmp_path: Path, monkeypatch) -> Non
 
 
 # ---------------------------------------------------------------------------
+# PDF delegation to the layered pipeline (issue #376)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_text_pdf_delegates_to_layered_pipeline(tmp_path: Path, monkeypatch) -> None:
+    """PDFs flow through ``tools.pdf.extract_sync`` with resolved caps."""
+    from research_agent.tools import pdf as pdf_mod
+
+    captured: dict[str, Any] = {}
+
+    def _fake_extract_sync(path, **kwargs):
+        captured["path"] = path
+        captured.update(kwargs)
+        return "DELEGATED MARKDOWN"
+
+    monkeypatch.setattr(pdf_mod, "extract_sync", _fake_extract_sync)
+
+    f = tmp_path / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4\n")
+    text, kind = local_corpus._extract_text(f)
+    assert kind == "pdf"
+    assert text == "DELEGATED MARKDOWN"
+    assert captured["hybrid_pages"] is False
+    assert captured["max_pages"] == pdf_mod.CORPUS_MAX_PAGES
+    assert captured["max_chars"] == pdf_mod.CORPUS_MAX_CHARS
+
+
+def test_extract_text_pdf_forwards_intake_knobs(tmp_path: Path, monkeypatch) -> None:
+    """``job.intake`` values flow through the resolvers into ``extract_sync``."""
+    from research_agent.tools import pdf as pdf_mod
+
+    captured: dict[str, Any] = {}
+
+    def _fake_extract_sync(path, **kwargs):
+        captured.update(kwargs)
+        return ""
+
+    monkeypatch.setattr(pdf_mod, "extract_sync", _fake_extract_sync)
+
+    class _StubJob:
+        intake = {
+            "pdf_hybrid_pages": True,
+            "pdf_max_pages": 50,
+            "pdf_max_chars": 12345,
+        }
+
+    f = tmp_path / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4\n")
+    local_corpus._extract_text(f, job=_StubJob())  # type: ignore[arg-type]
+
+    assert captured["hybrid_pages"] is True
+    assert captured["max_pages"] == 50
+    assert captured["max_chars"] == 12345
+
+
+def test_clamp_pdf_max_pages_enforces_hard_cap() -> None:
+    """Misconfigured intake values can't push extraction beyond the hard cap."""
+    from research_agent.tools.pdf import MAX_PAGES_HARD_CAP
+
+    assert local_corpus._clamp_pdf_max_pages(0) == 1
+    assert local_corpus._clamp_pdf_max_pages(-5) == 1
+    assert local_corpus._clamp_pdf_max_pages(MAX_PAGES_HARD_CAP) == MAX_PAGES_HARD_CAP
+    assert (
+        local_corpus._clamp_pdf_max_pages(MAX_PAGES_HARD_CAP + 1000) == MAX_PAGES_HARD_CAP
+    )
+
+
+def test_resolve_pdf_hybrid_pages_priority() -> None:
+    """Explicit kwarg > intake > default False."""
+
+    class _StubJob:
+        intake = {"pdf_hybrid_pages": True}
+
+    class _StringFalseJob:
+        intake = {"pdf_hybrid_pages": "false"}
+
+    assert local_corpus._resolve_pdf_hybrid_pages(None, None) is False
+    assert local_corpus._resolve_pdf_hybrid_pages(_StubJob(), None) is True  # type: ignore[arg-type]
+    assert local_corpus._resolve_pdf_hybrid_pages(_StubJob(), False) is False  # type: ignore[arg-type]
+    assert local_corpus._resolve_pdf_hybrid_pages(_StringFalseJob(), None) is False  # type: ignore[arg-type]
+
+
+def test_embed_dim_matches_qwen3_embedding_4b_dwq() -> None:
+    """The 768-d setting must move in lock-step with the embeddings model
+    in ``config/models.yaml`` (issue #375). Tripping this assertion means
+    someone changed the embedding model without re-indexing or vice versa.
+    """
+    assert local_corpus.EMBED_DIM == 768
+
+
+# ---------------------------------------------------------------------------
 # index() — happy path with stubbed embeddings
 # ---------------------------------------------------------------------------
 
@@ -322,7 +414,7 @@ def test_index_extraction_failure_records_reason(
     target = corpus / "broken.txt"
     target.write_text("payload")
 
-    def _boom(path: Path):
+    def _boom(path: Path, **_kwargs):
         raise RuntimeError("synthetic extract failure")
 
     monkeypatch.setattr(local_corpus, "_extract_text", _boom)
@@ -506,7 +598,10 @@ def test_index_per_page_pdf_writes_one_source_per_page(
         (3, "Page three pivots to Gamma incidents. " * 30),
     ]
 
-    def _fake_extract_pages_sync(path, **_kwargs):
+    captured: dict[str, Any] = {}
+
+    def _fake_extract_pages_sync(path, **kwargs):
+        captured.update(kwargs)
         return list(fake_pages)
 
     from research_agent.tools import pdf as pdf_mod
@@ -514,7 +609,11 @@ def test_index_per_page_pdf_writes_one_source_per_page(
     monkeypatch.setattr(pdf_mod, "extract_pages_sync", _fake_extract_pages_sync)
 
     summary = local_corpus.index(
-        corpus, job, models_config=stub_models_config, per_page=True
+        corpus,
+        job,
+        models_config=stub_models_config,
+        per_page=True,
+        hybrid_pages=True,
     )
 
     assert summary["files_indexed"] == 1
@@ -523,6 +622,9 @@ def test_index_per_page_pdf_writes_one_source_per_page(
     assert summary["pages_skipped"] == 0
     assert summary["chunks_indexed"] == 3
     assert summary["per_page"] is True
+    assert captured["hybrid_pages"] is True
+    assert captured["max_pages"] == pdf_mod.CORPUS_MAX_PAGES
+    assert captured["max_chars"] == pdf_mod.CORPUS_MAX_CHARS
 
     conn = db.connect(job.db_path)
     try:


### PR DESCRIPTION
Closes #376

## Why

\`local_corpus._extract_pdf\` was an inline \`pypdf -> unstructured\` fallback. It missed everything the canonical \`tools.pdf.extract_sync\` pipeline gained over the past year — pdfplumber tables, density-gated Tesseract OCR, hybrid per-page mode (#374), VLM escalation, and the per-job page/char knobs. A scanned FOIA PDF silently produced an empty corpus row.

Companion change: the embedding tier now emits 768-d vectors after #375's model lineup refresh, so \`EMBED_DIM\` drops to 768 here.

## What

- \`_extract_pdf\` body is now a single call to \`tools.pdf.extract_sync\` with resolved \`hybrid_pages\`, \`max_pages\`, \`max_chars\`.
- New resolvers: \`_resolve_pdf_hybrid_pages\`, \`_resolve_pdf_max_pages\`, \`_resolve_pdf_max_chars\`, \`_clamp_pdf_max_pages\`.
- \`_extract_text\` and \`index\` accept the new \`hybrid_pages\` kwarg.
- \`EMBED_DIM = 768\` (was 1024).
- \`docs/CONFIG.md\` documents the three new per-job knobs and adds a migration section explaining the index-sqlite re-index requirement.
- 5 new tests covering delegation, intake passthrough, clamp, resolver priority, and the EMBED_DIM regression guard.

## Behavior

- Scanned PDFs in a corpus now flow through Tesseract OCR — non-empty Source rows where they were previously dropped.
- \`research search\` against pre-upgrade jobs requires \`rm data/index.sqlite\` (or per-job source row deletion) — documented in the migration note.

## Test plan

- [x] \`pytest tests/test_tools_local_corpus.py\` — 26 pass (5 new)
- [x] Full suite: 2263 passed, 2 skipped, 1 deselected
- [x] \`ruff check\` clean

## Stacking note

4/6 of the parked-changes stack. Stacked on #381 (model lineup) so \`EMBED_DIM\` and the embedding model land coupled. Base is \`main\`.

Made with [Cursor](https://cursor.com)