### PR TITLE
feat(orchestrator): local_corpus_query fans out to extract_findings (#378)

### DIFF
--- a/src/research_agent/orchestrator/loop.py
+++ b/src/research_agent/orchestrator/loop.py
@@ -556,7 +556,7 @@ def default_handlers(router: Any) -> dict[str, Handler]:
                 top_k=payload.get("top_k", 10),
             ),
         )
-        return {"results": results}
+        return _expand_corpus_query_to_extract_findings(job, payload, results)
 
     async def _cornerstone_query(job: Job, task: dict[str, Any]) -> dict[str, Any]:
         return await _run_cornerstone_query(job, task, router=router)
@@ -1792,6 +1792,65 @@ def _expand_search_to_fetches(
 
     return {
         "results": [r.model_dump(mode="json") for r in results],
+        "follow_up_tasks": [t.model_dump() for t in follow_ups],
+    }
+
+
+def _expand_corpus_query_to_extract_findings(
+    job: Job,
+    payload: dict[str, Any],
+    results: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Turn a ``local_corpus.search`` return into ``extract_findings``
+    follow-ups, mirroring :func:`_expand_search_to_fetches` for web search.
+
+    Without this fan-out, ``local_corpus_query`` returned the raw hit list
+    and no claims ever landed against those chunks — the planner kept
+    re-issuing the same semantic search because nothing in the queue
+    extracted findings from the matched sources. Each top-K hit becomes
+    one ``extract_findings`` task carrying the chunk's ``source_id`` and
+    the inherited ``sub_question``.
+
+    ``payload`` knobs:
+      * ``expand_top_k`` — when set, caps the number of follow-ups
+        emitted; otherwise the default scales with the plan's
+        ``scope_class`` (matches ``_expand_search_to_fetches``).
+      * ``sub_question`` — overrides the auto-derived question; falls
+        back to ``payload['query']`` then ``job.goal``.
+
+    Hits without an integer ``source_id`` (defensive — every
+    ``local_corpus.search`` row has one today) are silently dropped from
+    the follow-up list but stay in ``results``.
+    """
+    from research_agent.orchestrator.plan import TaskSpec
+
+    if "expand_top_k" in payload:
+        top_k = int(payload["expand_top_k"])
+    else:
+        plan = _load_latest_plan(job)
+        scope = plan.scope_class if plan is not None else None
+        top_k = _DEFAULT_TOP_K_BY_SCOPE.get(scope or "", _DEFAULT_TOP_K_FALLBACK)
+
+    sub_question = payload.get("sub_question") or payload.get("query") or job.goal
+
+    follow_ups: list[TaskSpec] = []
+    for hit in results[:top_k]:
+        source_id = hit.get("source_id") if isinstance(hit, dict) else None
+        if not isinstance(source_id, int):
+            continue
+        follow_ups.append(
+            TaskSpec(
+                kind="extract_findings",
+                payload={
+                    "source_id": source_id,
+                    "sub_question": sub_question,
+                    **_task_passthrough_payload(payload),
+                },
+            )
+        )
+
+    return {
+        "results": results,
         "follow_up_tasks": [t.model_dump() for t in follow_ups],
     }
 

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -784,6 +784,50 @@ def test_default_handlers_covers_every_task_kind() -> None:
 
 
 @pytest.mark.asyncio
+async def test_local_corpus_query_handler_returns_extract_follow_ups(
+    job: Job,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from research_agent.tools import local_corpus as lc_mod
+
+    _persist_plan_with_scope(job, "narrow")
+    calls: list[dict[str, Any]] = []
+
+    def _fake_search(query: str, job_arg: Job, top_k: int = 10) -> list[dict[str, Any]]:
+        calls.append({"query": query, "job_id": job_arg.id, "top_k": top_k})
+        return [
+            {
+                "source_id": 42,
+                "sha256": "deadbeef",
+                "md_path": "sources/deadbeef.md",
+                "score": 0.99,
+            }
+        ]
+
+    monkeypatch.setattr(lc_mod, "search", _fake_search)
+    handler = default_handlers(router=None)["local_corpus_query"]
+
+    result = await handler(
+        job,
+        {"payload": {"query": "who funded Widget Co?", "top_k": 4}},
+    )
+
+    assert calls == [{"query": "who funded Widget Co?", "job_id": job.id, "top_k": 4}]
+    assert result["results"][0]["source_id"] == 42
+    assert result["follow_up_tasks"] == [
+        {
+            "kind": "extract_findings",
+            "payload": {
+                "source_id": 42,
+                "sub_question": "who funded Widget Co?",
+            },
+            "priority": 0,
+            "depends_on": [],
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_synthesize_handler_routes_to_legacy_when_fragment_flag_unset(
     job: Job,
     plan: Plan,
@@ -2545,6 +2589,131 @@ def test_expand_search_to_fetches_no_plan_falls_back_to_three(job: Job) -> None:
     out = _expand_search_to_fetches(job, {"query": "q"}, results)
 
     assert len(out["follow_up_tasks"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# _expand_corpus_query_to_extract_findings (issue #378)
+# ---------------------------------------------------------------------------
+
+
+def _make_corpus_hits(n: int) -> list[dict[str, Any]]:
+    return [
+        {
+            "source_id": 100 + i,
+            "sha256": f"deadbeef{i:04d}",
+            "md_path": f"sources/deadbeef{i:04d}.md",
+            "score": 0.9 - i * 0.05,
+        }
+        for i in range(n)
+    ]
+
+
+def test_expand_corpus_query_broad_scope_emits_seven_extract_findings(job: Job) -> None:
+    """Mirrors ``_expand_search_to_fetches`` cardinality at broad scope."""
+    from research_agent.orchestrator.loop import _expand_corpus_query_to_extract_findings
+
+    _persist_plan_with_scope(job, "broad")
+    hits = _make_corpus_hits(10)
+
+    out = _expand_corpus_query_to_extract_findings(job, {"query": "q"}, hits)
+
+    assert len(out["follow_up_tasks"]) == 7
+    assert len(out["results"]) == 10
+    assert all(t["kind"] == "extract_findings" for t in out["follow_up_tasks"])
+    assert all(
+        t["payload"]["source_id"] == hit["source_id"]
+        for t, hit in zip(out["follow_up_tasks"], hits[:7], strict=True)
+    )
+
+
+@pytest.mark.parametrize(
+    "scope,expected",
+    [
+        ("narrow", 3),
+        ("medium", 5),
+        ("broad", 7),
+        ("comprehensive", 10),
+    ],
+)
+def test_expand_corpus_query_scope_mapping(
+    job: Job, scope: ScopeClass, expected: int
+) -> None:
+    """Default-K table is reused; no duplicate constants drift."""
+    from research_agent.orchestrator.loop import _expand_corpus_query_to_extract_findings
+
+    _persist_plan_with_scope(job, scope)
+    hits = _make_corpus_hits(10)
+
+    out = _expand_corpus_query_to_extract_findings(job, {"query": "q"}, hits)
+
+    assert len(out["follow_up_tasks"]) == expected
+
+
+def test_expand_corpus_query_payload_top_k_override_wins(job: Job) -> None:
+    """Explicit ``expand_top_k`` overrides the scope default."""
+    from research_agent.orchestrator.loop import _expand_corpus_query_to_extract_findings
+
+    _persist_plan_with_scope(job, "broad")
+    hits = _make_corpus_hits(10)
+
+    out = _expand_corpus_query_to_extract_findings(
+        job, {"query": "q", "expand_top_k": 2}, hits
+    )
+
+    assert len(out["follow_up_tasks"]) == 2
+
+
+def test_expand_corpus_query_skips_hits_without_source_id(job: Job) -> None:
+    """Hits missing an integer ``source_id`` stay in ``results`` but emit no follow-up."""
+    from research_agent.orchestrator.loop import _expand_corpus_query_to_extract_findings
+
+    _persist_plan_with_scope(job, "broad")
+    hits = [
+        {"source_id": 1, "sha256": "abc", "md_path": "p", "score": 0.9},
+        {"sha256": "xyz", "md_path": "p2", "score": 0.7},  # no source_id
+        {"source_id": None, "sha256": "qqq", "md_path": "p3", "score": 0.5},
+    ]
+
+    out = _expand_corpus_query_to_extract_findings(job, {"query": "q"}, hits)
+
+    assert len(out["results"]) == 3
+    assert len(out["follow_up_tasks"]) == 1
+    assert out["follow_up_tasks"][0]["payload"]["source_id"] == 1
+
+
+def test_expand_corpus_query_empty_results_emit_no_follow_ups(job: Job) -> None:
+    """Empty semantic search → empty follow-up list, no errors."""
+    from research_agent.orchestrator.loop import _expand_corpus_query_to_extract_findings
+
+    _persist_plan_with_scope(job, "broad")
+    out = _expand_corpus_query_to_extract_findings(job, {"query": "q"}, [])
+
+    assert out["results"] == []
+    assert out["follow_up_tasks"] == []
+
+
+def test_expand_corpus_query_sub_question_fallback_chain(job: Job) -> None:
+    """``sub_question`` > ``query`` > ``job.goal``."""
+    from research_agent.orchestrator.loop import _expand_corpus_query_to_extract_findings
+
+    _persist_plan_with_scope(job, "narrow")
+    hits = _make_corpus_hits(3)
+
+    # 1. explicit sub_question wins
+    out = _expand_corpus_query_to_extract_findings(
+        job,
+        {"sub_question": "explicit Q", "query": "ignored"},
+        hits,
+    )
+    assert all(t["payload"]["sub_question"] == "explicit Q" for t in out["follow_up_tasks"])
+
+    # 2. fall back to query
+    out = _expand_corpus_query_to_extract_findings(job, {"query": "from-query"}, hits)
+    assert all(t["payload"]["sub_question"] == "from-query" for t in out["follow_up_tasks"])
+
+    # 3. fall back to job.goal
+    out = _expand_corpus_query_to_extract_findings(job, {}, hits)
+    assert all(t["payload"]["sub_question"] == job.goal for t in out["follow_up_tasks"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #378

## Why

\`_local_corpus_query\` ran a semantic search and returned bare \`{\"results\": [...]}\` — no findings written, so the planner kept re-issuing searches against the same chunks. \`_expand_search_to_fetches\` already solves the equivalent for web search; this PR adds the mirror for local corpus hits.

(Note: dossier mode supersedes this with \`dossier_extract_page\` in M2, but semantic-style corpus jobs stay supported.)

## What

- New \`_expand_corpus_query_to_extract_findings(job, payload, results)\` mirroring \`_expand_search_to_fetches\`. Reuses \`_DEFAULT_TOP_K_BY_SCOPE\` — no duplicate constants.
- \`_local_corpus_query\` now returns \`{\"results\": ..., \"follow_up_tasks\": ...}\`.
- One \`extract_findings\` task per top-K hit, carrying \`source_id\` and the inherited \`sub_question\`.
- 9 new tests covering scope mapping, payload top_k override, missing-source_id defensive drop, empty results, and the sub_question fallback chain.

## Test plan

- [x] \`pytest tests/test_orchestrator_loop.py\` — 167 pass (9 new)
- [x] Full suite: 2277 passed, 2 skipped, 1 deselected
- [x] \`ruff check\` clean

## Stacking note

6/6 of the parked-changes stack — the final one. Stacked on #383 (daemon startup corpus indexing) so there's actually a populated corpus to query against in end-to-end runs. Base is \`main\`.

Made with [Cursor](https://cursor.com)