### PR TITLE
feat(daemon): index intake corpus at startup + corpus_indexed event (#377)

### DIFF
--- a/src/research_agent/cli.py
+++ b/src/research_agent/cli.py
@@ -147,6 +147,24 @@ def start_command(
         " and writes one Source row per page so the dossier rollup can"
         " group findings by file. Requires --corpus.",
     ),
+    pdf_hybrid_pages: bool = typer.Option(
+        False,
+        "--pdf-hybrid-pages",
+        help=(
+            "When indexing corpus PDFs, merge each page's text layer with a"
+            " Tesseract OCR supplement (for mixed text + scanned regions)."
+        ),
+    ),
+    pdf_max_pages: int = typer.Option(
+        1000,
+        "--pdf-max-pages",
+        min=1,
+        max=1000,
+        help=(
+            "Max pages to extract from each PDF when indexing a local corpus"
+            " (default 1000)."
+        ),
+    ),
     disk_cap_gb: float = typer.Option(
         10.0,
         "--disk-cap-gb",
@@ -249,8 +267,11 @@ def start_command(
         }
         if corpus:
             intake_data["corpus"] = corpus
+            intake_data["pdf_max_pages"] = pdf_max_pages
         if corpus_dossier:
             intake_data["corpus_dossier"] = True
+        if pdf_hybrid_pages:
+            intake_data["pdf_hybrid_pages"] = True
     else:
         answers = intake.run_intake(
             corpus=corpus,
@@ -308,6 +329,14 @@ def start_command(
 
     if fragments:
         intake_data["fragments"] = True
+
+    if pdf_hybrid_pages:
+        intake_data["pdf_hybrid_pages"] = True
+
+    if intake_data.get("corpus") or corpus:
+        if corpus:
+            intake_data.setdefault("corpus", corpus)
+        intake_data["pdf_max_pages"] = pdf_max_pages
 
     goal_text = str(intake_data.get("goal") or "").strip()
     effective_corpus = str(intake_data.get("corpus") or "").strip() or None

--- a/src/research_agent/daemon.py
+++ b/src/research_agent/daemon.py
@@ -734,7 +734,7 @@ async def _inbox_watcher(
     (inbox_dir / "processed").mkdir(parents=True, exist_ok=True)
     # Dossier mode: opted-in jobs index per-page so the dossier rollup
     # (epic #359) can group findings by file. Off by default.
-    per_page = bool((job.intake or {}).get("corpus_dossier"))
+    per_page = _intake_bool((job.intake or {}).get("corpus_dossier"))
 
     try:
         while not should_stop.is_set():
@@ -1011,6 +1011,55 @@ async def _stop_flag_watcher(
         return
 
 
+_INTAKE_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _intake_bool(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in _INTAKE_TRUTHY
+    return bool(value)
+
+
+async def _index_intake_corpus(job: Job) -> dict[str, Any] | None:
+    """Index ``intake['corpus']`` once at daemon startup (impl guide §7).
+
+    Idempotent — already-indexed chunks are linked without re-embedding.
+    Returns the :func:`local_corpus.index` summary, or ``None`` when no
+    corpus path is configured. Honors ``intake['pdf_hybrid_pages']`` so
+    operators can opt into the per-page text+OCR merge from intake.
+
+    Runs the synchronous extractor on the default thread-pool executor —
+    the daemon's event loop stays responsive to SIGTERM and STOP-file
+    polls while OCR / pdfplumber crunch through large FOIA dumps.
+    """
+    from research_agent.tools import local_corpus
+
+    intake = job.intake or {}
+    corpus_raw = intake.get("corpus")
+    if not isinstance(corpus_raw, str) or not corpus_raw.strip():
+        return None
+
+    corpus_path = Path(corpus_raw.strip())
+    if not corpus_path.is_absolute():
+        corpus_path = Path.cwd() / corpus_path
+    if not corpus_path.exists():
+        raise FileNotFoundError(f"corpus path does not exist: {corpus_path}")
+
+    hybrid_pages = _intake_bool(intake.get("pdf_hybrid_pages"))
+    per_page = _intake_bool(intake.get("corpus_dossier"))
+
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        None,
+        lambda: local_corpus.index(
+            corpus_path,
+            job,
+            per_page=per_page,
+            hybrid_pages=hybrid_pages,
+        ),
+    )
+
+
 async def run_daemon(
     job_id: str,
     *,
@@ -1092,6 +1141,45 @@ async def run_daemon(
             return 1
 
     job.set_status("running")
+
+    try:
+        corpus_summary = await _index_intake_corpus(job)
+        if corpus_summary is not None:
+            intake = job.intake or {}
+            emit(
+                job,
+                "INFO",
+                "daemon",
+                "corpus_indexed",
+                {
+                    "corpus": str(intake.get("corpus")),
+                    "corpus_dossier": _intake_bool(intake.get("corpus_dossier")),
+                    "pdf_hybrid_pages": _intake_bool(intake.get("pdf_hybrid_pages")),
+                    "pdf_max_pages": intake.get("pdf_max_pages"),
+                    **corpus_summary,
+                },
+            )
+    except Exception as exc:
+        logger.exception("daemon: corpus indexing failed for job %s", job.id)
+        try:
+            emit(
+                job,
+                "ERROR",
+                "daemon",
+                "error",
+                {
+                    "stage": "corpus_index",
+                    "error": str(exc),
+                    "traceback": traceback.format_exc(),
+                },
+            )
+        except Exception:
+            pass
+        try:
+            job.set_status("failed")
+        except Exception:
+            pass
+        return 1
 
     if _loop._load_latest_plan(job) is None:
         try:

--- a/src/research_agent/observability/events.py
+++ b/src/research_agent/observability/events.py
@@ -65,6 +65,7 @@ EventKind = Literal[
     "corpus_doc_added",
     "corpus_file_gap",
     "coverage_declared",
+    "corpus_indexed",
     "llm_call",
     "lmstudio_degraded",
     "lmstudio_recovered",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -331,6 +331,39 @@ def test_start_corpus_dossier_flag_persists_intake(
     assert intake_data["corpus"] == str(corpus_dir)
 
 
+def test_start_pdf_corpus_flags_persist_intake(
+    isolated_jobs_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--pdf-hybrid-pages/--pdf-max-pages write corpus PDF knobs to intake."""
+    monkeypatch.setattr(cli.daemon, "spawn_daemon", lambda _job_id: 12345)
+    corpus_dir = isolated_jobs_repo / "corpus" / "pdf-flags"
+    corpus_dir.mkdir(parents=True)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            "start",
+            "--skip-intake",
+            "--goal",
+            "PDF corpus flags",
+            "--corpus",
+            str(corpus_dir),
+            "--pdf-hybrid-pages",
+            "--pdf-max-pages",
+            "250",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    job_root = isolated_jobs_repo / "jobs" / f"{today}-pdf-corpus-flags"
+    intake_data = json.loads((job_root / "intake.json").read_text(encoding="utf-8"))
+    assert intake_data["corpus"] == str(corpus_dir)
+    assert intake_data["pdf_hybrid_pages"] is True
+    assert intake_data["pdf_max_pages"] == 250
+
+
 def test_start_corpus_dossier_without_corpus_exits_2(
     isolated_jobs_repo: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1728,3 +1728,210 @@ async def test_cancel_with_timeout_no_op_for_already_done_task() -> None:
     assert task.done()
     # Should be a no-op — neither raise nor block.
     await daemon._cancel_with_timeout(task, "already_done", timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# _index_intake_corpus + corpus_indexed event (issue #377)
+# ---------------------------------------------------------------------------
+
+
+def _update_intake(job: Job, **fields: Any) -> None:
+    """Mutate ``job.intake`` in-memory, persist the JSON sidecar, AND update
+    the ``jobs.intake_json`` row so ``Job.load(...)`` inside ``run_daemon``
+    sees the new fields. ``Job.load`` reads from the DB, not the sidecar.
+    """
+    job.intake.update(fields)
+    intake_json = json.dumps(job.intake, sort_keys=True)
+    (job.root / "intake.json").write_text(intake_json, encoding="utf-8")
+    conn = db.connect(job.db_path)
+    try:
+        conn.execute(
+            "UPDATE jobs SET intake_json = ? WHERE id = ?",
+            (intake_json, job.id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_index_intake_corpus_returns_none_when_no_corpus_configured(
+    seeded_job: Job,
+) -> None:
+    """Jobs without ``intake.corpus`` skip the indexing pass entirely."""
+    result = await daemon._index_intake_corpus(seeded_job)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_index_intake_corpus_raises_when_corpus_missing(
+    seeded_job: Job, tmp_path: Path
+) -> None:
+    """A configured but-non-existent corpus path fails fast (operator typo)."""
+    _update_intake(seeded_job, corpus=str(tmp_path / "does-not-exist"))
+
+    with pytest.raises(FileNotFoundError):
+        await daemon._index_intake_corpus(seeded_job)
+
+
+@pytest.mark.asyncio
+async def test_index_intake_corpus_calls_local_corpus_with_hybrid_pages(
+    seeded_job: Job,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Intake corpus path + hybrid flag flow into ``local_corpus.index``."""
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    (corpus_dir / "doc.txt").write_text("hello", encoding="utf-8")
+
+    _update_intake(
+        seeded_job,
+        corpus=str(corpus_dir),
+        corpus_dossier=True,
+        pdf_hybrid_pages=True,
+    )
+
+    captured: dict[str, Any] = {}
+
+    def _fake_index(
+        path: Path,
+        job: Job,
+        *,
+        per_page: bool = False,
+        hybrid_pages: bool = False,
+    ) -> dict[str, int]:
+        captured["path"] = path
+        captured["job_id"] = job.id
+        captured["per_page"] = per_page
+        captured["hybrid_pages"] = hybrid_pages
+        return {
+            "files_indexed": 1,
+            "files_skipped": 0,
+            "chunks_indexed": 1,
+            "chunks_skipped": 0,
+            "embed_dim": 768,
+        }
+
+    monkeypatch.setattr("research_agent.tools.local_corpus.index", _fake_index)
+
+    result = await daemon._index_intake_corpus(seeded_job)
+
+    assert result is not None
+    assert result["files_indexed"] == 1
+    assert captured["job_id"] == seeded_job.id
+    assert captured["per_page"] is True
+    assert captured["hybrid_pages"] is True
+    assert captured["path"] == corpus_dir
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_indexes_intake_corpus_on_startup(
+    seeded_job: Job,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``run_daemon`` emits ``corpus_indexed`` before the planner fires."""
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    (corpus_dir / "doc.txt").write_text("hello", encoding="utf-8")
+
+    _update_intake(seeded_job, corpus=str(corpus_dir), pdf_max_pages=250)
+
+    index_calls: list[Path] = []
+
+    def _fake_index(
+        path: Path,
+        job: Job,
+        *,
+        per_page: bool = False,
+        hybrid_pages: bool = False,
+    ) -> dict[str, int]:
+        index_calls.append(path)
+        return {
+            "files_indexed": 1,
+            "files_skipped": 0,
+            "chunks_indexed": 1,
+            "chunks_skipped": 0,
+            "embed_dim": 768,
+        }
+
+    monkeypatch.setattr("research_agent.tools.local_corpus.index", _fake_index)
+
+    async def _instant_run_loop(job: Job, router: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"tasks_done": 0, "stopped": False, "completed": True, "cap_hit": False}
+
+    _patch_run_daemon_for_in_process(monkeypatch, run_loop_impl=_instant_run_loop)
+
+    exit_code = await daemon.run_daemon(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    assert exit_code == 0
+    assert index_calls == [corpus_dir]
+
+    conn = db.connect(seeded_job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT payload_json FROM events"
+            " WHERE job_id = ? AND kind = 'corpus_indexed'",
+            (seeded_job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert len(rows) == 1
+    payload = json.loads(rows[0]["payload_json"])
+    assert payload["corpus"] == str(corpus_dir)
+    assert payload["corpus_dossier"] is False
+    assert payload["pdf_hybrid_pages"] is False
+    assert payload["pdf_max_pages"] == 250
+    assert payload["files_indexed"] == 1
+    assert payload["embed_dim"] == 768
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_fails_when_corpus_indexing_raises(
+    seeded_job: Job,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A FileNotFoundError on corpus index marks the job ``failed`` with
+    a single ``error`` event tagged ``stage=corpus_index``.
+    """
+    _update_intake(seeded_job, corpus=str(tmp_path / "missing-corpus"))
+
+    _patch_run_daemon_for_in_process(
+        monkeypatch,
+        run_loop_impl=lambda job, router, **kw: (_ for _ in ()).throw(
+            AssertionError("run_loop must not be called when corpus index fails")
+        ),
+    )
+
+    exit_code = await daemon.run_daemon(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    assert exit_code == 1
+
+    refreshed = Job.load(
+        seeded_job.id,
+        jobs_root=seeded_job.root.parent,
+        db_path=seeded_job.db_path,
+    )
+    assert refreshed.status == "failed"
+
+    conn = db.connect(seeded_job.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT payload_json FROM events"
+            " WHERE job_id = ? AND kind = 'error'",
+            (seeded_job.id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    stages = [json.loads(r["payload_json"]).get("stage") for r in rows]
+    assert "corpus_index" in stages


### PR DESCRIPTION
Closes #377

## Why

\`intake.corpus\` has been documented since v1 but the daemon never actually indexed it — the only call site for \`local_corpus.index()\` was the inbox watcher. A \`corpus:\` declared at start time produced nothing until the operator manually dropped files into \`inbox/\`.

## What

- \`daemon._index_intake_corpus(job)\` — runs once after the job goes to \`running\`, before the planner fires. Idempotent (chunks are content-addressed), honors \`intake['pdf_hybrid_pages']\`, executes on the thread-pool executor so the event loop stays responsive.
- \`run_daemon\` emits \`corpus_indexed\` on success with the full index summary; on exception marks the job \`failed\` with an \`error\` event tagged \`stage=corpus_index\`.
- New \`EventKind\` literal: \`corpus_indexed\`.
- CLI: \`--pdf-hybrid-pages\` and \`--pdf-max-pages N\` flags on \`research start\`, both writing to intake.
- 5 new tests covering the no-corpus skip, missing-path fast-fail, hybrid-flag pass-through, full \`run_daemon\` happy path with event assertion, and the failure-path job-status flip.

## Test plan

- [x] \`pytest tests/test_daemon.py\` — 44 pass (5 new)
- [x] Full suite: 2268 passed, 2 skipped, 1 deselected
- [x] \`ruff check\` clean

## Stacking note

5/6 of the parked-changes stack. Stacked on #382 (local_corpus layered PDF) so the \`hybrid_pages\` parameter exists on \`local_corpus.index\`. Base is \`main\`.

Made with [Cursor](https://cursor.com)